### PR TITLE
SQL server fixes

### DIFF
--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net6.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net6.0.cs
@@ -259,9 +259,16 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServer : Azure.Provisioning.Resource<Azure.ResourceManager.Sql.SqlServerData>
     {
-        public SqlServer(Azure.Provisioning.IConstruct scope, string name, string version = "2022-08-01-preview", Azure.Core.AzureLocation? location = default(Azure.Core.AzureLocation?)) : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.Sql.SqlServerData>)) { }
+        public SqlServer(Azure.Provisioning.IConstruct scope, string name, Azure.Provisioning.Parameter? adminLogin = default(Azure.Provisioning.Parameter?), Azure.Provisioning.Parameter? adminPassword = default(Azure.Provisioning.Parameter?), Azure.Provisioning.Sql.SqlServerAdministrator? administrator = default(Azure.Provisioning.Sql.SqlServerAdministrator?), string version = "2022-08-01-preview", Azure.Core.AzureLocation? location = default(Azure.Core.AzureLocation?)) : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.Sql.SqlServerData>)) { }
         protected override Azure.Provisioning.Resource? FindParentInScope(Azure.Provisioning.IConstruct scope) { throw null; }
         protected override string GetAzureName(Azure.Provisioning.IConstruct scope, string resourceName) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct SqlServerAdministrator
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public SqlServerAdministrator(Azure.Provisioning.Parameter loginName, Azure.Provisioning.Parameter objectId) { throw null; }
     }
 }
 namespace Azure.Provisioning.Storage

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net6.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net6.0.cs
@@ -254,7 +254,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlFirewallRule : Azure.Provisioning.Resource<Azure.ResourceManager.Sql.SqlFirewallRuleData>
     {
-        public SqlFirewallRule(Azure.Provisioning.IConstruct scope, string name = "fw", string version = "2020-11-01-preview") : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.Sql.SqlFirewallRuleData>)) { }
+        public SqlFirewallRule(Azure.Provisioning.IConstruct scope, Azure.Provisioning.Sql.SqlServer? parent = null, string name = "fw", string version = "2020-11-01-preview") : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.Sql.SqlFirewallRuleData>)) { }
         protected override Azure.Provisioning.Resource? FindParentInScope(Azure.Provisioning.IConstruct scope) { throw null; }
     }
     public partial class SqlServer : Azure.Provisioning.Resource<Azure.ResourceManager.Sql.SqlServerData>

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -259,9 +259,16 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServer : Azure.Provisioning.Resource<Azure.ResourceManager.Sql.SqlServerData>
     {
-        public SqlServer(Azure.Provisioning.IConstruct scope, string name, string version = "2022-08-01-preview", Azure.Core.AzureLocation? location = default(Azure.Core.AzureLocation?)) : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.Sql.SqlServerData>)) { }
+        public SqlServer(Azure.Provisioning.IConstruct scope, string name, Azure.Provisioning.Parameter? adminLogin = default(Azure.Provisioning.Parameter?), Azure.Provisioning.Parameter? adminPassword = default(Azure.Provisioning.Parameter?), Azure.Provisioning.Sql.SqlServerAdministrator? administrator = default(Azure.Provisioning.Sql.SqlServerAdministrator?), string version = "2022-08-01-preview", Azure.Core.AzureLocation? location = default(Azure.Core.AzureLocation?)) : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.Sql.SqlServerData>)) { }
         protected override Azure.Provisioning.Resource? FindParentInScope(Azure.Provisioning.IConstruct scope) { throw null; }
         protected override string GetAzureName(Azure.Provisioning.IConstruct scope, string resourceName) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct SqlServerAdministrator
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public SqlServerAdministrator(Azure.Provisioning.Parameter loginName, Azure.Provisioning.Parameter objectId) { throw null; }
     }
 }
 namespace Azure.Provisioning.Storage

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -254,7 +254,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlFirewallRule : Azure.Provisioning.Resource<Azure.ResourceManager.Sql.SqlFirewallRuleData>
     {
-        public SqlFirewallRule(Azure.Provisioning.IConstruct scope, string name = "fw", string version = "2020-11-01-preview") : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.Sql.SqlFirewallRuleData>)) { }
+        public SqlFirewallRule(Azure.Provisioning.IConstruct scope, Azure.Provisioning.Sql.SqlServer? parent = null, string name = "fw", string version = "2020-11-01-preview") : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.Sql.SqlFirewallRuleData>)) { }
         protected override Azure.Provisioning.Resource? FindParentInScope(Azure.Provisioning.IConstruct scope) { throw null; }
     }
     public partial class SqlServer : Azure.Provisioning.Resource<Azure.ResourceManager.Sql.SqlServerData>

--- a/sdk/provisioning/Azure.Provisioning/src/ModuleInfrastructure.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/ModuleInfrastructure.cs
@@ -157,7 +157,7 @@ namespace Azure.Provisioning
             {
                 foreach (var child in resourceTree[resource])
                 {
-                    if (child is not ResourceGroup || (child is ResourceGroup && child.Id.Name != ResourceGroup.AnonymousResourceGroupName))
+                    if (child is not ResourceGroup || (child is ResourceGroup && child.Id.Name != ResourceGroup.ResourceGroupFunction))
                     {
                         return true;
                     }

--- a/sdk/provisioning/Azure.Provisioning/src/ResourceOfT.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/ResourceOfT.cs
@@ -46,12 +46,11 @@ namespace Azure.Provisioning
         {
             Properties = (T)ResourceData;
 
-            // Resources that have a non-RG parent do not require a location value
-            if (scope.Configuration?.UseInteractiveMode == true && Parent is ResourceGroup)
+            if (scope.Configuration?.UseInteractiveMode == true)
             {
                 // We can't use the lambda overload because not all of the T's will inherit from TrackedResourceData
                 // TODO we may need to add a protected LocationSelector property in the future if there are exceptions to the rule
-                AssignParameter(Properties, "Location", new Parameter("location", null, defaultValue: $"{ResourceGroup.AnonymousResourceGroupName}.location", isExpression: true));
+                AssignParameter(Properties, "Location", new Parameter("location", null, defaultValue: $"{ResourceGroup.ResourceGroupFunction}.location", isExpression: true));
             }
         }
 

--- a/sdk/provisioning/Azure.Provisioning/src/keyvault/KeyVault.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/keyvault/KeyVault.cs
@@ -48,7 +48,7 @@ namespace Azure.Provisioning.KeyVaults
             AddOutput(kv => kv.Properties.VaultUri, "vaultUri");
             if (scope.Root.Properties.TenantId == Guid.Empty)
             {
-                AssignProperty(kv => kv.Properties.TenantId, "tenant()");
+                AssignProperty(kv => kv.Properties.TenantId, Tenant.TenantIdExpression);
             }
         }
 

--- a/sdk/provisioning/Azure.Provisioning/src/resourcemanager/ResourceGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/resourcemanager/ResourceGroup.cs
@@ -15,7 +15,7 @@ namespace Azure.Provisioning.ResourceManager
     public class ResourceGroup : Resource<ResourceGroupData>
     {
         internal static readonly ResourceType ResourceType = "Microsoft.Resources/resourceGroups";
-        internal const string AnonymousResourceGroupName = "resourceGroup()";
+        internal const string ResourceGroupFunction = "resourceGroup()";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceGroup"/>.
@@ -48,7 +48,7 @@ namespace Azure.Provisioning.ResourceManager
         /// <inheritdoc/>
         protected override string GetAzureName(IConstruct scope, string resourceName)
         {
-            return scope.Configuration?.UseInteractiveMode == true ? AnonymousResourceGroupName : base.GetAzureName(scope, resourceName);
+            return scope.Configuration?.UseInteractiveMode == true ? ResourceGroupFunction : base.GetAzureName(scope, resourceName);
         }
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/resourcemanager/Tenant.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/resourcemanager/Tenant.cs
@@ -15,6 +15,7 @@ namespace Azure.Provisioning.ResourceManager
 #pragma warning restore AZC0012 // Avoid single word type names
     {
         private const string ResourceTypeName = "Microsoft.Resources/tenants";
+        internal const string TenantIdExpression = "tenant().tenantId";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tenant"/>.

--- a/sdk/provisioning/Azure.Provisioning/src/sqlmanagement/SqlFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/sqlmanagement/SqlFirewallRule.cs
@@ -17,10 +17,11 @@ namespace Azure.Provisioning.Sql
         /// Initializes a new instance of the <see cref="SqlFirewallRule"/>.
         /// </summary>
         /// <param name="scope">The scope.</param>
+        /// <param name="parent">The parent.</param>
         /// <param name="name">The name.</param>
         /// <param name="version">The version.</param>
-        public SqlFirewallRule(IConstruct scope, string name = "fw", string version = "2020-11-01-preview")
-            : base(scope, null, name, ResourceTypeName, version, (name) => ArmSqlModelFactory.SqlFirewallRuleData(
+        public SqlFirewallRule(IConstruct scope, SqlServer? parent = default, string name = "fw", string version = "2020-11-01-preview")
+            : base(scope, parent, name, ResourceTypeName, version, (name) => ArmSqlModelFactory.SqlFirewallRuleData(
                 name: name,
                 resourceType: ResourceTypeName,
                 startIPAddress: "0.0.0.1",

--- a/sdk/provisioning/Azure.Provisioning/src/sqlmanagement/SqlServer.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/sqlmanagement/SqlServer.cs
@@ -21,9 +21,19 @@ namespace Azure.Provisioning.Sql
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="name">The name.</param>
+        /// <param name="adminLogin">The administrator login.</param>
+        /// <param name="adminPassword">The administrator password.</param>
+        /// <param name="administrator">The administrator when using Entra.</param>
         /// <param name="version">The version.</param>
         /// <param name="location">The location.</param>
-        public SqlServer(IConstruct scope, string name, string version = "2022-08-01-preview", AzureLocation? location = default)
+        public SqlServer(
+            IConstruct scope,
+            string name,
+            Parameter? adminLogin = default,
+            Parameter? adminPassword = default,
+            SqlServerAdministrator? administrator = default,
+            string version = "2022-08-01-preview",
+            AzureLocation? location = default)
             : base(scope, null, name, ResourceTypeName, version, (name) => ArmSqlModelFactory.SqlServerData(
                 name: name,
                 location: location ?? Environment.GetEnvironmentVariable("AZURE_LOCATION") ?? AzureLocation.WestUS,
@@ -31,10 +41,27 @@ namespace Azure.Provisioning.Sql
                 version: "12.0",
                 minTlsVersion: "1.2",
                 publicNetworkAccess: ServerNetworkAccessFlag.Enabled,
-                administratorLogin: "sqladmin",
-                administratorLoginPassword: Guid.Empty.ToString()))
+                administrators: new ServerExternalAdministrator()))
         {
             AssignProperty(data => data.Name, GetAzureName(scope, name));
+            if (adminLogin != null)
+            {
+                AssignParameter(data => data.AdministratorLogin, adminLogin.Value);
+            }
+            if (adminPassword != null)
+            {
+                AssignParameter(data => data.AdministratorLoginPassword, adminPassword.Value);
+            }
+            if (administrator != null)
+            {
+                AssignParameter(data => data.Administrators.Login, administrator.Value.LoginName);
+                AssignParameter(data => data.Administrators.Sid, administrator.Value.ObjectId);
+                AssignProperty(data => data.Administrators.AdministratorType, "'ActiveDirectory'");
+                if (scope.Root.Properties.TenantId == Guid.Empty)
+                {
+                    AssignProperty(data => data.Administrators.TenantId, Tenant.TenantIdExpression);
+                }
+            }
         }
 
         /// <inheritdoc/>

--- a/sdk/provisioning/Azure.Provisioning/src/sqlmanagement/SqlServerAdministrator.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/sqlmanagement/SqlServerAdministrator.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Provisioning.Sql
+{
+    /// <summary>
+    /// Represents a SQL Server administrator.
+    /// </summary>
+    public readonly struct SqlServerAdministrator
+    {
+        internal Parameter ObjectId { get; }
+        internal Parameter LoginName { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlServerAdministrator"/>.
+        /// </summary>
+        /// <param name="loginName"></param>
+        /// <param name="objectId"></param>
+        public SqlServerAdministrator(
+            Parameter loginName,
+            Parameter objectId)
+        {
+            LoginName = loginName;
+            ObjectId = objectId;
+        }
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning/src/storage/StorageAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/storage/StorageAccount.cs
@@ -33,7 +33,7 @@ namespace Azure.Provisioning.Storage
                 sku: new StorageSku(sku),
                 kind: kind,
                 // access tier cannot be set for premium accounts
-                accessTier: sku != StorageSkuName.PremiumLrs && sku != StorageSkuName.PremiumZrs ? StorageAccountAccessTier.Hot : null))
+                accessTier: kind == StorageKind.BlobStorage || kind == StorageKind.StorageV2 ? StorageAccountAccessTier.Hot : null))
         {
             AssignProperty(data => data.Name, GetAzureName(scope, name));
         }

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/CanAssignParameterToMultipleResources/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/CanAssignParameterToMultipleResources/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -29,7 +29,7 @@ resource storageAccount_I0kTuAmmD 'Microsoft.Storage/storageAccounts@2022-09-01'
   name: toLower(take(concat('sa2', uniqueString(resourceGroup().id)), 24))
   location: overrideLocation
   sku: {
-    name: 'Standard_LRS'
+    name: 'Premium_LRS'
   }
   kind: 'BlobStorage'
   properties: {

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/OutputsSpanningModules/resources/rg1_TEST_module/rg1_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/OutputsSpanningModules/resources/rg1_TEST_module/rg1_TEST_module.bicep
@@ -49,7 +49,7 @@ resource keyVault_BRsYQF4qT 'Microsoft.KeyVault/vaults@2023-02-01' = {
   name: 'kv-TEST'
   location: 'westus'
   properties: {
-    tenantId: tenant()
+    tenantId: tenant().tenantId
     sku: {
       name: 'standard'
       family: 'A'

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/SqlServerUsingAdminPassword/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/SqlServerUsingAdminPassword/main.bicep
@@ -1,0 +1,32 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+@description('SQL Server administrator login')
+param adminLogin string
+
+@secure()
+@description('SQL Server administrator password')
+param adminPassword string
+
+
+resource sqlServer_Yt40VknQJ 'Microsoft.Sql/servers@2022-08-01-preview' = {
+  name: toLower(take(concat('sqlserver', uniqueString(resourceGroup().id)), 24))
+  location: location
+  properties: {
+    administratorLogin: adminLogin
+    administratorLoginPassword: adminPassword
+    version: '12.0'
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource sqlDatabase_qFhDi2oga 'Microsoft.Sql/servers/databases@2022-08-01-preview' = {
+  parent: sqlServer_Yt40VknQJ
+  name: 'db'
+  location: location
+  properties: {
+  }
+}

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/SqlServerUsingHybrid/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/SqlServerUsingHybrid/main.bicep
@@ -42,3 +42,12 @@ resource sqlDatabase_qFhDi2oga 'Microsoft.Sql/servers/databases@2022-08-01-previ
   properties: {
   }
 }
+
+resource sqlFirewallRule_l3kW1XrET 'Microsoft.Sql/servers/firewallRules@2020-11-01-preview' = {
+  parent: sqlServer_Yt40VknQJ
+  name: 'fw'
+  properties: {
+    startIpAddress: '0.0.0.1'
+    endIpAddress: '255.255.255.254'
+  }
+}

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/SqlServerUsingHybrid/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/SqlServerUsingHybrid/main.bicep
@@ -1,0 +1,44 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+@description('SQL Server administrator login')
+param adminLogin string
+
+@secure()
+@description('SQL Server administrator password')
+param adminPassword string
+
+@description('SQL Server administrator login')
+param adminIdentityLogin string
+
+@description('SQL Server administrator Object ID')
+param adminObjectId string
+
+
+resource sqlServer_Yt40VknQJ 'Microsoft.Sql/servers@2022-08-01-preview' = {
+  name: toLower(take(concat('sqlserver', uniqueString(resourceGroup().id)), 24))
+  location: location
+  properties: {
+    administratorLogin: adminLogin
+    administratorLoginPassword: adminPassword
+    version: '12.0'
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+    administrators: {
+      administratorType: 'ActiveDirectory'
+      login: adminIdentityLogin
+      sid: adminObjectId
+      tenantId: tenant().tenantId
+    }
+  }
+}
+
+resource sqlDatabase_qFhDi2oga 'Microsoft.Sql/servers/databases@2022-08-01-preview' = {
+  parent: sqlServer_Yt40VknQJ
+  name: 'db'
+  location: location
+  properties: {
+  }
+}

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/SqlServerUsingIdentity/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/SqlServerUsingIdentity/main.bicep
@@ -1,0 +1,35 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+@description('SQL Server administrator login')
+param adminLogin string
+
+@description('SQL Server administrator Object ID')
+param adminObjectId string
+
+
+resource sqlServer_Yt40VknQJ 'Microsoft.Sql/servers@2022-08-01-preview' = {
+  name: toLower(take(concat('sqlserver', uniqueString(resourceGroup().id)), 24))
+  location: location
+  properties: {
+    version: '12.0'
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+    administrators: {
+      administratorType: 'ActiveDirectory'
+      login: adminLogin
+      sid: adminObjectId
+      tenantId: tenant().tenantId
+    }
+  }
+}
+
+resource sqlDatabase_qFhDi2oga 'Microsoft.Sql/servers/databases@2022-08-01-preview' = {
+  parent: sqlServer_Yt40VknQJ
+  name: 'db'
+  location: location
+  properties: {
+  }
+}

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL1/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL1/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -75,7 +75,7 @@ resource keyVault_CRoMbemLF 'Microsoft.KeyVault/vaults@2023-02-01' = {
   name: 'kv-TEST'
   location: 'westus'
   properties: {
-    tenantId: tenant()
+    tenantId: tenant().tenantId
     sku: {
       name: 'standard'
       family: 'A'

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL2/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL2/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -22,7 +22,7 @@ resource keyVault_CRoMbemLF 'Microsoft.KeyVault/vaults@2023-02-01' = {
   name: 'kv-TEST'
   location: 'westus'
   properties: {
-    tenantId: tenant()
+    tenantId: tenant().tenantId
     sku: {
       name: 'standard'
       family: 'A'

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL3/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL3/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -25,7 +25,7 @@ resource keyVault_CRoMbemLF 'Microsoft.KeyVault/vaults@2023-02-01' = {
     'key': 'value'
   }
   properties: {
-    tenantId: tenant()
+    tenantId: tenant().tenantId
     sku: {
       name: 'standard'
       family: 'A'

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL3ResourceGroupScope/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL3ResourceGroupScope/main.bicep
@@ -30,7 +30,7 @@ resource keyVault_zomsD2kWf 'Microsoft.KeyVault/vaults@2023-02-01' = {
     'key': 'value'
   }
   properties: {
-    tenantId: tenant()
+    tenantId: tenant().tenantId
     sku: {
       name: 'standard'
       family: 'A'
@@ -42,6 +42,7 @@ resource keyVault_zomsD2kWf 'Microsoft.KeyVault/vaults@2023-02-01' = {
 resource keyVaultAddAccessPolicy_P5xc7PJ0z 'Microsoft.KeyVault/vaults/accessPolicies@2023-02-01' = {
   parent: keyVault_zomsD2kWf
   name: 'add'
+  location: location
   properties: {
     accessPolicies: [
       {
@@ -61,6 +62,7 @@ resource keyVaultAddAccessPolicy_P5xc7PJ0z 'Microsoft.KeyVault/vaults/accessPoli
 resource keyVaultSecret_i5d2MB0md 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
   parent: keyVault_zomsD2kWf
   name: 'sqlAdminPassword'
+  location: location
   properties: {
     value: sqlAdminPassword
   }
@@ -69,6 +71,7 @@ resource keyVaultSecret_i5d2MB0md 'Microsoft.KeyVault/vaults/secrets@2023-02-01'
 resource keyVaultSecret_LNzTHfBsZ 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
   parent: keyVault_zomsD2kWf
   name: 'appUserPassword'
+  location: location
   properties: {
     value: appUserPassword
   }
@@ -77,6 +80,7 @@ resource keyVaultSecret_LNzTHfBsZ 'Microsoft.KeyVault/vaults/secrets@2023-02-01'
 resource keyVaultSecret_67mSbXkng 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
   parent: keyVault_zomsD2kWf
   name: 'connectionString'
+  location: location
   properties: {
     value: 'Server=${sqlServer_9wIHMU1zj.properties.fullyQualifiedDomainName}; Database=${sqlDatabase_6rAKZufXn.name}; User=appUser; Password=${appUserPassword}'
   }
@@ -150,6 +154,7 @@ resource sqlServer_9wIHMU1zj 'Microsoft.Sql/servers@2022-08-01-preview' = {
 resource sqlDatabase_6rAKZufXn 'Microsoft.Sql/servers/databases@2022-08-01-preview' = {
   parent: sqlServer_9wIHMU1zj
   name: 'db'
+  location: location
   properties: {
   }
 }

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL3SpecificSubscription/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/WebSiteUsingL3SpecificSubscription/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -25,7 +25,7 @@ resource keyVault_CRoMbemLF 'Microsoft.KeyVault/vaults@2023-02-01' = {
     'key': 'value'
   }
   properties: {
-    tenantId: tenant()
+    tenantId: tenant().tenantId
     sku: {
       name: 'standard'
       family: 'A'

--- a/sdk/provisioning/Azure.Provisioning/tests/ProvisioningTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/ProvisioningTests.cs
@@ -79,7 +79,7 @@ namespace Azure.Provisioning.Tests
             KeyVaultSecret sqlAzureConnectionStringSecret = new KeyVaultSecret(infra, "connectionString", sqlDatabase.GetConnectionString(appUserPasswordParam));
             Assert.False(sqlAzureConnectionStringSecret.Properties.Name.EndsWith(infra.EnvironmentName));
 
-            SqlFirewallRule sqlFirewallRule = new SqlFirewallRule(infra, "firewallRule");
+            SqlFirewallRule sqlFirewallRule = new SqlFirewallRule(infra, name: "firewallRule");
             Assert.False(sqlFirewallRule.Properties.Name.EndsWith(infra.EnvironmentName));
 
             DeploymentScript deploymentScript = new DeploymentScript(
@@ -182,6 +182,7 @@ namespace Azure.Provisioning.Tests
                 administrator: admin);
 
             _ = new SqlDatabase(infrastructure, sqlServer);
+            _ = new SqlFirewallRule(infrastructure, sqlServer);
             infrastructure.Build(GetOutputPath());
 
             await ValidateBicepAsync(

--- a/sdk/provisioning/Azure.Provisioning/tests/ProvisioningTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/ProvisioningTests.cs
@@ -69,6 +69,7 @@ namespace Azure.Provisioning.Tests
             appUserSecret.AssignParameter(secret => secret.Properties.Value, appUserPasswordParam);
 
             SqlServer sqlServer = new SqlServer(infra, "sqlserver");
+            sqlServer.AssignProperty(sql => sql.AdministratorLogin, "'sqladmin'");
             sqlServer.AssignParameter(sql => sql.AdministratorLoginPassword, sqlAdminPasswordParam);
             Output sqlServerName = sqlServer.AddOutput(sql => sql.FullyQualifiedDomainName, "sqlServerName");
 
@@ -113,6 +114,86 @@ namespace Azure.Provisioning.Tests
             infrastructure.Build(GetOutputPath());
 
             await ValidateBicepAsync();
+        }
+
+        [Test]
+        public async Task SqlServerUsingAdminPassword()
+        {
+            TestInfrastructure infrastructure = new TestInfrastructure(configuration: new Configuration { UseInteractiveMode = true });
+            var sqlServer = new SqlServer(
+                infrastructure,
+                "sqlserver",
+                adminLogin: new Parameter("adminLogin", "SQL Server administrator login"),
+                adminPassword: new Parameter("adminPassword", "SQL Server administrator password", isSecure: true));
+            _ = new SqlDatabase(infrastructure, sqlServer);
+            infrastructure.Build(GetOutputPath());
+
+            await ValidateBicepAsync(
+                parameters: BinaryData.FromObjectAsJson(
+                    new
+                    {
+                        adminLogin = new { value = "admin" },
+                        adminPassword = new { value = "password" }
+                    }),
+                interactiveMode: true);
+        }
+
+        [Test]
+        public async Task SqlServerUsingIdentity()
+        {
+            TestInfrastructure infrastructure = new TestInfrastructure(configuration: new Configuration { UseInteractiveMode = true });
+
+            var admin = new SqlServerAdministrator(
+                new Parameter("adminLogin", "SQL Server administrator login"),
+                new Parameter("adminObjectId", "SQL Server administrator Object ID"));
+
+            var sqlServer = new SqlServer(
+                infrastructure,
+                "sqlserver",
+                administrator: admin);
+
+            _ = new SqlDatabase(infrastructure, sqlServer);
+            infrastructure.Build(GetOutputPath());
+
+            await ValidateBicepAsync(
+                parameters: BinaryData.FromObjectAsJson(
+                    new
+                    {
+                        adminLogin = new { value = "admin" },
+                        adminObjectId = new { value = Guid.Empty.ToString() }
+                    }),
+                interactiveMode: true);
+        }
+
+        [Test]
+        public async Task SqlServerUsingHybrid()
+        {
+            TestInfrastructure infrastructure = new TestInfrastructure(configuration: new Configuration { UseInteractiveMode = true });
+
+            var admin = new SqlServerAdministrator(
+                new Parameter("adminIdentityLogin", "SQL Server administrator login"),
+                new Parameter("adminObjectId", "SQL Server administrator Object ID"));
+
+            var sqlServer = new SqlServer(
+                infrastructure,
+                "sqlserver",
+                adminLogin: new Parameter("adminLogin", "SQL Server administrator login"),
+                adminPassword: new Parameter("adminPassword", "SQL Server administrator password", isSecure: true),
+                administrator: admin);
+
+            _ = new SqlDatabase(infrastructure, sqlServer);
+            infrastructure.Build(GetOutputPath());
+
+            await ValidateBicepAsync(
+                parameters: BinaryData.FromObjectAsJson(
+                    new
+                    {
+                        adminLogin = new { value = "admin" },
+                        adminPassword = new { value = "password" },
+                        adminIdentityLogin = new { value = "admin" },
+                        adminObjectId = new { value = Guid.Empty.ToString() }
+                    }),
+                interactiveMode: true);
         }
 
         [Test]
@@ -317,7 +398,7 @@ namespace Azure.Provisioning.Tests
             var account2 = infra.AddStorageAccount(
                 name: "sa2",
                 kind: StorageKind.BlobStorage,
-                sku: StorageSkuName.StandardLrs
+                sku: StorageSkuName.PremiumLrs
             );
             account2.AssignParameter(a => a.Location, overrideLocation);
 

--- a/sdk/provisioning/Azure.Provisioning/tests/TestCommonSqlDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/TestCommonSqlDatabase.cs
@@ -35,6 +35,7 @@ namespace Azure.Provisioning.Tests
 
             SqlServer sqlServer = new SqlServer(this, "sqlserver");
             sqlServer.AssignParameter(sql => sql.AdministratorLoginPassword, sqlAdminPasswordParam);
+            sqlServer.AssignProperty(sql => sql.AdministratorLogin, "'sqladmin'");
             Output sqlServerName = sqlServer.AddOutput(sql => sql.FullyQualifiedDomainName, "sqlServerName");
 
             SqlDatabase = new SqlDatabase(this, sqlServer);

--- a/sdk/provisioning/Azure.Provisioning/tests/TestCommonSqlDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/TestCommonSqlDatabase.cs
@@ -42,7 +42,7 @@ namespace Azure.Provisioning.Tests
 
             KeyVaultSecret sqlAzureConnectionStringSecret = new KeyVaultSecret(this, "connectionString", SqlDatabase.GetConnectionString(appUserPasswordParam));
 
-            SqlFirewallRule sqlFirewallRule = new SqlFirewallRule(this, "firewallRule");
+            SqlFirewallRule sqlFirewallRule = new SqlFirewallRule(this, name: "firewallRule");
             Parameter databaseName = new Parameter("appUserPassword", "Application user password", isSecure: true);
             DeploymentScript deploymentScript = new DeploymentScript(
                 this,


### PR DESCRIPTION
- add parent to SqlFirewallRule ctor
- Don't default sql admin password
- add parameters for sql admin login/password/adminstrator
- fix storage access tier bug
- include location property for child resources
- use `tenant().tenantId` instead of `tenant()` in tenantId properties