### PR TITLE
[LiveMetrics] perf counters (part 1) - scaffolding for platform based collection

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -71,6 +71,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         /// <summary>
         /// INTERNAL ONLY. Used by LiveMetrics to detect premium containers in Azure App Service.
         /// </summary>
+        // TODO: THIS ENVIRONMENT VARIABLE IS NOT DOCUMENTED. NEED TO FOLLOW UP WITH APP SERVICE IF WE CAN CONTINUE TO RELY ON THIS.
+        // https://learn.microsoft.com/azure/app-service/reference-app-settings
         public const string WEBSITE_ISOLATION = "WEBSITE_ISOLATION";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -52,7 +52,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         public const string WEBSITE_HOSTNAME = "WEBSITE_HOSTNAME";
 
         /// <summary>
-        /// INTERNAL ONLY. Used by Statsbeat to get the App Service Website Name.
+        /// INTERNAL ONLY.
+        /// Used by Statsbeat to get the App Service Website Name.
+        /// Used by LiveMetrics to detect running in Azure App Service.
         /// </summary>
         public const string WEBSITE_SITE_NAME = "WEBSITE_SITE_NAME";
 
@@ -65,5 +67,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         /// When set to true, exporter will emit resources as metric telemetry.
         /// </summary>
         public const string EXPORT_RESOURCE_METRIC = "OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS";
+
+        /// <summary>
+        /// INTERNAL ONLY. Used by LiveMetrics to detect premium containers in Azure App Service.
+        /// </summary>
+        public const string WEBSITE_ISOLATION = "WEBSITE_ISOLATION";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -67,12 +67,5 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         /// When set to true, exporter will emit resources as metric telemetry.
         /// </summary>
         public const string EXPORT_RESOURCE_METRIC = "OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS";
-
-        /// <summary>
-        /// INTERNAL ONLY. Used by LiveMetrics to detect premium containers in Azure App Service.
-        /// </summary>
-        // TODO: THIS ENVIRONMENT VARIABLE IS NOT DOCUMENTED. NEED TO FOLLOW UP WITH APP SERVICE IF WE CAN CONTINUE TO RELY ON THIS.
-        // https://learn.microsoft.com/azure/app-service/reference-app-settings
-        public const string WEBSITE_ISOLATION = "WEBSITE_ISOLATION";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
@@ -67,17 +67,18 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         [Event(2, Message = "Failed to read environment variables due to an exception. This may prevent the Exporter from initializing. {0}", Level = EventLevel.Warning)]
         public void FailedToReadEnvironmentVariables(string errorMessage) => WriteEvent(2, errorMessage);
 
-        [NonEvent]
-        public void AccessingEnvironmentVariableFailedWarning(string environmentVariable, System.Exception ex)
-        {
-            if (IsEnabled(EventLevel.Warning))
-            {
-                AccessingEnvironmentVariableFailedWarning(environmentVariable, ex.FlattenException().ToInvariantString());
-            }
-        }
+        // TODO: REMOVE AND RENUMBER
+        //[NonEvent]
+        //public void AccessingEnvironmentVariableFailedWarning(string environmentVariable, System.Exception ex)
+        //{
+        //    if (IsEnabled(EventLevel.Warning))
+        //    {
+        //        AccessingEnvironmentVariableFailedWarning(environmentVariable, ex.FlattenException().ToInvariantString());
+        //    }
+        //}
 
-        [Event(3, Message = "Accessing environment variable - {0} failed with exception: {1}.", Level = EventLevel.Warning)]
-        public void AccessingEnvironmentVariableFailedWarning(string environmentVariable, string exceptionMessage) => WriteEvent(3, environmentVariable, exceptionMessage);
+        //[Event(3, Message = "Accessing environment variable - {0} failed with exception: {1}.", Level = EventLevel.Warning)]
+        //public void AccessingEnvironmentVariableFailedWarning(string environmentVariable, string exceptionMessage) => WriteEvent(3, environmentVariable, exceptionMessage);
 
         [NonEvent]
         public void SdkVersionCreateFailed(System.Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
@@ -197,7 +197,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         public void DroppedDocument(string documentType) => WriteEvent(12, documentType);
 
         [Event(13, Message = "PerformanceCounterCollectorFactory initialized a PerformanceCounterCollector. IsWindows: {0}. IsAzureAppService: {1}. Collector Type: {2}.", Level = EventLevel.Informational)]
-        public void PerformanceCounterCollectorFactoryDecision(bool isWindows, bool isAzureAppService, string collectorTypeName) => WriteEvent(13, isWindows, isAzureAppService, collectorTypeName);
+        public void ResolvedPerformanceCounterCollector(bool isWindows, bool isAzureAppService, string collectorTypeName) => WriteEvent(13, isWindows, isAzureAppService, collectorTypeName);
 
         [NonEvent]
         public void PerformanceCounterCollectorFactoryFailed(System.Exception ex)
@@ -208,7 +208,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
             }
         }
 
-        [Event(14, Message = "erformanceCounterCollectorFactory failed to initialize a PerformanceCounterCollector due to an exception: {0}", Level = EventLevel.Error)]
+        [Event(14, Message = "PerformanceCounterCollectorFactory failed to initialize a PerformanceCounterCollector due to an exception: {0}", Level = EventLevel.Error)]
         public void PerformanceCounterCollectorFactoryFailed(string exceptionMessage) => WriteEvent(14, exceptionMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
@@ -195,5 +195,20 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
 
         [Event(12, Message = "Document was dropped. DocumentType: {0}. Not user actionable.", Level = EventLevel.Warning)]
         public void DroppedDocument(string documentType) => WriteEvent(12, documentType);
+
+        [Event(13, Message = "PerformanceCounterCollectorFactory initialized a PerformanceCounterCollector. IsWindows: {0}. IsAzureAppService: {1}. Collector Type: {2}.", Level = EventLevel.Informational)]
+        public void PerformanceCounterCollectorFactoryDecision(bool isWindows, bool isAzureAppService, string collectorTypeName) => WriteEvent(13, isWindows, isAzureAppService, collectorTypeName);
+
+        [NonEvent]
+        public void PerformanceCounterCollectorFactoryFailed(System.Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                PerformanceCounterCollectorFactoryFailed(ex.ToInvariantString());
+            }
+        }
+
+        [Event(14, Message = "erformanceCounterCollectorFactory failed to initialize a PerformanceCounterCollector due to an exception: {0}", Level = EventLevel.Error)]
+        public void PerformanceCounterCollectorFactoryFailed(string exceptionMessage) => WriteEvent(14, exceptionMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
@@ -38,7 +38,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                 StreamId = _streamId,
                 Timestamp = DateTime.UtcNow, // Represents timestamp sample was created
                 TransmissionTime = DateTime.UtcNow, // represents timestamp transmission was sent
-                IsWebApp = IsWebAppRunningInAzure(), // TODO: THIS LOOKS LIKE A BUG. THIS METHOD RETURNS BOOL INDICATING IF IT SHOULD COLLECT PERF COUNTERS. AI SDK IS DOING THE SAME THING.
+                IsWebApp = IsWebAppRunningInAzure(), // TODO: THIS LOOKS LIKE A BUG. THIS METHOD RETURNS BOOL INDICATING IF IT SHOULD COLLECT PERF COUNTERS. AI SDK IS DOING THE SAME THING. NEED TO REVIEW THIS WITH SERVICE TEAM.
                 PerformanceCollectionSupported = true,
                 // AI SDK relies on PerformanceCounter to collect CPU and Memory metrics.
                 // Follow up with service team to get this removed for OTEL based live metrics.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
@@ -24,6 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         {
             // TODO: ENABLE THIS AFTER IMPLEMENTING OTHER CLASSES
             // PerformanceCounterCollectorFactory.TryGetInstance(platform, out _performanceCounterCollector);
+            _performanceCounterCollector = null;
         }
 
         public MonitoringDataPoint GetDataPoint()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
@@ -26,6 +26,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 
             if (options.EnableLiveMetrics)
             {
+                InitializeMetrics(platform);
                 InitializeState();
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/AzureWebAppWindowsPerformanceCounterCollector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/AzureWebAppWindowsPerformanceCounterCollector.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
+{
+    /// <summary>
+    /// Read fake environment variables from a Wisdows-based Azure App Service.
+    /// </summary>
+    /// <remarks>
+    /// Azure App Service doc:
+    /// <see href="https://learn.microsoft.com/azure/app-service/reference-app-settings#performance-counters"/>.
+    /// </remarks>
+    internal class AzureWebAppWindowsPerformanceCounterCollector : IPerformanceCounterCollector
+    {
+        public IEnumerable<Models.MetricPoint> Collect()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/AzureWebAppWindowsPerformanceCounterCollector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/AzureWebAppWindowsPerformanceCounterCollector.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
 {
     /// <summary>
-    /// Read fake environment variables from a Wisdows-based Azure App Service.
+    /// Read fake environment variables from a Windows-based Azure App Service.
     /// </summary>
     /// <remarks>
     /// Azure App Service doc:

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/IPerformanceCounterCollector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/IPerformanceCounterCollector.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
+{
+    internal interface IPerformanceCounterCollector
+    {
+        public IEnumerable<Models.MetricPoint> Collect();
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/NonWindowsPerformanceCounterCollector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/NonWindowsPerformanceCounterCollector.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
+{
+    /// <summary>
+    /// Uses <see cref="System.Diagnostics.Process"/> to collect process metrics.
+    /// </summary>
+    internal class NonWindowsPerformanceCounterCollector : IPerformanceCounterCollector
+    {
+        public IEnumerable<Models.MetricPoint> Collect()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/PerformanceCounterCollectorFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/PerformanceCounterCollectorFactory.cs
@@ -38,7 +38,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
             catch (Exception ex)
             {
                 // Since these are platform specific classes, exceptions could be thrown during constructor call.
-                // This shouldn't happen, but here we catch the exception.
                 LiveMetricsExporterEventSource.Log.PerformanceCounterCollectorFactoryFailed(ex);
                 performanceCounterCollector = null;
                 return false;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/PerformanceCounterCollectorFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/PerformanceCounterCollectorFactory.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
+{
+    internal static class PerformanceCounterCollectorFactory
+    {
+        private const string WEBSITE_ISOLATION_HYPERV = "hyperv";
+
+        public static bool TryGetInstance(IPlatform platform, out IPerformanceCounterCollector? performanceCounterCollector)
+        {
+            try
+            {
+                var isWindows = platform.IsOSPlatform(OSPlatform.Windows);
+                var isAzureAppService = IsAzureAppService(platform);
+
+                if (isAzureAppService && isWindows)
+                {
+                    performanceCounterCollector = new AzureWebAppWindowsPerformanceCounterCollector();
+                }
+                else if (isWindows)
+                {
+                    performanceCounterCollector = new WindowsPerformanceCounterCollector();
+                }
+                else
+                {
+                    performanceCounterCollector = new NonWindowsPerformanceCounterCollector();
+                }
+
+                LiveMetricsExporterEventSource.Log.PerformanceCounterCollectorFactoryDecision(isWindows, isAzureAppService, performanceCounterCollector.GetType().Name);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // Since these are platform specific classes, exceptions could be thrown during constructor call.
+                // This shouldn't happen, but here we catch the exception.
+                LiveMetricsExporterEventSource.Log.PerformanceCounterCollectorFactoryFailed(ex);
+                performanceCounterCollector = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Evaluates environment variables specific to Azure Web App.
+        /// </summary>
+        /// <remarks>
+        /// Presence of "WEBSITE_SITE_NAME" indicate web apps.
+        /// "WEBSITE_ISOLATION"=="hyperv" indicate premium containers.
+        /// In the case of premium containers, perf counters can be read using regular mechanism and hence this method returns false.
+        /// </remarks>
+        private static bool IsAzureAppService(IPlatform platform)
+        {
+            return !string.IsNullOrEmpty(platform.GetEnvironmentVariable(EnvironmentVariableConstants.WEBSITE_SITE_NAME))
+                && platform.GetEnvironmentVariable(EnvironmentVariableConstants.WEBSITE_ISOLATION) != WEBSITE_ISOLATION_HYPERV;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/PerformanceCounterCollectorFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/PerformanceCounterCollectorFactory.cs
@@ -32,7 +32,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
                     performanceCounterCollector = new NonWindowsPerformanceCounterCollector();
                 }
 
-                LiveMetricsExporterEventSource.Log.PerformanceCounterCollectorFactoryDecision(isWindows, isAzureAppService, performanceCounterCollector.GetType().Name);
+                LiveMetricsExporterEventSource.Log.ResolvedPerformanceCounterCollector(isWindows, isAzureAppService, performanceCounterCollector.GetType().Name);
                 return true;
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/PerformanceCounterCollectorFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/PerformanceCounterCollectorFactory.cs
@@ -10,14 +10,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
 {
     internal static class PerformanceCounterCollectorFactory
     {
-        private const string WEBSITE_ISOLATION_HYPERV = "hyperv";
-
-        public static bool TryGetInstance(IPlatform platform, out IPerformanceCounterCollector? performanceCounterCollector)
+        public static bool TryGetInstance(IPlatform platform, bool isAzureAppService, out IPerformanceCounterCollector? performanceCounterCollector)
         {
             try
             {
                 var isWindows = platform.IsOSPlatform(OSPlatform.Windows);
-                var isAzureAppService = IsAzureAppService(platform);
 
                 if (isAzureAppService && isWindows)
                 {
@@ -42,20 +39,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
                 performanceCounterCollector = null;
                 return false;
             }
-        }
-
-        /// <summary>
-        /// Evaluates environment variables specific to Azure Web App.
-        /// </summary>
-        /// <remarks>
-        /// Presence of "WEBSITE_SITE_NAME" indicate web apps.
-        /// "WEBSITE_ISOLATION"=="hyperv" indicate premium containers.
-        /// In the case of premium containers, perf counters can be read using regular mechanism and hence this method returns false.
-        /// </remarks>
-        private static bool IsAzureAppService(IPlatform platform)
-        {
-            return !string.IsNullOrEmpty(platform.GetEnvironmentVariable(EnvironmentVariableConstants.WEBSITE_SITE_NAME))
-                && platform.GetEnvironmentVariable(EnvironmentVariableConstants.WEBSITE_ISOLATION) != WEBSITE_ISOLATION_HYPERV;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/WindowsPerformanceCounterCollector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/WindowsPerformanceCounterCollector.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
 {
     /// <summary>
-    /// Use <see cref="System.Diagnostics.PerformanceCounter"/> to read performance counters in Windows.
+    /// Use System.Diagnostics.PerformanceCounter to read performance counters in Windows.
     /// </summary>
     internal class WindowsPerformanceCounterCollector : IPerformanceCounterCollector
     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/WindowsPerformanceCounterCollector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/PerformanceCounters/WindowsPerformanceCounterCollector.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters
+{
+    /// <summary>
+    /// Use <see cref="System.Diagnostics.PerformanceCounter"/> to read performance counters in Windows.
+    /// </summary>
+    internal class WindowsPerformanceCounterCollector : IPerformanceCounterCollector
+    {
+        public IEnumerable<Models.MetricPoint> Collect()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <Compile Include="..\..\..\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.Tests\CommonTestFramework\EventSourceTestHelper.cs" LinkBase="CommonTestFramework" />
     <Compile Include="..\..\..\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.Tests\CommonTestFramework\TestEventListener.cs" LinkBase="CommonTestFramework" />
+    <Compile Include="..\..\..\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.Tests\CommonTestFramework\MockPlatform.cs" LinkBase="CommonTestFramework" />
   </ItemGroup>
   
 </Project>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/PerformanceCounters/PerformanceCounterCollectorFactoryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/PerformanceCounters/PerformanceCounterCollectorFactoryTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Tests.PerformanceCounters
+{
+    public class PerformanceCounterCollectorFactoryTests
+    {
+        [Theory]
+        [InlineData(true, true, nameof(AzureWebAppWindowsPerformanceCounterCollector))]
+        [InlineData(true, false, nameof(WindowsPerformanceCounterCollector))]
+        [InlineData(false, true, nameof(NonWindowsPerformanceCounterCollector))]
+        [InlineData(false, false, nameof(NonWindowsPerformanceCounterCollector))]
+        public void VerifyFactoryDecision(bool isWindows, bool isAzureAppService, string expectedTypeName)
+        {
+            var platform = new MockPlatform();
+
+            platform.IsOsPlatformFunc = (os) => os.ToString() == (isWindows ? "WINDOWS" : "LINUX");
+
+            if (isAzureAppService)
+            {
+                platform.SetEnvironmentVariable(EnvironmentVariableConstants.WEBSITE_SITE_NAME, "UnitTest");
+            }
+
+            PerformanceCounterCollectorFactory.TryGetInstance(platform, out var perfCounterCollector);
+
+            Assert.Equal(expectedTypeName, perfCounterCollector!.GetType().Name);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/PerformanceCounters/PerformanceCounterCollectorFactoryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/PerformanceCounters/PerformanceCounterCollectorFactoryTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.PerformanceCounters;
 using Xunit;
@@ -17,16 +16,12 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Tests.PerformanceCounters
         [InlineData(false, false, nameof(NonWindowsPerformanceCounterCollector))]
         public void VerifyFactoryDecision(bool isWindows, bool isAzureAppService, string expectedTypeName)
         {
-            var platform = new MockPlatform();
-
-            platform.IsOsPlatformFunc = (os) => os.ToString() == (isWindows ? "WINDOWS" : "LINUX");
-
-            if (isAzureAppService)
+            var platform = new MockPlatform
             {
-                platform.SetEnvironmentVariable(EnvironmentVariableConstants.WEBSITE_SITE_NAME, "UnitTest");
-            }
+                IsOsPlatformFunc = (os) => os.ToString() == (isWindows ? "WINDOWS" : "LINUX")
+            };
 
-            PerformanceCounterCollectorFactory.TryGetInstance(platform, out var perfCounterCollector);
+            PerformanceCounterCollectorFactory.TryGetInstance(platform, isAzureAppService, out var perfCounterCollector);
 
             Assert.Equal(expectedTypeName, perfCounterCollector!.GetType().Name);
         }


### PR DESCRIPTION
I've broken the LiveMetrics Performance Counters into two parts for review.
This first PR introduces new classes which will be used to collect performance counters based on platform.


### Changes
- Manager classes have new initialization and cleanup old code.
- new class `PerformanceCounterCollectorFactory` is used to inspect the platform and return the appropriate implementation.
- new classes based on `IPerformanceCounterCollector` are returned from the Factory. 
  These will be fully implemented in following PR. I'm currently deploying and testing these now.