### PR TITLE
Storage kind fix roleassignment namespacefix

### DIFF
--- a/sdk/provisioning/Azure.Provisioning/src/authorization/RoleAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/authorization/RoleAssignment.cs
@@ -13,7 +13,7 @@ namespace Azure.Provisioning.Authorization
     /// </summary>
     public class RoleAssignment : Resource<RoleAssignmentData>
     {
-        private static readonly ResourceType ResourceType = "Microsoft.Resources/roleAssignments";
+        private static readonly ResourceType ResourceType = "Microsoft.Authorization/roleAssignments";
         private static readonly ResourceType RoleDefinitionResourceType = "Microsoft.Authorization/roleDefinitions";
 
         private const string SubscriptionResourceIdFunction = "subscriptionResourceId";

--- a/sdk/provisioning/Azure.Provisioning/src/storage/StorageAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/storage/StorageAccount.cs
@@ -31,7 +31,7 @@ namespace Azure.Provisioning.Storage
                 resourceType: ResourceTypeName,
                 location: Environment.GetEnvironmentVariable("AZURE_LOCATION") ?? AzureLocation.WestUS,
                 sku: new StorageSku(sku),
-                kind: StorageKind.StorageV2))
+                kind: kind))
         {
             AssignProperty(data => data.Name, GetAzureName(scope, name));
         }

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/RoleAssignmentWithParameter/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/RoleAssignmentWithParameter/main.bicep
@@ -13,7 +13,7 @@ resource storageAccount_YRiDhR43q 'Microsoft.Storage/storageAccounts@2022-09-01'
   sku: {
     name: 'Premium_LRS'
   }
-  kind: 'StorageV2'
+  kind: 'BlockBlobStorage'
   properties: {
   }
 }
@@ -25,7 +25,7 @@ resource blobService_lnEDXlX5c 'Microsoft.Storage/storageAccounts/blobServices@2
   }
 }
 
-resource roleAssignment_ZBWGKDk4O 'Microsoft.Resources/roleAssignments@2022-04-01' = {
+resource roleAssignment_ZBWGKDk4O 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: storageAccount_YRiDhR43q
   name: guid('storageAccount_YRiDhR43q', principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
   properties: {

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/RoleAssignmentWithoutParameter/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/RoleAssignmentWithoutParameter/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -5,7 +5,7 @@ resource storageAccount_melvnlpF2 'Microsoft.Storage/storageAccounts@2022-09-01'
   sku: {
     name: 'Premium_LRS'
   }
-  kind: 'StorageV2'
+  kind: 'BlockBlobStorage'
   properties: {
   }
 }
@@ -17,7 +17,7 @@ resource blobService_NVMDcYVF9 'Microsoft.Storage/storageAccounts/blobServices@2
   }
 }
 
-resource roleAssignment_lDOSGTMrV 'Microsoft.Resources/roleAssignments@2022-04-01' = {
+resource roleAssignment_lDOSGTMrV 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: storageAccount_melvnlpF2
   name: guid('storageAccount_melvnlpF2', '00000000-0000-0000-0000-000000000000', subscriptionResourceId('00000000-0000-0000-0000-000000000000', 'Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
   properties: {

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/RoleAssignmentWithoutParameterInteractiveMode/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/RoleAssignmentWithoutParameterInteractiveMode/main.bicep
@@ -10,7 +10,7 @@ resource storageAccount_YRiDhR43q 'Microsoft.Storage/storageAccounts@2022-09-01'
   sku: {
     name: 'Premium_LRS'
   }
-  kind: 'StorageV2'
+  kind: 'BlockBlobStorage'
   properties: {
   }
 }
@@ -22,7 +22,7 @@ resource blobService_lnEDXlX5c 'Microsoft.Storage/storageAccounts/blobServices@2
   }
 }
 
-resource roleAssignment_ZBWGKDk4O 'Microsoft.Resources/roleAssignments@2022-04-01' = {
+resource roleAssignment_ZBWGKDk4O 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: storageAccount_YRiDhR43q
   name: guid('storageAccount_YRiDhR43q', '00000000-0000-0000-0000-000000000000', subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
   properties: {

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/StorageBlobDefaults/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/StorageBlobDefaults/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -5,7 +5,7 @@ resource storageAccount_melvnlpF2 'Microsoft.Storage/storageAccounts@2022-09-01'
   sku: {
     name: 'Premium_LRS'
   }
-  kind: 'StorageV2'
+  kind: 'BlockBlobStorage'
   properties: {
   }
 }

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/StorageBlobDefaultsInPromptMode/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/StorageBlobDefaultsInPromptMode/main.bicep
@@ -10,7 +10,7 @@ resource storageAccount_YRiDhR43q 'Microsoft.Storage/storageAccounts@2022-09-01'
   sku: {
     name: 'Premium_LRS'
   }
-  kind: 'StorageV2'
+  kind: 'BlockBlobStorage'
   properties: {
   }
 }

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/StorageBlobDropDown/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/StorageBlobDropDown/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -5,7 +5,7 @@ resource storageAccount_melvnlpF2 'Microsoft.Storage/storageAccounts@2022-09-01'
   sku: {
     name: 'Premium_LRS'
   }
-  kind: 'StorageV2'
+  kind: 'BlockBlobStorage'
   properties: {
   }
 }


### PR DESCRIPTION
@JoshLove-msft noticed these two bugs whilst I was doing the Aspire integration.

Fix 1: kind wasn't being used on `StorageAccount`.
Fix 2: ARM Namespace for role assignment should be `Microsoft.Authorization` not `Microsoft.Resources`.