### PR TITLE
[Service Bus] Emulator connection string support

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -79,6 +79,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="host">The fully qualified host name for the Service Bus namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Service Bus namespace or the requested Service Bus entity, depending on Azure configuration.</param>
         /// <param name="options">A set of options to apply when configuring the client.</param>
+        /// <param name="useTls"><c>true</c> if the client should secure the connection using TLS; otherwise, <c>false</c>.</param>
         ///
         /// <remarks>
         ///   As an internal type, this class performs only basic sanity checks against its arguments.  It
@@ -92,7 +93,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
         internal AmqpClient(
             string host,
             ServiceBusTokenCredential credential,
-            ServiceBusClientOptions options)
+            ServiceBusClientOptions options,
+            bool useTls = true)
         {
             Argument.AssertNotNullOrEmpty(host, nameof(host));
             Argument.AssertNotNull(credential, nameof(credential));
@@ -102,14 +104,15 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             ServiceEndpoint = new UriBuilder
             {
-                Scheme = options.TransportType.GetUriScheme(),
+                Scheme = options.TransportType.GetUriScheme(useTls),
                 Host = host
             }.Uri;
 
             ConnectionEndpoint = (options.CustomEndpointAddress == null) ? ServiceEndpoint : new UriBuilder
             {
                 Scheme = ServiceEndpoint.Scheme,
-                Host = options.CustomEndpointAddress.Host
+                Host = options.CustomEndpointAddress.Host,
+                Port = options.CustomEndpointAddress.IsDefaultPort ? -1 : options.CustomEndpointAddress.Port
             }.Uri;
 
             Credential = credential;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -94,7 +94,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string host,
             ServiceBusTokenCredential credential,
             ServiceBusClientOptions options,
-            bool useTls = true)
+            bool useTls)
         {
             Argument.AssertNotNullOrEmpty(host, nameof(host));
             Argument.AssertNotNull(credential, nameof(credential));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -36,7 +36,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
         private const string WebSocketsPathSuffix = "/$servicebus/websocket/";
 
         /// <summary>The URI scheme to apply when using web sockets for service communication.</summary>
-        private const string WebSocketsUriScheme = "wss";
+        private const string WebSocketsSecureUriScheme = "wss";
+
+        /// <summary>The URI scheme to apply when using web sockets for service communication.</summary>
+        private const string WebSocketsInsecureUriScheme = "ws";
 
         /// <summary>The seed to use for initializing random number generated for a given thread-specific instance.</summary>
         private static int s_randomSeed = Environment.TickCount;
@@ -461,13 +464,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
             TimeSpan timeout)
         {
             var serviceHostName = serviceEndpoint.Host;
-            var connectionHostName = connectionEndpoint.Host;
             AmqpSettings amqpSettings = CreateAmpqSettings(AmqpVersion);
             AmqpConnectionSettings connectionSetings = CreateAmqpConnectionSettings(serviceHostName, scopeIdentifier, _connectionIdleTimeoutMilliseconds);
 
             TransportSettings transportSettings = transportType.IsWebSocketTransport()
-                ? CreateTransportSettingsForWebSockets(connectionHostName, proxy)
-                : CreateTransportSettingsforTcp(connectionHostName, connectionEndpoint.Port);
+                ? CreateTransportSettingsForWebSockets(connectionEndpoint, proxy)
+                : CreateTransportSettingsforTcp(connectionEndpoint);
 
             // Create and open the connection, respecting the timeout constraint
             // that was received.
@@ -1312,29 +1314,37 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///  Creates the transport settings for use with TCP.
         /// </summary>
         ///
-        /// <param name="hostName">The host name of the Service Bus service endpoint.</param>
-        /// <param name="port">The port to use for connecting to the endpoint.</param>
+        /// <param name="connectionEndpoint">The Event Hubs service endpoint to connect to.</param>
         ///
         /// <returns>The settings to use for transport.</returns>
-        private static TransportSettings CreateTransportSettingsforTcp(
-            string hostName,
-            int port)
+        private static TransportSettings CreateTransportSettingsforTcp(Uri connectionEndpoint)
         {
+            var useTls = ShouldUseTls(connectionEndpoint.Scheme);
+            var port = connectionEndpoint.Port < 0 ? (useTls ? AmqpConstants.DefaultSecurePort : AmqpConstants.DefaultPort) : connectionEndpoint.Port;
+
             // Allow the host to control the size of the transport buffers for sending and
             // receiving by setting the value to -1.  This results in much improved throughput
             // across platforms, as different Linux distros have different needs to
             // maximize efficiency, with Window having its own needs as well.
             var tcpSettings = new TcpTransportSettings
             {
-                Host = hostName,
-                Port = port < 0 ? AmqpConstants.DefaultSecurePort : port,
+                Host = connectionEndpoint.Host,
+                Port = port,
                 ReceiveBufferSize = -1,
                 SendBufferSize = -1
             };
 
-            return new TlsTransportSettings(tcpSettings)
+            // If TLS is explicitly disabled, then use the TCP settings as-is.  Otherwise,
+            // wrap them for TLS usage.
+
+            return useTls switch
             {
-                TargetHost = hostName,
+                false => tcpSettings,
+
+                _ => new TlsTransportSettings(tcpSettings)
+                {
+                    TargetHost = connectionEndpoint.Host
+                }
             };
         }
 
@@ -1342,19 +1352,21 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///  Creates the transport settings for use with web sockets.
         /// </summary>
         ///
-        /// <param name="hostName">The host name of the Service Bus service endpoint.</param>
+        /// <param name="connectionEndpoint">The Event Hubs service endpoint to connect to.</param>
         /// <param name="proxy">The proxy to use for connecting to the endpoint.</param>
         ///
         /// <returns>The settings to use for transport.</returns>
         private static TransportSettings CreateTransportSettingsForWebSockets(
-            string hostName,
+            Uri connectionEndpoint,
             IWebProxy proxy)
         {
-            var uriBuilder = new UriBuilder(hostName)
+            var useTls = ShouldUseTls(connectionEndpoint.Scheme);
+
+            var uriBuilder = new UriBuilder(connectionEndpoint.Host)
             {
                 Path = WebSocketsPathSuffix,
-                Scheme = WebSocketsUriScheme,
-                Port = -1
+                Scheme = useTls ? WebSocketsSecureUriScheme : WebSocketsInsecureUriScheme,
+                Port = connectionEndpoint.Port < 0 ? -1 : connectionEndpoint.Port
             };
 
             return new WebSocketTransportSettings
@@ -1393,6 +1405,22 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             return connectionSettings;
         }
+
+        /// <summary>
+        ///   Determines if the specified URL scheme should use TLS when creating an AMQP connection.
+        /// </summary>
+        ///
+        /// <param name="urlScheme">The URL scheme to consider.</param>
+        ///
+        /// <returns><c>true</c> if the connection should use TLS; otherwise, <c>false</c>.</returns>
+        ///
+        private static bool ShouldUseTls(string urlScheme) => urlScheme switch
+        {
+            "ws" => false,
+            "amqp" => false,
+            "http" => false,
+            _ => true
+        };
 
         /// <summary>
         ///   Validates the transport associated with the scope, throwing an argument exception

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportTypeExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportTypeExtensions.cs
@@ -12,24 +12,32 @@ namespace Azure.Messaging.ServiceBus.Core
     ///
     internal static class TransportTypeExtensions
     {
-        /// <summary>The URI scheme used for an AMQP-based connection.</summary>
-        private const string AmqpUriScheme = "amqps";
+        /// <summary>The URI scheme used for a TLS-secured AMQP-based connection.</summary>
+        private const string AmqpTlsUriScheme = "amqps";
+
+        /// <summary>The URI scheme used for an insecure AMQP-based connection.</summary>
+        private const string AmqpInsecureUriScheme = "amqp";
 
         /// <summary>
         ///   Determines the URI scheme to be used for the given connection type.
         /// </summary>
         ///
         /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="useTls"><c>true</c> if the scheme should be for a TLS-secured connection; otherwise, <c>false</c>.</param>
         ///
         /// <returns>The scheme that should be used for the given connection type when forming an associated URI.</returns>
         ///
-        public static string GetUriScheme(this ServiceBusTransportType instance)
+        public static string GetUriScheme(this ServiceBusTransportType instance, bool useTls = true)
         {
             switch (instance)
             {
+                case ServiceBusTransportType.AmqpTcp when useTls:
+                case ServiceBusTransportType.AmqpWebSockets when useTls:
+                    return AmqpTlsUriScheme;
+
                 case ServiceBusTransportType.AmqpTcp:
                 case ServiceBusTransportType.AmqpWebSockets:
-                    return AmqpUriScheme;
+                    return AmqpInsecureUriScheme;
 
                 default:
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidTransportType, instance.ToString(), nameof(instance)));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpClientTests.cs
@@ -47,5 +47,28 @@ namespace Azure.Messaging.ServiceBus.Tests
             Assert.That(client.ConnectionEndpoint.Host, Is.EqualTo(options.CustomEndpointAddress.Host), "The connection endpoint should have used the custom endpoint URI from the options.");
             Assert.That(client.ServiceEndpoint.Host, Is.EqualTo(endpoint.Host), "The service endpoint should have used the namespace URI.");
         }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true, "amqps")]
+        [TestCase(false, "amqp")]
+        public void ConstructorRespectsTheUseTlsOption(bool useTls,
+                                                       string expectedScheme)
+        {
+            var options = new ServiceBusClientOptions
+            {
+                CustomEndpointAddress = new Uri("sb://iam.custom.net"),
+                TransportType = ServiceBusTransportType.AmqpTcp
+            };
+
+            var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
+            var client = new AmqpClient("my.endpoint.com", credential.Object, options, useTls);
+
+            Assert.That(client.ConnectionEndpoint.Host, Is.EqualTo(options.CustomEndpointAddress.Host), "The connection endpoint should have used the custom endpoint URI from the options.");
+            Assert.That(client.ConnectionEndpoint.Scheme, Is.EqualTo(expectedScheme), "The connection endpoint scheme should reflect the TLS setting.");
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpClientTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var options = new ServiceBusClientOptions();
             var endpoint = new Uri("http://fake.endpoint.com");
             var token = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var client = new AmqpClient(endpoint.Host, token.Object, options);
+            var client = new AmqpClient(endpoint.Host, token.Object, options, true);
 
             Assert.That(client.ConnectionEndpoint.Host, Is.EqualTo(endpoint.Host), "The connection endpoint should have used the namespace URI.");
             Assert.That(client.ServiceEndpoint.Host, Is.EqualTo(endpoint.Host), "The service endpoint should have used the namespace URI.");
@@ -42,7 +42,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var options = new ServiceBusClientOptions() { CustomEndpointAddress = new Uri("http://fake.custom.com") };
             var endpoint = new Uri("http://fake.endpoint.com");
             var token = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var client = new AmqpClient(endpoint.Host, token.Object, options);
+            var client = new AmqpClient(endpoint.Host, token.Object, options, true);
 
             Assert.That(client.ConnectionEndpoint.Host, Is.EqualTo(options.CustomEndpointAddress.Host), "The connection endpoint should have used the custom endpoint URI from the options.");
             Assert.That(client.ServiceEndpoint.Host, Is.EqualTo(endpoint.Host), "The service endpoint should have used the namespace URI.");

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -1307,7 +1307,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             mockConnection.Setup(
                 connection => connection.CreateTransportClient(
                     It.IsAny<ServiceBusTokenCredential>(),
-                    It.IsAny<ServiceBusClientOptions>()))
+                    It.IsAny<ServiceBusClientOptions>(),
+                    It.IsAny<bool>()))
                 .Returns(Mock.Of<TransportClient>());
 
             return mockConnection;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestUtilities.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestUtilities.cs
@@ -129,7 +129,8 @@ namespace Azure.Messaging.ServiceBus.Tests
             mockConnection
                 .Setup(connection => connection.CreateTransportClient(
                     It.IsAny<ServiceBusTokenCredential>(),
-                    It.IsAny<ServiceBusClientOptions>()))
+                    It.IsAny<ServiceBusClientOptions>(),
+                    It.IsAny<bool>()))
                 .Returns(Mock.Of<TransportClient>());
 
             return mockConnection;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -442,7 +442,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             mockConnection
                 .Setup(connection => connection.CreateTransportClient(
                     It.IsAny<ServiceBusTokenCredential>(),
-                    It.IsAny<ServiceBusClientOptions>()))
+                    It.IsAny<ServiceBusClientOptions>(),
+                    It.IsAny<bool>()))
                 .Returns(mockTransportClient.Object);
 
             var processor = new ServiceBusProcessor(


### PR DESCRIPTION
# Summary

The focus of these changes is to add support for the connection string format used by the emulator currently in development.  This is intended to support internal testing on very early alpha builds.