### PR TITLE
[CODEOWNERS] Use Azure.Core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 
 # Catch all for loose files in the root, which are mostly global configuration and
 # should not be changed without team discussion.
-/*                                                                 @jsquire @pallavit @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina
+/*                                                                 @jsquire @pallavit @Azure/azure-sdk-write-net-core
 
 ################
 # Automation
@@ -57,7 +57,7 @@
 # ######## Core Libraries ########
 
 # PRLabel: %Azure.Core
-/sdk/core/                                                         @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @jsquire
+/sdk/core/                                                         @Azure/azure-sdk-write-net-core
 
 # PRLabel: %Azure.Identity
 /sdk/identity/                                                     @schaabs @christothes @Azure/azure-sdk-write-identity


### PR DESCRIPTION
# Summary

The focus of these changes is to replace the list of individuals working on Azure.Core with the GitHub Azure Core team.

## NOTE
  This cannot merge until after the GitHub sync process completes on Friday, Feb 9.