### PR TITLE
Revert "Drain excess credits when using sessions to ensure FIFO (#40457)"

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -26,7 +26,6 @@
 - Adjusted retries to consider an unreachable host address as terminal.  Previously, all socket-based errors were considered transient and would be retried.
 - Updated the `ServiceBusMessage` constructor that takes a `ServiceBusReceivedMessage` to no longer copy over the
   `x-opt-partition-id` key as this is meant to apply only to the original message.
-- Drain excess credits when attempting to receive using sessions to ensure FIFO ordering.
 
 ### Other Changes
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeActivitySourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeActivitySourceLiveTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         [TestCase(false)]
         public async Task SenderReceiverActivitiesDisabled(bool useSessions)
         {
-            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
+            using var listener = new TestActivitySourceListener(DiagnosticProperty.DiagnosticNamespace);
 
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: useSessions))
             {
@@ -72,7 +72,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 }
                 else
                 {
-                    await receiver.RenewMessageLockAsync(received[1]);
+                    await receiver.RenewMessageLockAsync(received[-1]);
                 }
 
                 // schedule
@@ -262,7 +262,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var messages = ServiceBusTestUtilities.GetMessages(messageCt);
 
             using var listener = new TestActivitySourceListener(
-                source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace),
+                DiagnosticProperty.DiagnosticNamespace,
                 activityStartedCallback: activity =>
                 {
                     if (activity.OperationName == DiagnosticProperty.ProcessMessageActivityName)
@@ -321,7 +321,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var messages = ServiceBusTestUtilities.GetMessages(messageCt, "sessionId");
 
             using var listener = new TestActivitySourceListener(
-                source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace),
+                DiagnosticProperty.DiagnosticNamespace,
                 activityStartedCallback: activity =>
                 {
                     if (activity.OperationName == DiagnosticProperty.ProcessSessionMessageActivityName)
@@ -374,7 +374,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         public async Task RuleManagerActivities()
         {
             using var _ = SetAppConfigSwitch();
-            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
+            using var listener = new TestActivitySourceListener(DiagnosticProperty.DiagnosticNamespace);
 
             await using (var scope = await ServiceBusScope.CreateWithTopic(enablePartitioning: false, enableSession: false))
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -1148,55 +1148,5 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         .EqualTo(ServiceBusFailureReason.SessionLockLost));
             }
         }
-
-        [Test]
-        public async Task SessionOrderingIsGuaranteed()
-        {
-            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
-            {
-                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
-                var receiver = await client.AcceptSessionAsync(scope.QueueName, "session");
-                var sender = client.CreateSender(scope.QueueName);
-
-                CancellationTokenSource cts = new CancellationTokenSource();
-                cts.CancelAfter(TimeSpan.FromSeconds(60));
-
-                var receive = ReceiveMessagesAsync();
-
-                var send = SendMessagesAsync();
-
-                await Task.WhenAll(send, receive);
-
-                async Task SendMessagesAsync()
-                {
-                    while (!cts.IsCancellationRequested)
-                    {
-                        await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("session"));
-                        await Task.Delay(TimeSpan.FromMilliseconds(100));
-                    }
-                }
-
-                async Task ReceiveMessagesAsync()
-                {
-                    long lastSequenceNumber = 0;
-                    while (!cts.IsCancellationRequested)
-                    {
-                        var messages = await receiver.ReceiveMessagesAsync(10);
-                        foreach (var message in messages)
-                        {
-                            if (message.SequenceNumber != lastSequenceNumber + 1)
-                            {
-                                Assert.Fail(
-                                    $"Last sequence number: {lastSequenceNumber}, current sequence number: {message.SequenceNumber}");
-                            }
-
-                            lastSequenceNumber = message.SequenceNumber;
-
-                            await receiver.CompleteMessageAsync(message);
-                        }
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
had trouble with #40457

await link.DrainAsyc(cancellationToken).ConfigureAwait(false);

caused:
System.TimeoutException: The operation did not complete within the allocated time 00:01:00 for object drain.
   at Microsoft.Azure.Amqp.ExceptionDispatcher.Throw(Exception exception)
   at Microsoft.Azure.Amqp.AsyncResult.End[TAsyncResult](IAsyncResult result)
   at Microsoft.Azure.Amqp.ReceivingAmqpLink.DrainAsyncResult.End(IAsyncResult result)
   at Microsoft.Azure.Amqp.ReceivingAmqpLink.<>c.<DrainAsyc>b__35_1(IAsyncResult r)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
--- End of stack trace from previous location ---
   at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.ReceiveMessagesAsyncInternal(Int32 maxMessages, Nullable`1 maxWaitTime, TimeSpan timeout, CancellationToken cancellationToken) in ...\azure-sdk-for-net\sdk\servicebus\Azure.Messaging.ServiceBus\src\Amqp\AmqpReceiver.cs:line 375   

and subsequent in ServiceBusSessionProcessor.ProcessErrorAsync handler:
Azure.Messaging.ServiceBus.ServiceBusException: The session lock has expired on the MessageSession. Accept a new MessageSession. TrackingId:<id>, SystemTracker:...
      (SessionLockLost). For troubleshooting information, see https://aka.ms/azsdk/net/servicebus/exceptions/troubleshoot.
         at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.ThrowIfSessionLockLost()
         at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.ReceiveMessagesAsyncInternal(Int32 maxMessages, Nullable`1 maxWaitTime, TimeSpan timeout, CancellationToken cancellationToken)
         at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.<>c.<<ReceiveMessagesAsync>b__44_0>d.MoveNext()
      --- End of stack trace from previous location ---
         at Azure.Messaging.ServiceBus.ServiceBusRetryPolicy.RunOperation[T1,TResult](Func`4 operation, T1 t1, TransportConnectionScope scope, CancellationToken cancellationToken, Boolean logTimeoutRetriesAsVerbose)
         at Azure.Messaging.ServiceBus.ServiceBusRetryPolicy.RunOperation[T1,TResult](Func`4 operation, T1 t1, TransportConnectionScope scope, CancellationToken cancellationToken, Boolean logTimeoutRetriesAsVerbose)
         at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.ReceiveMessagesAsync(Int32 maxMessages, Nullable`1 maxWaitTime, CancellationToken cancellationToken)
         at Azure.Messaging.ServiceBus.ServiceBusReceiver.ReceiveMessagesAsync(Int32 maxMessages, Nullable`1 maxWaitTime, Boolean isProcessor, CancellationToken cancellationToken)
         at Azure.Messaging.ServiceBus.SessionReceiverManager.ReceiveAndProcessMessagesAsync(CancellationToken processorCancellationToken)

This reverts commit 8ee6482f16d7ae11fa350f352a34e9be170aa9e0.