### PR TITLE
[Event Hubs] Post-release fixes

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -224,7 +224,7 @@
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Identity" Version="1.10.4" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.17.0" />
-		<PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.10.0" />
+		<PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.11.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.16.0" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.2.0" />
     <PackageReference Update="Azure.ResourceManager.CognitiveServices" Version="1.3.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -13,8 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />-->
-    <PackageReference Include="Azure.Messaging.EventHubs" />
+    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the version of the processor package used by samples and to restore the project references for the stress tests.