### PR TITLE
[AzureMonitorExporter] fix eventsource name spam in debug console

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventListener.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventListener.cs
@@ -36,8 +36,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            string message = EventSourceEventFormatting.Format(eventData);
-            TelemetryDebugWriter.WriteMessage($"{eventData.EventSource.Name} - EventId: [{eventData.EventId}], EventName: [{eventData.EventName}], Message: [{message}]");
+            if (eventData.EventSource.Name == AzureMonitorExporterEventSource.EventSourceName)
+            {
+                string message = EventSourceEventFormatting.Format(eventData);
+                TelemetryDebugWriter.WriteMessage($"{eventData.EventSource.Name} - EventId: [{eventData.EventId}], EventName: [{eventData.EventName}], Message: [{message}]");
+            }
         }
     }
 }


### PR DESCRIPTION
This is to fix the issue where the Debug Console is spammed with messages like:

```
Payload = System.Diagnostics.Tracing.EventPayload]
Microsoft-AspNetCore-Server-Kestrel - EventId: [-1], EventName: [EventCounters], Message: [EventCounters
Payload = System.Diagnostics.Tracing.EventPayload]
Microsoft-AspNetCore-Server-Kestrel - EventId: [-1], EventName: [EventCounters], Message: [EventCounters
Payload = System.Diagnostics.Tracing.EventPayload]
```