### PR TITLE
OpenAI Assistants: changelog update for tiny beta.2 release

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI.Assistants/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI.Assistants/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2024-02-05)
 
-### Features Added
+This small release fixes a bug with function tools that use arguments.
 
 ### Breaking Changes
 
@@ -22,8 +22,6 @@
 ### Bugs Fixed
 
 - Function calls initiated by the model (when a run enters a RequiresAction status involving function tools) will now provide the intended JSON `Arguments` string corresponding to the earlier `FunctionDefinition`'s `Parameters`. The latter `Parameters` was previously reused within the required action flow, effectively ignoring the proper `Arguments`.
-
-### Other Changes
 
 ## 1.0.0-beta.1 (2024-02-01)
 


### PR DESCRIPTION
As finalized via `prepare-release`.