### PR TITLE
[Analyzers] Adding additional approved namespaces

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -203,7 +203,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20240207.2" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20240214.1" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20240214.2" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -203,7 +203,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20240207.2" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20240123.2" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20240214.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />


### PR DESCRIPTION
# Summary

The focus of these changes is to update the approved namespaces to include:
- Azure.Compute
- Azure.Health
- Azure.Verticals

The validation approach was also adjusted to allow the exact namespace match and sub-namespaces rooted to them.

## References and Related

- [[.NET Analyzers] Add new approved namespace (#7674)](https://github.com/Azure/azure-sdk-tools/pull/7674)
- [[.NET] Add missing prefixes to list of allowed namespace prefixes (#7597)](https://github.com/Azure/azure-sdk-tools/pull/7597)
- [[.NET Analyzers] Fix Template special case (#7683)](https://github.com/Azure/azure-sdk-tools/pull/7683)