### PR TITLE
Azure.Core: Preserve extracted ContentStream when response is disposed

### DIFF
--- a/sdk/core/Azure.Core/src/HttpMessage.cs
+++ b/sdk/core/Azure.Core/src/HttpMessage.cs
@@ -182,6 +182,11 @@ namespace Azure.Core
         /// <returns>The content stream or null if response didn't have any.</returns>
         public Stream? ExtractResponseContent()
         {
+            if (_response?.ContentStream is not null)
+            {
+                _response.ContentExtracted = true;
+            }
+
             switch (_response?.ContentStream)
             {
                 case ResponseShouldNotBeUsedStream responseContent:

--- a/sdk/core/Azure.Core/src/Response.cs
+++ b/sdk/core/Azure.Core/src/Response.cs
@@ -92,6 +92,8 @@ namespace Azure
 
         internal RequestFailedDetailsParser? RequestFailedDetailsParser { get; set; }
 
+        internal bool ContentExtracted { get; set; }
+
         /// <summary>
         /// Returns header value if the header is stored in the collection. If header has multiple values they are going to be joined with a comma.
         /// </summary>
@@ -142,13 +144,13 @@ namespace Azure
             return $"Status: {Status}, ReasonPhrase: {ReasonPhrase}";
         }
 
-        internal static void DisposeStreamIfNotBuffered(ref Stream? stream)
+        internal void DisposeStreamIfNotBuffered(ref Stream? stream)
         {
             // We want to keep the ContentStream readable
             // even after the response is disposed but only if it's a
             // buffered memory stream otherwise we can leave a network
             // connection hanging open
-            if (stream is not MemoryStream)
+            if (stream is not MemoryStream && !ContentExtracted)
             {
                 stream?.Dispose();
                 stream = null;

--- a/sdk/core/Azure.Core/tests/HttpPipelineMessageTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineMessageTest.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Moq;
@@ -99,6 +101,34 @@ namespace Azure.Core.Tests
 
             Assert.AreSame(memoryStream, stream);
             Assert.Throws<InvalidOperationException>(() => { var x = response.Content; });
+        }
+
+        [Test]
+        public async Task UnbufferedStreamAccessibleAfterMessageDisposed()
+        {
+            var streamBytes = new byte[0x1000];
+            new Random().NextBytes(streamBytes);
+
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(new TestClientOptions() { Retry = { NetworkTimeout = Timeout.InfiniteTimeSpan } });
+
+            using TestServer testServer = new(async context =>
+            {
+                await context.Response.Body.WriteAsync(streamBytes, 0, streamBytes.Length).ConfigureAwait(false);
+            });
+
+            Response response;
+            using (HttpMessage message = pipeline.CreateMessage())
+            {
+                message.Request.Uri.Reset(testServer.Address);
+                message.BufferResponse = false;
+
+                await pipeline.SendAsync(message, default).ConfigureAwait(false);
+                response = message.Response;
+                response.ContentStream = message.ExtractResponseContent();
+            }
+
+            Assert.NotNull(response.ContentStream);
+            Assert.AreEqual(streamBytes[0], response.ContentStream.ReadByte());
         }
     }
 }


### PR DESCRIPTION
Unblock generator work to generate protocol methods for streaming APIs where message.BufferResponse is set to false (address problem described by @AlexanderSher in https://gist.github.com/AlexanderSher/df22ed21acaa938a4371c188f0699b11).

The problem is that today we always dispose the response stream in subtypes of Response if they are not buffered.  We provide HttpMessage.ExtractResponseContent, but that relies on the idea that someone has a convenience-method return type containing the stream, so it doesn't work if we want to set response.ContentStream back to the extracted stream prior to calling Dispose on the response -- since response.ContentStream no longer holds the no-op stream set by ExtractResponseContent, the stream we want to return still gets disposed.

This PR adds an internal property to Response to indicate that ExtractResponseContent has been called, and then if it has, it will not dispose the ContentStream.  This does not change the behavior from explicitly calling dispose on the no-op stream, since that does nothing anyway.

