### PR TITLE
Core 2.0: Make cancellation token optional in BinaryContent.WriteTo

### DIFF
--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -13,8 +13,8 @@ namespace System.ClientModel
         public static System.ClientModel.BinaryContent Create<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
         public abstract void Dispose();
         public abstract bool TryComputeLength(out long length);
-        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken);
-        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken);
+        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
     }
     public partial class ClientResult
     {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -13,8 +13,8 @@ namespace System.ClientModel
         public static System.ClientModel.BinaryContent Create<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
         public abstract void Dispose();
         public abstract bool TryComputeLength(out long length);
-        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken);
-        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken);
+        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
     }
     public partial class ClientResult
     {

--- a/sdk/core/System.ClientModel/src/Message/BinaryContent.cs
+++ b/sdk/core/System.ClientModel/src/Message/BinaryContent.cs
@@ -40,14 +40,14 @@ public abstract class BinaryContent : IDisposable
     /// </summary>
     /// <param name="stream">The stream to write to.</param>
     /// <param name="cancellationToken">To cancellation token to use.</param>
-    public abstract Task WriteToAsync(Stream stream, CancellationToken cancellationToken);
+    public abstract Task WriteToAsync(Stream stream, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Writes contents of this object to an instance of <see cref="Stream"/>.
     /// </summary>
     /// <param name="stream">The stream to write to.</param>
     /// <param name="cancellationToken">To cancellation token to use.</param>
-    public abstract void WriteTo(Stream stream, CancellationToken cancellationToken);
+    public abstract void WriteTo(Stream stream, CancellationToken cancellationToken = default);
 
     /// <inheritdoc/>
     public abstract void Dispose();


### PR DESCRIPTION
Validation PR for https://github.com/Azure/azure-sdk-for-net/issues/41362 -- make sure it isn't a breaking change to Core APIs.