### PR TITLE
[Event Hubs] Change trigger checkpointing behavior

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Adjusted checkpointing logic to no longer write a checkpoint when the listener is shutting down.  This was necessary to prevent potential data loss from occurring when shutting down Function retries.  Because the trigger cannot know if the Function host would have retried a failure if it were not shutting down, we cannot assume that it is safe to checkpoint. This change ensures that the batch of events being processed when shut down was requested will be retried by another instance or the next time the Function app is run.
+
 - Updated the `Azure.Messaging.EventHubs`, which includes a new build of the AMQP transport library.  The notable bug fix addresses an obscure race condition when a cancellation token is signaled while service operations are being invoked concurrently which caused those operations to hang.
 
 ## 6.1.0 (2024-02-13)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Diagnostics;
 using Azure.Core.TestFramework;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Consumer;
@@ -93,14 +94,18 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Test]
         public async Task EventHub_SingleDispatch()
         {
+            var watch = ValueStopwatch.StartNew();
             var (jobHost, host) = BuildHost<EventHubTestSingleDispatchJobs>();
+
             using (jobHost)
             {
                 await jobHost.CallAsync(nameof(EventHubTestSingleDispatchJobs.SendEvent_TestHub), new { input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait1.WaitOne(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
                 Assert.True(result);
 
+                using var cancellationSource = new CancellationTokenSource(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
+                await AwaitCheckpointing(host, cancellationSource.Token);
                 await StopWithDrainAsync(host);
             }
 
@@ -158,14 +163,18 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Test]
         public async Task EventHub_SingleDispatch_BinaryData()
         {
+            var watch = ValueStopwatch.StartNew();
             var (jobHost, host) = BuildHost<EventHubTestSingleDispatchJobsBinaryData>();
+
             using (jobHost)
             {
                 await jobHost.CallAsync(nameof(EventHubTestSingleDispatchJobsBinaryData.SendEvent_TestHub), new { input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait1.WaitOne(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
                 Assert.True(result);
 
+                using var cancellationSource = new CancellationTokenSource(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
+                await AwaitCheckpointing(host, cancellationSource.Token);
                 await StopWithDrainAsync(host);
             }
 
@@ -209,30 +218,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 bool result = _eventWait1.WaitOne(Timeout);
                 Assert.True(result);
             }
-        }
-
-        private static void AssertSingleDispatchLogs(IHost host)
-        {
-            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider()
-                .GetAllLogMessages();
-
-            Assert.AreEqual(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("Trigger Details:")
-                && x.FormattedMessage.Contains("Offset:")).Count(), 1);
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("OpenAsync")).Any());
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("CheckpointAsync")
-                && x.FormattedMessage.Contains("lease")
-                && x.FormattedMessage.Contains("offset")
-                && x.FormattedMessage.Contains("sequenceNumber")).Any());
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("Sending events to EventHub")).Any());
-
-            AssertAzureSdkLogs(logMessages);
         }
 
         [Test]
@@ -332,15 +317,19 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Test]
         public async Task EventHub_MultipleDispatch()
         {
+            var watch = ValueStopwatch.StartNew();
             var (jobHost, host) = BuildHost<EventHubTestMultipleDispatchJobs>();
+
             using (jobHost)
             {
                 int numEvents = 5;
                 await jobHost.CallAsync(nameof(EventHubTestMultipleDispatchJobs.SendEvents_TestHub), new { numEvents = numEvents, input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait1.WaitOne(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
                 Assert.True(result);
 
+                using var cancellationSource = new CancellationTokenSource(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
+                await AwaitCheckpointing(host, cancellationSource.Token);
                 await StopWithDrainAsync(host);
             }
 
@@ -350,15 +339,19 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Test]
         public async Task EventHub_MultipleDispatch_BinaryData()
         {
+            var watch = ValueStopwatch.StartNew();
             var (jobHost, host) = BuildHost<EventHubTestMultipleDispatchJobsBinaryData>();
+
             using (jobHost)
             {
                 int numEvents = 5;
                 await jobHost.CallAsync(nameof(EventHubTestMultipleDispatchJobsBinaryData.SendEvents_TestHub), new { numEvents = numEvents, input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait1.WaitOne(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
                 Assert.True(result);
 
+                using var cancellationSource = new CancellationTokenSource(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
+                await AwaitCheckpointing(host, cancellationSource.Token);
                 await StopWithDrainAsync(host);
             }
 
@@ -370,6 +363,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         {
             const int minEventBatchSize = 5;
 
+            var watch = ValueStopwatch.StartNew();
             var (jobHost, host) = BuildHost<EventHubTestMultipleDispatchMinBatchSizeJobs>(
                 builder =>
                 {
@@ -393,9 +387,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 int numEvents = 5;
                 await jobHost.CallAsync(nameof(EventHubTestMultipleDispatchMinBatchSizeJobs.SendEvents_TestHub), new { numEvents = numEvents, input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait1.WaitOne(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
                 Assert.True(result);
 
+                using var cancellationSource = new CancellationTokenSource(GetRemainingTimeoutMilliseconds(watch.GetElapsedTime()));
+                await AwaitCheckpointing(host, cancellationSource.Token);
                 await StopWithDrainAsync(host);
             }
 
@@ -558,6 +554,30 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             }
         }
 
+        private static void AssertSingleDispatchLogs(IHost host)
+        {
+            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider()
+                .GetAllLogMessages();
+
+            Assert.AreEqual(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("Trigger Details:")
+                && x.FormattedMessage.Contains("Offset:")).Count(), 1);
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("OpenAsync")).Any());
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("CheckpointAsync")
+                && x.FormattedMessage.Contains("lease")
+                && x.FormattedMessage.Contains("offset")
+                && x.FormattedMessage.Contains("sequenceNumber")).Any());
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("Sending events to EventHub")).Any());
+
+            AssertAzureSdkLogs(logMessages);
+        }
+
         private static void AssertMultipleDispatchLogsMinBatch(IHost host)
         {
             IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider()
@@ -606,17 +626,36 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             AssertAzureSdkLogs(logMessages);
         }
 
+        private static void AssertAzureSdkLogs(IEnumerable<LogMessage> logMessages)
+        {
+            Assert.True(logMessages.Any(x => x.Category.StartsWith("Azure.")));
+        }
+
         private static async Task StopWithDrainAsync(IHost host)
         {
-            // Enable drain mode so checkpointing occurs when stopping
             var drainModeManager = host.Services.GetService<IDrainModeManager>();
             await drainModeManager.EnableDrainModeAsync(CancellationToken.None);
             await host.StopAsync();
         }
 
-        private static void AssertAzureSdkLogs(IEnumerable<LogMessage> logMessages)
+         private static async Task AwaitCheckpointing(IHost host, CancellationToken cancellationToken)
         {
-            Assert.True(logMessages.Any(x => x.Category.StartsWith("Azure.")));
+            var logMessages = host.GetTestLoggerProvider()
+                .GetAllLogMessages();
+
+            while (true)
+            {
+                if (logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                    && x.FormattedMessage.Contains("CheckpointAsync")
+                    && x.FormattedMessage.Contains("sequenceNumber")).Any())
+                {
+                    return;
+                }
+
+                // No need to explicitly check the cancellation token;
+                // the delay will throw if the token is signaled.
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public class EventHubTestSingleDispatchJobs

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
 
             for (int i = 0; i < 100; i++)
             {
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default, default);
 
             for (int i = 0; i < 100; i++)
             {
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default, default);
 
             for (int i = 0; i < 60; i++)
             {
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default, default);
 
             for (int i = 0; i < 60; i++)
             {
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default, default);
 
             for (int i = 0; i < 60; i++)
             {
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 })
                 .ReturnsAsync(new FunctionResult(true));
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default, default);
 
             for (int i = 0; i < 60; i++)
             {
@@ -371,7 +371,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var loggerMock = new Mock<ILogger>();
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
 
             await eventProcessor.ProcessEventsAsync(partitionContext, events);
 
@@ -398,7 +398,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
 
             List<EventData> events = new List<EventData>();
             List<FunctionResult> results = new List<FunctionResult>();
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             int execution = 0;
             var loggerMock = new Mock<ILogger>();
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
 
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
             {
@@ -496,7 +496,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             int execution = 0;
             var loggerMock = new Mock<ILogger>();
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
 
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
             {
@@ -515,6 +515,98 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 Times.Once);
         }
 
+        /// <summary>
+        /// If function execution succeeds when the listener is shutting down, we should not checkpoint.
+        /// </summary>
+        [Test]
+        public async Task ProcessEvents_Succeeds_ListenerStopping_DoesNotCheckpoint()
+        {
+            var partitionContext = EventHubTests.GetPartitionContext();
+            var options = new EventHubOptions();
+
+            using var listenerRunningCancellationSource = new CancellationTokenSource();
+
+            var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
+            processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            processor.Setup(p => p.GetLastReadCheckpoint(It.IsAny<string>())).Returns(default(CheckpointInfo));
+            partitionContext.ProcessorHost = processor.Object;
+
+            List<EventData> events = new List<EventData>();
+            List<FunctionResult> results = new List<FunctionResult>();
+            for (int i = 0; i < 10; i++)
+            {
+                events.Add(new EventData(new byte[0]));
+                results.Add(new FunctionResult(true));
+            }
+
+            var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+            int execution = 0;
+            var loggerMock = new Mock<ILogger>();
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, listenerRunningCancellationSource.Token, default);
+
+            executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
+            {
+                if (execution == 0)
+                {
+                    listenerRunningCancellationSource.Cancel();
+                }
+                var result = results[execution++];
+                return result;
+            });
+
+            await eventProcessor.ProcessEventsAsync(partitionContext, events);
+
+            processor.Verify(
+                p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        /// <summary>
+        /// If function execution fails when the listener is shutting down, we should not checkpoint.
+        /// </summary>
+        [Test]
+        public async Task ProcessEvents_Fails_ListenerStopping_DoesNotCheckpoint()
+        {
+            var partitionContext = EventHubTests.GetPartitionContext();
+            var options = new EventHubOptions();
+
+            using var listenerRunningCancellationSource = new CancellationTokenSource();
+
+            var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
+            processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            processor.Setup(p => p.GetLastReadCheckpoint(It.IsAny<string>())).Returns(default(CheckpointInfo));
+            partitionContext.ProcessorHost = processor.Object;
+
+            List<EventData> events = new List<EventData>();
+            List<FunctionResult> results = new List<FunctionResult>();
+            for (int i = 0; i < 10; i++)
+            {
+                events.Add(new EventData(new byte[0]));
+                results.Add(new FunctionResult(false));
+            }
+
+            var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+            int execution = 0;
+            var loggerMock = new Mock<ILogger>();
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, listenerRunningCancellationSource.Token, default);
+
+            executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
+            {
+                if (execution == 0)
+                {
+                    listenerRunningCancellationSource.Cancel();
+                }
+                var result = results[execution++];
+                return result;
+            });
+
+            await eventProcessor.ProcessEventsAsync(partitionContext, events);
+
+            processor.Verify(
+                p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
         [Test]
         public async Task CloseAsync_Shutdown_DoesNotCheckpoint()
         {
@@ -528,7 +620,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var loggerMock = new Mock<ILogger>();
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
 
             await eventProcessor.CloseAsync(partitionContext, ProcessingStoppedReason.Shutdown);
 
@@ -550,7 +642,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var loggerMock = new Mock<ILogger>();
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
             var mockStoredEvents = new Queue<EventData>();
             mockStoredEvents.Enqueue(new EventData("E1"));
             eventProcessor.CachedEventsManager.CachedEvents = mockStoredEvents;
@@ -567,7 +659,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var options = new EventHubOptions();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, testLogger, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, testLogger, true, default, default);
 
             var ex = new InvalidOperationException("My InvalidOperationException!");
 
@@ -585,7 +677,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var options = new EventHubOptions();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, testLogger, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, testLogger, true, default, default);
 
             var disconnectedEx = new EventHubsException(true, "My ReceiverDisconnectedException!", EventHubsException.FailureReason.ConsumerDisconnected);
 
@@ -697,7 +789,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 }
             })
             .ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
             List<EventData> events = new List<EventData>() { new EventData(new byte[0]) };
             CancellationTokenSource source = new CancellationTokenSource();
             // Start another thread to cancel execution

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure.Core.Diagnostics;
 using Azure.Messaging.EventHubs.Tests;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Configuration;
@@ -93,5 +94,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             return (jobHost, host);
         }
+
+        protected int GetRemainingTimeoutMilliseconds(TimeSpan elapsedTime) =>
+            (int)(Timeout - elapsedTime.TotalMilliseconds);
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to change the behavior of the Event Hubs trigger to not checkpoint when the listener is shutting down. This is necessary to prevent potential data loss from occurring when shutting down Function retries.  Because the trigger cannot know if the Function host would have retried a failure if it were not shutting down, we cannot assume that it is safe to checkpoint.  This change ensures that the batch of events being processed when shut down was requested will be retried by another instance or the next time the Function app is run.  Though this may cause duplicate processing, it is consistent with the Event Hubs at-least-once guarantee.