### PR TITLE
[CODEOWNERS] Metadata fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -134,7 +134,7 @@
 /sdk/attestation/Azure.Security.Attestation                        @anilba06 @gkostal @Azure/azure-sdk-write-attestation
 
 # ServiceLabel: %Attestation
-/sdk/attestation/                                                  @anilba06 @gkostal
+# ServiceOwners:                                                   @anilba06 @gkostal
 
 # ServiceLabel: %Authorization
 # ServiceOwners:                                                   @darshanhs90 @AshishGargMicrosoft


### PR DESCRIPTION
# Summary

Fixing a mistake that left a path segment where `ServiceOwners` should appear.