### PR TITLE
ClientModel Prototype: Add TransferResponseDisposeOwnership method

### DIFF
--- a/sdk/core/Azure.Core/tests/HttpMessageTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpMessageTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
+using System.Threading;
+using System;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -380,7 +383,48 @@ namespace Azure.Core.Tests
             Assert.IsTrue(message.ResponseClassifier.IsErrorResponse(message));
         }
 
+        [Test]
+        public async Task UnbufferedStreamAccessibleAfterMessageDisposed()
+        {
+            byte[] serverBytes = new byte[1000];
+            new Random().NextBytes(serverBytes);
+
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(new MockClientOptions { Retry = { NetworkTimeout = Timeout.InfiniteTimeSpan } });
+
+            using TestServer testServer = new(async context =>
+            {
+                await context.Response.Body.WriteAsync(serverBytes, 0, serverBytes.Length).ConfigureAwait(false);
+            });
+
+            Response response;
+            using (HttpMessage message = pipeline.CreateMessage())
+            {
+                message.Request.Uri.Reset(testServer.Address);
+                message.BufferResponse = false;
+
+                await pipeline.SendAsync(message, default).ConfigureAwait(false);
+
+                message.TransferResponseDisposeOwnership();
+                response = message.Response;
+            }
+
+            Assert.NotNull(response.ContentStream);
+            byte[] clientBytes = new byte[serverBytes.Length];
+            int readLength = 0;
+            while (readLength < serverBytes.Length)
+            {
+                readLength += await response.ContentStream.ReadAsync(clientBytes, 0, serverBytes.Length);
+            }
+
+            Assert.AreEqual(serverBytes.Length, readLength);
+            CollectionAssert.AreEqual(serverBytes, clientBytes);
+        }
+
         #region Helpers
+        internal class MockClientOptions : ClientOptions
+        {
+        }
+
         private class StatusCodeHandler : ResponseClassificationHandler
         {
             private readonly int _statusCode;

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -150,6 +150,7 @@ namespace System.ClientModel.Primitives
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void SetProperty(System.Type type, object value) { }
+        public void TransferResponseDisposeOwnership() { }
         public bool TryGetProperty(System.Type type, out object? value) { throw null; }
     }
     public abstract partial class PipelineMessageClassifier

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -149,6 +149,7 @@ namespace System.ClientModel.Primitives
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void SetProperty(System.Type type, object value) { }
+        public void TransferResponseDisposeOwnership() { }
         public bool TryGetProperty(System.Type type, out object? value) { throw null; }
     }
     public abstract partial class PipelineMessageClassifier


### PR DESCRIPTION
Today, we have a bug in ClientModel that would prevent being able to support streaming APIs in protocol methods.  This prototype proposes an API for the ClientModel type, that, if agreed-upon, could be transferred to Azure.Core before the Core-ClientModel integration happens.