### PR TITLE
[LiveMetricsExporter] Add Filtering Support part 2 - Parse the Query parameters and store the compiled Filters and Projections

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/Models/CollectionConfigurationError.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/Models/CollectionConfigurationError.cs
@@ -1,0 +1,63 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Represents an error while parsing and applying an instance of <see cref="CollectionConfigurationInfo"/>.
+    /// </summary>
+    [DataContract]
+    internal class CollectionConfigurationError
+    {
+        [DataMember(Name = "CollectionConfigurationErrorType")]
+        public string CollectionConfigurationErrorTypeForSerialization
+        {
+            get
+            {
+                return this.ErrorType.ToString();
+            }
+
+            set
+            {
+                CollectionConfigurationErrorType errorType;
+                if (!Enum.TryParse(value, out errorType))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        string.Format(CultureInfo.InvariantCulture, "Unsupported CollectionConfigurationErrorType value: {0}", value));
+                }
+
+                this.ErrorType = errorType;
+            }
+        }
+
+        public CollectionConfigurationErrorType ErrorType { get; set; }
+
+        [DataMember]
+        public string Message { get; set; }
+
+        [DataMember]
+        public string FullException { get; set; }
+
+        [DataMember]
+        public Dictionary<string, string> Data { get; set; }
+
+        public static CollectionConfigurationError CreateError(
+            CollectionConfigurationErrorType errorType,
+            string message,
+            Exception exception,
+            params Tuple<string, string>[] data)
+        {
+            return new CollectionConfigurationError()
+            {
+                ErrorType = errorType,
+                Message = message,
+                FullException = exception?.ToString() ?? string.Empty,
+                Data = data.ToDictionary(tuple => tuple.Item1, tuple => tuple.Item2),
+            };
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/Models/CollectionConfigurationError.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/Models/CollectionConfigurationError.cs
@@ -1,63 +1,24 @@
-﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-    using System.Runtime.Serialization;
-
-    /// <summary>
-    /// Represents an error while parsing and applying an instance of <see cref="CollectionConfigurationInfo"/>.
-    /// </summary>
-    [DataContract]
-    internal class CollectionConfigurationError
+    internal partial class CollectionConfigurationError
     {
-        [DataMember(Name = "CollectionConfigurationErrorType")]
-        public string CollectionConfigurationErrorTypeForSerialization
-        {
-            get
-            {
-                return this.ErrorType.ToString();
-            }
-
-            set
-            {
-                CollectionConfigurationErrorType errorType;
-                if (!Enum.TryParse(value, out errorType))
-                {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        string.Format(CultureInfo.InvariantCulture, "Unsupported CollectionConfigurationErrorType value: {0}", value));
-                }
-
-                this.ErrorType = errorType;
-            }
-        }
-
-        public CollectionConfigurationErrorType ErrorType { get; set; }
-
-        [DataMember]
-        public string Message { get; set; }
-
-        [DataMember]
-        public string FullException { get; set; }
-
-        [DataMember]
-        public Dictionary<string, string> Data { get; set; }
-
         public static CollectionConfigurationError CreateError(
             CollectionConfigurationErrorType errorType,
             string message,
-            Exception exception,
+            System.Exception? exception,
             params Tuple<string, string>[] data)
         {
-            return new CollectionConfigurationError()
-            {
-                ErrorType = errorType,
-                Message = message,
-                FullException = exception?.ToString() ?? string.Empty,
-                Data = data.ToDictionary(tuple => tuple.Item1, tuple => tuple.Item2),
-            };
+            return new CollectionConfigurationError(
+                errorType,
+                message,
+                exception?.ToString() ?? string.Empty,
+                Array.ConvertAll(data, tuple => new KeyValuePairString(tuple.Item1, tuple.Item2))
+            );
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CalculatedMetric.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CalculatedMetric.cs
@@ -1,0 +1,212 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    using Microsoft.ApplicationInsights.Common;
+
+    /// <summary>
+    /// Represents a single configured metric that needs to be calculated and reported on top of the telemetry items 
+    /// that pass through the pipeline. Includes a set of filters that define which telemetry items to consider, a projection 
+    /// which defines which field to use as a value, and an aggregation which dictates the algorithm of arriving at 
+    /// a single reportable value within a second.
+    /// </summary>
+    internal class CalculatedMetric<TTelemetry>
+    {
+        private const string ProjectionCount = "Count()";
+
+        private static readonly MethodInfo DoubleParseMethodInfo = typeof(double).GetMethod(
+           "Parse",
+           new[] { typeof(string), typeof(IFormatProvider) });
+
+        private static readonly MethodInfo ObjectToStringMethodInfo = typeof(object).GetMethod(
+            "ToString",
+            BindingFlags.Public | BindingFlags.Instance);
+
+        private static readonly MethodInfo DoubleToStringMethodInfo = typeof(double).GetMethod(
+            "ToString",
+            new[] { typeof(IFormatProvider) });
+
+        private readonly CalculatedMetricInfo info;
+
+        /// <summary>
+        /// OR-connected collection of AND-connected filter groups.
+        /// </summary>
+        private readonly List<FilterConjunctionGroup<TTelemetry>> filterGroups = new List<FilterConjunctionGroup<TTelemetry>>();
+
+        private Func<TTelemetry, double> projectionLambda;
+
+        public CalculatedMetric(CalculatedMetricInfo info, out CollectionConfigurationError[] errors)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            this.info = info;
+
+            this.CreateFilters(out errors);
+
+            this.CreateProjection();
+        }
+
+        public string Id => this.info.Id;
+
+        public AggregationType AggregationType => this.info.Aggregation;
+
+        public bool CheckFilters(TTelemetry document, out CollectionConfigurationError[] errors)
+        {
+            if (this.filterGroups.Count < 1)
+            {
+                errors = ArrayExtensions.Empty<CollectionConfigurationError>();
+                return true;
+            }
+
+            var errorList = new List<CollectionConfigurationError>(this.filterGroups.Count);
+
+            // iterate over OR-connected groups
+            foreach (FilterConjunctionGroup<TTelemetry> conjunctionFilterGroup in this.filterGroups)
+            {
+                CollectionConfigurationError[] groupErrors;
+                bool groupPassed = conjunctionFilterGroup.CheckFilters(document, out groupErrors);
+
+                errorList.AddRange(groupErrors);
+
+                if (groupPassed)
+                {
+                    // one group has passed, we don't care about others
+                    errors = errorList.ToArray();
+                    return true;
+                }
+            }
+
+            errors = errorList.ToArray();
+            return false;
+        }
+
+        public double Project(TTelemetry document)
+        {
+            try
+            {
+                return this.projectionLambda(document);
+            }
+            catch (FormatException e)
+            {
+                // the projected value could not be parsed by double.Parse()
+                throw new ArgumentOutOfRangeException(
+                    string.Format(CultureInfo.InvariantCulture, "Projected field {0} was not a number", this.info.Projection),
+                    e);
+            }
+        }
+
+        public override string ToString()
+        {
+            return this.info.ToString();
+        }
+
+        private void CreateFilters(out CollectionConfigurationError[] errors)
+        {
+            var errorList = new List<CollectionConfigurationError>();
+            if (this.info.FilterGroups != null)
+            {
+                foreach (FilterConjunctionGroupInfo filterConjunctionGroupInfo in this.info.FilterGroups)
+                {
+                    CollectionConfigurationError[] groupErrors = null;
+                    try
+                    {
+                        var conjunctionFilterGroup = new FilterConjunctionGroup<TTelemetry>(filterConjunctionGroupInfo, out groupErrors);
+                        this.filterGroups.Add(conjunctionFilterGroup);
+                    }
+                    catch (Exception e)
+                    {
+                        errorList.Add(
+                            CollectionConfigurationError.CreateError(
+                                CollectionConfigurationErrorType.MetricFailureToCreateFilterUnexpected,
+                                string.Format(CultureInfo.InvariantCulture, "Failed to create a filter group {0}.", filterConjunctionGroupInfo),
+                                e,
+                                Tuple.Create("MetricId", this.info.Id)));
+                    }
+
+                    if (groupErrors != null)
+                    {
+                        foreach (var error in groupErrors)
+                        {
+                            error.Data["MetricId"] = this.info.Id;
+                        }
+
+                        errorList.AddRange(groupErrors);
+                    }
+                }
+            }
+
+            errors = errorList.ToArray();
+        }
+
+        private void CreateProjection()
+        {
+            ParameterExpression documentExpression = Expression.Variable(typeof(TTelemetry));
+
+            Expression projectionExpression;
+
+            try
+            {
+                Expression fieldExpression;
+
+                if (string.Equals(this.info.Projection, ProjectionCount, StringComparison.OrdinalIgnoreCase))
+                {
+                    fieldExpression = Expression.Constant(1, typeof(int));
+                }
+                else
+                {
+                    Filter<TTelemetry>.FieldNameType fieldNameType;
+                    Type fieldType = Filter<TTelemetry>.GetFieldType(this.info.Projection, out fieldNameType);
+                    if (fieldNameType == Filter<TTelemetry>.FieldNameType.AnyField)
+                    {
+                        throw new ArgumentOutOfRangeException(
+                            string.Format(CultureInfo.InvariantCulture, "Unsupported field type for projection: {0}", this.info.Projection));
+                    }
+
+                    fieldExpression = Filter<TTelemetry>.ProduceFieldExpression(documentExpression, this.info.Projection, fieldNameType);
+
+                    // special case - for TimeSpan values ToString() will not result in a value convertable to double, so we must take care of that ourselves
+                    if (fieldType == typeof(TimeSpan))
+                    {
+                        fieldExpression = Expression.Property(fieldExpression, "TotalMilliseconds");
+                    }
+                }
+
+                ConstantExpression invariantCulture = Expression.Constant(CultureInfo.InvariantCulture);
+                if (fieldExpression.Type == typeof(double))
+                {
+                    // Expression fieldAsObjectExpression = Expression.ConvertChecked(fieldExpression, typeof(object));
+                    MethodCallExpression fieldExpressionToString = Expression.Call(fieldExpression, DoubleToStringMethodInfo, invariantCulture);
+                    projectionExpression = Expression.Call(DoubleParseMethodInfo, fieldExpressionToString, invariantCulture);
+                }
+                else
+                {
+                    Expression fieldAsObjectExpression = Expression.ConvertChecked(fieldExpression, typeof(object));
+                    MethodCallExpression fieldExpressionToString = Expression.Call(fieldExpression, ObjectToStringMethodInfo);
+                    projectionExpression = Expression.Call(DoubleParseMethodInfo, fieldExpressionToString, invariantCulture);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "Could not construct the projection."), e);
+            }
+
+            try
+            {
+                Expression<Func<TTelemetry, double>> lambdaExpression = Expression.Lambda<Func<TTelemetry, double>>(projectionExpression, documentExpression);
+
+                this.projectionLambda = lambdaExpression.Compile();
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "Could not compile the projection."), e);
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
@@ -1,0 +1,332 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.Helpers;
+
+    /// <summary>
+    /// Represents the collection configuration - a set of calculated metrics, performance counters, and full telemetry documents to be collected by the SDK.
+    /// </summary>
+    /// <remarks>
+    /// This class is a hub for all pieces of configurable collection configuration.
+    /// Upon initialization
+    ///   - it creates collection-time instances of <see cref="CalculatedMetric&lt;T&gt;"/> and maintains them in separate collections by telemetry type.
+    ///     These are used to filter and calculated calculated metrics configured by the service.
+    ///   - it creates collection-time instances of <see cref="DocumentStream"/> which are used to filter and send out full telemetry documents.
+    ///   - it creates certain metadata collections which are used by other collection-time components to learn more about what is being collected at any given time.
+    /// </remarks>
+    internal class CollectionConfiguration
+    {
+        private readonly CollectionConfigurationInfo info;
+
+        #region Collection-time instances used to filter and calculate data on telemetry passing through the pipeline
+        private readonly List<CalculatedMetric<RequestTelemetry>> requestTelemetryMetrics = new List<CalculatedMetric<RequestTelemetry>>();
+
+        private readonly List<CalculatedMetric<DependencyTelemetry>> dependencyTelemetryMetrics =
+            new List<CalculatedMetric<DependencyTelemetry>>();
+
+        private readonly List<CalculatedMetric<ExceptionTelemetry>> exceptionTelemetryMetrics =
+            new List<CalculatedMetric<ExceptionTelemetry>>();
+
+        private readonly List<CalculatedMetric<EventTelemetry>> eventTelemetryMetrics = new List<CalculatedMetric<EventTelemetry>>();
+
+        private readonly List<CalculatedMetric<TraceTelemetry>> traceTelemetryMetrics = new List<CalculatedMetric<TraceTelemetry>>();
+
+        private readonly List<DocumentStream> documentStreams = new List<DocumentStream>();
+        #endregion
+
+        #region Metadata used by other components
+        private readonly List<Tuple<string, AggregationType>> telemetryMetadata = new List<Tuple<string, AggregationType>>();
+
+        private readonly List<Tuple<string, string>> performanceCounters = new List<Tuple<string, string>>();
+        #endregion
+
+        public CollectionConfiguration(
+           CollectionConfigurationInfo info,
+           out CollectionConfigurationError[] errors,
+           Clock timeProvider,
+           IEnumerable<DocumentStream> previousDocumentStreams = null)
+        {
+            this.info = info ?? throw new ArgumentNullException(nameof(info));
+
+            // create metrics based on descriptions in info
+            this.CreateTelemetryMetrics(out CollectionConfigurationError[] metricErrors);
+
+            // maintain a separate collection of all (Id, AggregationType) pairs with some additional data - to allow for uniform access to all types of metrics
+            // this includes both telemetry metrics and Metric metrics
+            this.CreateMetadata();
+
+            // create document streams based on description in info
+            this.CreateDocumentStreams(out CollectionConfigurationError[] documentStreamErrors, timeProvider, previousDocumentStreams ?? ArrayExtensions.Empty<DocumentStream>());
+
+            // create performance counters
+            this.CreatePerformanceCounters(out CollectionConfigurationError[] performanceCounterErrors);
+            
+            errors = metricErrors.Concat(documentStreamErrors).Concat(performanceCounterErrors).ToArray();
+
+            foreach (var error in errors)
+            {
+                error.Data["ETag"] = this.info.ETag;
+            }
+        }
+
+        public IEnumerable<CalculatedMetric<RequestTelemetry>> RequestMetrics => this.requestTelemetryMetrics;
+
+        public IEnumerable<CalculatedMetric<DependencyTelemetry>> DependencyMetrics => this.dependencyTelemetryMetrics;
+
+        public IEnumerable<CalculatedMetric<ExceptionTelemetry>> ExceptionMetrics => this.exceptionTelemetryMetrics;
+
+        public IEnumerable<CalculatedMetric<EventTelemetry>> EventMetrics => this.eventTelemetryMetrics;
+
+        public IEnumerable<CalculatedMetric<TraceTelemetry>> TraceMetrics => this.traceTelemetryMetrics;
+
+        /// <summary>
+        /// Gets Telemetry types only. Used by QuickPulseTelemetryProcessor.
+        /// </summary>
+        public IEnumerable<Tuple<string, AggregationType>> TelemetryMetadata => this.telemetryMetadata;
+        
+        /// <summary>
+        /// Gets document streams. Telemetry items are provided by QuickPulseTelemetryProcessor.
+        /// </summary>
+        public IEnumerable<DocumentStream> DocumentStreams => this.documentStreams; 
+        
+        /// <summary>
+        /// Gets a list of performance counters.
+        /// </summary>
+        /// <remarks>
+        /// Performance counter name is stored in CalculatedMetricInfo.Projection.
+        /// </remarks>
+        public IEnumerable<Tuple<string, string>> PerformanceCounters => this.performanceCounters;
+        
+        public string ETag => this.info.ETag;
+
+        private static void AddMetric<TTelemetry>(
+          CalculatedMetricInfo metricInfo,
+          List<CalculatedMetric<TTelemetry>> metrics,
+          out CollectionConfigurationError[] errors)
+        {
+            errors = ArrayExtensions.Empty<CollectionConfigurationError>();
+
+            try
+            {
+                metrics.Add(new CalculatedMetric<TTelemetry>(metricInfo, out errors));
+            }
+            catch (Exception e)
+            {
+                // error creating the metric
+                errors =
+                    errors.Concat(
+                        new[]
+                        {
+                            CollectionConfigurationError.CreateError(
+                                CollectionConfigurationErrorType.MetricFailureToCreate,
+                                string.Format(CultureInfo.InvariantCulture, "Failed to create metric {0}.", metricInfo),
+                                e,
+                                Tuple.Create("MetricId", metricInfo.Id)),
+                        }).ToArray();
+            }
+        }
+
+        private void CreatePerformanceCounters(out CollectionConfigurationError[] errors)
+        {
+            var errorList = new List<CollectionConfigurationError>();
+
+            CalculatedMetricInfo[] performanceCounterMetrics =
+                (this.info.Metrics ?? ArrayExtensions.Empty<CalculatedMetricInfo>()).Where(metric => metric.TelemetryType == TelemetryType.PerformanceCounter)
+                    .ToArray();
+
+            this.performanceCounters.AddRange(
+                performanceCounterMetrics.GroupBy(metric => metric.Id, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .Select(pc => Tuple.Create(pc.Id, pc.Projection)));
+
+            IEnumerable<string> duplicateMetricIds =
+                performanceCounterMetrics.GroupBy(pc => pc.Id, StringComparer.Ordinal).Where(group => group.Count() > 1).Select(group => group.Key);
+
+            foreach (var duplicateMetricId in duplicateMetricIds)
+            {
+                errorList.Add(
+                    CollectionConfigurationError.CreateError(
+                        CollectionConfigurationErrorType.PerformanceCounterDuplicateIds,
+                        string.Format(CultureInfo.InvariantCulture, "Duplicate performance counter id '{0}'", duplicateMetricId),
+                        null,
+                        Tuple.Create("MetricId", duplicateMetricId)));
+            }
+
+            errors = errorList.ToArray();
+        }
+        
+        private void CreateDocumentStreams(
+            out CollectionConfigurationError[] errors,
+            Clock timeProvider,
+            IEnumerable<DocumentStream> previousDocumentStreams)
+        {
+            var errorList = new List<CollectionConfigurationError>();
+            var documentStreamIds = new HashSet<string>();
+
+            // quota might be changing concurrently on the collection thread, but we don't need the exact value at any given time
+            // we will try to carry over the last known values to this new configuration
+            Dictionary<string, Tuple<float, float, float, float, float>> previousQuotasByStreamId =
+                previousDocumentStreams.ToDictionary(
+                    documentStream => documentStream.Id,
+                    documentStream =>
+                    Tuple.Create(
+                        documentStream.RequestQuotaTracker.CurrentQuota,
+                        documentStream.DependencyQuotaTracker.CurrentQuota,
+                        documentStream.ExceptionQuotaTracker.CurrentQuota,
+                        documentStream.EventQuotaTracker.CurrentQuota,
+                        documentStream.TraceQuotaTracker.CurrentQuota));
+
+            if (this.info.DocumentStreams != null)
+            {
+                float? maxQuota = this.info.QuotaInfo?.MaxQuota;
+                float? quotaAccrualRatePerSec = this.info.QuotaInfo?.QuotaAccrualRatePerSec;
+
+                foreach (DocumentStreamInfo documentStreamInfo in this.info.DocumentStreams)
+                {
+                    if (documentStreamIds.Contains(documentStreamInfo.Id))
+                    {
+                        // there must not be streams with duplicate ids
+                        errorList.Add(
+                            CollectionConfigurationError.CreateError(
+                                CollectionConfigurationErrorType.DocumentStreamDuplicateIds,
+                                string.Format(CultureInfo.InvariantCulture, "Document stream with a duplicate id ignored: {0}", documentStreamInfo.Id),
+                                null,
+                                Tuple.Create("DocumentStreamId", documentStreamInfo.Id)));
+
+                        continue;
+                    }
+
+                    CollectionConfigurationError[] localErrors = null;
+                    try
+                    {
+                        previousQuotasByStreamId.TryGetValue(documentStreamInfo.Id, out Tuple<float, float, float, float, float> previousQuotas);
+                        float? initialQuota = this.info.QuotaInfo?.InitialQuota;
+
+                        var documentStream = new DocumentStream(
+                            documentStreamInfo,
+                            out localErrors,
+                            timeProvider,
+                            initialRequestQuota: initialQuota ?? previousQuotas?.Item1,
+                            initialDependencyQuota: initialQuota ?? previousQuotas?.Item2,
+                            initialExceptionQuota: initialQuota ?? previousQuotas?.Item3,
+                            initialEventQuota: initialQuota ?? previousQuotas?.Item4,
+                            initialTraceQuota: initialQuota ?? previousQuotas?.Item5,
+                            maxRequestQuota: maxQuota,
+                            maxDependencyQuota: maxQuota,
+                            maxExceptionQuota: maxQuota,
+                            maxEventQuota: maxQuota,
+                            maxTraceQuota: maxQuota,
+                            quotaAccrualRatePerSec: quotaAccrualRatePerSec);
+
+                        documentStreamIds.Add(documentStreamInfo.Id);
+                        this.documentStreams.Add(documentStream);
+                    }
+                    catch (Exception e)
+                    {
+                        errorList.Add(
+                            CollectionConfigurationError.CreateError(
+                                CollectionConfigurationErrorType.DocumentStreamFailureToCreate,
+                                string.Format(CultureInfo.InvariantCulture, "Failed to create document stream {0}", documentStreamInfo),
+                                e,
+                                Tuple.Create("DocumentStreamId", documentStreamInfo.Id)));
+                    }
+
+                    if (localErrors != null)
+                    {
+                        foreach (var error in localErrors)
+                        {
+                            error.Data["DocumentStreamId"] = documentStreamInfo.Id;
+                        }
+
+                        errorList.AddRange(localErrors);
+                    }
+                }
+            }
+
+            errors = errorList.ToArray();
+        }
+
+        private void CreateTelemetryMetrics(out CollectionConfigurationError[] errors)
+        {
+            var errorList = new List<CollectionConfigurationError>();
+            var metricIds = new HashSet<string>();
+
+            foreach (CalculatedMetricInfo metricInfo in this.info.Metrics ?? ArrayExtensions.Empty<CalculatedMetricInfo>())
+            {
+                if (metricIds.Contains(metricInfo.Id))
+                {
+                    // there must not be metrics with duplicate ids
+                    errorList.Add(
+                        CollectionConfigurationError.CreateError(
+                            CollectionConfigurationErrorType.MetricDuplicateIds,
+                            string.Format(CultureInfo.InvariantCulture, "Metric with a duplicate id ignored: {0}", metricInfo.Id),
+                            null,
+                            Tuple.Create("MetricId", metricInfo.Id)));
+
+                    continue;
+                }
+
+                CollectionConfigurationError[] localErrors = null;
+                switch (metricInfo.TelemetryType)
+                {
+                    case TelemetryType.Request:
+                        CollectionConfiguration.AddMetric(metricInfo, this.requestTelemetryMetrics, out localErrors);
+                        break;
+                    case TelemetryType.Dependency:
+                        CollectionConfiguration.AddMetric(metricInfo, this.dependencyTelemetryMetrics, out localErrors);
+                        break;
+                    case TelemetryType.Exception:
+                        CollectionConfiguration.AddMetric(metricInfo, this.exceptionTelemetryMetrics, out localErrors);
+                        break;
+                    case TelemetryType.Event:
+                        CollectionConfiguration.AddMetric(metricInfo, this.eventTelemetryMetrics, out localErrors);
+                        break;
+                    case TelemetryType.PerformanceCounter:
+                        // no need to create a wrapper, we rely on the underlying CollectionConfigurationInfo to provide data about performance counters
+                        // move on to the next metric
+                        continue;
+                    case TelemetryType.Trace:
+                        CollectionConfiguration.AddMetric(metricInfo, this.traceTelemetryMetrics, out localErrors);
+                        break;
+                    default:
+                        errorList.Add(
+                            CollectionConfigurationError.CreateError(
+                                CollectionConfigurationErrorType.MetricTelemetryTypeUnsupported,
+                                string.Format(CultureInfo.InvariantCulture, "TelemetryType is not supported: {0}", metricInfo.TelemetryType),
+                                null,
+                                Tuple.Create("MetricId", metricInfo.Id),
+                                Tuple.Create("TelemetryType", metricInfo.TelemetryType.ToString())));
+                        break;
+                }
+
+                if (localErrors != null)
+                {
+                    errorList.AddRange(localErrors);
+                }
+
+                metricIds.Add(metricInfo.Id);
+            }
+
+            errors = errorList.ToArray();
+        }
+
+        private void CreateMetadata()
+        {
+            foreach (var metricIds in
+                this.requestTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))
+                .Concat(this.dependencyTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
+                .Concat(this.exceptionTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
+                .Concat(this.eventTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
+                .Concat(this.traceTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))))
+            {
+                this.telemetryMetadata.Add(metricIds);
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
@@ -12,7 +12,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
     using ExceptionDocument = Azure.Monitor.OpenTelemetry.LiveMetrics.Models.Exception;
 
     /// <summary>
-    /// Represents the collection configuration - a set of calculated metrics, performance counters, and full telemetry documents to be collected by the SDK.
+    /// Represents the collection configuration - a set of calculated metrics, and full telemetry documents to be collected by the SDK.
     /// </summary>
     /// <remarks>
     /// This class is a hub for all pieces of configurable collection configuration.
@@ -44,8 +44,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
         #region Metadata used by other components
         private readonly List<Tuple<string, DerivedMetricInfoAggregation?>> telemetryMetadata = new List<Tuple<string, DerivedMetricInfoAggregation?>>();
-
-        private readonly List<Tuple<string, string>> performanceCounters = new List<Tuple<string, string>>();
         #endregion
 
         public CollectionConfiguration(
@@ -108,14 +106,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
         ///// </summary>
         //public IEnumerable<DocumentStream> DocumentStreams => this.documentStreams;
 
-        ///// <summary>
-        ///// Gets a list of performance counters.
-        ///// </summary>
-        ///// <remarks>
-        ///// Performance counter name is stored in CalculatedMetricInfo.Projection.
-        ///// </remarks>
-        //public IEnumerable<Tuple<string, string>> PerformanceCounters => this.performanceCounters;
-
         public string ETag => this.info.Etag;
 
         private static void AddMetric<DocumentIngress>(
@@ -145,7 +135,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
             }
         }
 
-        // TODO: Add back the removed CreatePerformanceCounters method and CreateDocumentStreams.
+        // TODO: Add back the removed CreateDocumentStreams method.
 
         private void CreateTelemetryMetrics(out CollectionConfigurationError[] errors)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
@@ -1,13 +1,15 @@
-﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 {
     using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
-    using Microsoft.ApplicationInsights.Common;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.Helpers;
+    using ExceptionDocument = Azure.Monitor.OpenTelemetry.LiveMetrics.Models.Exception;
 
     /// <summary>
     /// Represents the collection configuration - a set of calculated metrics, performance counters, and full telemetry documents to be collected by the SDK.
@@ -15,9 +17,9 @@
     /// <remarks>
     /// This class is a hub for all pieces of configurable collection configuration.
     /// Upon initialization
-    ///   - it creates collection-time instances of <see cref="CalculatedMetric&lt;T&gt;"/> and maintains them in separate collections by telemetry type.
+    ///   - it creates collection-time instances of <see cref="DerivedMetric&lt;T&gt;"/> and maintains them in separate collections by telemetry type.
     ///     These are used to filter and calculated calculated metrics configured by the service.
-    ///   - it creates collection-time instances of <see cref="DocumentStream"/> which are used to filter and send out full telemetry documents.
+    ///   - it creates collection-time instances of DocumentStream which are used to filter and send out full telemetry documents. // TODO: Add DocumentStream back
     ///   - it creates certain metadata collections which are used by other collection-time components to learn more about what is being collected at any given time.
     /// </remarks>
     internal class CollectionConfiguration
@@ -25,32 +27,30 @@
         private readonly CollectionConfigurationInfo info;
 
         #region Collection-time instances used to filter and calculate data on telemetry passing through the pipeline
-        private readonly List<CalculatedMetric<RequestTelemetry>> requestTelemetryMetrics = new List<CalculatedMetric<RequestTelemetry>>();
+        private readonly List<DerivedMetric<Request>> requestDocumentIngressMetrics = new List<DerivedMetric<Request>>();
 
-        private readonly List<CalculatedMetric<DependencyTelemetry>> dependencyTelemetryMetrics =
-            new List<CalculatedMetric<DependencyTelemetry>>();
+        private readonly List<DerivedMetric<RemoteDependency>> dependencyTelemetryMetrics =
+            new List<DerivedMetric<RemoteDependency>>();
 
-        private readonly List<CalculatedMetric<ExceptionTelemetry>> exceptionTelemetryMetrics =
-            new List<CalculatedMetric<ExceptionTelemetry>>();
+        private readonly List<DerivedMetric<ExceptionDocument>> exceptionTelemetryMetrics =
+            new List<DerivedMetric<ExceptionDocument>>();
 
-        private readonly List<CalculatedMetric<EventTelemetry>> eventTelemetryMetrics = new List<CalculatedMetric<EventTelemetry>>();
+        // private readonly List<DerivedMetric<EventTelemetry>> eventTelemetryMetrics = new List<DerivedMetric<EventTelemetry>>();
 
-        private readonly List<CalculatedMetric<TraceTelemetry>> traceTelemetryMetrics = new List<CalculatedMetric<TraceTelemetry>>();
+        // private readonly List<DerivedMetric<TraceTelemetry>> traceTelemetryMetrics = new List<DerivedMetric<TraceTelemetry>>();
 
-        private readonly List<DocumentStream> documentStreams = new List<DocumentStream>();
+        // TODO: Add back: private readonly List<DocumentStream> documentStreams = new List<DocumentStream>();
         #endregion
 
         #region Metadata used by other components
-        private readonly List<Tuple<string, AggregationType>> telemetryMetadata = new List<Tuple<string, AggregationType>>();
+        private readonly List<Tuple<string, DerivedMetricInfoAggregation?>> telemetryMetadata = new List<Tuple<string, DerivedMetricInfoAggregation?>>();
 
         private readonly List<Tuple<string, string>> performanceCounters = new List<Tuple<string, string>>();
         #endregion
 
         public CollectionConfiguration(
            CollectionConfigurationInfo info,
-           out CollectionConfigurationError[] errors,
-           Clock timeProvider,
-           IEnumerable<DocumentStream> previousDocumentStreams = null)
+           out CollectionConfigurationError[] errors)
         {
             this.info = info ?? throw new ArgumentNullException(nameof(info));
 
@@ -61,62 +61,75 @@
             // this includes both telemetry metrics and Metric metrics
             this.CreateMetadata();
 
-            // create document streams based on description in info
-            this.CreateDocumentStreams(out CollectionConfigurationError[] documentStreamErrors, timeProvider, previousDocumentStreams ?? ArrayExtensions.Empty<DocumentStream>());
+            //// create document streams based on description in info
+            //this.CreateDocumentStreams(out CollectionConfigurationError[] documentStreamErrors, timeProvider, previousDocumentStreams ?? ArrayExtensions.Empty<DocumentStream>());
 
-            // create performance counters
-            this.CreatePerformanceCounters(out CollectionConfigurationError[] performanceCounterErrors);
-            
-            errors = metricErrors.Concat(documentStreamErrors).Concat(performanceCounterErrors).ToArray();
+            //// create performance counters
+            //this.CreatePerformanceCounters(out CollectionConfigurationError[] performanceCounterErrors);
+
+            //errors = metricErrors.Concat(documentStreamErrors).Concat(performanceCounterErrors).ToArray();
+            errors = metricErrors.ToArray();
 
             foreach (var error in errors)
             {
-                error.Data["ETag"] = this.info.ETag;
+                UpdateMetricIdOfError(error, this.info.Etag);
             }
         }
 
-        public IEnumerable<CalculatedMetric<RequestTelemetry>> RequestMetrics => this.requestTelemetryMetrics;
+        private void UpdateMetricIdOfError(CollectionConfigurationError error, string id)
+        {
+            for (int i = 0; i < error.Data.Count; i++)
+            {
+                if (error.Data[i].Key == "ETag")
+                {
+                    error.Data[i].Value = id;
+                    return;
+                }
+            }
+        }
 
-        public IEnumerable<CalculatedMetric<DependencyTelemetry>> DependencyMetrics => this.dependencyTelemetryMetrics;
+        public IEnumerable<DerivedMetric<Request>> RequestMetrics => this.requestDocumentIngressMetrics;
 
-        public IEnumerable<CalculatedMetric<ExceptionTelemetry>> ExceptionMetrics => this.exceptionTelemetryMetrics;
+        public IEnumerable<DerivedMetric<RemoteDependency>> DependencyMetrics => this.dependencyTelemetryMetrics;
 
-        public IEnumerable<CalculatedMetric<EventTelemetry>> EventMetrics => this.eventTelemetryMetrics;
+        public IEnumerable<DerivedMetric<ExceptionDocument>> ExceptionMetrics => this.exceptionTelemetryMetrics;
 
-        public IEnumerable<CalculatedMetric<TraceTelemetry>> TraceMetrics => this.traceTelemetryMetrics;
+        // public IEnumerable<CalculatedMetric<EventTelemetry>> EventMetrics => this.eventTelemetryMetrics;
+
+        // public IEnumerable<CalculatedMetric<TraceTelemetry>> TraceMetrics => this.traceTelemetryMetrics;
 
         /// <summary>
         /// Gets Telemetry types only. Used by QuickPulseTelemetryProcessor.
         /// </summary>
-        public IEnumerable<Tuple<string, AggregationType>> TelemetryMetadata => this.telemetryMetadata;
-        
-        /// <summary>
-        /// Gets document streams. Telemetry items are provided by QuickPulseTelemetryProcessor.
-        /// </summary>
-        public IEnumerable<DocumentStream> DocumentStreams => this.documentStreams; 
-        
-        /// <summary>
-        /// Gets a list of performance counters.
-        /// </summary>
-        /// <remarks>
-        /// Performance counter name is stored in CalculatedMetricInfo.Projection.
-        /// </remarks>
-        public IEnumerable<Tuple<string, string>> PerformanceCounters => this.performanceCounters;
-        
-        public string ETag => this.info.ETag;
+        public IEnumerable<Tuple<string, DerivedMetricInfoAggregation?>> TelemetryMetadata => this.telemetryMetadata;
 
-        private static void AddMetric<TTelemetry>(
-          CalculatedMetricInfo metricInfo,
-          List<CalculatedMetric<TTelemetry>> metrics,
+        ///// <summary>
+        ///// Gets document streams. Telemetry items are provided by QuickPulseTelemetryProcessor.
+        ///// </summary>
+        //public IEnumerable<DocumentStream> DocumentStreams => this.documentStreams;
+
+        ///// <summary>
+        ///// Gets a list of performance counters.
+        ///// </summary>
+        ///// <remarks>
+        ///// Performance counter name is stored in CalculatedMetricInfo.Projection.
+        ///// </remarks>
+        //public IEnumerable<Tuple<string, string>> PerformanceCounters => this.performanceCounters;
+
+        public string ETag => this.info.Etag;
+
+        private static void AddMetric<DocumentIngress>(
+          DerivedMetricInfo metricInfo,
+          List<DerivedMetric<DocumentIngress>> metrics,
           out CollectionConfigurationError[] errors)
         {
-            errors = ArrayExtensions.Empty<CollectionConfigurationError>();
+            errors = Array.Empty<CollectionConfigurationError>();
 
             try
             {
-                metrics.Add(new CalculatedMetric<TTelemetry>(metricInfo, out errors));
+                metrics.Add(new DerivedMetric<DocumentIngress>(metricInfo, out errors));
             }
-            catch (Exception e)
+            catch (System.Exception e)
             {
                 // error creating the metric
                 errors =
@@ -132,132 +145,14 @@
             }
         }
 
-        private void CreatePerformanceCounters(out CollectionConfigurationError[] errors)
-        {
-            var errorList = new List<CollectionConfigurationError>();
-
-            CalculatedMetricInfo[] performanceCounterMetrics =
-                (this.info.Metrics ?? ArrayExtensions.Empty<CalculatedMetricInfo>()).Where(metric => metric.TelemetryType == TelemetryType.PerformanceCounter)
-                    .ToArray();
-
-            this.performanceCounters.AddRange(
-                performanceCounterMetrics.GroupBy(metric => metric.Id, StringComparer.Ordinal)
-                    .Select(group => group.First())
-                    .Select(pc => Tuple.Create(pc.Id, pc.Projection)));
-
-            IEnumerable<string> duplicateMetricIds =
-                performanceCounterMetrics.GroupBy(pc => pc.Id, StringComparer.Ordinal).Where(group => group.Count() > 1).Select(group => group.Key);
-
-            foreach (var duplicateMetricId in duplicateMetricIds)
-            {
-                errorList.Add(
-                    CollectionConfigurationError.CreateError(
-                        CollectionConfigurationErrorType.PerformanceCounterDuplicateIds,
-                        string.Format(CultureInfo.InvariantCulture, "Duplicate performance counter id '{0}'", duplicateMetricId),
-                        null,
-                        Tuple.Create("MetricId", duplicateMetricId)));
-            }
-
-            errors = errorList.ToArray();
-        }
-        
-        private void CreateDocumentStreams(
-            out CollectionConfigurationError[] errors,
-            Clock timeProvider,
-            IEnumerable<DocumentStream> previousDocumentStreams)
-        {
-            var errorList = new List<CollectionConfigurationError>();
-            var documentStreamIds = new HashSet<string>();
-
-            // quota might be changing concurrently on the collection thread, but we don't need the exact value at any given time
-            // we will try to carry over the last known values to this new configuration
-            Dictionary<string, Tuple<float, float, float, float, float>> previousQuotasByStreamId =
-                previousDocumentStreams.ToDictionary(
-                    documentStream => documentStream.Id,
-                    documentStream =>
-                    Tuple.Create(
-                        documentStream.RequestQuotaTracker.CurrentQuota,
-                        documentStream.DependencyQuotaTracker.CurrentQuota,
-                        documentStream.ExceptionQuotaTracker.CurrentQuota,
-                        documentStream.EventQuotaTracker.CurrentQuota,
-                        documentStream.TraceQuotaTracker.CurrentQuota));
-
-            if (this.info.DocumentStreams != null)
-            {
-                float? maxQuota = this.info.QuotaInfo?.MaxQuota;
-                float? quotaAccrualRatePerSec = this.info.QuotaInfo?.QuotaAccrualRatePerSec;
-
-                foreach (DocumentStreamInfo documentStreamInfo in this.info.DocumentStreams)
-                {
-                    if (documentStreamIds.Contains(documentStreamInfo.Id))
-                    {
-                        // there must not be streams with duplicate ids
-                        errorList.Add(
-                            CollectionConfigurationError.CreateError(
-                                CollectionConfigurationErrorType.DocumentStreamDuplicateIds,
-                                string.Format(CultureInfo.InvariantCulture, "Document stream with a duplicate id ignored: {0}", documentStreamInfo.Id),
-                                null,
-                                Tuple.Create("DocumentStreamId", documentStreamInfo.Id)));
-
-                        continue;
-                    }
-
-                    CollectionConfigurationError[] localErrors = null;
-                    try
-                    {
-                        previousQuotasByStreamId.TryGetValue(documentStreamInfo.Id, out Tuple<float, float, float, float, float> previousQuotas);
-                        float? initialQuota = this.info.QuotaInfo?.InitialQuota;
-
-                        var documentStream = new DocumentStream(
-                            documentStreamInfo,
-                            out localErrors,
-                            timeProvider,
-                            initialRequestQuota: initialQuota ?? previousQuotas?.Item1,
-                            initialDependencyQuota: initialQuota ?? previousQuotas?.Item2,
-                            initialExceptionQuota: initialQuota ?? previousQuotas?.Item3,
-                            initialEventQuota: initialQuota ?? previousQuotas?.Item4,
-                            initialTraceQuota: initialQuota ?? previousQuotas?.Item5,
-                            maxRequestQuota: maxQuota,
-                            maxDependencyQuota: maxQuota,
-                            maxExceptionQuota: maxQuota,
-                            maxEventQuota: maxQuota,
-                            maxTraceQuota: maxQuota,
-                            quotaAccrualRatePerSec: quotaAccrualRatePerSec);
-
-                        documentStreamIds.Add(documentStreamInfo.Id);
-                        this.documentStreams.Add(documentStream);
-                    }
-                    catch (Exception e)
-                    {
-                        errorList.Add(
-                            CollectionConfigurationError.CreateError(
-                                CollectionConfigurationErrorType.DocumentStreamFailureToCreate,
-                                string.Format(CultureInfo.InvariantCulture, "Failed to create document stream {0}", documentStreamInfo),
-                                e,
-                                Tuple.Create("DocumentStreamId", documentStreamInfo.Id)));
-                    }
-
-                    if (localErrors != null)
-                    {
-                        foreach (var error in localErrors)
-                        {
-                            error.Data["DocumentStreamId"] = documentStreamInfo.Id;
-                        }
-
-                        errorList.AddRange(localErrors);
-                    }
-                }
-            }
-
-            errors = errorList.ToArray();
-        }
+        // TODO: Add back the removed CreatePerformanceCounters method and CreateDocumentStreams.
 
         private void CreateTelemetryMetrics(out CollectionConfigurationError[] errors)
         {
             var errorList = new List<CollectionConfigurationError>();
             var metricIds = new HashSet<string>();
 
-            foreach (CalculatedMetricInfo metricInfo in this.info.Metrics ?? ArrayExtensions.Empty<CalculatedMetricInfo>())
+            foreach (DerivedMetricInfo metricInfo in info.Metrics)
             {
                 if (metricIds.Contains(metricInfo.Id))
                 {
@@ -272,11 +167,11 @@
                     continue;
                 }
 
-                CollectionConfigurationError[] localErrors = null;
+                CollectionConfigurationError[] localErrors = Array.Empty<CollectionConfigurationError>();
                 switch (metricInfo.TelemetryType)
                 {
                     case TelemetryType.Request:
-                        CollectionConfiguration.AddMetric(metricInfo, this.requestTelemetryMetrics, out localErrors);
+                        CollectionConfiguration.AddMetric(metricInfo, this.requestDocumentIngressMetrics, out localErrors);
                         break;
                     case TelemetryType.Dependency:
                         CollectionConfiguration.AddMetric(metricInfo, this.dependencyTelemetryMetrics, out localErrors);
@@ -284,16 +179,13 @@
                     case TelemetryType.Exception:
                         CollectionConfiguration.AddMetric(metricInfo, this.exceptionTelemetryMetrics, out localErrors);
                         break;
-                    case TelemetryType.Event:
-                        CollectionConfiguration.AddMetric(metricInfo, this.eventTelemetryMetrics, out localErrors);
-                        break;
-                    case TelemetryType.PerformanceCounter:
-                        // no need to create a wrapper, we rely on the underlying CollectionConfigurationInfo to provide data about performance counters
-                        // move on to the next metric
-                        continue;
-                    case TelemetryType.Trace:
-                        CollectionConfiguration.AddMetric(metricInfo, this.traceTelemetryMetrics, out localErrors);
-                        break;
+                    //TODO: Add back:
+                    //case TelemetryType.Event:
+                    //    CollectionConfiguration.AddMetric(metricInfo, this.evenDocumentIngressMetrics, out localErrors);
+                    //    break;
+                    //case TelemetryType.Trace:
+                    //    CollectionConfiguration.AddMetric(metricInfo, this.traceTelemetryMetrics, out localErrors);
+                    //    break;
                     default:
                         errorList.Add(
                             CollectionConfigurationError.CreateError(
@@ -319,11 +211,12 @@
         private void CreateMetadata()
         {
             foreach (var metricIds in
-                this.requestTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))
+                this.requestDocumentIngressMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))
                 .Concat(this.dependencyTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
-                .Concat(this.exceptionTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
-                .Concat(this.eventTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
-                .Concat(this.traceTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))))
+                .Concat(this.exceptionTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))))
+            //TODO: Add back:
+            //.Concat(this.evenDocumentIngressMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
+            //.Concat(this.traceTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
             {
                 this.telemetryMetadata.Add(metricIds);
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -1,0 +1,704 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    /// <summary>
+    /// Filter determines whether a telemetry document matches the criterion.
+    /// The filter's configuration (condition) is specified in a <see cref="FilterInfo"/> DTO.
+    /// </summary>
+    /// <typeparam name="TTelemetry">Type of telemetry documents.</typeparam>
+    internal class Filter<TTelemetry>
+    {
+        private const string FieldNameCustomDimensionsPrefix = "CustomDimensions.";
+
+        private const string FieldNameCustomMetricsPrefix = "CustomMetrics.";
+
+        private const string FieldNameAsterisk = "*";
+
+        private const string CustomMetricsPropertyName = "Metrics";
+
+        private const string CustomDimensionsPropertyName = "Properties";
+
+        private const char FieldNameTrainSeparator = '.';
+
+        private static readonly MethodInfo DoubleToStringMethodInfo = GetMethodInfo<double, string>(x => x.ToString(CultureInfo.InvariantCulture));
+
+        private static readonly MethodInfo NullableDoubleToStringMethodInfo = GetMethodInfo<double?, string>(x => x.ToString());
+
+        private static readonly MethodInfo ObjectToStringMethodInfo = GetMethodInfo<object, string>(x => x.ToString());
+
+        private static readonly MethodInfo ValueTypeToStringMethodInfo = GetMethodInfo<ValueType, string>(x => x.ToString());
+
+        private static readonly MethodInfo UriToStringMethodInfo = GetMethodInfo<Uri, string>(x => x.ToString());
+
+        private static readonly MethodInfo StringIndexOfMethodInfo =
+            GetMethodInfo<string, string, int>((x, y) => x.IndexOf(y, StringComparison.OrdinalIgnoreCase));
+
+        private static readonly MethodInfo StringEqualsMethodInfo =
+            GetMethodInfo<string, string, bool>((x, y) => x.Equals(y, StringComparison.OrdinalIgnoreCase));
+
+        private static readonly MethodInfo DoubleTryParseMethodInfo = typeof(double).GetMethod(
+            "TryParse",
+            new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(double).MakeByRefType() });
+
+        private static readonly MethodInfo DictionaryStringStringTryGetValueMethodInfo = typeof(IDictionary<string, string>).GetMethod("TryGetValue");
+
+        private static readonly MethodInfo DictionaryStringDoubleTryGetValueMethodInfo = typeof(IDictionary<string, double>).GetMethod("TryGetValue");
+
+        private static readonly MethodInfo DictionaryStringStringScanMethodInfo =
+            GetMethodInfo<IDictionary<string, string>, string, bool>((dict, searchValue) => Filter<int>.ScanDictionary(dict, searchValue));
+
+        private static readonly MethodInfo DictionaryStringDoubleScanMethodInfo =
+           GetMethodInfo<IDictionary<string, double>, string, bool>((dict, searchValue) => Filter<int>.ScanDictionary(dict, searchValue));
+
+        private static readonly ConstantExpression DoubleDefaultNumberStyles = Expression.Constant(NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowThousands | NumberStyles.AllowExponent);
+        private static readonly ConstantExpression InvariantCulture = Expression.Constant(CultureInfo.InvariantCulture);
+
+        private readonly Func<TTelemetry, bool> filterLambda;
+
+        private readonly double? comparandDouble;
+
+        private readonly bool? comparandBoolean;
+
+        private readonly TimeSpan? comparandTimeSpan;
+
+        private readonly string comparand;
+
+        private readonly Predicate predicate;
+
+        private readonly string fieldName;
+
+        private readonly FilterInfo info;
+
+        public Filter(FilterInfo filterInfo)
+        {
+            ValidateInput(filterInfo);
+
+            this.info = filterInfo;
+
+            this.fieldName = filterInfo.FieldName;
+            this.predicate = filterInfo.Predicate;
+            this.comparand = filterInfo.Comparand;
+
+            FieldNameType fieldNameType;
+            Type fieldType = GetFieldType(filterInfo.FieldName, out fieldNameType);
+            this.ThrowOnInvalidFilter(
+                null,
+                fieldNameType == FieldNameType.AnyField && this.predicate != Predicate.Contains && this.predicate != Predicate.DoesNotContain);
+
+            double comparandDouble;
+            this.comparandDouble = double.TryParse(filterInfo.Comparand, NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowThousands | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out comparandDouble) ? comparandDouble : (double?)null;
+
+            bool comparandBoolean;
+            this.comparandBoolean = bool.TryParse(filterInfo.Comparand, out comparandBoolean) ? comparandBoolean : (bool?)null;
+
+            TimeSpan comparandTimeSpan;
+            this.comparandTimeSpan = TimeSpan.TryParse(filterInfo.Comparand, CultureInfo.InvariantCulture, out comparandTimeSpan)
+                                         ? comparandTimeSpan
+                                         : (TimeSpan?)null;
+
+            ParameterExpression documentExpression = Expression.Variable(typeof(TTelemetry));
+
+            Expression comparisonExpression;
+
+            try
+            {
+                if (fieldNameType == FieldNameType.AnyField)
+                {
+                    // multiple fields => multiple comparison expressions connected with ORs
+                    comparisonExpression = this.ProduceComparatorExpressionForAnyFieldCondition(documentExpression);
+                }
+                else
+                {
+                    // a single field filterInfo.FieldName of type fieldType => a single comparison expression
+                    Expression fieldExpression = ProduceFieldExpression(documentExpression, filterInfo.FieldName, fieldNameType);
+
+                    comparisonExpression = this.ProduceComparatorExpressionForSingleFieldCondition(fieldExpression, fieldType);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "Could not construct the filter."), e);
+            }
+
+            try
+            {
+                Expression<Func<TTelemetry, bool>> lambdaExpression = Expression.Lambda<Func<TTelemetry, bool>>(
+                    comparisonExpression,
+                    documentExpression);
+
+                this.filterLambda = lambdaExpression.Compile();
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "Could not compile the filter."), e);
+            }
+        }
+
+        internal enum FieldNameType
+        {
+            FieldName,
+
+            CustomMetricName,
+
+            CustomDimensionName,
+
+            AnyField,
+        }
+
+        public bool Check(TTelemetry document)
+        {
+            try
+            {
+                return this.filterLambda(document);
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Runtime error while filtering."), e);
+            }
+        }
+
+        public override string ToString()
+        {
+            return this.info?.ToString() ?? string.Empty;
+        }
+
+        internal static Expression ProduceFieldExpression(ParameterExpression documentExpression, string fieldName, FieldNameType fieldNameType)
+        {
+            switch (fieldNameType)
+            {
+                case FieldNameType.FieldName:
+                    return fieldName.Split(FieldNameTrainSeparator).Aggregate<string, Expression>(documentExpression, Expression.Property);
+                case FieldNameType.CustomMetricName:
+                    string customMetricName = fieldName.Substring(
+                        FieldNameCustomMetricsPrefix.Length,
+                        fieldName.Length - FieldNameCustomMetricsPrefix.Length);
+
+                    return CreateDictionaryAccessExpression(
+                        documentExpression,
+                        CustomMetricsPropertyName,
+                        DictionaryStringDoubleTryGetValueMethodInfo,
+                        typeof(double),
+                        customMetricName);
+                case FieldNameType.CustomDimensionName:
+                    string customDimensionName = fieldName.Substring(
+                        FieldNameCustomDimensionsPrefix.Length,
+                        fieldName.Length - FieldNameCustomDimensionsPrefix.Length);
+
+                    return CreateDictionaryAccessExpression(
+                        documentExpression,
+                        CustomDimensionsPropertyName,
+                        DictionaryStringStringTryGetValueMethodInfo,
+                        typeof(string),
+                        customDimensionName);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(fieldNameType), fieldNameType, null);
+            }
+        }
+
+        internal static Type GetFieldType(string fieldName, out FieldNameType fieldNameType)
+        {
+            if (fieldName.StartsWith(FieldNameCustomDimensionsPrefix, StringComparison.Ordinal))
+            {
+                fieldNameType = FieldNameType.CustomDimensionName;
+                return typeof(string);
+            }
+
+            if (fieldName.StartsWith(FieldNameCustomMetricsPrefix, StringComparison.Ordinal))
+            {
+                fieldNameType = FieldNameType.CustomMetricName;
+                return typeof(double);
+            }
+
+            if (fieldName.StartsWith(FieldNameAsterisk, StringComparison.Ordinal))
+            {
+                fieldNameType = FieldNameType.AnyField;
+                return null;
+            }
+
+            // no special case in filterInfo.FieldName, treat it as the name of a property in TTelemetry type
+            fieldNameType = FieldNameType.FieldName;
+            return GetPropertyTypeFromFieldName(fieldName);
+        }
+
+        private static Expression CreateDictionaryAccessExpression(ParameterExpression documentExpression, string dictionaryName, MethodInfo tryGetValueMethodInfo, Type valueType, string keyValue)
+        {
+            // valueType value;
+            // document.dictionaryName.TryGetValue(keyValue, out value)
+            // return value;
+            ParameterExpression valueVariable = Expression.Variable(valueType);
+
+            MemberExpression properties = Expression.Property(documentExpression, dictionaryName);
+            MethodCallExpression tryGetValueCall = Expression.Call(properties, tryGetValueMethodInfo, Expression.Constant(keyValue), valueVariable);
+
+            // a block will "return" its last expression
+            return Expression.Block(valueType, new[] { valueVariable }, tryGetValueCall, valueVariable);
+        }
+
+        private static MethodInfo GetMethodInfo<T, TResult>(Expression<Func<T, TResult>> expression)
+        {
+            if (expression.Body is MethodCallExpression member)
+            {
+                return member.Method;
+            }
+
+            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Expression is not a method"), nameof(expression));
+        }
+
+        private static MethodInfo GetMethodInfo<T1, T2, TResult>(Expression<Func<T1, T2, TResult>> expression)
+        {
+            if (expression.Body is MethodCallExpression member)
+            {
+                return member.Method;
+            }
+
+            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Expression is not a method"), nameof(expression));
+        }
+
+        private static Type GetPropertyTypeFromFieldName(string fieldName)
+        {
+            try
+            {
+                Type propertyType = fieldName.Split(FieldNameTrainSeparator)
+                    .Aggregate(
+                        typeof(TTelemetry),
+                        (type, propertyName) => type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public).PropertyType);
+
+                if (propertyType == null)
+                {
+                    string propertyNotFoundMessage = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Error finding property {0} in the type {1}",
+                        fieldName,
+                        typeof(TTelemetry).FullName);
+
+                    throw new ArgumentOutOfRangeException(nameof(fieldName), propertyNotFoundMessage);
+                }
+
+                return propertyType;
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentOutOfRangeException(
+                    string.Format(CultureInfo.InvariantCulture, "Error finding property {0} in the type {1}", fieldName, typeof(TTelemetry).FullName),
+                    e);
+            }
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Justification = "Argument exceptions are valid.")]
+        private static void ValidateInput(FilterInfo filterInfo)
+        {
+            if (filterInfo == null)
+            {
+                throw new ArgumentNullException(nameof(filterInfo));
+            }
+
+            if (string.IsNullOrEmpty(filterInfo.FieldName))
+            {
+                throw new ArgumentNullException(nameof(filterInfo.FieldName), string.Format(CultureInfo.InvariantCulture, "Parameter must be specified."));
+            }
+
+            if (filterInfo.Comparand == null)
+            {
+                throw new ArgumentNullException(nameof(filterInfo.Comparand), string.Format(CultureInfo.InvariantCulture, "Parameter cannot be null."));
+            }
+        }
+
+        private static bool ScanDictionary(IDictionary<string, string> dict, string searchValue)
+        {
+            return dict?.Values.Any(val => (val ?? string.Empty).IndexOf(searchValue ?? string.Empty, StringComparison.OrdinalIgnoreCase) != -1)
+                   ?? false;
+        }
+
+        private static bool ScanDictionary(IDictionary<string, double> dict, string searchValue)
+        {
+            return dict?.Values.Any(val => val.ToString(CultureInfo.InvariantCulture).IndexOf(searchValue, StringComparison.OrdinalIgnoreCase) != -1)
+                   ?? false;
+        }
+
+        private Expression ProduceComparatorExpressionForSingleFieldCondition(Expression fieldExpression, Type fieldType, bool isFieldTypeNullable = false)
+        {
+            // this must determine an appropriate runtime comparison given the field type, the predicate, and the comparand
+            TypeCode fieldTypeCode = Type.GetTypeCode(fieldType);
+            switch (fieldTypeCode)
+            {
+                case TypeCode.Boolean:
+                    {
+                        this.ThrowOnInvalidFilter(fieldType, !this.comparandBoolean.HasValue);
+
+                        switch (this.predicate)
+                        {
+                            case Predicate.Equal:
+                                // fieldValue == this.comparandBoolean.Value;
+                                return Expression.Equal(fieldExpression, Expression.Constant(this.comparandBoolean.Value, isFieldTypeNullable ? typeof(bool?) : typeof(bool)));
+                            case Predicate.NotEqual:
+                                // fieldValue != this.comparandBoolean.Value;
+                                return Expression.NotEqual(fieldExpression, Expression.Constant(this.comparandBoolean.Value, isFieldTypeNullable ? typeof(bool?) : typeof(bool)));
+                            default:
+                                this.ThrowOnInvalidFilter(fieldType);
+                                break;
+                        }
+                    }
+
+                    break;
+                case TypeCode.SByte:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.Byte:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                case TypeCode.Single:
+                case TypeCode.Double:
+                    {
+                        if (fieldType.GetTypeInfo().IsEnum)
+                        {
+                            // this is actually an Enum
+                            object enumValue = null;
+                            try
+                            {
+                                enumValue = Enum.Parse(fieldType, this.comparand, true);
+                            }
+                            catch (Exception)
+                            {
+                                // we must throw unless this.predicate is either Contains or DoesNotContain, in which case it's ok
+                                this.ThrowOnInvalidFilter(fieldType, this.predicate != Predicate.Contains && this.predicate != Predicate.DoesNotContain);
+                            }
+
+                            Type enumUnderlyingType = fieldType.GetTypeInfo().GetEnumUnderlyingType();
+
+                            switch (this.predicate)
+                            {
+                                case Predicate.Equal:
+                                    // fieldValue == enumValue
+                                    return Expression.Equal(fieldExpression, Expression.Constant(enumValue, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(fieldType) : fieldType));
+                                case Predicate.NotEqual:
+                                    // fieldValue != enumValue
+                                    return Expression.NotEqual(fieldExpression, Expression.Constant(enumValue, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(fieldType) : fieldType));
+                                case Predicate.LessThan:
+                                    // (int)fieldValue < (int)enumValue
+                                    // (int?)fieldValue < (int?)enumValue
+                                    Type underlyingType = isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(enumUnderlyingType) : enumUnderlyingType;
+                                    return Expression.LessThan(
+                                        Expression.Convert(fieldExpression, underlyingType),
+                                        Expression.Convert(Expression.Constant(enumValue, fieldType), underlyingType));
+                                case Predicate.GreaterThan:
+                                    // (int)fieldValue > (int)enumValue
+                                    // (int?)fieldValue > (int?)enumValue
+                                    underlyingType = isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(enumUnderlyingType) : enumUnderlyingType;
+                                    return Expression.GreaterThan(
+                                        Expression.Convert(fieldExpression, underlyingType),
+                                        Expression.Convert(Expression.Constant(enumValue, fieldType), underlyingType));
+                                case Predicate.LessThanOrEqual:
+                                    // (int)fieldValue <= (int)enumValue
+                                    // (int?)fieldValue <= (int?)enumValue
+                                    underlyingType = isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(enumUnderlyingType) : enumUnderlyingType;
+                                    return Expression.LessThanOrEqual(
+                                        Expression.Convert(fieldExpression, underlyingType),
+                                        Expression.Convert(Expression.Constant(enumValue, fieldType), underlyingType));
+                                case Predicate.GreaterThanOrEqual:
+                                    // (int)fieldValue >= (int)enumValue
+                                    // (int?)fieldValue >= (int?)enumValue
+                                    underlyingType = isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(enumUnderlyingType) : enumUnderlyingType;
+                                    return Expression.GreaterThanOrEqual(
+                                        Expression.Convert(fieldExpression, underlyingType),
+                                        Expression.Convert(Expression.Constant(enumValue, fieldType), underlyingType));
+                                case Predicate.Contains:
+                                    // fieldValue.ToString(CultureInfo.InvariantCulture).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) != -1
+                                    Expression toStringCall = Expression.Call(fieldExpression, isFieldTypeNullable ? ValueTypeToStringMethodInfo : ObjectToStringMethodInfo);
+                                    Expression indexOfCall = Expression.Call(toStringCall, StringIndexOfMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase));
+                                    return Expression.NotEqual(indexOfCall, Expression.Constant(-1));
+                                case Predicate.DoesNotContain:
+                                    // fieldValue.ToString(CultureInfo.InvariantCulture).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) == -1
+                                    toStringCall = Expression.Call(fieldExpression, isFieldTypeNullable ? ValueTypeToStringMethodInfo : ObjectToStringMethodInfo);
+                                    indexOfCall = Expression.Call(toStringCall, StringIndexOfMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase));
+                                    return Expression.Equal(indexOfCall, Expression.Constant(-1));
+                                default:
+                                    this.ThrowOnInvalidFilter(fieldType);
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            // this is a regular numerical type
+                            // in order for the expression to compile, we must cast to double unless it's already double
+                            // we're using double as the lowest common denominator for all numerical types
+                            Expression fieldConvertedExpression = fieldTypeCode == TypeCode.Double
+                                                                      ? fieldExpression
+                                                                      : Expression.ConvertChecked(fieldExpression, isFieldTypeNullable ? typeof(double?) : typeof(double));
+
+                            switch (this.predicate)
+                            {
+                                case Predicate.Equal:
+                                    this.ThrowOnInvalidFilter(fieldType, !this.comparandDouble.HasValue);
+                                    return Expression.Equal(
+                                        fieldConvertedExpression,
+                                        Expression.Constant(this.comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                case Predicate.NotEqual:
+                                    this.ThrowOnInvalidFilter(fieldType, !this.comparandDouble.HasValue);
+                                    return Expression.NotEqual(
+                                        fieldConvertedExpression,
+                                        Expression.Constant(this.comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                case Predicate.LessThan:
+                                    this.ThrowOnInvalidFilter(fieldType, !this.comparandDouble.HasValue);
+                                    return Expression.LessThan(
+                                        fieldConvertedExpression,
+                                        Expression.Constant(this.comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                case Predicate.GreaterThan:
+                                    this.ThrowOnInvalidFilter(fieldType, !this.comparandDouble.HasValue);
+                                    return Expression.GreaterThan(
+                                        fieldConvertedExpression,
+                                        Expression.Constant(this.comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                case Predicate.LessThanOrEqual:
+                                    this.ThrowOnInvalidFilter(fieldType, !this.comparandDouble.HasValue);
+                                    return Expression.LessThanOrEqual(
+                                        fieldConvertedExpression,
+                                        Expression.Constant(this.comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                case Predicate.GreaterThanOrEqual:
+                                    this.ThrowOnInvalidFilter(fieldType, !this.comparandDouble.HasValue);
+                                    return Expression.GreaterThanOrEqual(
+                                        fieldConvertedExpression,
+                                        Expression.Constant(this.comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                case Predicate.Contains:
+                                    // fieldValue.ToString(CultureInfo.InvariantCulture).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) != -1
+                                    Expression toStringCall = isFieldTypeNullable
+                                                                  ? Expression.Call(fieldConvertedExpression, NullableDoubleToStringMethodInfo)
+                                                                  : Expression.Call(fieldConvertedExpression, DoubleToStringMethodInfo, Expression.Constant(CultureInfo.InvariantCulture));
+                                    Expression indexOfCall = Expression.Call(toStringCall, StringIndexOfMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase));
+                                    return Expression.NotEqual(indexOfCall, Expression.Constant(-1));
+                                case Predicate.DoesNotContain:
+                                    // fieldValue.ToString(CultureInfo.InvariantCulture).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) == -1
+                                    toStringCall = isFieldTypeNullable
+                                                       ? Expression.Call(fieldConvertedExpression, NullableDoubleToStringMethodInfo)
+                                                       : Expression.Call(fieldConvertedExpression, DoubleToStringMethodInfo, Expression.Constant(CultureInfo.InvariantCulture));
+                                    indexOfCall = Expression.Call(toStringCall, StringIndexOfMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase));
+                                    return Expression.Equal(indexOfCall, Expression.Constant(-1));
+                                default:
+                                    this.ThrowOnInvalidFilter(fieldType);
+                                    break;
+                            }
+                        }
+                    }
+
+                    break;
+                case TypeCode.String:
+                    {
+                        Expression fieldValueOrEmptyString = Expression.Condition(Expression.Equal(fieldExpression, Expression.Constant(null)), Expression.Constant(string.Empty), fieldExpression);
+
+                        Expression indexOfCall = Expression.Call(fieldValueOrEmptyString, StringIndexOfMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase));
+
+                        switch (this.predicate)
+                        {
+                            case Predicate.Equal:
+                                // (fieldValue ?? string.Empty).Equals(this.comparand, StringComparison.OrdinalIgnoreCase)
+                                return Expression.Call(fieldValueOrEmptyString, StringEqualsMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase));
+                            case Predicate.NotEqual:
+                                // !(fieldValue ?? string.Empty).Equals(this.comparand, StringComparison.OrdinalIgnoreCase)
+                                return Expression.Not(Expression.Call(fieldValueOrEmptyString, StringEqualsMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase)));
+                            case Predicate.LessThan:
+                            case Predicate.GreaterThan:
+                            case Predicate.LessThanOrEqual:
+                            case Predicate.GreaterThanOrEqual:
+                                // double.TryParse(fieldValue, out temp) && temp {<, <=, >, >=} comparandDouble
+                                this.ThrowOnInvalidFilter(fieldType, !this.comparandDouble.HasValue);
+                                return this.CreateStringToDoubleComparisonBlock(fieldExpression, this.predicate);
+                            case Predicate.Contains:
+                                // fieldValue => (fieldValue ?? string.Empty).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) != -1;
+                                return Expression.NotEqual(indexOfCall, Expression.Constant(-1));
+                            case Predicate.DoesNotContain:
+                                // fieldValue => (fieldValue ?? string.Empty).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) == -1;
+                                return Expression.Equal(indexOfCall, Expression.Constant(-1));
+                            default:
+                                this.ThrowOnInvalidFilter(fieldType);
+                                break;
+                        }
+                    }
+
+                    break;
+                default:
+                    Type nullableUnderlyingType;
+                    if (fieldType == typeof(TimeSpan))
+                    {
+                        this.ThrowOnInvalidFilter(fieldType, !this.comparandTimeSpan.HasValue);
+
+                        switch (this.predicate)
+                        {
+                            case Predicate.Equal:
+                                Func<TimeSpan, bool> comparator = fieldValue => fieldValue == this.comparandTimeSpan.Value;
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                            case Predicate.NotEqual:
+                                comparator = fieldValue => fieldValue != this.comparandTimeSpan.Value;
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                            case Predicate.LessThan:
+                                comparator = fieldValue => fieldValue < this.comparandTimeSpan.Value;
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                            case Predicate.GreaterThan:
+                                comparator = fieldValue => fieldValue > this.comparandTimeSpan.Value;
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                            case Predicate.LessThanOrEqual:
+                                comparator = fieldValue => fieldValue <= this.comparandTimeSpan.Value;
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                            case Predicate.GreaterThanOrEqual:
+                                comparator = fieldValue => fieldValue >= this.comparandTimeSpan.Value;
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                            default:
+                                this.ThrowOnInvalidFilter(fieldType);
+                                break;
+                        }
+                    }
+                    else if (fieldType == typeof(Uri))
+                    {
+                        Expression toStringCall = Expression.Call(fieldExpression, UriToStringMethodInfo);
+
+                        Expression fieldValueOrEmptyString = Expression.Condition(Expression.Equal(fieldExpression, Expression.Constant(null)), Expression.Constant(string.Empty), toStringCall);
+
+                        Expression indexOfCall = Expression.Call(fieldValueOrEmptyString, StringIndexOfMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase));
+
+                        switch (this.predicate)
+                        {
+                            case Predicate.Equal:
+                                // (fieldValue?.ToString() ?? string.Empty).Equals(this.comparand, StringComparison.OrdinalIgnoreCase)
+                                return Expression.Call(fieldValueOrEmptyString, StringEqualsMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase));
+                            case Predicate.NotEqual:
+                                // !(fieldValue?.ToString() ?? string.Empty).Equals(this.comparand, StringComparison.OrdinalIgnoreCase)
+                                return Expression.Not(Expression.Call(fieldValueOrEmptyString, StringEqualsMethodInfo, Expression.Constant(this.comparand), Expression.Constant(StringComparison.OrdinalIgnoreCase)));
+                            case Predicate.Contains:
+                                // fieldValue => (fieldValue?.ToString() ?? string.Empty).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) != -1;
+                                return Expression.NotEqual(indexOfCall, Expression.Constant(-1));
+                            case Predicate.DoesNotContain:
+                                // fieldValue => (fieldValue?.ToString() ?? string.Empty).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) == -1;
+                                return Expression.Equal(indexOfCall, Expression.Constant(-1));
+                            default:
+                                this.ThrowOnInvalidFilter(fieldType);
+                                break;
+                        }
+                    }
+                    else if ((nullableUnderlyingType = Nullable.GetUnderlyingType(fieldType)) != null)
+                    {
+                        // make a recursive call for the underlying type
+                        return ProduceComparatorExpressionForSingleFieldCondition(fieldExpression, nullableUnderlyingType, true);
+                    }
+                    else
+                    {
+                        this.ThrowOnInvalidFilter(fieldType);
+                    }
+
+                    break;
+            }
+
+            return null;
+        }
+
+        private Expression ProduceComparatorExpressionForAnyFieldCondition(ParameterExpression documentExpression)
+        {
+            // this.predicate is either Predicate.Contains or Predicate.DoesNotContain at this point
+            if (this.predicate != Predicate.Contains && this.predicate != Predicate.DoesNotContain)
+            {
+                throw new InvalidOperationException(
+                    "ProduceComparatorExpressionForAnyFieldCondition is called while this.predicate is neither Predicate.Contains nor Predicate.DoesNotContain");
+            }
+
+            Expression comparisonExpression = this.predicate == Predicate.Contains ? Expression.Constant(false) : Expression.Constant(true);
+
+            foreach (PropertyInfo propertyInfo in typeof(TTelemetry).GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                try
+                {
+                    Expression propertyComparatorExpression;
+                    if (string.Equals(propertyInfo.Name, CustomDimensionsPropertyName, StringComparison.Ordinal))
+                    {
+                        // ScanDictionary(document.<CustomDimensionsPropertyName>, <this.comparand>)
+                        MemberExpression customDimensionsProperty = Expression.Property(documentExpression, CustomDimensionsPropertyName);
+                        propertyComparatorExpression = Expression.Call(
+                            null,
+                            DictionaryStringStringScanMethodInfo,
+                            customDimensionsProperty,
+                            Expression.Constant(this.comparand));
+
+                        if (this.predicate == Predicate.DoesNotContain)
+                        {
+                            propertyComparatorExpression = Expression.Not(propertyComparatorExpression);
+                        }
+                    }
+                    else if (string.Equals(propertyInfo.Name, CustomMetricsPropertyName, StringComparison.Ordinal))
+                    {
+                        // ScanDictionary(document.<CustomMetricsPropertyName>, <this.comparand>)
+                        MemberExpression customMetricsProperty = Expression.Property(documentExpression, CustomMetricsPropertyName);
+                        propertyComparatorExpression = Expression.Call(
+                            null,
+                            DictionaryStringDoubleScanMethodInfo,
+                            customMetricsProperty,
+                            Expression.Constant(this.comparand));
+
+                        if (this.predicate == Predicate.DoesNotContain)
+                        {
+                            propertyComparatorExpression = Expression.Not(propertyComparatorExpression);
+                        }
+                    }
+                    else
+                    {
+                        // regular property, create a comparator
+                        Expression fieldExpression = ProduceFieldExpression(documentExpression, propertyInfo.Name, FieldNameType.FieldName);
+                        propertyComparatorExpression = this.ProduceComparatorExpressionForSingleFieldCondition(fieldExpression, propertyInfo.PropertyType);
+                    }
+
+                    comparisonExpression = this.predicate == Predicate.Contains
+                                               ? Expression.OrElse(comparisonExpression, propertyComparatorExpression)
+                                               : Expression.AndAlso(comparisonExpression, propertyComparatorExpression);
+                }
+                catch (Exception)
+                {
+                    // probably an unsupported property (e.g. bool), ignore and continue
+                }
+            }
+
+            return comparisonExpression;
+        }
+
+        private Expression CreateStringToDoubleComparisonBlock(Expression fieldExpression, Predicate predicate)
+        {
+            ParameterExpression tempVariable = Expression.Variable(typeof(double));
+            MethodCallExpression doubleTryParseCall = Expression.Call(DoubleTryParseMethodInfo, fieldExpression, DoubleDefaultNumberStyles, InvariantCulture, tempVariable);
+
+            BinaryExpression comparisonExpression;
+            switch (predicate)
+            {
+                case Predicate.LessThan:
+                    comparisonExpression = Expression.LessThan(tempVariable, Expression.Constant(this.comparandDouble.Value));
+                    break;
+                case Predicate.LessThanOrEqual:
+                    comparisonExpression = Expression.LessThanOrEqual(tempVariable, Expression.Constant(this.comparandDouble.Value));
+                    break;
+                case Predicate.GreaterThan:
+                    comparisonExpression = Expression.GreaterThan(tempVariable, Expression.Constant(this.comparandDouble.Value));
+                    break;
+                case Predicate.GreaterThanOrEqual:
+                    comparisonExpression = Expression.GreaterThanOrEqual(tempVariable, Expression.Constant(this.comparandDouble.Value));
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(predicate));
+            }
+
+            BinaryExpression andExpression = Expression.AndAlso(
+                doubleTryParseCall,
+                comparisonExpression);
+
+            return Expression.Block(typeof(bool), new[] { tempVariable }, andExpression);
+        }
+
+        private void ThrowOnInvalidFilter(Type fieldType, bool conditionToThrow = true)
+        {
+            if (conditionToThrow)
+            {
+                throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "The filter is invalid. Field: '{0}', field type: '{1}', predicate: '{2}', comparand: '{3}', document type: '{4}'", this.fieldName, fieldType?.FullName ?? "---", this.predicate, this.comparand, typeof(TTelemetry).FullName));
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -39,7 +39,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
         private static readonly MethodInfo ValueTypeToStringMethodInfo = GetMethodInfo<ValueType, string>(x => x.ToString());
 
-        private static readonly MethodInfo UriToStringMethodInfo = GetMethodInfo<Uri, string>(x => x.AbsoluteUri);
+#pragma warning disable RS0030 // Do not used banned APIs. Using AbsoluteUri will fail test case FilterIntContains and FilterIntDoesNotContain.
+        private static readonly MethodInfo UriToStringMethodInfo = GetMethodInfo<Uri, string>(x => x.ToString());
+#pragma warning restore RS0030 // Do not used banned APIs
 
         private static readonly MethodInfo StringIndexOfMethodInfo =
             GetMethodInfo<string, string, int>((x, y) => x.IndexOf(y, StringComparison.OrdinalIgnoreCase));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
@@ -1,0 +1,88 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+
+    /// <summary>
+    /// Defines an AND group of filters.
+    /// </summary>
+    internal class FilterConjunctionGroup<TTelemetry>
+    {
+        private readonly FilterConjunctionGroupInfo info;
+
+        private readonly List<Filter<TTelemetry>> filters = new List<Filter<TTelemetry>>();
+
+        public FilterConjunctionGroup(FilterConjunctionGroupInfo info, out CollectionConfigurationError[] errors)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            this.info = info;
+
+            this.CreateFilters(out errors);
+        }
+
+        public bool CheckFilters(TTelemetry document, out CollectionConfigurationError[] errors)
+        {
+            var errorList = new List<CollectionConfigurationError>(this.filters.Count);
+
+            foreach (Filter<TTelemetry> filter in this.filters)
+            {
+                bool filterPassed;
+                try
+                {
+                    filterPassed = filter.Check(document);
+                }
+                catch (Exception)
+                {
+                    // the filter has failed to run (possibly incompatible field value in telemetry), consider the telemetry item filtered out by this conjunction group
+                    ////!!!
+                    ////errorList.Add(
+                    ////    CollectionConfigurationError.CreateError(
+                    ////        CollectionConfigurationErrorType.FilterFailureToRun,
+                    ////        string.Format(CultureInfo.InvariantCulture, "Failter failed to run: {0}.", filter),
+                    ////        e));
+                    filterPassed = false;
+                }
+
+                if (!filterPassed)
+                {
+                    errors = errorList.ToArray();
+                    return false;
+                }
+            }
+
+            errors = errorList.ToArray();
+            return true;
+        }
+
+        private void CreateFilters(out CollectionConfigurationError[] errors)
+        {
+            var errorList = new List<CollectionConfigurationError>();
+            foreach (FilterInfo filterInfo in this.info.Filters)
+            {
+                try
+                {
+                    var filter = new Filter<TTelemetry>(filterInfo);
+                    this.filters.Add(filter);
+                }
+                catch (Exception e)
+                {
+                    errorList.Add(
+                        CollectionConfigurationError.CreateError(
+                            CollectionConfigurationErrorType.FilterFailureToCreateUnexpected,
+                            string.Format(CultureInfo.InvariantCulture, "Failed to create a filter {0}.", filterInfo),
+                            e,
+                            Tuple.Create("FilterFieldName", filterInfo.FieldName),
+                            Tuple.Create("FilterPredicate", filterInfo.Predicate.ToString()),
+                            Tuple.Create("FilterComparand", filterInfo.Comparand)));
+                }
+            }
+
+            errors = errorList.ToArray();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
@@ -1,8 +1,12 @@
-﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 {
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
     /// <summary>
     /// Defines an AND group of filters.
@@ -36,7 +40,7 @@
                 {
                     filterPassed = filter.Check(document);
                 }
-                catch (Exception)
+                catch (System.Exception)
                 {
                     // the filter has failed to run (possibly incompatible field value in telemetry), consider the telemetry item filtered out by this conjunction group
                     ////!!!
@@ -69,7 +73,7 @@
                     var filter = new Filter<TTelemetry>(filterInfo);
                     this.filters.Add(filter);
                 }
-                catch (Exception e)
+                catch (System.Exception e)
                 {
                     errorList.Add(
                         CollectionConfigurationError.CreateError(

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterInfoPredicateUtility.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterInfoPredicateUtility.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
+{
+    internal static class FilterInfoPredicateUtility
+    {
+        public static Predicate? ToPredicate(FilterInfoPredicate? filterInfoPredicate)
+        {
+            if (filterInfoPredicate == null)
+            {
+                return null;
+            }
+
+            if (!Enum.TryParse<Predicate>(filterInfoPredicate.ToString(), out Predicate predicate))
+            {
+                throw new ArgumentOutOfRangeException(nameof(filterInfoPredicate), $"Unknown predicate value '{filterInfoPredicate}'");
+            }
+            return predicate;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Predicate.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Predicate.cs
@@ -1,0 +1,21 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+{
+    internal enum Predicate
+    {
+        Equal = 0,
+
+        NotEqual = 1,
+
+        LessThan = 2,
+
+        GreaterThan = 3,
+
+        LessThanOrEqual = 4,
+
+        GreaterThanOrEqual = 5,
+
+        Contains = 6,
+
+        DoesNotContain = 7,
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Predicate.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Predicate.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 {
     internal enum Predicate
     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/TelemetryType.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/TelemetryType.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+{
+    internal enum TelemetryType
+    {
+        Request = 0,
+
+        Dependency = 1,
+
+        Exception = 2,
+
+        Event = 3,
+
+        PerformanceCounter = 5,
+
+        Trace = 6,
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/TelemetryType.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/TelemetryType.cs
@@ -1,17 +1,14 @@
-﻿namespace Microsoft.ApplicationInsights.Extensibility.Filtering
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 {
-    internal enum TelemetryType
+    internal class TelemetryType
     {
-        Request = 0,
-
-        Dependency = 1,
-
-        Exception = 2,
-
-        Event = 3,
-
-        PerformanceCounter = 5,
-
-        Trace = 6,
+        public const string Request = "Request";
+        public const string Dependency = "Dependency";
+        public const string Exception = "Exception";
+        public const string Event = "Event";
+        public const string Trace = "Trace";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/TelemetryType.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/TelemetryType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 {
     internal class TelemetryType
     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
@@ -48,6 +48,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             {
                 // TODO: Filtering would be taken into account here before adding a document to the dataPoint.
                 // TODO: item.DocumentStreamIds = new List<string> { "" }; - Will add the identifier for the specific filtering rules (if applicable). See also "matchingDocumentStreamIds" in AI SDK.
+                //TODO: Apply filters
+                //foreach (CalculatedMetric<TTelemetry> metric in metrics)
+                //    if (metric.CheckFilters(telemetry, out filteringErrors))
 
                 dataPoint.Documents.Add(item);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -102,6 +102,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                         Debug.WriteLine($"OnPost: Subscribed: {response.Subscribed}.");
                         _etag = string.Empty;
                         SetPingState();
+                        // TODO: double check if subscribedValue is false, we should stop collecting properly: (QuickPulseTelemetryModule.OnStopCollection).
                     }
                     else
                     {


### PR DESCRIPTION
PR following up on https://github.com/Azure/azure-sdk-for-net/pull/41523.

Parse the Query parameters and store the compiled Filters and Projections.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
