### PR TITLE
Correct unit mismatch in backoff calculation

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/AzureBlobXmlRepository.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/AzureBlobXmlRepository.cs
@@ -234,7 +234,7 @@ namespace Azure.Extensions.AspNetCore.DataProtection.Blobs
             // returns a TimeSpan in the range [0.8, 1.0) * ConflictBackoffPeriod
             // not used for crypto purposes
             var multiplier = 0.8 + (_random.NextDouble() * 0.2);
-            return (int) (multiplier * ConflictBackoffPeriod.Ticks);
+            return (int) (multiplier * ConflictBackoffPeriod.TotalMilliseconds);
         }
 
         private sealed class BlobData


### PR DESCRIPTION
While debugging locally, I noticed some unusually long delays and tracked it back to the fact that delays are computed in ticks but applied in milliseconds.