### PR TITLE
ClientModel: Fix build break caused by merge conflict

### DIFF
--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Response.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.Response.cs
@@ -53,7 +53,7 @@ public partial class HttpClientPipelineTransport
                     return _contentStream;
                 }
 
-                return ReadContent().ToStream();
+                return BufferContent().ToStream();
             }
             set
             {

--- a/sdk/core/System.ClientModel/tests/Pipeline/HttpClientPipelineTransportTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/HttpClientPipelineTransportTests.cs
@@ -396,7 +396,7 @@ public class HttpClientPipelineTransportTests : SyncAsyncTestBase
 
         await transport.ProcessSyncOrAsync(message, IsAsync);
 
-        BinaryData content = await message.Response!.ReadContentSyncOrAsync(default, IsAsync);
+        BinaryData content = await message.Response!.BufferContentSyncOrAsync(default, IsAsync);
 
         Assert.AreEqual(message.Response!.Content, content);
     }
@@ -416,7 +416,7 @@ public class HttpClientPipelineTransportTests : SyncAsyncTestBase
 
         await transport.ProcessSyncOrAsync(message, IsAsync);
 
-        BinaryData content = await message.Response!.ReadContentSyncOrAsync(default, IsAsync);
+        BinaryData content = await message.Response!.BufferContentSyncOrAsync(default, IsAsync);
 
         Assert.AreEqual(0, content.ToMemory().Length);
     }
@@ -439,7 +439,7 @@ public class HttpClientPipelineTransportTests : SyncAsyncTestBase
         // Explicitly assign ContentStream via property setter
         message.Response!.ContentStream = null;
 
-        BinaryData content = await message.Response!.ReadContentSyncOrAsync(default, IsAsync);
+        BinaryData content = await message.Response!.BufferContentSyncOrAsync(default, IsAsync);
 
         Assert.AreEqual(0, content.ToMemory().Length);
     }
@@ -467,7 +467,7 @@ public class HttpClientPipelineTransportTests : SyncAsyncTestBase
 
         message.Response!.ContentStream!.ReadByte();
 
-        Assert.ThrowsAsync<InvalidOperationException>(async() => { await message.Response!.ReadContentSyncOrAsync(default, IsAsync); });
+        Assert.ThrowsAsync<InvalidOperationException>(async() => { await message.Response!.BufferContentSyncOrAsync(default, IsAsync); });
     }
 
     [Test]

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockSyncAsyncExtensions.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockSyncAsyncExtensions.cs
@@ -85,15 +85,15 @@ public static class MockSyncAsyncExtensions
         }
     }
 
-    public static async Task<BinaryData> ReadContentSyncOrAsync(this PipelineResponse response, CancellationToken cancellationToken, bool isAsync)
+    public static async Task<BinaryData> BufferContentSyncOrAsync(this PipelineResponse response, CancellationToken cancellationToken, bool isAsync)
     {
         if (isAsync)
         {
-            return await response.ReadContentAsync(cancellationToken).ConfigureAwait(false);
+            return await response.BufferContentAsync(cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            return response.ReadContent(cancellationToken);
+            return response.BufferContent(cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Due to https://github.com/Azure/azure-sdk-for-net/pull/42020 and https://github.com/Azure/azure-sdk-for-net/pull/42010 auto-merging unsuccessfully.