### PR TITLE
Fix typo in resource manager readme

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/README.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/README.md
@@ -388,7 +388,7 @@ ResourceIdentifier id = new ResourceIdentifier("/subscriptions/{subscription_id}
 var createResult = await client.GetGenericResources().CreateOrUpdateAsync(WaitUntil.Completed, id, data);
 Console.WriteLine($"Resource {createResult.Value.Id.Name} in resource group {createResult.Value.Id.ResourceGroupName} updated");
 ```
-### Update GenericResourc Tags
+### Update GenericResource Tags
 ```C# Snippet:Update_GenericResourc_Tags
 ArmClient client = new ArmClient(new DefaultAzureCredential());
 ResourceIdentifier id = new ResourceIdentifier("/subscriptions/{subscription_id}/resourceGroups/{resourcegroup_name}/providers/Microsoft.Network/virtualNetworks/{vnet_name}");


### PR DESCRIPTION
`Resource` is mistakenly spelt `Resourc`. Figured I'd make a quick PR to fix :)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
