### PR TITLE
Azure.Core 2.0: Update Request and RequestContent

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.39.0-beta.1 (Unreleased)
+## 2.0.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- Moved Azure.Core types to use functionality implemented in System.ClientModel library.
 
 ## 1.38.0 (2024-02-26)
 

--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -542,28 +542,31 @@ namespace Azure.Core
         string System.ClientModel.Primitives.IPersistableModel<object>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<object>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
-    public abstract partial class Request : System.IDisposable
+    public abstract partial class Request : System.ClientModel.Primitives.PipelineRequest
     {
         protected Request() { }
-        public abstract string ClientRequestId { get; set; }
-        public virtual Azure.Core.RequestContent? Content { get { throw null; } set { } }
-        public Azure.Core.RequestHeaders Headers { get { throw null; } }
-        public virtual Azure.Core.RequestMethod Method { get { throw null; } set { } }
-        public virtual Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        public virtual string ClientRequestId { get { throw null; } set { } }
+        public virtual new Azure.Core.RequestContent? Content { get { throw null; } set { } }
+        protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
+        public new Azure.Core.RequestHeaders Headers { get { throw null; } }
+        protected override System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get { throw null; } }
+        public virtual new Azure.Core.RequestMethod Method { get { throw null; } set { } }
+        protected override string MethodCore { get { throw null; } set { } }
+        public virtual new Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        protected override System.Uri? UriCore { get { throw null; } set { } }
         protected internal abstract void AddHeader(string name, string value);
         protected internal abstract bool ContainsHeader(string name);
-        public abstract void Dispose();
         protected internal abstract System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders();
         protected internal abstract bool RemoveHeader(string name);
         protected internal virtual void SetHeader(string name, string value) { }
         protected internal abstract bool TryGetHeader(string name, out string? value);
         protected internal abstract bool TryGetHeaderValues(string name, out System.Collections.Generic.IEnumerable<string>? values);
     }
-    public abstract partial class RequestContent : System.IDisposable
+    public abstract partial class RequestContent : System.ClientModel.BinaryContent
     {
         protected RequestContent() { }
         public static Azure.Core.RequestContent Create(Azure.Core.Serialization.DynamicData content) { throw null; }
-        public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
+        public static new Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes, int index, int length) { throw null; }
@@ -573,13 +576,10 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(object serializable, Azure.Core.Serialization.ObjectSerializer? serializer) { throw null; }
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
-        public abstract void Dispose();
+        public static Azure.Core.RequestContent Create<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
         public static implicit operator Azure.Core.RequestContent (Azure.Core.Serialization.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
-        public abstract bool TryComputeLength(out long length);
-        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
-        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
     }
     public abstract partial class RequestFailedDetailsParser
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -545,7 +545,7 @@ namespace Azure.Core
     public abstract partial class Request : System.ClientModel.Primitives.PipelineRequest
     {
         protected Request() { }
-        public virtual string ClientRequestId { get { throw null; } set { } }
+        public abstract string ClientRequestId { get; set; }
         public virtual new Azure.Core.RequestContent? Content { get { throw null; } set { } }
         protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
         public new Azure.Core.RequestHeaders Headers { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -542,28 +542,31 @@ namespace Azure.Core
         string System.ClientModel.Primitives.IPersistableModel<object>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<object>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
-    public abstract partial class Request : System.IDisposable
+    public abstract partial class Request : System.ClientModel.Primitives.PipelineRequest
     {
         protected Request() { }
-        public abstract string ClientRequestId { get; set; }
-        public virtual Azure.Core.RequestContent? Content { get { throw null; } set { } }
-        public Azure.Core.RequestHeaders Headers { get { throw null; } }
-        public virtual Azure.Core.RequestMethod Method { get { throw null; } set { } }
-        public virtual Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        public virtual string ClientRequestId { get { throw null; } set { } }
+        public virtual new Azure.Core.RequestContent? Content { get { throw null; } set { } }
+        protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
+        public new Azure.Core.RequestHeaders Headers { get { throw null; } }
+        protected override System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get { throw null; } }
+        public virtual new Azure.Core.RequestMethod Method { get { throw null; } set { } }
+        protected override string MethodCore { get { throw null; } set { } }
+        public virtual new Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        protected override System.Uri? UriCore { get { throw null; } set { } }
         protected internal abstract void AddHeader(string name, string value);
         protected internal abstract bool ContainsHeader(string name);
-        public abstract void Dispose();
         protected internal abstract System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders();
         protected internal abstract bool RemoveHeader(string name);
         protected internal virtual void SetHeader(string name, string value) { }
         protected internal abstract bool TryGetHeader(string name, out string? value);
         protected internal abstract bool TryGetHeaderValues(string name, out System.Collections.Generic.IEnumerable<string>? values);
     }
-    public abstract partial class RequestContent : System.IDisposable
+    public abstract partial class RequestContent : System.ClientModel.BinaryContent
     {
         protected RequestContent() { }
         public static Azure.Core.RequestContent Create(Azure.Core.Serialization.DynamicData content) { throw null; }
-        public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
+        public static new Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes, int index, int length) { throw null; }
@@ -573,13 +576,10 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(object serializable, Azure.Core.Serialization.ObjectSerializer? serializer) { throw null; }
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
-        public abstract void Dispose();
+        public static Azure.Core.RequestContent Create<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
         public static implicit operator Azure.Core.RequestContent (Azure.Core.Serialization.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
-        public abstract bool TryComputeLength(out long length);
-        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
-        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
     }
     public abstract partial class RequestFailedDetailsParser
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -545,7 +545,7 @@ namespace Azure.Core
     public abstract partial class Request : System.ClientModel.Primitives.PipelineRequest
     {
         protected Request() { }
-        public virtual string ClientRequestId { get { throw null; } set { } }
+        public abstract string ClientRequestId { get; set; }
         public virtual new Azure.Core.RequestContent? Content { get { throw null; } set { } }
         protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
         public new Azure.Core.RequestHeaders Headers { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -545,7 +545,7 @@ namespace Azure.Core
     public abstract partial class Request : System.ClientModel.Primitives.PipelineRequest
     {
         protected Request() { }
-        public virtual string ClientRequestId { get { throw null; } set { } }
+        public abstract string ClientRequestId { get; set; }
         public virtual new Azure.Core.RequestContent? Content { get { throw null; } set { } }
         protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
         public new Azure.Core.RequestHeaders Headers { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -542,28 +542,31 @@ namespace Azure.Core
         string System.ClientModel.Primitives.IPersistableModel<object>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<object>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
-    public abstract partial class Request : System.IDisposable
+    public abstract partial class Request : System.ClientModel.Primitives.PipelineRequest
     {
         protected Request() { }
-        public abstract string ClientRequestId { get; set; }
-        public virtual Azure.Core.RequestContent? Content { get { throw null; } set { } }
-        public Azure.Core.RequestHeaders Headers { get { throw null; } }
-        public virtual Azure.Core.RequestMethod Method { get { throw null; } set { } }
-        public virtual Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        public virtual string ClientRequestId { get { throw null; } set { } }
+        public virtual new Azure.Core.RequestContent? Content { get { throw null; } set { } }
+        protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
+        public new Azure.Core.RequestHeaders Headers { get { throw null; } }
+        protected override System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get { throw null; } }
+        public virtual new Azure.Core.RequestMethod Method { get { throw null; } set { } }
+        protected override string MethodCore { get { throw null; } set { } }
+        public virtual new Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        protected override System.Uri? UriCore { get { throw null; } set { } }
         protected internal abstract void AddHeader(string name, string value);
         protected internal abstract bool ContainsHeader(string name);
-        public abstract void Dispose();
         protected internal abstract System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders();
         protected internal abstract bool RemoveHeader(string name);
         protected internal virtual void SetHeader(string name, string value) { }
         protected internal abstract bool TryGetHeader(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out string? value);
         protected internal abstract bool TryGetHeaderValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values);
     }
-    public abstract partial class RequestContent : System.IDisposable
+    public abstract partial class RequestContent : System.ClientModel.BinaryContent
     {
         protected RequestContent() { }
         public static Azure.Core.RequestContent Create(Azure.Core.Serialization.DynamicData content) { throw null; }
-        public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
+        public static new Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes, int index, int length) { throw null; }
@@ -576,13 +579,10 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(object serializable, Azure.Core.Serialization.ObjectSerializer? serializer) { throw null; }
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
-        public abstract void Dispose();
+        public static Azure.Core.RequestContent Create<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
         public static implicit operator Azure.Core.RequestContent (Azure.Core.Serialization.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
-        public abstract bool TryComputeLength(out long length);
-        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
-        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
     }
     public abstract partial class RequestFailedDetailsParser
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -542,28 +542,31 @@ namespace Azure.Core
         string System.ClientModel.Primitives.IPersistableModel<object>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<object>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
-    public abstract partial class Request : System.IDisposable
+    public abstract partial class Request : System.ClientModel.Primitives.PipelineRequest
     {
         protected Request() { }
-        public abstract string ClientRequestId { get; set; }
-        public virtual Azure.Core.RequestContent? Content { get { throw null; } set { } }
-        public Azure.Core.RequestHeaders Headers { get { throw null; } }
-        public virtual Azure.Core.RequestMethod Method { get { throw null; } set { } }
-        public virtual Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        public virtual string ClientRequestId { get { throw null; } set { } }
+        public virtual new Azure.Core.RequestContent? Content { get { throw null; } set { } }
+        protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
+        public new Azure.Core.RequestHeaders Headers { get { throw null; } }
+        protected override System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get { throw null; } }
+        public virtual new Azure.Core.RequestMethod Method { get { throw null; } set { } }
+        protected override string MethodCore { get { throw null; } set { } }
+        public virtual new Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        protected override System.Uri? UriCore { get { throw null; } set { } }
         protected internal abstract void AddHeader(string name, string value);
         protected internal abstract bool ContainsHeader(string name);
-        public abstract void Dispose();
         protected internal abstract System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders();
         protected internal abstract bool RemoveHeader(string name);
         protected internal virtual void SetHeader(string name, string value) { }
         protected internal abstract bool TryGetHeader(string name, out string? value);
         protected internal abstract bool TryGetHeaderValues(string name, out System.Collections.Generic.IEnumerable<string>? values);
     }
-    public abstract partial class RequestContent : System.IDisposable
+    public abstract partial class RequestContent : System.ClientModel.BinaryContent
     {
         protected RequestContent() { }
         public static Azure.Core.RequestContent Create(Azure.Core.Serialization.DynamicData content) { throw null; }
-        public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
+        public static new Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes, int index, int length) { throw null; }
@@ -573,13 +576,10 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(object serializable, Azure.Core.Serialization.ObjectSerializer? serializer) { throw null; }
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
-        public abstract void Dispose();
+        public static Azure.Core.RequestContent Create<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
         public static implicit operator Azure.Core.RequestContent (Azure.Core.Serialization.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
-        public abstract bool TryComputeLength(out long length);
-        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
-        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
     }
     public abstract partial class RequestFailedDetailsParser
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -545,7 +545,7 @@ namespace Azure.Core
     public abstract partial class Request : System.ClientModel.Primitives.PipelineRequest
     {
         protected Request() { }
-        public virtual string ClientRequestId { get { throw null; } set { } }
+        public abstract string ClientRequestId { get; set; }
         public virtual new Azure.Core.RequestContent? Content { get { throw null; } set { } }
         protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
         public new Azure.Core.RequestHeaders Headers { get { throw null; } }

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.39.0-beta.1</Version>
+    <Version>2.0.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.38.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
@@ -73,6 +73,10 @@
     <Compile Include="Shared\CancellationHelper.cs" />
     <Compile Include="Shared\OperationPoller.cs" />
     <Compile Include="Shared\TypeReferenceTypeAttribute.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.ClientModel\src\System.ClientModel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Net.Http;
 using Azure.Core.Pipeline;
 
 namespace Azure.Core
@@ -13,36 +14,112 @@ namespace Azure.Core
     /// Represents an HTTP request. Use <see cref="HttpPipeline.CreateMessage()"/> or <see cref="HttpPipeline.CreateRequest"/> to create an instance.
     /// </summary>
 #pragma warning disable AZC0012 // Avoid single word type names
-    public abstract class Request : IDisposable
+    public abstract class Request : PipelineRequest
 #pragma warning restore AZC0012 // Avoid single word type names
     {
-        private RequestUriBuilder? _uri;
+        private RequestMethod _method;
+        private RequestUriBuilder? _uriBuilder;
+        private RequestContent? _content;
 
-        /// <summary>
-        /// Gets or sets and instance of <see cref="RequestUriBuilder"/> used to create the Uri.
-        /// </summary>
-        public virtual RequestUriBuilder Uri
-        {
-            get
-            {
-                return _uri ??= new RequestUriBuilder();
-            }
-            set
-            {
-                Argument.AssertNotNull(value, nameof(value));
-                _uri = value;
-            }
-        }
+        private string? _clientRequestId;
 
         /// <summary>
         /// Gets or sets the request HTTP method.
         /// </summary>
-        public virtual RequestMethod Method { get; set; }
+        public new virtual RequestMethod Method
+        {
+            // TODO
+            get => _method;
+            set => MethodCore = value.Method;
+        }
+
+        /// <summary>
+        /// Gets or sets and instance of <see cref="RequestUriBuilder"/> used to create the Uri.
+        /// </summary>
+        public new virtual RequestUriBuilder Uri
+        {
+            get => _uriBuilder ??= new RequestUriBuilder();
+            set
+            {
+                Argument.AssertNotNull(value, nameof(value));
+
+                _uriBuilder = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the request content.
         /// </summary>
-        public virtual RequestContent? Content { get; set; }
+        public new virtual RequestContent? Content
+        {
+            get => (RequestContent?)ContentCore;
+            set => ContentCore = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the client request id that was sent to the server as <c>x-ms-client-request-id</c> headers.
+        /// </summary>
+        public virtual string ClientRequestId
+        {
+            get => _clientRequestId ??= Guid.NewGuid().ToString();
+            set
+            {
+                Argument.AssertNotNull(value, nameof(value));
+                _clientRequestId = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the request HTTP headers.
+        /// </summary>
+        public new RequestHeaders Headers => new(this);
+
+        #region Overrides for "Core" methods from the PipelineRequest Template pattern
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        protected override string MethodCore
+        {
+            get => _method.Method;
+            set => _method = RequestMethod.Parse(value);
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        protected override Uri? UriCore
+        {
+            get => Uri.ToUri();
+            set
+            {
+                if (value is null)
+                {
+                    Uri = new();
+                }
+                else
+                {
+                    Uri.Reset(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        protected override BinaryContent? ContentCore
+        {
+            get => _content;
+            set => _content = (RequestContent?)value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        protected override PipelineRequestHeaders HeadersCore
+            => new AzureCoreRequestHeaders(Headers);
+
+        #endregion
 
         /// <summary>
         /// Adds a header value to the header collection.
@@ -98,18 +175,43 @@ namespace Azure.Core
         protected internal abstract IEnumerable<HttpHeader> EnumerateHeaders();
 
         /// <summary>
-        /// Gets or sets the client request id that was sent to the server as <c>x-ms-client-request-id</c> headers.
+        /// Backwards adapter to RequestHeaders to implement GetHeadersCore.
         /// </summary>
-        public abstract string ClientRequestId { get; set; }
+        private sealed class AzureCoreRequestHeaders : PipelineRequestHeaders
+        {
+            /// <summary>
+            /// Headers on the Azure.Core.Request type to adapt to.
+            /// </summary>
+            private readonly RequestHeaders _headers;
 
-        /// <summary>
-        /// Gets the response HTTP headers.
-        /// </summary>
-        public RequestHeaders Headers => new(this);
+            public AzureCoreRequestHeaders(RequestHeaders headers)
+                => _headers = headers;
 
-        /// <summary>
-        /// Frees resources held by this <see cref="Response"/> instance.
-        /// </summary>
-        public abstract void Dispose();
+            public override void Add(string name, string value)
+                => _headers.Add(name, value);
+
+            public override bool Remove(string name)
+                => _headers.Remove(name);
+
+            public override void Set(string name, string value)
+                => _headers.SetValue(name, value);
+
+            public override IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+                => GetHeadersCompositeValues().GetEnumerator();
+
+            private IEnumerable<KeyValuePair<string, string>> GetHeadersCompositeValues()
+            {
+                foreach (HttpHeader header in _headers)
+                {
+                    yield return new KeyValuePair<string, string>(header.Name, header.Value);
+                }
+            }
+
+            public override bool TryGetValue(string name, out string? value)
+                => _headers.TryGetValue(name, out value);
+
+            public override bool TryGetValues(string name, out IEnumerable<string>? values)
+                => _headers.TryGetValues(name, out values);
+        }
     }
 }

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -18,18 +18,11 @@ namespace Azure.Core
     public abstract class Request : PipelineRequest
 #pragma warning restore AZC0012 // Avoid single word type names
     {
+        private string _method = RequestMethod.Get.Method;
         private RequestUriBuilder? _uriBuilder;
         private RequestContent? _content;
 
         private string? _clientRequestId;
-
-        /// <summary>
-        /// Creates a new instance of <see cref="Request"/>.
-        /// </summary>
-        protected Request()
-        {
-            MethodCore = RequestMethod.Get.Method;
-        }
 
         /// <summary>
         /// Gets or sets the request HTTP method.
@@ -86,7 +79,11 @@ namespace Azure.Core
         /// Gets or sets the value of <see cref="PipelineRequest.Method"/> on
         /// the base <see cref="PipelineRequest"/> type.
         /// </summary>
-        protected override string MethodCore { get; set; }
+        protected override string MethodCore
+        {
+            get => _method;
+            set => _method = value;
+        }
 
         /// <summary>
         /// Gets or sets the value of <see cref="PipelineRequest.Uri"/> on

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -49,7 +49,6 @@ namespace Azure.Core
             set
             {
                 Argument.AssertNotNull(value, nameof(value));
-
                 _uriBuilder = value;
             }
         }
@@ -95,7 +94,16 @@ namespace Azure.Core
         /// </summary>
         protected override Uri? UriCore
         {
+            // The _uriBuilder field on this type is the source of truth for
+            // the type's Uri implementation. Accessing it through the Uri
+            // property allows us to reuse the lazy-instantation implemented
+            // there.
             get => Uri.ToUri();
+
+            // This setter effectively adapts the BCL Uri type to the Azure.Core
+            // RequestUriBuilder interface, in that the only way
+            // RequestUriBuilder provides to fully reset the Uri (i.e. from null)
+            // is to create a new instance of the builder.
             set
             {
                 if (value is null)

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -18,20 +18,10 @@ namespace Azure.Core
     public abstract class Request : PipelineRequest
 #pragma warning restore AZC0012 // Avoid single word type names
     {
-        private string _method = RequestMethod.Get.Method;
         private RequestUriBuilder? _uriBuilder;
+        private string _method = RequestMethod.Get.Method;
         private RequestContent? _content;
-
         private string? _clientRequestId;
-
-        /// <summary>
-        /// Gets or sets the request HTTP method.
-        /// </summary>
-        public new virtual RequestMethod Method
-        {
-            get => RequestMethod.Parse(MethodCore);
-            set => MethodCore = value.Method;
-        }
 
         /// <summary>
         /// Gets or sets and instance of <see cref="RequestUriBuilder"/> used to create the Uri.
@@ -44,6 +34,15 @@ namespace Azure.Core
                 Argument.AssertNotNull(value, nameof(value));
                 _uriBuilder = value;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the request HTTP method.
+        /// </summary>
+        public new virtual RequestMethod Method
+        {
+            get => RequestMethod.Parse(MethodCore);
+            set => MethodCore = value.Method;
         }
 
         /// <summary>

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -21,7 +21,6 @@ namespace Azure.Core
         private RequestUriBuilder? _uriBuilder;
         private string _method = RequestMethod.Get.Method;
         private RequestContent? _content;
-        private string? _clientRequestId;
 
         /// <summary>
         /// Gets or sets and instance of <see cref="RequestUriBuilder"/> used to create the Uri.
@@ -57,15 +56,7 @@ namespace Azure.Core
         /// <summary>
         /// Gets or sets the client request id that was sent to the server as <c>x-ms-client-request-id</c> headers.
         /// </summary>
-        public virtual string ClientRequestId
-        {
-            get => _clientRequestId ??= Guid.NewGuid().ToString();
-            set
-            {
-                Argument.AssertNotNull(value, nameof(value));
-                _clientRequestId = value;
-            }
-        }
+        public abstract string ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets the request HTTP headers.

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -111,7 +111,12 @@ namespace Azure.Core
         protected override BinaryContent? ContentCore
         {
             get => _content;
-            set => _content = (RequestContent?)value;
+            set => _content = value switch
+            {
+                RequestContent content => content,
+                BinaryContent => new RequestContent.BinaryContentAdapter(value),
+                null => null,
+            };
         }
 
         /// <summary>

--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -335,8 +335,8 @@ namespace Azure.Core
         }
 
         /// <summary>
-        /// This adapter adapts the ClientModel BinaryContent type to the
-        /// Azure.Core RequestContent interface, so that it can be used as
+        /// This adapter adapts the System.ClientModel BinaryContent type to
+        /// the Azure.Core RequestContent interface, so that it can be used as
         /// though it were a RequestContent in Azure.Core.
         /// </summary>
         private sealed class BinaryContentAdapter : RequestContent

--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -339,7 +339,7 @@ namespace Azure.Core
         /// the Azure.Core RequestContent interface, so that it can be used as
         /// though it were a RequestContent in Azure.Core.
         /// </summary>
-        private sealed class BinaryContentAdapter : RequestContent
+        internal sealed class BinaryContentAdapter : RequestContent
         {
             private readonly BinaryContent _content;
 

--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -75,8 +75,7 @@ namespace Azure.Core
         /// </summary>
         /// <param name="content">The <see cref="BinaryData"/> to use.</param>
         /// <returns>An instance of <see cref="RequestContent"/> that wraps a <see cref="BinaryData"/>.</returns>
-        public static new RequestContent Create(BinaryData content)
-            => new MemoryContent(content.ToMemory());
+        public static new RequestContent Create(BinaryData content) => new MemoryContent(content.ToMemory());
 
         /// <summary>
         /// Creates an instance of <see cref="RequestContent"/> that wraps a <see cref="DynamicData"/>.
@@ -151,33 +150,6 @@ namespace Azure.Core
         /// </summary>
         /// <param name="content">The <see cref="DynamicData"/> to use.</param>
         public static implicit operator RequestContent(DynamicData content) => Create(content);
-
-        /// <summary>
-        /// This adapter adapts the ClientModel BinaryContent type to the
-        /// Azure.Core RequestContent interface, so that it can be used as
-        /// though it were a RequestContent in Azure.Core.
-        /// </summary>
-        private sealed class BinaryContentAdapter : RequestContent
-        {
-            private readonly BinaryContent _content;
-
-            public BinaryContentAdapter(BinaryContent content)
-            {
-                _content = content;
-            }
-
-            public override void Dispose()
-                => _content?.Dispose();
-
-            public override bool TryComputeLength(out long length)
-                => _content.TryComputeLength(out length);
-
-            public override void WriteTo(Stream stream, CancellationToken cancellationToken)
-                => _content.WriteTo(stream, cancellationToken);
-
-            public override async Task WriteToAsync(Stream stream, CancellationToken cancellationToken)
-                => await _content.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
-        }
 
         private sealed class StreamContent : RequestContent
         {
@@ -360,6 +332,33 @@ namespace Azure.Core
                 _data.WriteTo(stream);
                 return Task.CompletedTask;
             }
+        }
+
+        /// <summary>
+        /// This adapter adapts the ClientModel BinaryContent type to the
+        /// Azure.Core RequestContent interface, so that it can be used as
+        /// though it were a RequestContent in Azure.Core.
+        /// </summary>
+        private sealed class BinaryContentAdapter : RequestContent
+        {
+            private readonly BinaryContent _content;
+
+            public BinaryContentAdapter(BinaryContent content)
+            {
+                _content = content;
+            }
+
+            public override void Dispose()
+                => _content?.Dispose();
+
+            public override bool TryComputeLength(out long length)
+                => _content.TryComputeLength(out length);
+
+            public override void WriteTo(Stream stream, CancellationToken cancellationToken)
+                => _content.WriteTo(stream, cancellationToken);
+
+            public override async Task WriteToAsync(Stream stream, CancellationToken cancellationToken)
+                => await _content.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Buffers;
+using System.ClientModel;
+using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
@@ -17,10 +19,11 @@ namespace Azure.Core
     /// <summary>
     /// Represents the content sent as part of the <see cref="Request"/>.
     /// </summary>
-    public abstract class RequestContent : IDisposable
+    public abstract class RequestContent : BinaryContent
     {
         internal const string SerializationRequiresUnreferencedCode = "This method uses reflection-based serialization which is incompatible with trimming. Try using one of the 'Create' overloads that doesn't wrap a serialized version of an object.";
         private static readonly Encoding s_UTF8NoBomEncoding = new UTF8Encoding(false);
+        private static readonly ModelReaderWriterOptions ModelWriteWireOptions = new("W");
 
         /// <summary>
         /// Creates an instance of <see cref="RequestContent"/> that wraps a <see cref="Stream"/>.
@@ -72,7 +75,8 @@ namespace Azure.Core
         /// </summary>
         /// <param name="content">The <see cref="BinaryData"/> to use.</param>
         /// <returns>An instance of <see cref="RequestContent"/> that wraps a <see cref="BinaryData"/>.</returns>
-        public static RequestContent Create(BinaryData content) => new MemoryContent(content.ToMemory());
+        public static new RequestContent Create(BinaryData content)
+            => new MemoryContent(content.ToMemory());
 
         /// <summary>
         /// Creates an instance of <see cref="RequestContent"/> that wraps a <see cref="DynamicData"/>.
@@ -80,6 +84,15 @@ namespace Azure.Core
         /// <param name="content">The <see cref="DynamicData"/> to use.</param>
         /// <returns>An instance of <see cref="RequestContent"/> that wraps a <see cref="DynamicData"/>.</returns>
         public static RequestContent Create(DynamicData content) => new DynamicDataContent(content);
+
+        /// <summary>
+        /// Creates an instance of <see cref="RequestContent"/> that wraps a <see cref="IPersistableModel{T}"/>.
+        /// </summary>
+        /// <param name="model">The <see cref="IPersistableModel{T}"/> to write.</param>
+        /// <param name="options">The <see cref="ModelReaderWriterOptions"/> to use.</param>
+        /// <returns>An instance of <see cref="RequestContent"/> that wraps a a <see cref="IPersistableModel{T}"/>.</returns>
+        public static new RequestContent Create<T>(T model, ModelReaderWriterOptions? options = default) where T : IPersistableModel<T>
+            => new BinaryContentAdapter(BinaryContent.Create(model, options ?? ModelWriteWireOptions));
 
         /// <summary>
         /// Creates an instance of <see cref="RequestContent"/> that wraps a serialized version of an object.
@@ -140,29 +153,31 @@ namespace Azure.Core
         public static implicit operator RequestContent(DynamicData content) => Create(content);
 
         /// <summary>
-        /// Writes contents of this object to an instance of <see cref="Stream"/>.
+        /// This adapter adapts the ClientModel BinaryContent type to the
+        /// Azure.Core RequestContent interface, so that it can be used as
+        /// though it were a RequestContent in Azure.Core.
         /// </summary>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="cancellation">To cancellation token to use.</param>
-        public abstract Task WriteToAsync(Stream stream, CancellationToken cancellation);
+        private sealed class BinaryContentAdapter : RequestContent
+        {
+            private readonly BinaryContent _content;
 
-        /// <summary>
-        /// Writes contents of this object to an instance of <see cref="Stream"/>.
-        /// </summary>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="cancellation">To cancellation token to use.</param>
-        public abstract void WriteTo(Stream stream, CancellationToken cancellation);
+            public BinaryContentAdapter(BinaryContent content)
+            {
+                _content = content;
+            }
 
-        /// <summary>
-        /// Attempts to compute the length of the underlying content, if available.
-        /// </summary>
-        /// <param name="length">The length of the underlying data.</param>
-        public abstract bool TryComputeLength(out long length);
+            public override void Dispose()
+                => _content?.Dispose();
 
-        /// <summary>
-        /// Frees resources held by the <see cref="RequestContent"/> object.
-        /// </summary>
-        public abstract void Dispose();
+            public override bool TryComputeLength(out long length)
+                => _content.TryComputeLength(out length);
+
+            public override void WriteTo(Stream stream, CancellationToken cancellationToken)
+                => _content.WriteTo(stream, cancellationToken);
+
+            public override async Task WriteToAsync(Stream stream, CancellationToken cancellationToken)
+                => await _content.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
 
         private sealed class StreamContent : RequestContent
         {

--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -23,7 +23,6 @@ namespace Azure.Core
     {
         internal const string SerializationRequiresUnreferencedCode = "This method uses reflection-based serialization which is incompatible with trimming. Try using one of the 'Create' overloads that doesn't wrap a serialized version of an object.";
         private static readonly Encoding s_UTF8NoBomEncoding = new UTF8Encoding(false);
-        private static readonly ModelReaderWriterOptions ModelWriteWireOptions = new("W");
 
         /// <summary>
         /// Creates an instance of <see cref="RequestContent"/> that wraps a <see cref="Stream"/>.
@@ -91,7 +90,7 @@ namespace Azure.Core
         /// <param name="options">The <see cref="ModelReaderWriterOptions"/> to use.</param>
         /// <returns>An instance of <see cref="RequestContent"/> that wraps a a <see cref="IPersistableModel{T}"/>.</returns>
         public static new RequestContent Create<T>(T model, ModelReaderWriterOptions? options = default) where T : IPersistableModel<T>
-            => new BinaryContentAdapter(BinaryContent.Create(model, options ?? ModelWriteWireOptions));
+            => new BinaryContentAdapter(BinaryContent.Create(model, options));
 
         /// <summary>
         /// Creates an instance of <see cref="RequestContent"/> that wraps a serialized version of an object.

--- a/sdk/core/Azure.Core/tests/HttpPipelineRequestContentTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineRequestContentTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -136,6 +137,20 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public void JsonModelContent()
+        {
+            MockJsonModel model = new(404, "abcde");
+            using RequestContent content = RequestContent.Create(model, ModelReaderWriterOptions.Json);
+
+            MemoryStream destination = new();
+            content.WriteTo(destination, default);
+
+            destination.Position = 0;
+
+            Assert.AreEqual(model.Utf8BytesValue, destination.ToArray());
+        }
+
+        [Test]
         public void DynamicDataContent()
         {
             ReadOnlySpan<byte> utf8Json = """
@@ -196,5 +211,69 @@ namespace Azure.Core.Tests
 
             CollectionAssert.AreEqual(expected.ToArray(), destination.ToArray());
         }
+
+        #region Helpers
+
+        private class MockJsonModel : IJsonModel<MockJsonModel>
+        {
+            public int IntValue { get; set; }
+
+            public string StringValue { get; set; }
+
+            public byte[] Utf8BytesValue { get; }
+
+            public MockJsonModel(int intValue, string stringValue)
+            {
+                IntValue = intValue;
+                StringValue = stringValue;
+
+                dynamic json = BinaryData.FromString("{}").ToDynamicFromJson(JsonPropertyNames.CamelCase);
+                json.IntValue = IntValue;
+                json.StringValue = StringValue;
+
+                MemoryStream stream = new();
+                using Utf8JsonWriter writer = new Utf8JsonWriter(stream);
+
+                writer.WriteStartObject();
+                writer.WriteNumber("IntValue", IntValue);
+                writer.WriteString("StringValue", StringValue);
+                writer.WriteEndObject();
+
+                writer.Flush();
+                Utf8BytesValue = stream.ToArray();
+            }
+
+            MockJsonModel IPersistableModel<MockJsonModel>.Create(BinaryData data, ModelReaderWriterOptions options)
+            {
+                dynamic json = data.ToDynamicFromJson(JsonPropertyNames.CamelCase);
+                return new MockJsonModel(json.IntValue, json.StringValue);
+            }
+
+            MockJsonModel IJsonModel<MockJsonModel>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+            {
+                using JsonDocument doc = JsonDocument.ParseValue(ref reader);
+                int intValue = doc.RootElement.GetProperty("IntValue").GetInt32();
+                string stringValue = doc.RootElement.GetProperty("StringValue").GetString()!;
+                return new MockJsonModel(intValue, stringValue);
+            }
+
+            string IPersistableModel<MockJsonModel>.GetFormatFromOptions(ModelReaderWriterOptions options)
+                => "J";
+
+            BinaryData IPersistableModel<MockJsonModel>.Write(ModelReaderWriterOptions options)
+            {
+                return BinaryData.FromBytes(Utf8BytesValue);
+            }
+
+            void IJsonModel<MockJsonModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+            {
+                writer.WriteStartObject();
+                writer.WriteNumber("IntValue", IntValue);
+                writer.WriteString("StringValue", StringValue);
+                writer.WriteEndObject();
+            }
+        }
+
+        #endregion
     }
 }

--- a/sdk/core/Azure.Core/tests/RequestTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.IO;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests;
+
+internal class RequestTests
+{
+    [Test]
+    public void UriCoreSetsUri()
+    {
+        Uri mockUri = new Uri("https://www.example.com");
+
+        MockRequest request = new MockRequest();
+        PipelineRequest pipelineRequest = request;
+        pipelineRequest.Uri = mockUri;
+
+        Assert.AreEqual(mockUri, request.Uri.ToUri());
+    }
+
+    [Test]
+    public void MethodCoreSetsMethod()
+    {
+        MockRequest request = new MockRequest();
+        PipelineRequest pipelineRequest = request;
+        pipelineRequest.Method = "POST";
+
+        Assert.AreEqual(RequestMethod.Post, request.Method);
+    }
+
+    [Test]
+    public void ContentCoreSetsContent()
+    {
+        BinaryData mockContent = BinaryData.FromString("Mock content");
+
+        MockRequest request = new MockRequest();
+        PipelineRequest pipelineRequest = request;
+        pipelineRequest.Content = BinaryContent.Create(mockContent);
+
+        MemoryStream destination = new();
+        request.Content.WriteTo(destination);
+
+        Assert.AreEqual(mockContent.ToArray(), destination.ToArray());
+    }
+}


### PR DESCRIPTION
## Description

Many of the basic Azure.Core types now have analogous types in the System.ClientModel library.  In order to follow the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) engineering principle, we plan to update Azure.Core to reuse functionality from these types, using either inheritance or adapters in most cases.

This PR makes the following changes:
- Azure.Core `Request` inherits from System.ClientModel `PipelineRequest`
- Azure.Core `RequestContent` inherits from System.ClientModel `BinaryContent`

## Design Motivation

Despite some complexity in the implementation of the inheritance of `Request` from `PipelineRequest`, this is required in order to be able to write a single pipeline policy that will work in both Azure.Core and System.ClientModel pipelines.

## Context

This PR is a smaller chunk of https://github.com/Azure/azure-sdk-for-net/pull/41773 to make it easier to review.  In addition, it this PR targets the [feature/azure.core-2.0](https://github.com/Azure/azure-sdk-for-net/tree/[feature/azure.core-2.0](https://github.com/Azure/azure-sdk-for-net/tree/feature/azure.core-2.0)) feature branch because we cannot move the Azure.Core 2.0 integration into main until after System.ClientModel 1.1.0 is GA.