### PR TITLE
Re-Enable distro test

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2EAzureMonitorDistroTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2EAzureMonitorDistroTests.cs
@@ -51,14 +51,14 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             var res = await httpClient.GetStringAsync("http://localhost:9999").ConfigureAwait(false);
             Assert.NotNull(res);
 
+            // Should dispose the providers and flush out telemetry.
+            await app.DisposeAsync();
+
             // Wait for the backend/ingestion to receive requests
             WaitForRequest(transport);
 
             // Assert
             Assert.True(transport.Requests.Count > 0);
-
-            // Should dispose the providers and flush out telemetry.
-            await app.DisposeAsync();
 
             // Telemetry is serialized as json, and then byte encoded.
             // Need to parse the request content into something assertable.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2EAzureMonitorDistroTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2EAzureMonitorDistroTests.cs
@@ -51,11 +51,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             var res = await httpClient.GetStringAsync("http://localhost:9999").ConfigureAwait(false);
             Assert.NotNull(res);
 
-            // Should dispose the providers and flush out telemetry.
-            await app.DisposeAsync();
-
             // Wait for the backend/ingestion to receive requests
             WaitForRequest(transport);
+
+            // Should dispose the providers and flush out telemetry.
+            await app.DisposeAsync();
 
             // Assert
             Assert.True(transport.Requests.Count > 0);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2EAzureMonitorDistroTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2EAzureMonitorDistroTests.cs
@@ -54,11 +54,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             // Wait for the backend/ingestion to receive requests
             WaitForRequest(transport);
 
-            // Should dispose the providers and flush out telemetry.
-            await app.DisposeAsync();
-
             // Assert
             Assert.True(transport.Requests.Count > 0);
+
+            await app.DisposeAsync();
 
             // Telemetry is serialized as json, and then byte encoded.
             // Need to parse the request content into something assertable.


### PR DESCRIPTION
Re-enabling the test to validate that telemetry is emitted when distro is in use. This would catch any missing telemetry issues. This needs to be further improved.