### PR TITLE
suppress livemetrics service from being instrumented

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/QuickPulseSDKClientAPIsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/QuickPulseSDKClientAPIsRestClient.cs
@@ -37,9 +37,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                 throw new ArgumentNullException(nameof(ikey));
             }
 
-            // Prevents the http operations from being instrumented.
-            using var scope = SuppressInstrumentationScope.Begin();
-
             using var message = CreatePingRequest(ikey, apikey, xMsQpsTransmissionTime, xMsQpsMachineName, xMsQpsInstanceName, xMsQpsStreamId, xMsQpsRoleName, xMsQpsInvariantVersion, xMsQpsConfigurationEtag, monitoringDataPoint);
             _pipeline.Send(message, cancellationToken);
             var headers = new QuickPulseSDKClientAPIsPingHeaders(message.Response);
@@ -93,9 +90,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
             {
                 throw new ArgumentNullException(nameof(ikey));
             }
-
-            // Prevents the http operations from being instrumented.
-            using var scope = SuppressInstrumentationScope.Begin();
 
             using var message = CreatePostRequest(ikey, apikey, xMsQpsConfigurationEtag, xMsQpsTransmissionTime, monitoringDataPoints);
             _pipeline.Send(message, cancellationToken);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/QuickPulseSDKClientAPIsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/QuickPulseSDKClientAPIsRestClient.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
+using OpenTelemetry;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 {
@@ -35,6 +36,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
             {
                 throw new ArgumentNullException(nameof(ikey));
             }
+
+            // Prevents the http operations from being instrumented.
+            using var scope = SuppressInstrumentationScope.Begin();
 
             using var message = CreatePingRequest(ikey, apikey, xMsQpsTransmissionTime, xMsQpsMachineName, xMsQpsInstanceName, xMsQpsStreamId, xMsQpsRoleName, xMsQpsInvariantVersion, xMsQpsConfigurationEtag, monitoringDataPoint);
             _pipeline.Send(message, cancellationToken);
@@ -89,6 +93,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
             {
                 throw new ArgumentNullException(nameof(ikey));
             }
+
+            // Prevents the http operations from being instrumented.
+            using var scope = SuppressInstrumentationScope.Begin();
 
             using var message = CreatePostRequest(ikey, apikey, xMsQpsConfigurationEtag, xMsQpsTransmissionTime, monitoringDataPoints);
             _pipeline.Send(message, cancellationToken);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/QuickPulseSDKClientAPIsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/QuickPulseSDKClientAPIsRestClient.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
-using OpenTelemetry;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics;
+using OpenTelemetry;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 {
@@ -110,6 +111,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         {
             try
             {
+                // Prevents the http operations from being instrumented.
+                using var scope = SuppressInstrumentationScope.Begin();
+
                 while (true)
                 {
                     var callbackStarted = DateTimeOffset.UtcNow;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
@@ -111,7 +111,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         {
             try
             {
-                // Prevents the http operations from being instrumented.
+                // Suppress the outbound Live Metrics service calls from being collected as dependency telemetry.
                 using var scope = SuppressInstrumentationScope.Begin();
 
                 while (true)


### PR DESCRIPTION
use `SuppressInstrumentationScope.Begin()` to prevent Ping and Post from being instrumented. Set this once, when the dedicated thread starts.