### PR TITLE
[.NET] Communication Common | Microsoft Teams App Identifier feature GA release updates

### DIFF
--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0 (2023-02-13)
+## 1.3.0 (2024-02-13)
 
 ### Features Added
 - Added support for a new communication identifier `MicrosoftTeamsAppIdentifier`.

--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -1,22 +1,10 @@
 # Release History
 
-## 1.3.0 (Unreleased)
+## 1.3.0 (2023-02-13)
 
 ### Features Added
 - Added support for a new communication identifier `MicrosoftTeamsAppIdentifier`.
 - Introduction of `MicrosoftTeamsAppIdentifier` is a breaking change. It will impact any code that previously depended on the use of UnknownIdentifier with rawIDs starting with `28:orgid:`, `28:dod:`, or `28:gcch:`.
-
-### Bugs Fixed
-
-### Other Changes
-
-## 2.0.0-beta.1 (2023-03-29)
-
-### Features Added
-- Added support for a new communication identifier `MicrosoftBotIdentifier`.
-- 
-### Breaking Changes
-- Introduction of `MicrosoftBotIdentifier` is a breaking change. It will affect code that relied on using `UnknownIdentifier` with a rawID starting with `28:`.
 
 ## 1.2.1 (2022-11-01)
 

--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -6,6 +6,14 @@
 - Added support for a new communication identifier `MicrosoftTeamsAppIdentifier`.
 - Introduction of `MicrosoftTeamsAppIdentifier` is a breaking change. It will impact any code that previously depended on the use of UnknownIdentifier with rawIDs starting with `28:orgid:`, `28:dod:`, or `28:gcch:`.
 
+## 2.0.0-beta.1 (2023-03-29)
+
+### Features Added
+- Added support for a new communication identifier `MicrosoftBotIdentifier`.
+
+### Breaking Changes
+- Introduction of `MicrosoftBotIdentifier` is a breaking change. It will affect code that relied on using `UnknownIdentifier` with a rawID starting with `28:`.
+
 ## 1.2.1 (2022-11-01)
 
 ### Bugs Fixed


### PR DESCRIPTION
# Contributing to the Azure SDK

Microsoft Teams App Identifier GA release of the Azure.Communication.Common SDK - 1.3.0

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
