### PR TITLE
[Core] Add missing regions to AzureLocation

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 ### Other Changes
 
+- Additional Azure data centers are now included in `AzureLocation`.  The following were added:
+  - China East 3
+  - China North 3
+  - Israel Central
+  - Italy North
+  - Poland Central
+  - Sweden South
+
 ## 1.37.0 (2024-01-11)
 
 ### Bugs Fixed

--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -318,8 +318,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation CentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaEast { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaEast2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaEast3 { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaNorth { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaNorth2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaNorth3 { get { throw null; } }
         public string? DisplayName { get { throw null; } }
         public static Azure.Core.AzureLocation EastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation EastUS { get { throw null; } }
@@ -330,6 +332,8 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation GermanyNorth { get { throw null; } }
         public static Azure.Core.AzureLocation GermanyNorthEast { get { throw null; } }
         public static Azure.Core.AzureLocation GermanyWestCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation IsraelCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation ItalyNorth { get { throw null; } }
         public static Azure.Core.AzureLocation JapanEast { get { throw null; } }
         public static Azure.Core.AzureLocation JapanWest { get { throw null; } }
         public static Azure.Core.AzureLocation KoreaCentral { get { throw null; } }
@@ -339,6 +343,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation NorthEurope { get { throw null; } }
         public static Azure.Core.AzureLocation NorwayEast { get { throw null; } }
         public static Azure.Core.AzureLocation NorwayWest { get { throw null; } }
+        public static Azure.Core.AzureLocation PolandCentral { get { throw null; } }
         public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SouthAfricaNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SouthAfricaWest { get { throw null; } }
@@ -346,6 +351,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
         public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenSouth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -318,8 +318,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation CentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaEast { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaEast2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaEast3 { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaNorth { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaNorth2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaNorth3 { get { throw null; } }
         public string? DisplayName { get { throw null; } }
         public static Azure.Core.AzureLocation EastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation EastUS { get { throw null; } }
@@ -330,6 +332,8 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation GermanyNorth { get { throw null; } }
         public static Azure.Core.AzureLocation GermanyNorthEast { get { throw null; } }
         public static Azure.Core.AzureLocation GermanyWestCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation IsraelCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation ItalyNorth { get { throw null; } }
         public static Azure.Core.AzureLocation JapanEast { get { throw null; } }
         public static Azure.Core.AzureLocation JapanWest { get { throw null; } }
         public static Azure.Core.AzureLocation KoreaCentral { get { throw null; } }
@@ -339,6 +343,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation NorthEurope { get { throw null; } }
         public static Azure.Core.AzureLocation NorwayEast { get { throw null; } }
         public static Azure.Core.AzureLocation NorwayWest { get { throw null; } }
+        public static Azure.Core.AzureLocation PolandCentral { get { throw null; } }
         public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SouthAfricaNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SouthAfricaWest { get { throw null; } }
@@ -346,6 +351,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
         public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenSouth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -318,8 +318,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation CentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaEast { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaEast2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaEast3 { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaNorth { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaNorth2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaNorth3 { get { throw null; } }
         public string? DisplayName { get { throw null; } }
         public static Azure.Core.AzureLocation EastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation EastUS { get { throw null; } }
@@ -330,6 +332,8 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation GermanyNorth { get { throw null; } }
         public static Azure.Core.AzureLocation GermanyNorthEast { get { throw null; } }
         public static Azure.Core.AzureLocation GermanyWestCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation IsraelCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation ItalyNorth { get { throw null; } }
         public static Azure.Core.AzureLocation JapanEast { get { throw null; } }
         public static Azure.Core.AzureLocation JapanWest { get { throw null; } }
         public static Azure.Core.AzureLocation KoreaCentral { get { throw null; } }
@@ -339,6 +343,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation NorthEurope { get { throw null; } }
         public static Azure.Core.AzureLocation NorwayEast { get { throw null; } }
         public static Azure.Core.AzureLocation NorwayWest { get { throw null; } }
+        public static Azure.Core.AzureLocation PolandCentral { get { throw null; } }
         public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SouthAfricaNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SouthAfricaWest { get { throw null; } }
@@ -346,6 +351,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
         public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenSouth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -318,8 +318,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation CentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaEast { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaEast2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaEast3 { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaNorth { get { throw null; } }
         public static Azure.Core.AzureLocation ChinaNorth2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaNorth3 { get { throw null; } }
         public string? DisplayName { get { throw null; } }
         public static Azure.Core.AzureLocation EastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation EastUS { get { throw null; } }
@@ -330,6 +332,8 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation GermanyNorth { get { throw null; } }
         public static Azure.Core.AzureLocation GermanyNorthEast { get { throw null; } }
         public static Azure.Core.AzureLocation GermanyWestCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation IsraelCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation ItalyNorth { get { throw null; } }
         public static Azure.Core.AzureLocation JapanEast { get { throw null; } }
         public static Azure.Core.AzureLocation JapanWest { get { throw null; } }
         public static Azure.Core.AzureLocation KoreaCentral { get { throw null; } }
@@ -339,6 +343,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation NorthEurope { get { throw null; } }
         public static Azure.Core.AzureLocation NorwayEast { get { throw null; } }
         public static Azure.Core.AzureLocation NorwayWest { get { throw null; } }
+        public static Azure.Core.AzureLocation PolandCentral { get { throw null; } }
         public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SouthAfricaNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SouthAfricaWest { get { throw null; } }
@@ -346,6 +351,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
         public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenSouth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }

--- a/sdk/core/Azure.Core/src/AzureLocation.cs
+++ b/sdk/core/Azure.Core/src/AzureLocation.cs
@@ -200,6 +200,11 @@ namespace Azure.Core
         public static AzureLocation SwedenCentral { get; } = CreateStaticReference("swedencentral", "Sweden Central");
 
         /// <summary>
+        /// Public cloud location for Sweden South.
+        /// </summary>
+        public static AzureLocation SwedenSouth { get; } = CreateStaticReference("swedensouth", "Sweden South");
+
+        /// <summary>
         /// Public cloud location for Switzerland North.
         /// </summary>
         public static AzureLocation SwitzerlandNorth { get; } = CreateStaticReference("switzerlandnorth", "Switzerland North");
@@ -260,9 +265,19 @@ namespace Azure.Core
         public static AzureLocation ChinaNorth2 { get; } = CreateStaticReference("chinanorth2", "China North 2");
 
         /// <summary>
+        /// Public cloud location for China North 3.
+        /// </summary>
+        public static AzureLocation ChinaNorth3 { get; } = CreateStaticReference("chinanorth3", "China North 3");
+
+        /// <summary>
         /// Public cloud location for China East 2.
         /// </summary>
         public static AzureLocation ChinaEast2 { get; } = CreateStaticReference("chinaeast2", "China East 2");
+
+        /// <summary>
+        /// Public cloud location for China East 3.
+        /// </summary>
+        public static AzureLocation ChinaEast3 { get; } = CreateStaticReference("chinaeast3", "China East 3");
 
         /// <summary>
         /// Public cloud location for Qatar Central.
@@ -298,6 +313,21 @@ namespace Azure.Core
         /// Public cloud location for US Gov Iowa.
         /// </summary>
         public static AzureLocation USGovIowa { get; } = CreateStaticReference("usgoviowa", "US Gov Iowa");
+
+        /// <summary>
+        /// Public cloud location for Israel Central.
+        /// </summary>
+        public static AzureLocation IsraelCentral { get; } = CreateStaticReference("israelcentral", "Israel Central");
+
+        /// <summary>
+        /// Public cloud location for Italy North.
+        /// </summary>
+        public static AzureLocation ItalyNorth { get; } = CreateStaticReference("italynorth", "Italy North");
+
+        /// <summary>
+        /// Public cloud location for Poland Central.
+        /// </summary>
+        public static AzureLocation PolandCentral { get; } = CreateStaticReference("polandcentral", "Poland Central");
 
         #endregion
 

--- a/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
+++ b/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Core.Tests
 
         #region LocationResouceIdentifier
         [Test]
-        public void LocationFromDiffNamespaceWithChildResouce()
+        public void LocationFromDiffNamespaceWithChildResource()
         {
             string resourceId = $"{LocationInDifferentNamespace}/publishers/128technology";
             var id = GetResourceIdentifier(resourceId);
@@ -47,7 +47,7 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void LocationWithChildResouce()
+        public void LocationWithChildResource()
         {
             string resourceId = $"{LocationBaseResourceId}/myResourceType/myResourceName";
             var id = GetResourceIdentifier(resourceId);


### PR DESCRIPTION
# Summary

The focus of these changes is to add recent Azure regions to `AzureLocation`.  The following were missing and have been added:

- China East 3
- China North 3
- Israel Central
- Italy North
- Poland Central
- Sweden South

## References and resources

- [[BUG] Missing AzureLocation values: ItalyNorth, PolandCentral, IsraelCentral (possibly others) (#41683)](https://github.com/Azure/azure-sdk-for-net/issues/41683)
- [Azure products by region](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?rar=true&regions=all)