### PR TITLE
[Event Hubs] Fix backwards compatibility with new vs old SDK checkpointing

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
@@ -106,7 +106,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           int replicationSegment,
+                                           string replicationSegment,
                                            string offset,
                                            Exception exception) =>
             Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, exception.Message, sequenceNumber, replicationSegment, offset);
@@ -130,7 +130,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                               string consumerGroup,
                                               string clientIdentifier,
                                               string sequenceNumber,
-                                              int replicationSegment,
+                                              string replicationSegment,
                                               string offset) =>
             Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
@@ -153,7 +153,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           int replicationSegment,
+                                           string replicationSegment,
                                            string offset) =>
             Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
@@ -95,9 +95,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with the checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with the checkpoint.</param>
+        /// <param name="offset">The offset associated with the checkpoint.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
         partial void UpdateCheckpointError(string partitionId,
@@ -105,9 +105,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long? sequenceNumber,
+                                           string sequenceNumber,
                                            int replicationSegment,
-                                           long? offset,
+                                           string offset,
                                            Exception exception) =>
             Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, exception.Message, sequenceNumber, replicationSegment, offset);
 
@@ -120,18 +120,18 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         partial void UpdateCheckpointComplete(string partitionId,
                                               string fullyQualifiedNamespace,
                                               string eventHubName,
                                               string consumerGroup,
                                               string clientIdentifier,
-                                              long? sequenceNumber,
+                                              string sequenceNumber,
                                               int replicationSegment,
-                                              long? offset) =>
+                                              string offset) =>
             Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
         /// <summary>
@@ -143,18 +143,18 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         partial void UpdateCheckpointStart(string partitionId,
                                            string fullyQualifiedNamespace,
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long? sequenceNumber,
+                                           string sequenceNumber,
                                            int replicationSegment,
-                                           long? offset) =>
+                                           string offset) =>
             Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
@@ -95,9 +95,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with the checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with the checkpoint.</param>
-        /// <param name="offset">The offset associated with the checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
         partial void UpdateCheckpointError(string partitionId,
@@ -120,9 +120,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         partial void UpdateCheckpointComplete(string partitionId,
                                               string fullyQualifiedNamespace,
@@ -143,9 +143,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         partial void UpdateCheckpointStart(string partitionId,
                                            string fullyQualifiedNamespace,

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
@@ -105,9 +105,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long sequenceNumber,
+                                           long? sequenceNumber,
                                            int replicationSegment,
-                                           long offset,
+                                           long? offset,
                                            Exception exception) =>
             Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, exception.Message, sequenceNumber, replicationSegment, offset);
 
@@ -129,9 +129,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                               string eventHubName,
                                               string consumerGroup,
                                               string clientIdentifier,
-                                              long sequenceNumber,
+                                              long? sequenceNumber,
                                               int replicationSegment,
-                                              long offset) =>
+                                              long? offset) =>
             Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
         /// <summary>
@@ -152,9 +152,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long sequenceNumber,
+                                           long? sequenceNumber,
                                            int replicationSegment,
-                                           long offset) =>
+                                           long? offset) =>
             Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -677,16 +677,15 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void WriteEvent<TValue1>(int eventId,
-                                                string arg1,
-                                                string arg2,
-                                                string arg3,
-                                                string arg4,
-                                                string arg5,
-                                                string arg6,
-                                                string arg7,
-                                                string arg8)
-            where TValue1 : struct
+        private unsafe void WriteEvent(int eventId,
+                                       string arg1,
+                                       string arg2,
+                                       string arg3,
+                                       string arg4,
+                                       string arg5,
+                                       string arg6,
+                                       string arg7,
+                                       string arg8)
         {
             fixed (char* arg1Ptr = arg1)
             fixed (char* arg2Ptr = arg2)
@@ -745,17 +744,16 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void WriteEvent<TValue1>(int eventId,
-                                                string arg1,
-                                                string arg2,
-                                                string arg3,
-                                                string arg4,
-                                                string arg5,
-                                                string arg6,
-                                                string arg7,
-                                                string arg8,
-                                                string arg9)
-            where TValue1 : struct
+        private unsafe void WriteEvent(int eventId,
+                                       string arg1,
+                                       string arg2,
+                                       string arg3,
+                                       string arg4,
+                                       string arg5,
+                                       string arg6,
+                                       string arg7,
+                                       string arg8,
+                                       string arg9)
         {
             fixed (char* arg1Ptr = arg1)
             fixed (char* arg2Ptr = arg2)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -251,9 +251,9 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         [Event(32, Level = EventLevel.Verbose, Message = "Starting to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{4}'; at SequenceNumber: '{5}' ReplicationSegment: '{6}' Offset: '{7}'.")]
         public virtual void UpdateCheckpointStart(string partitionId,
@@ -280,9 +280,9 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         [Event(33, Level = EventLevel.Verbose, Message = "Completed the attempt to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{4}'; at SequenceNumber: '{5}' ReplicationSegment: '{6}' Offset: '{7}'.")]
         public virtual void UpdateCheckpointComplete(string partitionId,
@@ -310,9 +310,9 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the processor that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
-        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="errorMessage">The message for the exception that occurred. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         [Event(34, Level = EventLevel.Error, Message = "An exception occurred when creating/updating a checkpoint for  partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{5}'; at SequenceNumber: '{6}' ReplicationSegment '{7}' Offset '{8}'.  ErrorMessage: '{4}'.")]
         public virtual void UpdateCheckpointError(string partitionId,

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -262,12 +262,12 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                   string consumerGroup,
                                                   string clientIdentifier,
                                                   string sequenceNumber,
-                                                  int replicationSegment,
+                                                  string replicationSegment,
                                                   string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment, offset ?? string.Empty);
+                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment ?? string.Empty, offset ?? string.Empty);
             }
         }
 
@@ -291,12 +291,12 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                      string consumerGroup,
                                                      string clientIdentifier,
                                                      string sequenceNumber,
-                                                     int replicationSegment,
+                                                     string replicationSegment,
                                                      string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment, offset ?? string.Empty);
+                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment ?? string.Empty, offset ?? string.Empty);
             }
         }
 
@@ -322,12 +322,12 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                   string clientIdentifier,
                                                   string errorMessage,
                                                   string sequenceNumber,
-                                                  int replicationSegment,
+                                                  string replicationSegment,
                                                   string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment, offset ?? string.Empty);
+                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment ?? string.Empty, offset ?? string.Empty);
             }
         }
 
@@ -684,7 +684,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                 string arg4,
                                                 string arg5,
                                                 string arg6,
-                                                TValue1 arg7,
+                                                string arg7,
                                                 string arg8)
             where TValue1 : struct
         {
@@ -694,6 +694,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
             fixed (char* arg4Ptr = arg4)
             fixed (char* arg5Ptr = arg5)
             fixed (char* arg6Ptr = arg6)
+            fixed (char* arg7Ptr = arg7)
             fixed (char* arg8Ptr = arg8)
             {
                 var eventPayload = stackalloc EventData[8];
@@ -714,10 +715,10 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                 eventPayload[4].DataPointer = (IntPtr)arg5Ptr;
 
                 eventPayload[5].Size = (arg6.Length + 1) * sizeof(char);
-                eventPayload[5].DataPointer = (IntPtr)arg5Ptr;
+                eventPayload[5].DataPointer = (IntPtr)arg6Ptr;
 
-                eventPayload[6].Size = Unsafe.SizeOf<TValue1>();
-                eventPayload[6].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg7);
+                eventPayload[6].Size = (arg7.Length + 1) * sizeof(char);
+                eventPayload[6].DataPointer = (IntPtr)arg7Ptr;
 
                 eventPayload[7].Size = (arg8.Length + 1) * sizeof(char);
                 eventPayload[7].DataPointer = (IntPtr)arg8Ptr;
@@ -752,7 +753,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                 string arg5,
                                                 string arg6,
                                                 string arg7,
-                                                TValue1 arg8,
+                                                string arg8,
                                                 string arg9)
             where TValue1 : struct
         {
@@ -763,6 +764,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
             fixed (char* arg5Ptr = arg5)
             fixed (char* arg6Ptr = arg6)
             fixed (char* arg7Ptr = arg7)
+            fixed (char* arg8Ptr = arg8)
             fixed (char* arg9Ptr = arg9)
             {
                 var eventPayload = stackalloc EventData[9];
@@ -788,8 +790,8 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                 eventPayload[6].Size = (arg7.Length + 1) * sizeof(char);
                 eventPayload[6].DataPointer = (IntPtr)arg7Ptr;
 
-                eventPayload[7].Size = Unsafe.SizeOf<TValue1>();
-                eventPayload[7].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg8);
+                eventPayload[7].Size = (arg8.Length + 1) * sizeof(char);
+                eventPayload[7].DataPointer = (IntPtr)arg8Ptr;
 
                 eventPayload[8].Size = (arg9.Length + 1) * sizeof(char);
                 eventPayload[8].DataPointer = (IntPtr)arg9Ptr;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -261,13 +261,13 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                   string eventHubName,
                                                   string consumerGroup,
                                                   string clientIdentifier,
-                                                  long sequenceNumber,
+                                                  long? sequenceNumber,
                                                   int replicationSegment,
-                                                  long offset)
+                                                  long? offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber, replicationSegment, offset);
+                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? -1, replicationSegment, offset ?? -1);
             }
         }
 
@@ -290,13 +290,13 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                      string eventHubName,
                                                      string consumerGroup,
                                                      string clientIdentifier,
-                                                     long sequenceNumber,
+                                                     long? sequenceNumber,
                                                      int replicationSegment,
-                                                     long offset)
+                                                     long? offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber, replicationSegment, offset);
+                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? -1, replicationSegment, offset ?? -1);
             }
         }
 
@@ -321,13 +321,13 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                   string consumerGroup,
                                                   string clientIdentifier,
                                                   string errorMessage,
-                                                  long sequenceNumber,
+                                                  long? sequenceNumber,
                                                   int replicationSegment,
-                                                  long offset)
+                                                  long? offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber, replicationSegment, offset);
+                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? -1, replicationSegment, offset ?? -1);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -251,9 +251,9 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         [Event(32, Level = EventLevel.Verbose, Message = "Starting to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{4}'; at SequenceNumber: '{5}' ReplicationSegment: '{6}' Offset: '{7}'.")]
         public virtual void UpdateCheckpointStart(string partitionId,
@@ -261,13 +261,13 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                   string eventHubName,
                                                   string consumerGroup,
                                                   string clientIdentifier,
-                                                  long? sequenceNumber,
+                                                  string sequenceNumber,
                                                   int replicationSegment,
-                                                  long? offset)
+                                                  string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? -1, replicationSegment, offset ?? -1);
+                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment, offset ?? string.Empty);
             }
         }
 
@@ -280,9 +280,9 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         [Event(33, Level = EventLevel.Verbose, Message = "Completed the attempt to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{4}'; at SequenceNumber: '{5}' ReplicationSegment: '{6}' Offset: '{7}'.")]
         public virtual void UpdateCheckpointComplete(string partitionId,
@@ -290,13 +290,13 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                      string eventHubName,
                                                      string consumerGroup,
                                                      string clientIdentifier,
-                                                     long? sequenceNumber,
+                                                     string sequenceNumber,
                                                      int replicationSegment,
-                                                     long? offset)
+                                                     string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? -1, replicationSegment, offset ?? -1);
+                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment, offset ?? string.Empty);
             }
         }
 
@@ -310,9 +310,9 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the processor that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="errorMessage">The message for the exception that occurred. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(34, Level = EventLevel.Error, Message = "An exception occurred when creating/updating a checkpoint for  partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{5}'; at SequenceNumber: '{6}' ReplicationSegment '{7}' Offset '{8}'.  ErrorMessage: '{4}'.")]
         public virtual void UpdateCheckpointError(string partitionId,
@@ -321,13 +321,13 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                   string consumerGroup,
                                                   string clientIdentifier,
                                                   string errorMessage,
-                                                  long? sequenceNumber,
+                                                  string sequenceNumber,
                                                   int replicationSegment,
-                                                  long? offset)
+                                                  string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? -1, replicationSegment, offset ?? -1);
+                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment, offset ?? string.Empty);
             }
         }
 
@@ -677,24 +677,24 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void WriteEvent<TValue1, TValue2, TValue3>(int eventId,
-                                                                  string arg1,
-                                                                  string arg2,
-                                                                  string arg3,
-                                                                  string arg4,
-                                                                  string arg5,
-                                                                  TValue1 arg6,
-                                                                  TValue2 arg7,
-                                                                  TValue3 arg8)
+        private unsafe void WriteEvent<TValue1>(int eventId,
+                                                string arg1,
+                                                string arg2,
+                                                string arg3,
+                                                string arg4,
+                                                string arg5,
+                                                string arg6,
+                                                TValue1 arg7,
+                                                string arg8)
             where TValue1 : struct
-            where TValue2 : struct
-            where TValue3 : struct
         {
             fixed (char* arg1Ptr = arg1)
             fixed (char* arg2Ptr = arg2)
             fixed (char* arg3Ptr = arg3)
             fixed (char* arg4Ptr = arg4)
             fixed (char* arg5Ptr = arg5)
+            fixed (char* arg6Ptr = arg6)
+            fixed (char* arg8Ptr = arg8)
             {
                 var eventPayload = stackalloc EventData[8];
 
@@ -713,14 +713,14 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                 eventPayload[4].Size = (arg5.Length + 1) * sizeof(char);
                 eventPayload[4].DataPointer = (IntPtr)arg5Ptr;
 
+                eventPayload[5].Size = (arg6.Length + 1) * sizeof(char);
+                eventPayload[5].DataPointer = (IntPtr)arg5Ptr;
+
                 eventPayload[6].Size = Unsafe.SizeOf<TValue1>();
-                eventPayload[6].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg6);
+                eventPayload[6].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg7);
 
-                eventPayload[7].Size = Unsafe.SizeOf<TValue2>();
-                eventPayload[7].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg7);
-
-                eventPayload[8].Size = Unsafe.SizeOf<TValue3>();
-                eventPayload[8].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg8);
+                eventPayload[7].Size = (arg8.Length + 1) * sizeof(char);
+                eventPayload[7].DataPointer = (IntPtr)arg8Ptr;
 
                 WriteEventCore(eventId, 8, eventPayload);
             }
@@ -744,19 +744,17 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void WriteEvent<TValue1, TValue2, TValue3>(int eventId,
-                                                                  string arg1,
-                                                                  string arg2,
-                                                                  string arg3,
-                                                                  string arg4,
-                                                                  string arg5,
-                                                                  string arg6,
-                                                                  TValue1 arg7,
-                                                                  TValue2 arg8,
-                                                                  TValue3 arg9)
+        private unsafe void WriteEvent<TValue1>(int eventId,
+                                                string arg1,
+                                                string arg2,
+                                                string arg3,
+                                                string arg4,
+                                                string arg5,
+                                                string arg6,
+                                                string arg7,
+                                                TValue1 arg8,
+                                                string arg9)
             where TValue1 : struct
-            where TValue2 : struct
-            where TValue3 : struct
         {
             fixed (char* arg1Ptr = arg1)
             fixed (char* arg2Ptr = arg2)
@@ -764,6 +762,8 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
             fixed (char* arg4Ptr = arg4)
             fixed (char* arg5Ptr = arg5)
             fixed (char* arg6Ptr = arg6)
+            fixed (char* arg7Ptr = arg7)
+            fixed (char* arg9Ptr = arg9)
             {
                 var eventPayload = stackalloc EventData[9];
 
@@ -785,14 +785,14 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                 eventPayload[5].Size = (arg6.Length + 1) * sizeof(char);
                 eventPayload[5].DataPointer = (IntPtr)arg6Ptr;
 
-                eventPayload[6].Size = Unsafe.SizeOf<TValue1>();
-                eventPayload[6].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg7);
+                eventPayload[6].Size = (arg7.Length + 1) * sizeof(char);
+                eventPayload[6].DataPointer = (IntPtr)arg7Ptr;
 
-                eventPayload[7].Size = Unsafe.SizeOf<TValue2>();
+                eventPayload[7].Size = Unsafe.SizeOf<TValue1>();
                 eventPayload[7].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg8);
 
-                eventPayload[8].Size = Unsafe.SizeOf<TValue3>();
-                eventPayload[8].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg9);
+                eventPayload[8].Size = (arg9.Length + 1) * sizeof(char);
+                eventPayload[8].DataPointer = (IntPtr)arg9Ptr;
 
                 WriteEventCore(eventId, 9, eventPayload);
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
@@ -269,8 +269,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 0;
             await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), -1, string.Empty));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), -1, string.Empty));
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), "-1", string.Empty));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), "-1", string.Empty));
         }
 
         /// <summary>
@@ -299,8 +299,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedSequenceNumber = 0;
 
             await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), -1, string.Empty));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), -1, string.Empty));
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), "-1", string.Empty));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), "-1", string.Empty));
         }
 
         /// <summary>
@@ -325,7 +325,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 456;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), -1, string.Empty));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), "-1", string.Empty));
         }
 
         /// <summary>
@@ -349,7 +349,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 6;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), -1, string.Empty));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), "-1", string.Empty));
         }
 
         /// <summary>
@@ -368,7 +368,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 999;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber.ToString(), -1, string.Empty));
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber.ToString(), "-1", string.Empty));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
@@ -269,8 +269,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 0;
             await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, long.MinValue));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, long.MinValue));
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, -1));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, -1));
         }
 
         /// <summary>
@@ -299,8 +299,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedSequenceNumber = 0;
 
             await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, long.MinValue));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, long.MinValue));
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, -1));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, -1));
         }
 
         /// <summary>
@@ -325,7 +325,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 456;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, long.MinValue));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, -1));
         }
 
         /// <summary>
@@ -349,7 +349,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 6;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, long.MinValue));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, -1));
         }
 
         /// <summary>
@@ -368,7 +368,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 999;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber, -1, long.MinValue));
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber, -1, -1));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
@@ -269,8 +269,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 0;
             await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, null));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, null));
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), -1, string.Empty));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), -1, string.Empty));
         }
 
         /// <summary>
@@ -299,8 +299,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedSequenceNumber = 0;
 
             await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, null));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, null));
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), -1, string.Empty));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), -1, string.Empty));
         }
 
         /// <summary>
@@ -325,7 +325,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 456;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, null));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), -1, string.Empty));
         }
 
         /// <summary>
@@ -349,7 +349,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 6;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, null));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), -1, string.Empty));
         }
 
         /// <summary>
@@ -368,7 +368,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 999;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber, -1, null));
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber.ToString(), -1, string.Empty));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
@@ -269,8 +269,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 0;
             await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, -1));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, -1));
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, null));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, null));
         }
 
         /// <summary>
@@ -299,8 +299,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedSequenceNumber = 0;
 
             await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, -1));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, -1));
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, null));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber, -1, null));
         }
 
         /// <summary>
@@ -325,7 +325,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 456;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, -1));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, null));
         }
 
         /// <summary>
@@ -349,7 +349,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 6;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, -1));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber, -1, null));
         }
 
         /// <summary>
@@ -368,7 +368,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedSequenceNumber = 999;
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber, -1, -1));
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber, -1, null));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -400,7 +400,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         private async Task UpdateCheckpointInternalAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, string clientIdentifier, long? offset, long? sequenceNumber, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-            UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber.ToString(), -1, offset.ToString());
+            UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber.ToString(), "-1", offset.ToString());
 
             var blobName = string.Format(CultureInfo.InvariantCulture, CheckpointPrefix + partitionId, fullyQualifiedNamespace.ToLowerInvariant(), eventHubName.ToLowerInvariant(), consumerGroup.ToLowerInvariant());
             var blobClient = ContainerClient.GetBlobClient(blobName);
@@ -430,17 +430,17 @@ namespace Azure.Messaging.EventHubs.Primitives
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ContainerNotFound)
             {
-                UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber.ToString(), -1, offset.ToString(), ex);
+                UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber.ToString(), "-1", offset.ToString(), ex);
                 throw new RequestFailedException(BlobsResourceDoesNotExist, ex);
             }
             catch (Exception ex)
             {
-                UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber.ToString(), -1, offset.ToString(), ex);
+                UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber.ToString(), "-1", offset.ToString(), ex);
                 throw;
             }
             finally
             {
-                UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber.ToString(), -1, offset.ToString());
+                UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber.ToString(), "-1", offset.ToString());
             }
         }
 
@@ -788,7 +788,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           int replicationSegment,
+                                           string replicationSegment,
                                            string offset,
                                            Exception exception);
 
@@ -811,7 +811,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                               string consumerGroup,
                                               string clientIdentifier,
                                               string sequenceNumber,
-                                              int replicationSegment,
+                                              string replicationSegment,
                                               string offset);
 
         /// <summary>
@@ -833,7 +833,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           int replicationSegment,
+                                           string replicationSegment,
                                            string offset);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -373,7 +373,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                          long offset,
                                                          long? sequenceNumber,
                                                          CancellationToken cancellationToken)
-            => await UpdateCheckpointInternalAsync(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, string.Empty, offset, sequenceNumber ?? long.MinValue, cancellationToken).ConfigureAwait(false);
+            => await UpdateCheckpointInternalAsync(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, string.Empty, offset, null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         ///   Creates or updates a checkpoint for a specific partition, identifying a position in the partition's event stream
@@ -395,9 +395,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                          string clientIdentifier,
                                                          CheckpointPosition startingPosition,
                                                          CancellationToken cancellationToken)
-            => await UpdateCheckpointInternalAsync(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, clientIdentifier, long.MinValue, startingPosition.SequenceNumber, cancellationToken).ConfigureAwait(false);
+            => await UpdateCheckpointInternalAsync(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, clientIdentifier, null, startingPosition.SequenceNumber, cancellationToken).ConfigureAwait(false);
 
-        private async Task UpdateCheckpointInternalAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, string clientIdentifier, long offset, long sequenceNumber, CancellationToken cancellationToken)
+        private async Task UpdateCheckpointInternalAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, string clientIdentifier, long? offset, long? sequenceNumber, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, -1, offset);
@@ -407,8 +407,8 @@ namespace Azure.Messaging.EventHubs.Primitives
 
             var metadata = new Dictionary<string, string>()
             {
-                { BlobMetadataKey.Offset, (offset).ToString(CultureInfo.InvariantCulture) },
-                { BlobMetadataKey.SequenceNumber, (sequenceNumber).ToString(CultureInfo.InvariantCulture) },
+                { BlobMetadataKey.Offset, offset.HasValue ? offset.Value.ToString(CultureInfo.InvariantCulture) : "" },
+                { BlobMetadataKey.SequenceNumber, sequenceNumber.HasValue ? sequenceNumber.Value.ToString(CultureInfo.InvariantCulture) : "" },
                 { BlobMetadataKey.ClientIdentifier, clientIdentifier }
             };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -787,9 +787,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long sequenceNumber,
+                                           long? sequenceNumber,
                                            int replicationSegment,
-                                           long offset,
+                                           long? offset,
                                            Exception exception);
 
         /// <summary>
@@ -810,9 +810,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                               string eventHubName,
                                               string consumerGroup,
                                               string clientIdentifier,
-                                              long sequenceNumber,
+                                              long? sequenceNumber,
                                               int replicationSegment,
-                                              long offset);
+                                              long? offset);
 
         /// <summary>
         ///   Indicates that an attempt to create/update a checkpoint has started.
@@ -832,9 +832,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long sequenceNumber,
+                                           long? sequenceNumber,
                                            int replicationSegment,
-                                           long offset);
+                                           long? offset);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve claim partition ownership has completed.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -777,9 +777,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored the checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with the checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with the checkpoint.</param>
-        /// <param name="offset">The offset associated with the checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         /// <param name="exception">The message for the exception that occurred.</param>
         ///
         partial void UpdateCheckpointError(string partitionId,
@@ -801,9 +801,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored the checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with the checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with the checkpoint.</param>
-        /// <param name="offset">The offset associated with the checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         partial void UpdateCheckpointComplete(string partitionId,
                                               string fullyQualifiedNamespace,
@@ -823,9 +823,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with the checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with the checkpoint.</param>
-        /// <param name="offset">The offset associated with the checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with the checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         partial void UpdateCheckpointStart(string partitionId,
                                            string fullyQualifiedNamespace,

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalTests.cs
@@ -601,14 +601,14 @@ namespace Azure.Messaging.EventHubs.Tests
             if (useCheckpointPositionOverload)
             {
                 await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, checkpoint.ClientIdentifier, new CheckpointPosition(sequenceNumber), CancellationToken.None);
-                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty));
-                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty));
+                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), "-1", string.Empty));
+                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), "-1", string.Empty));
             }
             else
             {
                 await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, 123, null, CancellationToken.None);
-                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, string.Empty, -1, "123"));
-                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, string.Empty, -1, "123"));
+                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, string.Empty, "-1", "123"));
+                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, string.Empty, "-1", "123"));
             }
         }
 
@@ -654,14 +654,14 @@ namespace Azure.Messaging.EventHubs.Tests
             if (useCheckpointPositionOverload)
             {
                 await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, checkpoint.ClientIdentifier, new CheckpointPosition(sequenceNumber), CancellationToken.None);
-                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty));
-                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty));
+                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), "-1", string.Empty));
+                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), "-1", string.Empty));
             }
             else
             {
                 await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, offset, sequenceNumber, CancellationToken.None);
-                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), -1, offset.ToString()));
-                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), -1, offset.ToString()));
+                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), "-1", offset.ToString()));
+                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), "-1", offset.ToString()));
             }
         }
 
@@ -703,12 +703,12 @@ namespace Azure.Messaging.EventHubs.Tests
             if (useCheckpointPositionOverload)
             {
                 Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, checkpoint.ClientIdentifier, new CheckpointPosition(sequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty, expectedException.Message));
+                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), "-1", string.Empty, expectedException.Message));
             }
             else
             {
                 Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, offset, sequenceNumber, CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), -1, offset.ToString(), expectedException.Message));
+                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), "-1", offset.ToString(), expectedException.Message));
             }
         }
 
@@ -745,12 +745,12 @@ namespace Azure.Messaging.EventHubs.Tests
             if (useCheckpointPositionOverload)
             {
                 Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, checkpoint.ClientIdentifier, new CheckpointPosition(0), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, "0", -1, string.Empty, expectedException.Message));
+                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, "0", "-1", string.Empty, expectedException.Message));
             }
             else
             {
                 Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, 0, 0, CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, "0", -1, "0", expectedException.Message));
+                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, "0", "-1", "0", expectedException.Message));
             }
         }
 
@@ -769,7 +769,7 @@ namespace Azure.Messaging.EventHubs.Tests
             target.Logger = mockLog.Object;
 
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(0), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, "0", -1, string.Empty, ex.Message));
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, "0", "-1", string.Empty, ex.Message));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalTests.cs
@@ -601,14 +601,14 @@ namespace Azure.Messaging.EventHubs.Tests
             if (useCheckpointPositionOverload)
             {
                 await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, checkpoint.ClientIdentifier, new CheckpointPosition(sequenceNumber), CancellationToken.None);
-                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber, -1, long.MinValue));
-                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber, -1, long.MinValue));
+                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty));
+                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty));
             }
             else
             {
                 await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, 123, null, CancellationToken.None);
-                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, long.MinValue, -1, 123));
-                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, long.MinValue, -1, 123));
+                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, string.Empty, -1, "123"));
+                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, string.Empty, -1, "123"));
             }
         }
 
@@ -654,14 +654,14 @@ namespace Azure.Messaging.EventHubs.Tests
             if (useCheckpointPositionOverload)
             {
                 await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, checkpoint.ClientIdentifier, new CheckpointPosition(sequenceNumber), CancellationToken.None);
-                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber, -1, long.MinValue));
-                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber, -1, long.MinValue));
+                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty));
+                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty));
             }
             else
             {
                 await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, offset, sequenceNumber, CancellationToken.None);
-                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber, -1, offset));
-                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber, -1, offset));
+                mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), -1, offset.ToString()));
+                mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), -1, offset.ToString()));
             }
         }
 
@@ -703,12 +703,12 @@ namespace Azure.Messaging.EventHubs.Tests
             if (useCheckpointPositionOverload)
             {
                 Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, checkpoint.ClientIdentifier, new CheckpointPosition(sequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber, -1, long.MinValue, expectedException.Message));
+                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, sequenceNumber.ToString(), -1, string.Empty, expectedException.Message));
             }
             else
             {
                 Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, offset, sequenceNumber, CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber, -1, offset, expectedException.Message));
+                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, sequenceNumber.ToString(), -1, offset.ToString(), expectedException.Message));
             }
         }
 
@@ -745,12 +745,12 @@ namespace Azure.Messaging.EventHubs.Tests
             if (useCheckpointPositionOverload)
             {
                 Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, checkpoint.ClientIdentifier, new CheckpointPosition(0), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, 0, -1, long.MinValue, expectedException.Message));
+                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.ClientIdentifier, "0", -1, string.Empty, expectedException.Message));
             }
             else
             {
                 Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId, 0, 0, CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, 0, -1, 0, expectedException.Message));
+                mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, string.Empty, "0", -1, "0", expectedException.Message));
             }
         }
 
@@ -769,7 +769,7 @@ namespace Azure.Messaging.EventHubs.Tests
             target.Logger = mockLog.Object;
 
             Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(0), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, 0, -1, long.MinValue, ex.Message));
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, "0", -1, string.Empty, ex.Message));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
@@ -86,9 +86,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
         partial void UpdateCheckpointError(string partitionId,
@@ -111,9 +111,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         partial void UpdateCheckpointComplete(string partitionId,
                                               string fullyQualifiedNamespace,
@@ -134,9 +134,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         ///
         partial void UpdateCheckpointStart(string partitionId,
                                            string fullyQualifiedNamespace,

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
@@ -96,9 +96,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long sequenceNumber,
+                                           long? sequenceNumber,
                                            int replicationSegment,
-                                           long offset,
+                                           long? offset,
                                            Exception exception) =>
             Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset, exception.Message);
 
@@ -120,9 +120,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                               string eventHubName,
                                               string consumerGroup,
                                               string clientIdentifier,
-                                              long sequenceNumber,
+                                              long? sequenceNumber,
                                               int replicationSegment,
-                                              long offset) =>
+                                              long? offset) =>
             Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
         /// <summary>
@@ -143,9 +143,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long sequenceNumber,
+                                           long? sequenceNumber,
                                            int replicationSegment,
-                                           long offset) =>
+                                           long? offset) =>
             Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
@@ -97,7 +97,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           int replicationSegment,
+                                           string replicationSegment,
                                            string offset,
                                            Exception exception) =>
             Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset, exception.Message);
@@ -121,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                               string consumerGroup,
                                               string clientIdentifier,
                                               string sequenceNumber,
-                                              int replicationSegment,
+                                              string replicationSegment,
                                               string offset) =>
             Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
@@ -144,7 +144,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           int replicationSegment,
+                                           string replicationSegment,
                                            string offset) =>
             Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
@@ -86,9 +86,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
         partial void UpdateCheckpointError(string partitionId,
@@ -96,9 +96,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long? sequenceNumber,
+                                           string sequenceNumber,
                                            int replicationSegment,
-                                           long? offset,
+                                           string offset,
                                            Exception exception) =>
             Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset, exception.Message);
 
@@ -111,18 +111,18 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         partial void UpdateCheckpointComplete(string partitionId,
                                               string fullyQualifiedNamespace,
                                               string eventHubName,
                                               string consumerGroup,
                                               string clientIdentifier,
-                                              long? sequenceNumber,
+                                              string sequenceNumber,
                                               int replicationSegment,
-                                              long? offset) =>
+                                              string offset) =>
             Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
         /// <summary>
@@ -134,18 +134,18 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         partial void UpdateCheckpointStart(string partitionId,
                                            string fullyQualifiedNamespace,
                                            string eventHubName,
                                            string consumerGroup,
                                            string clientIdentifier,
-                                           long? sequenceNumber,
+                                           string sequenceNumber,
                                            int replicationSegment,
-                                           long? offset) =>
+                                           string offset) =>
             Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
@@ -125,9 +125,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                    string eventHubName,
                                    string consumerGroup,
                                    string clientIdentifier,
-                                   long sequenceNumber,
+                                   long? sequenceNumber,
                                    int replicationSegment,
-                                   long offset,
+                                   long? offset,
                                    string exception);
 
         /// <summary>
@@ -148,9 +148,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                       string eventHubName,
                                       string consumerGroup,
                                       string clientIdentifier,
-                                      long sequenceNumber,
+                                      long? sequenceNumber,
                                       int replicationSegment,
-                                      long offset);
+                                      long? offset);
 
         /// <summary>
         ///   Indicates that an attempt to create/update a checkpoint has started.
@@ -170,9 +170,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                    string eventHubName,
                                    string consumerGroup,
                                    string clientIdentifier,
-                                   long sequenceNumber,
+                                   long? sequenceNumber,
                                    int replicationSegment,
-                                   long offset);
+                                   long? offset);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve claim partition ownership has completed.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
@@ -115,9 +115,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
-        /// <param name="offset">The offset associated with this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
         void UpdateCheckpointError(string partitionId,
@@ -138,9 +138,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
-        /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         void UpdateCheckpointComplete(string partitionId,
@@ -160,9 +160,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
-        /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         void UpdateCheckpointStart(string partitionId,

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
@@ -126,7 +126,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                    string consumerGroup,
                                    string clientIdentifier,
                                    string sequenceNumber,
-                                   int replicationSegment,
+                                   string replicationSegment,
                                    string offset,
                                    string exception);
 
@@ -149,7 +149,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                       string consumerGroup,
                                       string clientIdentifier,
                                       string sequenceNumber,
-                                      int replicationSegment,
+                                      string replicationSegment,
                                       string offset);
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                    string consumerGroup,
                                    string clientIdentifier,
                                    string sequenceNumber,
-                                   int replicationSegment,
+                                   string replicationSegment,
                                    string offset);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
@@ -115,9 +115,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="offset">The offset associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
+        /// <param name="offset">The offset associated with this checkpoint.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
         void UpdateCheckpointError(string partitionId,
@@ -125,9 +125,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                    string eventHubName,
                                    string consumerGroup,
                                    string clientIdentifier,
-                                   long? sequenceNumber,
+                                   string sequenceNumber,
                                    int replicationSegment,
-                                   long? offset,
+                                   string offset,
                                    string exception);
 
         /// <summary>
@@ -138,9 +138,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
-        /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         void UpdateCheckpointComplete(string partitionId,
@@ -148,9 +148,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                       string eventHubName,
                                       string consumerGroup,
                                       string clientIdentifier,
-                                      long? sequenceNumber,
+                                      string sequenceNumber,
                                       int replicationSegment,
-                                      long? offset);
+                                      string offset);
 
         /// <summary>
         ///   Indicates that an attempt to create/update a checkpoint has started.
@@ -160,9 +160,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
-        /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="sequenceNumber">The sequence number associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint. This value is set to <c>-1</c> if one is not provided.</param>
+        /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
+        /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
+        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         void UpdateCheckpointStart(string partitionId,
@@ -170,9 +170,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                    string eventHubName,
                                    string consumerGroup,
                                    string clientIdentifier,
-                                   long? sequenceNumber,
+                                   string sequenceNumber,
                                    int replicationSegment,
-                                   long? offset);
+                                   string offset);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve claim partition ownership has completed.


### PR DESCRIPTION
The API updates in https://github.com/Azure/azure-sdk-for-net/pull/41829 created an unintentional side effect where processors running different versions of the SDK can no longer work together. Since offset was removed from the checkpoint position, new checkpoints no longer write the offset to the checkpoint. To preserve the formatting, a default value of long.MinValue was passed in. This leaves processors using the old SDK version to continue to try positioning at offset long.MinValue and failing.

This change sets the offset in the blob to string.Empty, so that when the processor pulls in the checkpoint, it will be able to fallover to the sequence number. The logging infrastructure now writes "" to the logs when an offset or sequence number is not provided.