### PR TITLE
[Service Bus] Clear diagnostic properties on clone

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- When creating a new `ServiceBusMessage` from an existing `ServiceBusReceivedMessage`, diagnostic properties will now be properly reset.  Previously, they were incorrectly retained which led to the new message being indistinguishable from the old in traces.
+
 ### Other Changes
 
 - Updated the `Microsoft.Azure.Amqp` dependency to 2.6.5, which includes several bug fixes.  One notable fix addresses an obscure race condition when a cancellation token is signaled while service operations are being invoked concurrently which caused those operations to hang.  Another notable fix is for an obscure race condition that occurred when attempting to complete a message which caused the operation to hang.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Text;
 using Azure.Core;
 using Azure.Core.Amqp;
+using Azure.Core.Shared;
 using Azure.Messaging.ServiceBus.Amqp;
 using Azure.Messaging.ServiceBus.Diagnostics;
 
@@ -66,7 +67,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(receivedMessage, nameof(receivedMessage));
 
-            AmqpMessageBody body = null;
+            AmqpMessageBody body;
             if (receivedMessage.AmqpMessage.Body.TryGetData(out IEnumerable<ReadOnlyMemory<byte>> dataBody))
             {
                 body = AmqpMessageBody.FromData(MessageBody.FromReadOnlyMemorySegments(dataBody));
@@ -136,7 +137,9 @@ namespace Azure.Messaging.ServiceBus
             // copy application properties except for broker set ones
             foreach (KeyValuePair<string, object> kvp in receivedMessage.AmqpMessage.ApplicationProperties)
             {
-                if (kvp.Key == AmqpMessageConstants.DeadLetterReasonHeader || kvp.Key == AmqpMessageConstants.DeadLetterErrorDescriptionHeader)
+                if (kvp.Key == AmqpMessageConstants.DeadLetterReasonHeader
+                    || kvp.Key == AmqpMessageConstants.DeadLetterErrorDescriptionHeader
+                    || kvp.Key == MessagingClientDiagnostics.DiagnosticIdAttribute)
                 {
                     continue;
                 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Azure.Core.Amqp;
 using Azure.Core.Serialization;
+using Azure.Core.Shared;
 using Azure.Messaging.ServiceBus.Amqp;
 using Azure.Messaging.ServiceBus.Primitives;
 using Microsoft.Azure.Amqp.Encoding;
@@ -187,6 +188,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 Assert.IsFalse(rawSend.MessageAnnotations.ContainsKey(AmqpMessageConstants.PartitionIdName));
                 Assert.IsFalse(toSend.ApplicationProperties.ContainsKey(AmqpMessageConstants.DeadLetterReasonHeader));
                 Assert.IsFalse(toSend.ApplicationProperties.ContainsKey(AmqpMessageConstants.DeadLetterErrorDescriptionHeader));
+                Assert.IsFalse(toSend.ApplicationProperties.ContainsKey(MessagingClientDiagnostics.DiagnosticIdAttribute));
 
                 // delivery annotations only apply to a single hop so they are cleared
                 Assert.AreEqual(0, rawSend.DeliveryAnnotations.Count);


### PR DESCRIPTION
# Summary

The focus of these changes is to ensure that the diagnostic properties of `ServiceBusReceivedMessage` are cleared when it is used to create a new `ServiceBusMessage`.  Previously, the diagnostic id was erroneously kept, making it look like a single message was being received and sent multiple times.

## References and resources

- [Azure Service Bus sender - opt out of automatic Diagnostic-Id setting](https://stackoverflow.com/questions/78074683/azure-service-bus-sender-opt-out-of-automatic-diagnostic-id-setting)