### PR TITLE
Enable per project central package version management

### DIFF
--- a/Packages.Props
+++ b/Packages.Props
@@ -1,0 +1,3 @@
+<Project>
+    <Import Project="$(RepoEngPath)/Packages.Data.props" />
+</Project>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -163,7 +163,6 @@
 
   <!-- CentralPackageVersions properties -->
   <PropertyGroup>
-    <CentralPackagesFile>$(MSBuildThisFileDirectory)Packages.Data.props</CentralPackagesFile>
     <CentralPackageVersionPackagePath>$(MSBuildThisFileDirectory)Microsoft.Build.CentralPackageVersions\2.0.46\Sdk</CentralPackageVersionPackagePath>
     <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">false</UseProjectReferenceToAzureClients>
   </PropertyGroup>


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

This is a pre-requisite for a CoreWCF/WCF PR. We have quite a few packages we need to pull in and would like to avoid polluting the main central package management Packages.Data.Props file. This change causes the build system to start at the project folder looking for a file called Packages.Props and will keep searching up the parent folders until it find it. This places a Packages.Props folder in the root of the repo which pulls in the existing Packages.Data.Props file so all existing projects keep their same behavior.  

This change will allow us to add the file sdk/extensions/wcf/Packages.Props with our own overrides in our PR. This file will have at the top of the following line:
```xml
<Import Project="$([MSBuild]::GetPathOfFileAbove(Packages.props, $(MSBuildThisFileDirectory)..))" />
```
This will result in pulling in the central Packages.Data.Props file and then allow us to override/add additional version overrides without disrupting the rest of the build system.  

This behavior closer matches the current central package management feature. FYI the one in repo is based off an earlier incarnation of the feature so some of the names are slightly different than what you see in central package management documentation.