### PR TITLE
Use common environment for releasing

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -21,6 +21,7 @@ stages:
             deploy:
               steps:
                 - checkout: azure-sdk-build-tools
+                  path: azure-sdk-build-tools
 
                 - download: current
                   artifact: ${{parameters.ArtifactName}}
@@ -141,6 +142,8 @@ stages:
                     deploy:
                       steps:
                         - checkout: azure-sdk-build-tools
+                          path: azure-sdk-build-tools
+
                         - task: MSBuild@1
                           displayName: 'Upload Symbols for ${{artifact.name}}'
                           inputs:
@@ -259,6 +262,8 @@ stages:
         vmImage: windows-2022
       steps:
       - checkout: azure-sdk-build-tools
+        path: azure-sdk-build-tools
+
       - download: current
         artifact: ${{parameters.ArtifactName}}-signed
       - pwsh: |

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -6,7 +6,6 @@ parameters:
   DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
   TargetDocRepoOwner: 'not-specified'
   TargetDocRepoName: 'not-specified'
-  Environment: nuget
 stages:
   - stage: Signing
     dependsOn: ${{parameters.DependsOn}}
@@ -21,18 +20,16 @@ stages:
           runOnce:
             deploy:
               steps:
-                - checkout: none
+                - checkout: azure-sdk-build-tools
 
                 - download: current
                   artifact: ${{parameters.ArtifactName}}
                   timeoutInMinutes: 5
 
-                - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
-
                 - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
                   parameters:
                     PackagesPath:  $(Pipeline.Workspace)/${{parameters.ArtifactName}}
-                    BuildToolsPath: $(AzureSDKBuildToolsPath)
+                    BuildToolsPath: $(Pipeline.Workspace)/azure-sdk-build-tools
 
                 - publish: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
                   artifact: ${{parameters.ArtifactName}}-signed
@@ -50,7 +47,7 @@ stages:
               - deployment: TagRepository
                 displayName: "Create release tag"
                 condition: ne(variables['Skip.TagRepository'], 'true')
-                environment: ${{parameters.Environment}}
+                environment: package-publish
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
@@ -102,7 +99,7 @@ stages:
               - deployment: PublishPackage
                 displayName: Publish package to Nuget.org and DevOps Feed
                 condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-                environment: ${{parameters.Environment}}
+                environment: package-publish
                 dependsOn: TagRepository
 
                 pool:
@@ -132,7 +129,7 @@ stages:
               - deployment: UploadSymbols
                 displayName: Upload Symbols to Symbols Server
                 condition: and(succeeded(), ne(variables['Skip.SymbolsUpload'], 'true'))
-                environment: ${{parameters.Environment}}
+                environment: package-publish
                 dependsOn: PublishPackage
 
                 pool:
@@ -143,12 +140,11 @@ stages:
                   runOnce:
                     deploy:
                       steps:
-                        - checkout: none
-                        - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
+                        - checkout: azure-sdk-build-tools
                         - task: MSBuild@1
                           displayName: 'Upload Symbols for ${{artifact.name}}'
                           inputs:
-                            solution: '$(AzureSDKBuildToolsPath)/tools/symboltool/SymbolUploader.proj'
+                            solution: '$(Pipeline.Workspace)/azure-sdk-build-tools/tools/symboltool/SymbolUploader.proj'
                             msbuildArguments: >-
                               /p:PackagesPath=$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}
                               /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat)
@@ -159,7 +155,7 @@ stages:
               - deployment: PublicDocsMS
                 displayName: Publish to Docs.MS
                 condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-                environment: ${{parameters.Environment}}
+                environment: package-publish
                 dependsOn: PublishPackage
 
                 pool:
@@ -192,7 +188,7 @@ stages:
               - deployment: PublishDocs
                 displayName: Publish Docs to GitHub pages
                 condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-                environment: ${{parameters.Environment}}
+                environment: package-publish
                 dependsOn: PublishPackage
 
                 pool:
@@ -218,7 +214,7 @@ stages:
               - deployment: UpdatePackageVersion
                 displayName: "Update Package Version"
                 condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
-                environment: ${{parameters.Environment}}
+                environment: package-publish
                 dependsOn: PublishPackage
 
                 pool:
@@ -262,8 +258,7 @@ stages:
         name: azsdk-pool-mms-win-2022-general
         vmImage: windows-2022
       steps:
-      - checkout: none
-      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
+      - checkout: azure-sdk-build-tools
       - download: current
         artifact: ${{parameters.ArtifactName}}-signed
       - pwsh: |

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -125,5 +125,3 @@ stages:
         ArtifactName: packages
         TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
         TargetDocRepoName: ${{ parameters.TargetDocRepoName }}
-        ${{ if eq(parameters.ReleaseDependsOnLiveTests, 'false') }}:
-          Environment: 'nuget-break-glass-approvers'


### PR DESCRIPTION
- Switch to using common package-publish environment for release
- Switch to using checkout instead of manual clone for azure-sdk-build-tools