### PR TITLE
Upgrade SignalR dependencies

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -141,7 +141,7 @@
     <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.56.0" />
 
     <!-- TODO: Make sure this package is arch-board approved -->
-    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
+    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Monitor.OpenTelemetry'))">
@@ -292,7 +292,7 @@
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.10" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.0" />	
+    <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Configuration" Version="8.0.0-rc.1.23419.4" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.32" />
     <PackageReference Update="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -141,8 +141,7 @@
     <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.56.0" />
 
     <!-- TODO: Make sure this package is arch-board approved -->
-    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-
+    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Monitor.OpenTelemetry'))">
@@ -169,10 +168,10 @@
     <PackageReference Update="Grpc.Tools" Version="2.51.0" PrivateAssets="all" />
     <PackageReference Update="MessagePack" Version="1.9.11" />
     <PackageReference Update="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="1.1.5" />
-    <PackageReference Update="Microsoft.Azure.SignalR" Version="1.22.0" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.22.0" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.22.0" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Serverless.Protocols" Version="1.9.0" />
+    <PackageReference Update="Microsoft.Azure.SignalR" Version="1.24.0" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.24.0" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.24.0" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Serverless.Protocols" Version="1.10.0" />
     <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.37" PrivateAssets="All"/>
     <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.Rpc" Version="3.0.37" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.13.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.13.0 (2024-02-06)
 
 ### Other Changes
+* Update `Microsoft.Azure.SignalR`, `Microsoft.Azure.SignalR.Management`, `Microsoft.Azure.SignalR.Protocols` to 1.24.0
+* Update `Microsoft.Azure.SignalR.Serverless.Protocols` to 1.10.0
+* Update `System.IdentityModel.Tokens.Jwt` to 6.35.0
 
 ## 1.12.0 (2023-11-07)
 ### Features Added

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Other Changes
 * Update `Microsoft.Azure.SignalR`, `Microsoft.Azure.SignalR.Management`, `Microsoft.Azure.SignalR.Protocols` to 1.24.0
 * Update `Microsoft.Azure.SignalR.Serverless.Protocols` to 1.10.0
-* Update `System.IdentityModel.Tokens.Jwt` to 6.35.0
 
 ## 1.12.0 (2023-11-07)
 ### Features Added

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
-    <Version>1.13.0-beta.1</Version>
+    <Version>1.13.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.12.0</ApiCompatVersion>
     <SignAssembly>true</SignAssembly>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -22,5 +22,6 @@
     <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 </Project>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
 {
     public class DefaultSecurityTokenValidatorTests
     {
-        private const string IssuerToken = "myfunctionauthtest";
+        // The issue token must be longer than 32 characters.
+        private const string IssuerToken = "1234567812345678912345678123456789";
         public static IEnumerable<object[]> TestData = new List<object[]>
         {
             new object []


### PR DESCRIPTION
`Microsoft.Azure.WebJobs.Extensions.SignalRService` has direct dependencies on `System.IdentityModel.Tokens.Jwt`. 

Previously, the package is referenced indirectly from the direct reference `Microsoft.Azure.SignalR.*` packages. However, the latest versions of `Microsoft.Azure.SignalR.*` don't depend on the package anymore, and   `Microsoft.Azure.WebJobs.Extensions.SignalRService` needs to explicitly refer to the package if we want to upgrade the versions of "Microsoft.Azure.SignalR.*" packages.

