### PR TITLE
[System.ClientModel] Add implicit cast to `ApiKeyCredential` from `string`

### DIFF
--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -4,6 +4,7 @@ namespace System.ClientModel
     {
         public ApiKeyCredential(string key) { }
         public void Deconstruct(out string key) { throw null; }
+        public static implicit operator System.ClientModel.ApiKeyCredential (string key) { throw null; }
         public void Update(string key) { }
     }
     public abstract partial class BinaryContent : System.IDisposable

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -4,6 +4,7 @@ namespace System.ClientModel
     {
         public ApiKeyCredential(string key) { }
         public void Deconstruct(out string key) { throw null; }
+        public static implicit operator System.ClientModel.ApiKeyCredential (string key) { throw null; }
         public void Update(string key) { }
     }
     public abstract partial class BinaryContent : System.IDisposable

--- a/sdk/core/System.ClientModel/src/Convenience/ApiKeyCredential.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ApiKeyCredential.cs
@@ -38,4 +38,7 @@ public class ApiKeyCredential
 
         Volatile.Write(ref _key, key);
     }
+
+    /// <summary> Converts a string to an <see cref="ApiKeyCredential"/>. </summary>
+    public static implicit operator ApiKeyCredential(string key) => new(key);
 }

--- a/sdk/core/System.ClientModel/tests/Pipeline/ApiKeyAuthenticationPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ApiKeyAuthenticationPolicyTests.cs
@@ -17,6 +17,19 @@ public class ApiKeyAuthenticationPolicyTests : SyncAsyncTestBase
     }
 
     [Test]
+    public void CanImplicitlyCastApiKeyCredential()
+    {
+        string keyValue = "test_key";
+        ApiKeyCredential credential1 = new(keyValue);
+        ApiKeyCredential credential2 = keyValue;
+
+        credential1.Deconstruct(out string deconstructed1);
+        credential2.Deconstruct(out string deconstructed2);
+
+        Assert.AreEqual(deconstructed1, deconstructed2);
+    }
+
+    [Test]
     public async Task HeaderPolicySetsKey()
     {
         string keyValue = "test_key";


### PR DESCRIPTION
Add implicit cast to `ApiKeyCredential` from `string` to make it easier to initialize clients. For example, instead of doing: 
```csharp
ChatClient client = new("gpt-3.5-turbo", new ApiKeyCredential("<insert-API-key-here>"));
```

We can now do:
```csharp
ChatClient client = new("gpt-3.5-turbo", "<insert-API-key-here>");
```