### PR TITLE
[Event Hubs] Processor cancellation bug fix

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -25,6 +25,8 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Fixed a race condition that could lead to a synchronization primitive being double-released if `IsRunning` was called concurrently while starting or stopping the processor.
 
+- Fixed a bug in which cancellation honored by the processor was interpreted as an error surfaced by developer code and a warning was inappropriately emitted to the error handler.
+
 - Fixed an issue with event processor validation where an exception for quota exceeded may inappropriately be surfaced when starting the processor.
 
 - In the rare case that an event processor's load balancing and health monitoring task cannot recover from an error, it will now properly surrender ownership when processing stops.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -1058,7 +1058,13 @@ namespace Azure.Messaging.EventHubs
                                                                   EventProcessorPartition partition,
                                                                   CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+            // If cancellation was requested, then do not dispatch the events to be handled.  This
+            // is considered a normal exit condition, rather than an exceptional case.
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
 
             var operation = Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture);
             var context = default(PartitionContext);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
@@ -980,7 +980,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             await processor.StartProcessingAsync(cancellationSource.Token);
 
-            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             await processor.StopProcessingAsync(cancellationSource.Token);


### PR DESCRIPTION
# Summary

The focus of these changes is to address a bug in the Event Processor Client which led to cancellation being detected as an error with developer code, which erroneously produced a warning surfaced to the error handler.  A flaky test was also addressed.