### PR TITLE
[Azure.Core] Prepare for OOB Release (2024-02-26)

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.38.0-beta.1 (Unreleased)
+## 1.38.0 (2024-02-26)
 
 ### Features Added
 
 - Add `GetRehydrationToken` to `Operation` for rehydration purpose.
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.38.0-beta.1</Version>
+    <Version>1.38.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.37.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare Azure.Core for an out-of-band release to unblock LRO rehydration.