### PR TITLE
[System.ClientModel] Add implicit cast to `T` from `ClientResult<T>`

### DIFF
--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -38,6 +38,7 @@ namespace System.ClientModel
     {
         protected internal ClientResult(T value, System.ClientModel.Primitives.PipelineResponse response) : base (default(System.ClientModel.Primitives.PipelineResponse)) { }
         public virtual T Value { get { throw null; } }
+        public static implicit operator T (System.ClientModel.ClientResult<T> result) { throw null; }
     }
 }
 namespace System.ClientModel.Primitives

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -38,6 +38,7 @@ namespace System.ClientModel
     {
         protected internal ClientResult(T value, System.ClientModel.Primitives.PipelineResponse response) : base (default(System.ClientModel.Primitives.PipelineResponse)) { }
         public virtual T Value { get { throw null; } }
+        public static implicit operator T (System.ClientModel.ClientResult<T> result) { throw null; }
     }
 }
 namespace System.ClientModel.Primitives

--- a/sdk/core/System.ClientModel/src/Convenience/ClientResultOfT.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ClientResultOfT.cs
@@ -14,4 +14,20 @@ public class ClientResult<T> : ClientResult
     }
 
     public virtual T Value { get; }
+
+    /// <summary>
+    /// Returns the value of this <see cref="ClientResult{T}"/> object.
+    /// </summary>
+    /// <param name="result">The <see cref="ClientResult{T}"/> instance.</param>
+    public static implicit operator T(ClientResult<T> result)
+    {
+        if (result == null)
+        {
+#pragma warning disable CA1065 // Don't throw from cast operators
+            throw new ArgumentNullException(nameof(result), $"The implicit cast from ClientResult<{typeof(T)}> to {typeof(T)} failed because the ClientResult<{typeof(T)}> was null.");
+#pragma warning restore CA1065
+        }
+
+        return result.Value!;
+    }
 }

--- a/sdk/core/System.ClientModel/tests/Convenience/ClientResultTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/ClientResultTests.cs
@@ -130,13 +130,24 @@ public class PipelineResponseTests
     [Test]
     public void CanImplicitlyCastClientResultOfT()
     {
-        string value = "hello";
         PipelineResponse response = new MockPipelineResponse(200);
 
-        ClientResult<string> resultAsClientResultOfT = ClientResult.FromValue(value, response);
-        string resultAsString = ClientResult.FromValue(value, response);
+        string plainString = "hello";
+        ClientResult<string> resultAsClientResultOfString = ClientResult.FromValue(plainString, response);
+        string resultAsPlainString = ClientResult.FromValue(plainString, response);
+        Assert.AreEqual(resultAsClientResultOfString.Value, resultAsPlainString);
 
-        Assert.AreEqual(resultAsClientResultOfT.Value, resultAsString);
+        string? nullableString = null;
+        ClientResult<string?> resultAsClientResultOfNullableString = ClientResult.FromOptionalValue(nullableString, response);
+        string? resultAsNullableString = ClientResult.FromOptionalValue(nullableString, response);
+        Assert.IsNull(resultAsNullableString);
+        Assert.AreEqual(resultAsClientResultOfNullableString.Value, resultAsNullableString);
+
+        int? nullableInt = null;
+        ClientResult<int?> resultAsClientResultOfNullableInt = ClientResult.FromOptionalValue(nullableInt, response);
+        int? resultAsNullableInt = ClientResult.FromOptionalValue(nullableInt, response);
+        Assert.IsNull(resultAsNullableInt);
+        Assert.AreEqual(resultAsClientResultOfNullableInt.Value, resultAsNullableInt);
     }
 
     #endregion

--- a/sdk/core/System.ClientModel/tests/Convenience/ClientResultTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/ClientResultTests.cs
@@ -127,6 +127,18 @@ public class PipelineResponseTests
         Assert.AreEqual(response.Status, result.GetRawResponse().Status);
     }
 
+    [Test]
+    public void CanImplicitlyCastClientResultOfT()
+    {
+        string value = "hello";
+        PipelineResponse response = new MockPipelineResponse(200);
+
+        ClientResult<string> resultAsClientResultOfT = ClientResult.FromValue(value, response);
+        string resultAsString = ClientResult.FromValue(value, response);
+
+        Assert.AreEqual(resultAsClientResultOfT.Value, resultAsString);
+    }
+
     #endregion
 
     #region MockClient Tests


### PR DESCRIPTION
This is a feature that we had in `Response<T>`. Now, instead of having to do this:

```csharp
ClientResult<ChatCompletion> result = client.CompleteChat("How does AI work? Explain it in simple terms.");
ChatCompletion chatCompletion = result.Value;
```

Users can do following instead:
```csharp
ChatCompletion chatCompletion = client.CompleteChat("How does AI work? Explain it in simple terms.");
```

Which is notably cleaner.