### PR TITLE
fix: pass attributes defined in the ResourceBuilder along with azure monitor telemetry 

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MessageData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MessageData.cs
@@ -12,9 +12,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class MessageData
     {
-        public MessageData(int version, LogRecord logRecord) : base(version)
+        public MessageData(int version, LogRecord logRecord, AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             Properties = new ChangeTrackingDictionary<string, string>();
+
+            azureMonitorResource?.CopyUserDefinedAttributes(Properties);
+
             Measurements = new ChangeTrackingDictionary<string, double>();
             Message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties).Truncate(SchemaConstants.MessageData_Message_MaxLength);
             SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MessageData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MessageData.cs
@@ -12,7 +12,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class MessageData
     {
-        public MessageData(int version, LogRecord logRecord, AzureMonitorResource? azureMonitorResource = null) : base(version)
+        public MessageData(
+            int version,
+            LogRecord logRecord,
+            AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             Properties = new ChangeTrackingDictionary<string, string>();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
@@ -13,7 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
     {
         private const string azureMonitorResourceKey = "_OTELRESOURCE_";
 
-        public MetricsData(int version, Metric metric, MetricPoint metricPoint) : base(version)
+        public MetricsData(int version, Metric metric, MetricPoint metricPoint, AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             if (metric == null)
             {
@@ -25,6 +25,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             metricDataPoints.Add(metricDataPoint);
             Metrics = metricDataPoints;
             Properties = new ChangeTrackingDictionary<string, string>();
+
+            azureMonitorResource?.CopyUserDefinedAttributes(Properties);
+
             foreach (var tag in metricPoint.Tags)
             {
                 if (tag.Key.Length <= SchemaConstants.MetricsData_Properties_MaxKeyLength && tag.Value != null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
@@ -13,7 +13,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
     {
         private const string azureMonitorResourceKey = "_OTELRESOURCE_";
 
-        public MetricsData(int version, Metric metric, MetricPoint metricPoint, AzureMonitorResource? azureMonitorResource = null) : base(version)
+        public MetricsData(
+            int version,
+            Metric metric,
+            MetricPoint metricPoint,
+            AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             if (metric == null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -10,12 +10,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class RemoteDependencyData
     {
-        public RemoteDependencyData(int version, Activity activity, ref ActivityTagsProcessor activityTagsProcessor) : base(version)
+        public RemoteDependencyData(
+            int version,
+            Activity activity,
+            ref ActivityTagsProcessor activityTagsProcessor,
+            AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             string? dependencyName = null;
             bool isNewSchemaVersion = false;
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
+            azureMonitorResource?.CopyUserDefinedAttributes(Properties);
 
             if (activityTagsProcessor.activityType.HasFlag(OperationType.V2))
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
@@ -11,11 +11,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class RequestData
     {
-        public RequestData(int version, Activity activity, ref ActivityTagsProcessor activityTagsProcessor) : base(version)
+        public RequestData(int version, Activity activity, ref ActivityTagsProcessor activityTagsProcessor, AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             string? responseCode = null;
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
+
+            azureMonitorResource?.CopyUserDefinedAttributes(Properties);
 
             switch (activityTagsProcessor.activityType)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
@@ -11,7 +11,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class RequestData
     {
-        public RequestData(int version, Activity activity, ref ActivityTagsProcessor activityTagsProcessor, AzureMonitorResource? azureMonitorResource = null) : base(version)
+        public RequestData(
+            int version,
+            Activity activity,
+            ref ActivityTagsProcessor activityTagsProcessor,
+            AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             string? responseCode = null;
             Properties = new ChangeTrackingDictionary<string, string>();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionData.cs
@@ -16,7 +16,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
     {
         internal const int MaxExceptionCountToSave = 10;
 
-        public TelemetryExceptionData(int version, LogRecord logRecord, AzureMonitorResource? azureMonitorResource = null) : base(version)
+        public TelemetryExceptionData(
+            int version,
+            LogRecord logRecord,
+            AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             if (logRecord.Exception == null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionData.cs
@@ -16,7 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
     {
         internal const int MaxExceptionCountToSave = 10;
 
-        public TelemetryExceptionData(int version, LogRecord logRecord) : base(version)
+        public TelemetryExceptionData(int version, LogRecord logRecord, AzureMonitorResource? azureMonitorResource = null) : base(version)
         {
             if (logRecord.Exception == null)
             {
@@ -25,6 +25,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
+
+            azureMonitorResource?.CopyUserDefinedAttributes(Properties);
 
             var message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -21,10 +21,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         {
             foreach (var userDefinedTag in UserDefinedAttributes)
             {
+                // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
                 if (userDefinedTag.Key.Length <= SchemaConstants.MessageData_Properties_MaxKeyLength)
                 {
-                    // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
-
                     var value = userDefinedTag.Value?.ToString();
 
                     if (value is null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
@@ -12,5 +13,28 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal string? RoleInstance { get; set; }
 
         internal MonitorBase? MonitorBaseData { get; set; }
+
+        internal List<KeyValuePair<string, object>> UserDefinedAttributes { get; set; } = new();
+
+        internal void CopyUserDefinedAttributes(
+            IDictionary<string, string> properties)
+        {
+            foreach (var userDefinedTag in UserDefinedAttributes)
+            {
+                if (userDefinedTag.Key.Length <= SchemaConstants.MessageData_Properties_MaxKeyLength)
+                {
+                    // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
+
+                    var value = userDefinedTag.Value?.ToString();
+
+                    if (value is null)
+                    {
+                        continue;
+                    }
+
+                    properties.Add(userDefinedTag.Key, value);
+                }
+            }
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -62,7 +62,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         telemetryItem.Data = new MonitorBase
                         {
                             BaseType = "ExceptionData",
-                            BaseData = new TelemetryExceptionData(Version, logRecord),
+                            BaseData = new TelemetryExceptionData(Version, logRecord, resource),
                         };
                     }
                     else
@@ -70,7 +70,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         telemetryItem.Data = new MonitorBase
                         {
                             BaseType = "MessageData",
-                            BaseData = new MessageData(Version, logRecord),
+                            BaseData = new MessageData(Version, logRecord, resource),
                         };
                     }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
@@ -29,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             Data = new MonitorBase
                             {
                                 BaseType = "MetricData",
-                                BaseData = new MetricsData(Version, metric, metricPoint)
+                                BaseData = new MetricsData(Version, metric, metricPoint, resource)
                             }
                         });
                     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -67,6 +67,7 @@ internal static class ResourceExtensions
                     {
                         SdkVersionUtils.IsDistro = true;
                     }
+
                     break;
                 default:
                     if (attribute.Key.StartsWith("k8s"))
@@ -74,8 +75,11 @@ internal static class ResourceExtensions
                         aksResourceProcessor = aksResourceProcessor ?? new AksResourceProcessor();
                         aksResourceProcessor.MapAttributeToProperty(attribute);
                     }
+
                     break;
             }
+
+            azureMonitorResource.UserDefinedAttributes = resource.Attributes.ToList();
 
             if (metricsData != null && attribute.Key.Length <= SchemaConstants.MetricsData_Properties_MaxKeyLength && attribute.Value != null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -47,7 +47,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     switch (activity.GetTelemetryType())
                     {
                         case TelemetryType.Request:
-                            var requestData = new RequestData(Version, activity, ref activityTagsProcessor);
+                            var requestData = new RequestData(Version, activity, ref activityTagsProcessor, azureMonitorResource);
                             requestData.Name = telemetryItem.Tags.TryGetValue(ContextTagKeys.AiOperationName.ToString(), out var operationName) ? operationName.Truncate(SchemaConstants.RequestData_Name_MaxLength) : activity.DisplayName.Truncate(SchemaConstants.RequestData_Name_MaxLength);
                             telemetryItem.Data = new MonitorBase
                             {
@@ -59,7 +59,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             telemetryItem.Data = new MonitorBase
                             {
                                 BaseType = "RemoteDependencyData",
-                                BaseData = new RemoteDependencyData(Version, activity, ref activityTagsProcessor),
+                                BaseData = new RemoteDependencyData(Version, activity, ref activityTagsProcessor, azureMonitorResource),
                             };
                             break;
                     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
@@ -31,7 +31,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs
                 builder.AddOpenTelemetry(options =>
                 {
                     options.SetResourceBuilder(resourceBuilder);
-;                    options.AddAzureMonitorLogExporter(o => o.ConnectionString = connectionString, credential);
+                    options.AddAzureMonitorLogExporter(o => o.ConnectionString = connectionString, credential);
                 });
             });
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Azure.Core;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Resources;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs
 {
@@ -13,11 +15,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs
 
         public LogDemo(string connectionString, TokenCredential? credential = null)
         {
+            var resourceAttributes = new Dictionary<string, object>
+            {
+                { "service.name", "my-service" },
+                { "service.namespace", "my-namespace" },
+                { "service.instance.id", "my-instance" },
+                { "foo", "bar" },
+                {"service.domain", "domain-here"}
+            };
+
+            var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+
             this.loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder.AddOpenTelemetry(options =>
                 {
-                    options.AddAzureMonitorLogExporter(o => o.ConnectionString = connectionString, credential);
+                    options.SetResourceBuilder(resourceBuilder);
+;                    options.AddAzureMonitorLogExporter(o => o.ConnectionString = connectionString, credential);
                 });
             });
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.Metrics;
 using Azure.Core;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics
 {
@@ -20,8 +21,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics
 
         public MetricDemo(string connectionString, TokenCredential? credential = null)
         {
+            var resourceAttributes = new Dictionary<string, object>
+            {
+                { "service.name", "my-service" },
+                { "service.namespace", "my-namespace" },
+                { "service.instance.id", "my-instance" },
+                { "foo", "bar" },
+                {"service.domain", "domain-here"}
+            };
+
+            var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+
             this.meterProvider = Sdk.CreateMeterProviderBuilder()
                                 .AddMeter(meterName)
+                                .SetResourceBuilder(resourceBuilder)
                                 .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString, credential)
                                 .Build();
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs;
 using Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics;
 using Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces;
@@ -11,7 +10,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo
 {
     public class Program
     {
-        private const string ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+        private static string ConnectionString = Environment.GetEnvironmentVariable("AI_CONNECTION_STRING") ?? "InstrumentationKey=00000000-0000-0000-0000-000000000000";
 
         public static void Main()
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -25,7 +25,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
                 { "service.name", "my-service" },
                 { "service.namespace", "my-namespace" },
                 { "service.instance.id", "my-instance" },
-                { "foo", "bar" }
+                { "foo", "bar" },
+                {"service.domain", "domain-here"}
             };
 
             var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorResourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorResourceTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using OpenTelemetry.Resources;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests;
+
+public class AzureMonitorResourceTests
+{
+    [Fact]
+    public void CopyUserDefinedAttributes()
+    {
+        var resource = ResourceBuilder.CreateDefault()
+            .AddAttributes(
+                new[]
+                {
+                    new KeyValuePair<string, object>(
+                        "key1",
+                        "value1"),
+                    new KeyValuePair<string, object>(
+                        "key2",
+                        "value2"),
+                })
+            .AddService("my-service").Build();
+
+        var properties = new Dictionary<string, string>();
+
+        var azureMonitorResource = resource.CreateAzureMonitorResource()!;
+        azureMonitorResource.CopyUserDefinedAttributes(properties);
+
+        Assert.Equal(
+            "my-service",
+            properties["service.name"]);
+
+        Assert.Equal(
+            "value1",
+            properties["key1"]);
+
+        Assert.Equal(
+            "value2",
+            properties["key2"]);
+    }
+
+    [Fact]
+    public void CopyUserDefinedAttributesWithDuplicateKeysExceedingMaxLengthSkipped()
+    {
+        const string longKey =
+            "key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1";
+
+        var resource = ResourceBuilder.CreateDefault()
+            .AddAttributes(
+                new[]
+                {
+                    new KeyValuePair<string, object>(
+                        longKey,
+                        "value1"),
+                    new KeyValuePair<string, object>(
+                        "key2",
+                        "value2")
+                })
+            .AddService("my-service").Build();
+
+        var properties = new Dictionary<string, string>();
+
+        var azureMonitorResource = resource.CreateAzureMonitorResource()!;
+        azureMonitorResource.CopyUserDefinedAttributes(properties);
+
+        Assert.False(properties.ContainsKey(longKey));
+
+        Assert.Equal(
+            "my-service",
+            properties["service.name"]);
+
+        Assert.Equal(
+            "value2",
+            properties["key2"]);
+    }
+
+    [Fact]
+    public void CopyToUserDefinedAttributesWithDuplicateKeysFirstOneWins()
+    {
+        var resource = ResourceBuilder.CreateDefault()
+            .AddAttributes(
+                new[]
+                {
+                    new KeyValuePair<string, object>(
+                        "key1",
+                        "value1"),
+                    new KeyValuePair<string, object>(
+                        "key1",
+                        "value2"),
+                    new KeyValuePair<string, object>(
+                        "key2",
+                        "value3"),
+                })
+            .AddService("my-service").Build();
+
+        var properties = new Dictionary<string, string>();
+
+        var azureMonitorResource = resource.CreateAzureMonitorResource()!;
+        azureMonitorResource.CopyUserDefinedAttributes(properties);
+
+        Assert.Equal(
+            "my-service",
+            properties["service.name"]);
+
+        Assert.Equal(
+            "value1",
+            properties["key1"]);
+
+        Assert.Equal(
+            "value3",
+            properties["key2"]);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -22,6 +22,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
     /// </summary>
     public class TracesTests
     {
+        private static readonly Dictionary<string, string> s_defaultProperties = new()
+        {
+            {
+                "telemetry.sdk.name", "opentelemetry"
+            },
+            {
+                "telemetry.sdk.version", "1.7.0"
+            },
+            {
+                "service.name", "unknown_service:dotnet"
+            },
+        };
+
         internal readonly TelemetryItemOutputHelper telemetryOutput;
 
         public TracesTests(ITestOutputHelper output)
@@ -180,7 +193,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
                 expectedAuthUserId: "TestUser",
-                expectedProperties: null,
+                expectedProperties: new Dictionary<string, string>
+                {
+                    {"telemetry.sdk.name", "opentelemetry"},
+                    {"telemetry.sdk.version", "1.7.0"},
+                    {"service.name", "unknown_service:dotnet"},
+                },
                 expectedSuccess: false);
 
             var exceptionTelemetryItem = telemetryItems.First(x => x.Name == "Exception");
@@ -271,7 +289,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
                 expectedAuthUserId: "TestUser",
-                expectedProperties: null);
+                expectedProperties: s_defaultProperties);
 
             Assert.True(logTelemetryItems?.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(logTelemetryItems!);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MessageDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MessageDataTests.cs
@@ -44,5 +44,64 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Empty(messageData.Properties);
             Assert.Empty(messageData.Measurements);
         }
+
+        [Fact]
+        public void ValidatePropertiesFromAzureMonitorResource()
+        {
+            var logRecords = new List<LogRecord>();
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecords);
+                });
+                builder.AddFilter(typeof(LogsHelperTests).FullName, LogLevel.Trace);
+            });
+
+            var logger = loggerFactory.CreateLogger<MessageDataTests>();
+
+            logger.LogInformation("Log Message");
+
+            var azureMonitorResource = new AzureMonitorResource();
+            azureMonitorResource.UserDefinedAttributes.Add(
+                new KeyValuePair<string, object>("key1", "value1"));
+            azureMonitorResource.UserDefinedAttributes.Add(
+                new KeyValuePair<string, object>("key2", "value2"));
+
+            var messageData = new MessageData(2, logRecords[0], azureMonitorResource);
+            Assert.Equal(2, messageData.Properties.Count);
+            Assert.Equal("value1", messageData.Properties["key1"]);
+            Assert.Equal("value2", messageData.Properties["key2"]);
+        }
+
+        [Fact]
+        public void ValidatePropertiesFromAzureMonitorResourceWithParameterInLog()
+        {
+            var logRecords = new List<LogRecord>();
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecords);
+                });
+                builder.AddFilter(typeof(LogsHelperTests).FullName, LogLevel.Trace);
+            });
+
+            var logger = loggerFactory.CreateLogger<MessageDataTests>();
+
+            logger.LogInformation("Log Message {Key3}", "value3");
+
+            var azureMonitorResource = new AzureMonitorResource();
+            azureMonitorResource.UserDefinedAttributes.Add(
+                new KeyValuePair<string, object>("key1", "value1"));
+            azureMonitorResource.UserDefinedAttributes.Add(
+                new KeyValuePair<string, object>("key2", "value2"));
+
+            var messageData = new MessageData(2, logRecords[0], azureMonitorResource);
+            Assert.Equal(3, messageData.Properties.Count);
+            Assert.Equal("value1", messageData.Properties["key1"]);
+            Assert.Equal("value2", messageData.Properties["key2"]);
+            Assert.Equal("value3", messageData.Properties["Key3"]);
+        }
     }
 }


### PR DESCRIPTION
Closes #40951 #40630 #35487

This is my first PR to this area, I have read the guide but anything I need to add please let me know :)

One question I do have, is that the idea of OTEL and the resource attributes are sent once per batch of signals, I know this PR sends it per telemetry item, is there another option or is this not supported by the azure monitor SDK?