### PR TITLE
[CODEOWNERS] Rule for repository config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,7 +49,7 @@
 # ######## Core Libraries ########
 
 # Repository configuration
-/*.*                                                               @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @jsquire @pallavit
+/*                                                                 @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @jsquire @pallavit
 
 # PRLabel: %Azure.Core
 /sdk/core/                                                         @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @jsquire

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,7 +39,6 @@
 /sdk/entra/                                                        @pallavit @jsquire
 /sdk/graphrbac/                                                    @pallavit @jsquire
 /sdk/machinelearningservices/                                      @pallavit @jsquire
-/sdk/maps/                                                         @dubiety @khmic5 @andykao1213
 # Note there are some sub-rules for this directory, defined below
 /sdk/operationalinsights/                                          @pallavit @jsquire
 /sdk/purview/                                                      @pallavit @jsquire
@@ -48,6 +47,9 @@
 /sdk/remoterendering/                                              @pallavit @jsquire
 
 # ######## Core Libraries ########
+
+# Repository configuration
+/*.*                                                               @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @jsquire @pallavit
 
 # PRLabel: %Azure.Core
 /sdk/core/                                                         @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @jsquire
@@ -546,6 +548,10 @@
 
 # ServiceLabel: %Managed Services %Service Attention
 /sdk/managedservices/Microsoft.Azure.Management.ManagedServices/   @Lighthouse-Azure
+
+# PRLabel: %Maps
+# ServiceLabel: %Maps %Service Attention
+/sdk/maps/                                                         @dubiety @khmic5 @andykao1213
 
 # ServiceLabel: %MariaDB %Service Attention
 #/<NotInRepo>/                                                     @ajlam @ambhatna @kummanish

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,14 @@
 # /samples/
 # /tools/
 
+##################
+# Repository root
+##################
+
+# Catch all for loose files in the root, which are mostly global configuration and
+# should not be changed without team discussion.
+/*                                                                 @jsquire @pallavit @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina
+
 ################
 # Automation
 ################
@@ -47,9 +55,6 @@
 /sdk/remoterendering/                                              @pallavit @jsquire
 
 # ######## Core Libraries ########
-
-# Repository configuration
-/*                                                                 @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @jsquire @pallavit
 
 # PRLabel: %Azure.Core
 /sdk/core/                                                         @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @jsquire


### PR DESCRIPTION
# Summary

Add the Azure.Core team as owners of the root-level files in the repository, which control basic repository configuration such as the SDK version in use, coding conventions, and engineering system tie-ins.  Currently, these can be changed in a random pull request without awareness.