### PR TITLE
ClientModel: PipelineRequest and PipelineResponse API updates

### DIFF
--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -180,17 +180,14 @@ namespace System.ClientModel.Primitives
     {
         protected PipelineRequest() { }
         public System.ClientModel.BinaryContent? Content { get { throw null; } set { } }
+        protected abstract System.ClientModel.BinaryContent? ContentCore { get; set; }
         public System.ClientModel.Primitives.PipelineRequestHeaders Headers { get { throw null; } }
+        protected abstract System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get; }
         public string Method { get { throw null; } set { } }
+        protected abstract string MethodCore { get; set; }
         public System.Uri Uri { get { throw null; } set { } }
+        protected abstract System.Uri UriCore { get; set; }
         public abstract void Dispose();
-        protected abstract System.ClientModel.BinaryContent? GetContentCore();
-        protected abstract System.ClientModel.Primitives.PipelineRequestHeaders GetHeadersCore();
-        protected abstract string GetMethodCore();
-        protected abstract System.Uri GetUriCore();
-        protected abstract void SetContentCore(System.ClientModel.BinaryContent? content);
-        protected abstract void SetMethodCore(string method);
-        protected abstract void SetUriCore(System.Uri uri);
     }
     public abstract partial class PipelineRequestHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
     {
@@ -209,14 +206,14 @@ namespace System.ClientModel.Primitives
         public abstract System.BinaryData Content { get; }
         public abstract System.IO.Stream? ContentStream { get; set; }
         public System.ClientModel.Primitives.PipelineResponseHeaders Headers { get { throw null; } }
+        protected abstract System.ClientModel.Primitives.PipelineResponseHeaders HeadersCore { get; }
         public virtual bool IsError { get { throw null; } }
+        protected internal virtual bool IsErrorCore { get { throw null; } set { } }
         public abstract string ReasonPhrase { get; }
         public abstract int Status { get; }
+        public abstract System.BinaryData BufferContent(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract System.Threading.Tasks.ValueTask<System.BinaryData> BufferContentAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         public abstract void Dispose();
-        protected abstract System.ClientModel.Primitives.PipelineResponseHeaders GetHeadersCore();
-        public abstract System.BinaryData ReadContent(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-        public abstract System.Threading.Tasks.ValueTask<System.BinaryData> ReadContentAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-        protected virtual void SetIsErrorCore(bool isError) { }
     }
     public abstract partial class PipelineResponseHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
     {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -185,8 +185,8 @@ namespace System.ClientModel.Primitives
         protected abstract System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get; }
         public string Method { get { throw null; } set { } }
         protected abstract string MethodCore { get; set; }
-        public System.Uri Uri { get { throw null; } set { } }
-        protected abstract System.Uri UriCore { get; set; }
+        public System.Uri? Uri { get { throw null; } set { } }
+        protected abstract System.Uri? UriCore { get; set; }
         public abstract void Dispose();
     }
     public abstract partial class PipelineRequestHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -179,17 +179,14 @@ namespace System.ClientModel.Primitives
     {
         protected PipelineRequest() { }
         public System.ClientModel.BinaryContent? Content { get { throw null; } set { } }
+        protected abstract System.ClientModel.BinaryContent? ContentCore { get; set; }
         public System.ClientModel.Primitives.PipelineRequestHeaders Headers { get { throw null; } }
+        protected abstract System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get; }
         public string Method { get { throw null; } set { } }
+        protected abstract string MethodCore { get; set; }
         public System.Uri Uri { get { throw null; } set { } }
+        protected abstract System.Uri UriCore { get; set; }
         public abstract void Dispose();
-        protected abstract System.ClientModel.BinaryContent? GetContentCore();
-        protected abstract System.ClientModel.Primitives.PipelineRequestHeaders GetHeadersCore();
-        protected abstract string GetMethodCore();
-        protected abstract System.Uri GetUriCore();
-        protected abstract void SetContentCore(System.ClientModel.BinaryContent? content);
-        protected abstract void SetMethodCore(string method);
-        protected abstract void SetUriCore(System.Uri uri);
     }
     public abstract partial class PipelineRequestHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
     {
@@ -208,14 +205,14 @@ namespace System.ClientModel.Primitives
         public abstract System.BinaryData Content { get; }
         public abstract System.IO.Stream? ContentStream { get; set; }
         public System.ClientModel.Primitives.PipelineResponseHeaders Headers { get { throw null; } }
+        protected abstract System.ClientModel.Primitives.PipelineResponseHeaders HeadersCore { get; }
         public virtual bool IsError { get { throw null; } }
+        protected internal virtual bool IsErrorCore { get { throw null; } set { } }
         public abstract string ReasonPhrase { get; }
         public abstract int Status { get; }
+        public abstract System.BinaryData BufferContent(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract System.Threading.Tasks.ValueTask<System.BinaryData> BufferContentAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         public abstract void Dispose();
-        protected abstract System.ClientModel.Primitives.PipelineResponseHeaders GetHeadersCore();
-        public abstract System.BinaryData ReadContent(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-        public abstract System.Threading.Tasks.ValueTask<System.BinaryData> ReadContentAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-        protected virtual void SetIsErrorCore(bool isError) { }
     }
     public abstract partial class PipelineResponseHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
     {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -184,8 +184,8 @@ namespace System.ClientModel.Primitives
         protected abstract System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get; }
         public string Method { get { throw null; } set { } }
         protected abstract string MethodCore { get; set; }
-        public System.Uri Uri { get { throw null; } set { } }
-        protected abstract System.Uri UriCore { get; set; }
+        public System.Uri? Uri { get { throw null; } set { } }
+        protected abstract System.Uri? UriCore { get; set; }
         public abstract void Dispose();
     }
     public abstract partial class PipelineRequestHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable

--- a/sdk/core/System.ClientModel/src/Convenience/ClientResultException.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ClientResultException.cs
@@ -82,11 +82,11 @@ public class ClientResultException : Exception, ISerializable
     {
         if (async)
         {
-            await response.ReadContentAsync().ConfigureAwait(false);
+            await response.BufferContentAsync().ConfigureAwait(false);
         }
         else
         {
-            response.ReadContent();
+            response.BufferContent();
         }
 
         StringBuilder messageBuilder = new();

--- a/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
@@ -16,13 +16,13 @@ public abstract class PipelineRequest : IDisposable
 
     protected abstract string MethodCore { get; set; }
 
-    public Uri Uri
+    public Uri? Uri
     {
         get => UriCore;
         set => UriCore = value;
     }
 
-    protected abstract Uri UriCore { get; set; }
+    protected abstract Uri? UriCore { get; set; }
 
     public PipelineRequestHeaders Headers => HeadersCore;
 

--- a/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
@@ -10,37 +10,31 @@ public abstract class PipelineRequest : IDisposable
     /// </summary>
     public string Method
     {
-        get => GetMethodCore();
-        set => SetMethodCore(value);
+        get => MethodCore;
+        set => MethodCore = value;
     }
 
-    protected abstract string GetMethodCore();
-
-    protected abstract void SetMethodCore(string method);
+    protected abstract string MethodCore { get; set; }
 
     public Uri Uri
     {
-        get => GetUriCore();
-        set => SetUriCore(value);
+        get => UriCore;
+        set => UriCore = value;
     }
 
-    protected abstract Uri GetUriCore();
+    protected abstract Uri UriCore { get; set; }
 
-    protected abstract void SetUriCore(Uri uri);
+    public PipelineRequestHeaders Headers => HeadersCore;
 
-    public PipelineRequestHeaders Headers { get => GetHeadersCore(); }
-
-    protected abstract PipelineRequestHeaders GetHeadersCore();
+    protected abstract PipelineRequestHeaders HeadersCore { get; }
 
     public BinaryContent? Content
     {
-        get => GetContentCore();
-        set => SetContentCore(value);
+        get => ContentCore;
+        set => ContentCore = value;
     }
 
-    protected abstract BinaryContent? GetContentCore();
-
-    protected abstract void SetContentCore(BinaryContent? content);
+    protected abstract BinaryContent? ContentCore { get; set; }
 
     public abstract void Dispose();
 }

--- a/sdk/core/System.ClientModel/src/Message/PipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineResponse.cs
@@ -33,9 +33,9 @@ public abstract class PipelineResponse : IDisposable
 
     public abstract BinaryData Content { get; }
 
-    public abstract BinaryData ReadContent(CancellationToken cancellationToken = default);
+    public abstract BinaryData BufferContent(CancellationToken cancellationToken = default);
 
-    public abstract ValueTask<BinaryData> ReadContentAsync(CancellationToken cancellationToken = default);
+    public abstract ValueTask<BinaryData> BufferContentAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Indicates whether the status code of the returned response is considered

--- a/sdk/core/System.ClientModel/src/Message/PipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineResponse.cs
@@ -12,8 +12,6 @@ public abstract class PipelineResponse : IDisposable
     // TODO(matell): The .NET Framework team plans to add BinaryData.Empty in dotnet/runtime#49670, and we can use it then.
     internal static readonly BinaryData s_EmptyBinaryData = new(Array.Empty<byte>());
 
-    private bool _isError = false;
-
     /// <summary>
     /// Gets the HTTP status code.
     /// </summary>
@@ -24,9 +22,9 @@ public abstract class PipelineResponse : IDisposable
     /// </summary>
     public abstract string ReasonPhrase { get; }
 
-    public PipelineResponseHeaders Headers => GetHeadersCore();
+    public PipelineResponseHeaders Headers => HeadersCore;
 
-    protected abstract PipelineResponseHeaders GetHeadersCore();
+    protected abstract PipelineResponseHeaders HeadersCore { get; }
 
     /// <summary>
     /// Gets the contents of HTTP response. Returns <c>null</c> for responses without content.
@@ -44,13 +42,9 @@ public abstract class PipelineResponse : IDisposable
     /// an error code.
     /// </summary>
     // IsError must be virtual in order to maintain Azure.Core back-compatibility.
-    public virtual bool IsError => _isError;
+    public virtual bool IsError => IsErrorCore;
 
-    // We have to have a separate method for setting IsError so that the IsError
-    // setter doesn't become virtual when we make the getter virtual.
-    internal void SetIsError(bool isError) => SetIsErrorCore(isError);
-
-    protected virtual void SetIsErrorCore(bool isError) => _isError = isError;
+    protected internal virtual bool IsErrorCore { get; set; }
 
     public abstract void Dispose();
 }

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Request.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Request.cs
@@ -85,7 +85,6 @@ public partial class HttpClientPipelineTransport
                 "PATCH" => _patchMethod,
                 _ => new HttpMethod(method),
             };
-            ;
         }
 
         internal static HttpRequestMessage BuildHttpRequestMessage(PipelineRequest request, CancellationToken cancellationToken)

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Request.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Request.cs
@@ -43,17 +43,9 @@ public partial class HttpClientPipelineTransport
             }
         }
 
-        protected override Uri UriCore
+        protected override Uri? UriCore
         {
-            get
-            {
-                if (_uri is null)
-                {
-                    throw new InvalidOperationException("Uri has not been set on this instance.");
-                }
-
-                return _uri;
-            }
+            get => _uri;
             set
             {
                 Argument.AssertNotNull(value, nameof(value));
@@ -89,6 +81,11 @@ public partial class HttpClientPipelineTransport
 
         internal static HttpRequestMessage BuildHttpRequestMessage(PipelineRequest request, CancellationToken cancellationToken)
         {
+            if (request.Uri is null)
+            {
+                throw new InvalidOperationException("Uri must be set on message request prior to sending message.");
+            }
+
             HttpMethod method = ToHttpMethod(request.Method);
             Uri uri = request.Uri;
             HttpRequestMessage httpRequest = new HttpRequestMessage(method, uri);

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Request.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Request.cs
@@ -32,41 +32,43 @@ public partial class HttpClientPipelineTransport
             _headers = new ArrayBackedRequestHeaders();
         }
 
-        protected override string GetMethodCore()
-            => _method;
-
-        protected override void SetMethodCore(string method)
+        protected override string MethodCore
         {
-            Argument.AssertNotNull(method, nameof(method));
-
-            _method = method;
-        }
-
-        protected override Uri GetUriCore()
-        {
-            if (_uri is null)
+            get => _method;
+            set
             {
-                throw new InvalidOperationException("Uri has not been set on this instance.");
+                Argument.AssertNotNull(value, nameof(value));
+
+                _method = value;
             }
-
-            return _uri;
         }
 
-        protected override void SetUriCore(Uri uri)
+        protected override Uri UriCore
         {
-            Argument.AssertNotNull(uri, nameof(uri));
+            get
+            {
+                if (_uri is null)
+                {
+                    throw new InvalidOperationException("Uri has not been set on this instance.");
+                }
 
-            _uri = uri;
+                return _uri;
+            }
+            set
+            {
+                Argument.AssertNotNull(value, nameof(value));
+
+                _uri = value;
+            }
         }
 
-        protected override BinaryContent? GetContentCore()
-            => _content;
+        protected override BinaryContent? ContentCore
+        {
+            get => _content;
+            set => _content = value;
+        }
 
-        protected override void SetContentCore(BinaryContent? content)
-            => _content = content;
-
-        protected override PipelineRequestHeaders GetHeadersCore()
-            => _headers;
+        protected override PipelineRequestHeaders HeadersCore => _headers;
 
         // PATCH value needed for compat with pre-net5.0 TFMs
         private static readonly HttpMethod _patchMethod = new HttpMethod("PATCH");
@@ -82,7 +84,8 @@ public partial class HttpClientPipelineTransport
                 "DELETE" => HttpMethod.Delete,
                 "PATCH" => _patchMethod,
                 _ => new HttpMethod(method),
-            }; ;
+            };
+            ;
         }
 
         internal static HttpRequestMessage BuildHttpRequestMessage(PipelineRequest request, CancellationToken cancellationToken)

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Response.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Response.cs
@@ -41,7 +41,7 @@ public partial class HttpClientPipelineTransport
         public override string ReasonPhrase
             => _httpResponse.ReasonPhrase ?? string.Empty;
 
-        protected override PipelineResponseHeaders GetHeadersCore()
+        protected override PipelineResponseHeaders HeadersCore
             => new HttpClientResponseHeaders(_httpResponse, _httpResponseContent);
 
         public override Stream? ContentStream

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Response.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Response.cs
@@ -80,17 +80,17 @@ public partial class HttpClientPipelineTransport
 
                 if (_contentStream is null || _contentStream is MemoryStream)
                 {
-                    return ReadContent();
+                    return BufferContent();
                 }
 
                 throw new InvalidOperationException($"The response is not buffered.");
             }
         }
 
-        public override BinaryData ReadContent(CancellationToken cancellationToken = default)
+        public override BinaryData BufferContent(CancellationToken cancellationToken = default)
             => ReadContentSyncOrAsync(cancellationToken, async: false).EnsureCompleted();
 
-        public override async ValueTask<BinaryData> ReadContentAsync(CancellationToken cancellationToken = default)
+        public override async ValueTask<BinaryData> BufferContentAsync(CancellationToken cancellationToken = default)
             => await ReadContentSyncOrAsync(cancellationToken, async: true).ConfigureAwait(false);
 
         private async ValueTask<BinaryData> ReadContentSyncOrAsync(CancellationToken cancellationToken, bool async)
@@ -160,7 +160,7 @@ public partial class HttpClientPipelineTransport
 
                 if (ContentStream is MemoryStream)
                 {
-                    ReadContent();
+                    BufferContent();
                 }
 
                 Stream? contentStream = _contentStream;

--- a/sdk/core/System.ClientModel/src/Pipeline/PipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/PipelineTransport.cs
@@ -127,11 +127,11 @@ public abstract class PipelineTransport : PipelinePolicy
 
             if (async)
             {
-                await message.Response.ReadContentAsync(timeoutTokenSource.Token).ConfigureAwait(false);
+                await message.Response.BufferContentAsync(timeoutTokenSource.Token).ConfigureAwait(false);
             }
             else
             {
-                message.Response.ReadContent(timeoutTokenSource.Token);
+                message.Response.BufferContent(timeoutTokenSource.Token);
             }
         }
         // We dispose stream on timeout or user cancellation so catch and check if

--- a/sdk/core/System.ClientModel/src/Pipeline/PipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/PipelineTransport.cs
@@ -90,7 +90,7 @@ public abstract class PipelineTransport : PipelinePolicy
         }
 
         message.AssertResponse();
-        message.Response!.SetIsError(ClassifyResponse(message));
+        message.Response!.IsErrorCore = ClassifyResponse(message);
 
         // The remainder of the method handles response content according to
         // buffering logic specified by value of message.BufferResponse.

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineRequest.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineRequest.cs
@@ -37,18 +37,9 @@ public class MockPipelineRequest : PipelineRequest
         set => _method = value;
     }
 
-    protected override Uri UriCore
+    protected override Uri? UriCore
     {
-        get
-        {
-            if (_uri is null)
-            {
-                throw new InvalidOperationException("Uri has not be set on HttpMessageRequest instance.");
-            }
-
-            return _uri;
-        }
-
+        get => _uri;
         set => _uri = value;
     }
 

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineRequest.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineRequest.cs
@@ -22,33 +22,35 @@ public class MockPipelineRequest : PipelineRequest
         _method = "GET";
     }
 
-    protected override BinaryContent? GetContentCore()
-        => _content;
-
-    protected override PipelineRequestHeaders GetHeadersCore()
-        => _headers;
-
-    protected override string GetMethodCore()
-        => _method;
-
-    protected override Uri GetUriCore()
+    protected override BinaryContent? ContentCore
     {
-        if (_uri is null)
-        {
-            throw new InvalidOperationException("Uri has not be set on HttpMessageRequest instance.");
-        }
-
-        return _uri;
+        get => _content;
+        set => _content = value;
     }
 
-    protected override void SetContentCore(BinaryContent? content)
-        => _content = content;
+    protected override PipelineRequestHeaders HeadersCore
+        => _headers;
 
-    protected override void SetMethodCore(string method)
-        => _method = method;
+    protected override string MethodCore
+    {
+        get => _method;
+        set => _method = value;
+    }
 
-    protected override void SetUriCore(Uri uri)
-        => _uri = uri;
+    protected override Uri UriCore
+    {
+        get
+        {
+            if (_uri is null)
+            {
+                throw new InvalidOperationException("Uri has not be set on HttpMessageRequest instance.");
+            }
+
+            return _uri;
+        }
+
+        set => _uri = value;
+    }
 
     public sealed override void Dispose()
     {

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineResponse.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineResponse.cs
@@ -78,7 +78,8 @@ public class MockPipelineResponse : PipelineResponse
         }
     }
 
-    protected override PipelineResponseHeaders GetHeadersCore() => _headers;
+    protected override PipelineResponseHeaders HeadersCore
+        => _headers;
 
     public sealed override void Dispose()
     {

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineResponse.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineResponse.cs
@@ -103,7 +103,7 @@ public class MockPipelineResponse : PipelineResponse
         }
     }
 
-    public override BinaryData ReadContent(CancellationToken cancellationToken = default)
+    public override BinaryData BufferContent(CancellationToken cancellationToken = default)
     {
         if (_bufferedContent is not null)
         {
@@ -127,7 +127,7 @@ public class MockPipelineResponse : PipelineResponse
         return _bufferedContent;
     }
 
-    public override async ValueTask<BinaryData> ReadContentAsync(CancellationToken cancellationToken = default)
+    public override async ValueTask<BinaryData> BufferContentAsync(CancellationToken cancellationToken = default)
     {
         if (_bufferedContent is not null)
         {

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineTransport.cs
@@ -119,7 +119,7 @@ public class MockPipelineTransport : PipelineTransport
 
     private class TransportRequest : PipelineRequest
     {
-        private Uri _uri;
+        private Uri? _uri;
         private readonly PipelineRequestHeaders _headers;
 
         public TransportRequest()
@@ -145,7 +145,7 @@ public class MockPipelineTransport : PipelineTransport
             set => throw new NotImplementedException();
         }
 
-        protected override Uri UriCore
+        protected override Uri? UriCore
         {
             get => _uri;
             set => _uri = value;

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineTransport.cs
@@ -130,34 +130,26 @@ public class MockPipelineTransport : PipelineTransport
 
         public override void Dispose() { }
 
-        protected override BinaryContent? GetContentCore()
+        protected override BinaryContent? ContentCore
         {
-            throw new NotImplementedException();
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
         }
 
-        protected override PipelineRequestHeaders GetHeadersCore()
+        protected override PipelineRequestHeaders HeadersCore
             => _headers;
 
-        protected override string GetMethodCore()
+        protected override string MethodCore
         {
-            throw new NotImplementedException();
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
         }
 
-        protected override Uri GetUriCore()
-            => _uri;
-
-        protected override void SetContentCore(BinaryContent? content)
+        protected override Uri UriCore
         {
-            throw new NotImplementedException();
+            get => _uri;
+            set => _uri = value;
         }
-
-        protected override void SetMethodCore(string method)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override void SetUriCore(Uri uri)
-            => _uri = uri;
     }
 
     private class RetriableTransportResponse : PipelineResponse
@@ -179,10 +171,8 @@ public class MockPipelineTransport : PipelineTransport
 
         public override BinaryData Content => throw new NotImplementedException();
 
-        protected override PipelineResponseHeaders GetHeadersCore()
-        {
-            throw new NotImplementedException();
-        }
+        protected override PipelineResponseHeaders HeadersCore
+            => throw new NotImplementedException();
 
         public override void Dispose() { }
 

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineTransport.cs
@@ -176,12 +176,12 @@ public class MockPipelineTransport : PipelineTransport
 
         public override void Dispose() { }
 
-        public override BinaryData ReadContent(CancellationToken cancellationToken = default)
+        public override BinaryData BufferContent(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public override ValueTask<BinaryData> ReadContentAsync(CancellationToken cancellationToken = default)
+        public override ValueTask<BinaryData> BufferContentAsync(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/ObservableTransport.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/ObservableTransport.cs
@@ -90,39 +90,25 @@ public class ObservableTransport : PipelineTransport
             throw new NotImplementedException();
         }
 
-        protected override BinaryContent? GetContentCore()
+        protected override BinaryContent? ContentCore
         {
-            throw new NotImplementedException();
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
         }
 
-        protected override PipelineRequestHeaders GetHeadersCore()
+        protected override PipelineRequestHeaders HeadersCore
+            => throw new NotImplementedException();
+
+        protected override string MethodCore
         {
-            throw new NotImplementedException();
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
         }
 
-        protected override string GetMethodCore()
+        protected override Uri UriCore
         {
-            throw new NotImplementedException();
-        }
-
-        protected override Uri GetUriCore()
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override void SetContentCore(BinaryContent? content)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override void SetMethodCore(string method)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override void SetUriCore(Uri uri)
-        {
-            throw new NotImplementedException();
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
         }
     }
 
@@ -140,10 +126,8 @@ public class ObservableTransport : PipelineTransport
 
         public override BinaryData Content => throw new NotImplementedException();
 
-        protected override PipelineResponseHeaders GetHeadersCore()
-        {
-            throw new NotImplementedException();
-        }
+        protected override PipelineResponseHeaders HeadersCore
+            => throw new NotImplementedException();
 
         public override void Dispose()
         {

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/ObservableTransport.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/ObservableTransport.cs
@@ -134,12 +134,12 @@ public class ObservableTransport : PipelineTransport
             throw new NotImplementedException();
         }
 
-        public override BinaryData ReadContent(CancellationToken cancellationToken = default)
+        public override BinaryData BufferContent(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public override ValueTask<BinaryData> ReadContentAsync(CancellationToken cancellationToken = default)
+        public override ValueTask<BinaryData> BufferContentAsync(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/ObservableTransport.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/ObservableTransport.cs
@@ -105,7 +105,7 @@ public class ObservableTransport : PipelineTransport
             set => throw new NotImplementedException();
         }
 
-        protected override Uri UriCore
+        protected override Uri? UriCore
         {
             get => throw new NotImplementedException();
             set => throw new NotImplementedException();


### PR DESCRIPTION
This PR:
1. Addresses https://github.com/Azure/azure-sdk-for-net/issues/41234 by changing request and response template methods named XxCore to properties named XxCore
2. Addresses APIView feedback by changing PipelineResponse.ReadContent to PipelineResponse.BufferContent