### PR TITLE
[AzureMonitorExporter] support Resource ServiceVersion

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features Added
 
+* Added support for "service.version" in Resource attributes.
+  This is mapped as Application Version in Application Insights.
+  ([#42174](https://github.com/Azure/azure-sdk-for-net/pull/42174))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Features Added
 
-* All three signals (Traces, Metrics, and Logs) now support "service.version" in Resource attributes.
-  This is mapped as Application Version in Application Insights.
+* All three signals (Traces, Metrics, and Logs) now support OpenTelemetry's ["service.version"](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#service) in Resource attributes.
+  This is mapped as [Application Version](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete#application-version) in Application Insights.
   ([#42174](https://github.com/Azure/azure-sdk-for-net/pull/42174))
 
 ### Breaking Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-* Added support for "service.version" in Resource attributes.
+* All three signals (Traces, Metrics, and Logs) now support "service.version" in Resource attributes.
   This is mapped as Application Version in Application Insights.
   ([#42174](https://github.com/Azure/azure-sdk-for-net/pull/42174))
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -82,6 +82,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             Tags[ContextTagKeys.AiCloudRole.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()].Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength);
             Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()].Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength);
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
+            Tags[ContextTagKeys.AiApplicationVer.ToString()] = telemetryItem.Tags[ContextTagKeys.AiApplicationVer.ToString()].Truncate(SchemaConstants.Tags_AiApplicationVer_MaxLength);
             InstrumentationKey = telemetryItem.InstrumentationKey;
 
             if (telemetryItem.SampleRate != 100f)
@@ -123,6 +124,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             InstrumentationKey = instrumentationKey;
             Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName.Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength);
             Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance.Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength);
+            Tags[ContextTagKeys.AiApplicationVer.ToString()] = resource?.ServiceVersion.Truncate(SchemaConstants.Tags_AiApplicationVer_MaxLength);
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -11,6 +11,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal string? RoleInstance { get; set; }
 
+        internal string? ServiceVersion { get; set; }
+
         internal MonitorBase? MonitorBaseData { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -32,6 +32,7 @@ internal static class ResourceExtensions
         string? serviceName = null;
         string? serviceNamespace = null;
         string? serviceInstance = null;
+        string? serviceVersion = null;
         bool? hasDefaultServiceName = null;
 
         if (instrumentationKey != null && resource.Attributes.Any())
@@ -62,6 +63,9 @@ internal static class ResourceExtensions
                 case AiSdkPrefixKey when attribute.Value is string _aiSdkPrefixValue:
                     SdkVersionUtils.SdkVersionPrefix = _aiSdkPrefixValue;
                     continue;
+                case SemanticConventions.AttributeServiceVersion when attribute.Value is string _serviceVersion:
+                    serviceVersion = _serviceVersion;
+                    break;
                 case TelemetryDistroNameKey when attribute.Value is string _aiSdkDistroValue:
                     if (_aiSdkDistroValue == "Azure.Monitor.OpenTelemetry.AspNetCore")
                     {
@@ -102,6 +106,11 @@ internal static class ResourceExtensions
         catch (Exception ex)
         {
             AzureMonitorExporterEventSource.Log.ErrorInitializingRoleInstanceToHostName(ex);
+        }
+
+        if (serviceVersion != null)
+        {
+            azureMonitorResource.ServiceVersion = serviceVersion;
         }
 
         if (aksResourceProcessor != null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -10,6 +10,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     /// <see href="https://github.com/Azure/azure-rest-api-specs/blob/4eb2ae1846ac79a993cabc378436b6218baaa1ed/specification/applicationinsights/data-plane/Monitor.Exporters/preview/2020-09-15_Preview/swagger.json"/>
     /// and the Ingestion service data models
     /// <see href="https://docs.microsoft.com/azure/azure-monitor/app/data-model"/>.
+    /// NOTE: Some of these max lengths are not defined in the Swagger. Must refer to the internal service repo.
     /// </summary>
     /// <remarks>
     /// MaxLength (inclusive) defines the maximum number of characters.
@@ -120,6 +121,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const int Tags_AiOperationName_MaxLength = 1024;
         public const int Tags_AiOperationParentId_MaxLength = 512;
         public const int Tags_AiUserAuthUserId_MaxLength = 1024;
+        public const int Tags_AiApplicationVer_MaxLength = 1024;
         public const int Tags_AiCloudRole_MaxLength = 256;
         public const int Tags_AiCloudRoleInstance_MaxLength = 256;
         public const int Tags_AiInternalSdkVersion_MaxLength = 64;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Azure.Core;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Resources;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs
 {
@@ -13,10 +15,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs
 
         public LogDemo(string connectionString, TokenCredential? credential = null)
         {
+            var resourceAttributes = new Dictionary<string, object>
+            {
+                { "service.name", "my-service" },
+                { "service.namespace", "my-namespace" },
+                { "service.instance.id", "my-instance" },
+                { "service.version", "1.0.0-demo" },
+            };
+
+            var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+
             this.loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder.AddOpenTelemetry(options =>
                 {
+                    options.SetResourceBuilder(resourceBuilder);
                     options.AddAzureMonitorLogExporter(o => o.ConnectionString = connectionString, credential);
                 });
             });

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.Metrics;
 using Azure.Core;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics
 {
@@ -20,10 +21,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics
 
         public MetricDemo(string connectionString, TokenCredential? credential = null)
         {
+            var resourceAttributes = new Dictionary<string, object>
+            {
+                { "service.name", "my-service" },
+                { "service.namespace", "my-namespace" },
+                { "service.instance.id", "my-instance" },
+                { "service.version", "1.0.0-demo" },
+            };
+
+            var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+
             this.meterProvider = Sdk.CreateMeterProviderBuilder()
-                                .AddMeter(meterName)
-                                .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString, credential)
-                                .Build();
+                .SetResourceBuilder(resourceBuilder)
+                .AddMeter(meterName)
+                .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString, credential)
+                .Build();
         }
 
         /// <remarks>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -25,6 +25,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
                 { "service.name", "my-service" },
                 { "service.namespace", "my-namespace" },
                 { "service.instance.id", "my-instance" },
+                { "service.version", "1.0.0-demo" },
                 { "foo", "bar" }
             };
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -26,7 +26,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
                 { "service.namespace", "my-namespace" },
                 { "service.instance.id", "my-instance" },
                 { "service.version", "1.0.0-demo" },
-                { "foo", "bar" }
             };
 
             var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -18,26 +18,30 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             string expectedMessage,
             IDictionary<string, string> expectedMessageProperties,
             string? expectedSpanId,
-            string? expectedTraceId)
+            string? expectedTraceId,
+            string expectedCloudRole = "[testNamespace]/testName",
+            string expectedCloudInstance = "testInstance",
+            string expectedApplicationVersion = "testVersion")
         {
             Assert.Equal("Message", telemetryItem.Name); // telemetry type
             Assert.Equal("MessageData", telemetryItem.Data.BaseType); // telemetry data type
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            var expectedTagsCount = 3;
+            var expectedTagsCount = 4;
 
             if (expectedSpanId != null && expectedTraceId != null)
             {
-                expectedTagsCount = 5;
+                expectedTagsCount += 2;
 
                 Assert.Equal(expectedSpanId, telemetryItem.Tags["ai.operation.parentId"]);
                 Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
             }
 
             Assert.Equal(expectedTagsCount, telemetryItem.Tags.Count);
-            Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
-            Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
+            Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
+            Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
+            Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
 
             var messageData = (MessageData)telemetryItem.Data.BaseData;
@@ -63,16 +67,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             TelemetryItem telemetryItem,
             string expectedSeverityLevel,
             string expectedMessage,
-            string expectedTypeName)
+            string expectedTypeName,
+            string expectedCloudRole = "[testNamespace]/testName",
+            string expectedCloudInstance = "testInstance",
+            string expectedApplicationVersion = "testVersion")
         {
             Assert.Equal("Exception", telemetryItem.Name); // telemetry type
             Assert.Equal("ExceptionData", telemetryItem.Data.BaseType); // telemetry data type
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(3, telemetryItem.Tags.Count);
-            Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
-            Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
+            Assert.Equal(4, telemetryItem.Tags.Count);
+            Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
+            Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
+            Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
 
             var telemetryExceptionData = (TelemetryExceptionData)telemetryItem.Data.BaseData;
@@ -94,18 +102,22 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             string? expectedSpanId,
             IDictionary<string, string>? expectedProperties,
             string expectedAuthUserId,
-            bool expectedSuccess = true)
+            bool expectedSuccess = true,
+            string expectedCloudRole = "[testNamespace]/testName",
+            string expectedCloudInstance = "testInstance",
+            string expectedApplicationVersion = "testVersion")
         {
             Assert.Equal("RemoteDependency", telemetryItem.Name); // telemetry type
             Assert.Equal("RemoteDependencyData", telemetryItem.Data.BaseType); // telemetry data type
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(5, telemetryItem.Tags.Count);
+            Assert.Equal(6, telemetryItem.Tags.Count);
             Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
             Assert.Equal(expectedAuthUserId, telemetryItem.Tags["ai.user.authUserId"]);
-            Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
-            Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
+            Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
+            Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
+            Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
 
             var remoteDependencyData = (RemoteDependencyData)telemetryItem.Data.BaseData;
@@ -134,20 +146,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             IDictionary<string, string> expectedProperties,
             string? expectedSpanId,
             string expectedAuthUserId,
-            bool expectedSuccess = true)
+            bool expectedSuccess = true,
+            string expectedCloudRole = "[testNamespace]/testName",
+            string expectedCloudInstance = "testInstance",
+            string expectedApplicationVersion = "testVersion")
         {
             Assert.Equal("Request", telemetryItem.Name); // telemetry type
             Assert.Equal("RequestData", telemetryItem.Data.BaseType); // telemetry data type
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            var expectedTagsCount = 6;
+            var expectedTagsCount = 7;
 
             Assert.Equal(expectedTagsCount, telemetryItem.Tags.Count);
             Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
             Assert.Equal(expectedAuthUserId, telemetryItem.Tags["ai.user.authUserId"]);
-            Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
-            Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
+            Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
+            Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
+            Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
 
             var requestData = (RequestData)telemetryItem.Data.BaseData;
@@ -175,18 +191,22 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             string? expectedTraceId,
             string? expectedSpanId,
             IDictionary<string, string>? expectedProperties,
-            Action<TelemetryExceptionData>? additionalChecks = null)
+            Action<TelemetryExceptionData>? additionalChecks = null,
+            string expectedCloudRole = "[testNamespace]/testName",
+            string expectedCloudInstance = "testInstance",
+            string expectedApplicationVersion = "testVersion")
         {
             Assert.Equal("Exception", telemetryItem.Name); // telemetry type
             Assert.Equal("ExceptionData", telemetryItem.Data.BaseType); // telemetry data type
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(5, telemetryItem.Tags.Count);
+            Assert.Equal(6, telemetryItem.Tags.Count);
             Assert.Equal(expectedSpanId, telemetryItem.Tags["ai.operation.parentId"]);
             Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
-            Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
-            Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
+            Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
+            Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
+            Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
 
             var telemetryExceptionData = (TelemetryExceptionData)telemetryItem.Data.BaseData;
@@ -224,16 +244,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             double? expectedMetricDataPointMax = null,
             double? expectedMetricDataPointMin = null,
             double? expectedMetricDataPointStdDev = null,
-            Dictionary<string, string>? expectedMetricsProperties = null)
+            Dictionary<string, string>? expectedMetricsProperties = null,
+            string expectedCloudRole = "[testNamespace]/testName",
+            string expectedCloudInstance = "testInstance",
+            string expectedApplicationVersion = "testVersion")
         {
             Assert.Equal("Metric", telemetryItem.Name); // telemetry type
             Assert.Equal("MetricData", telemetryItem.Data.BaseType); // telemetry data type
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(3, telemetryItem.Tags.Count);
-            Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
-            Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
+            Assert.Equal(4, telemetryItem.Tags.Count);
+            Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
+            Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
+            Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
 
             var metricsData = (MetricsData)telemetryItem.Data.BaseData;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -8,6 +8,7 @@ using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,6 +21,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
     public class LogsTests
     {
         internal readonly TelemetryItemOutputHelper telemetryOutput;
+
+        internal readonly Dictionary<string, object> testResourceAttributes = new()
+        {
+            { "service.instance.id", "testInstance" },
+            { "service.name", "testName" },
+            { "service.namespace", "testNamespace" },
+            { "service.version", "testVersion" },
+        };
 
         public LogsTests(ITestOutputHelper output)
         {
@@ -48,6 +57,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                     .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, logLevel)
                     .AddOpenTelemetry(options =>
                     {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
                         options.AddAzureMonitorLogExporterForTest(out telemetryItems);
                     });
             });
@@ -100,6 +110,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                     .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, logLevel)
                     .AddOpenTelemetry(options =>
                     {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
                         options.AddAzureMonitorLogExporterForTest(out telemetryItems);
                     });
             });

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -9,6 +9,7 @@ using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,6 +23,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
     public class MetricsTests
     {
         internal readonly TelemetryItemOutputHelper telemetryOutput;
+
+        internal readonly Dictionary<string, object> testResourceAttributes = new()
+        {
+            { "service.instance.id", "testInstance" },
+            { "service.name", "testName" },
+            { "service.namespace", "testNamespace" },
+            { "service.version", "testVersion" },
+        };
 
         public MetricsTests(ITestOutputHelper output)
         {
@@ -40,6 +49,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var meter = new Meter(meterName, "1.0");
 
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems);
 
@@ -86,6 +96,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var meter = new Meter(meterName, "1.0");
 
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems);
 
@@ -142,6 +153,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var meter = new Meter(meterName, "1.0");
 
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems);
 
@@ -186,6 +198,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var meter = new Meter(meterName, "1.0");
 
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems);
 
@@ -232,6 +245,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var meter = new Meter(meterName, "1.0");
 
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems, out MetricReader metricReader);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -10,6 +10,7 @@ using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,6 +24,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
     public class TracesTests
     {
         internal readonly TelemetryItemOutputHelper telemetryOutput;
+
+        internal readonly Dictionary<string, object> testResourceAttributes = new()
+        {
+            { "service.instance.id", "testInstance" },
+            { "service.name", "testName" },
+            { "service.namespace", "testNamespace" },
+            { "service.version", "testVersion" },
+        };
 
         public TracesTests(ITestOutputHelper output)
         {
@@ -42,6 +51,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var activitySource = new ActivitySource(activitySourceName);
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out List<TelemetryItem> telemetryItems)
                 .Build();
@@ -90,6 +100,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var activitySource = new ActivitySource(activitySourceName);
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out List<TelemetryItem> telemetryItems)
                 .Build();
@@ -137,6 +148,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var activitySource = new ActivitySource(activitySourceName);
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out List<TelemetryItem> telemetryItems)
                 .Build();
@@ -220,6 +232,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             List<TelemetryItem>? logTelemetryItems = null;
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out List<TelemetryItem> activityTelemetryItems)
                 .Build();
@@ -230,6 +243,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                     .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, logLevel)
                     .AddOpenTelemetry(options =>
                     {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
                         options.AddAzureMonitorLogExporterForTest(out logTelemetryItems);
                     });
             });
@@ -296,6 +310,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             using var activitySource = new ActivitySource(activitySourceName);
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .ConfigureResource(x => x.AddAttributes(testResourceAttributes))
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out List<TelemetryItem> telemetryItems)
                 .Build();


### PR DESCRIPTION
Fixes #27269

Adding support for `"service.version"` from Resource. This will be parsed along with the other Resource attributes we recognize.

### Changes
- add ServiceVersion to `AzureMonitorResource` and add support in `TelemetryItem` ctor.
- update tests
  - I had to add Resources ("service.name", "service.namespace", and "service.version") to all existing E2E tests to confirm that this was covered. Then added "service.version".
- update Demo project
