### PR TITLE
final changelog snap for beta.14

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.14 (2024-02-15)
+## 1.0.0-beta.14 (2024-03-04)
 
 ### Features Added
 


### PR DESCRIPTION
This tiny change merely corrects and finalizes the `changelog.md` release date for beta.14.