### PR TITLE
[Search] Add support for `sbyte` and `int16` types to FieldBuilder

### DIFF
--- a/sdk/search/Azure.Search.Documents/CHANGELOG.md
+++ b/sdk/search/Azure.Search.Documents/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release History
 
-## 11.6.0-beta.3 (2024-03-04)
+## 11.6.0-beta.3 (2024-03-05)
 
 ### Features Added
 - Added the `VectorSearch.Compressions` property, which can be utilized to configure options specific to the compression method used during indexing or querying.
 - Added the `SearchField.IsStored`, `VectorSearchField.IsStored`, and `VectorSearchFieldAttribute.IsStored` property. It represent an immutable value indicating whether the field will be persisted separately on disk to be returned in a search result. This property is applicable only for vector fields.
+- Added support for `sbyte` and `int16` to `SearchFieldDataType`.
 
 ## 11.6.0-beta.2 (2024-02-05)
 

--- a/sdk/search/Azure.Search.Documents/assets.json
+++ b/sdk/search/Azure.Search.Documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/search/Azure.Search.Documents",
-  "Tag": "net/search/Azure.Search.Documents_53f1013bad"
+  "Tag": "net/search/Azure.Search.Documents_c617e35c0c"
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchFieldDataType.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchFieldDataType.cs
@@ -34,6 +34,8 @@ namespace Azure.Search.Documents.Indexes.Models
         private const string HalfValue = "Edm.Half";
         private const string Int16Value = "Edm.Int16";
         private const string SByteValue = "Edm.SByte";
+        /// <summary> Indicates that a field contains a half-precision floating point number. This is only valid when used with Collection(Edm.Half). </summary>
+        public static SearchFieldDataType Half { get; } = new SearchFieldDataType(HalfValue);
         /// <summary> Determines if two <see cref="SearchFieldDataType"/> values are the same. </summary>
         public static bool operator ==(SearchFieldDataType left, SearchFieldDataType right) => left.Equals(right);
         /// <summary> Determines if two <see cref="SearchFieldDataType"/> values are not the same. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchFieldDataType.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchFieldDataType.cs
@@ -34,12 +34,6 @@ namespace Azure.Search.Documents.Indexes.Models
         private const string HalfValue = "Edm.Half";
         private const string Int16Value = "Edm.Int16";
         private const string SByteValue = "Edm.SByte";
-        /// <summary> Indicates that a field contains a half-precision floating point number. This is only valid when used with Collection(Edm.Half). </summary>
-        public static SearchFieldDataType Half { get; } = new SearchFieldDataType(HalfValue);
-        /// <summary> Indicates that a field contains a 16-bit signed integer. This is only valid when used with Collection(Edm.Int16). </summary>
-        public static SearchFieldDataType Int16 { get; } = new SearchFieldDataType(Int16Value);
-        /// <summary> Indicates that a field contains a 8-bit signed integer. This is only valid when used with Collection(Edm.SByte). </summary>
-        public static SearchFieldDataType SByte { get; } = new SearchFieldDataType(SByteValue);
         /// <summary> Determines if two <see cref="SearchFieldDataType"/> values are the same. </summary>
         public static bool operator ==(SearchFieldDataType left, SearchFieldDataType right) => left.Equals(right);
         /// <summary> Determines if two <see cref="SearchFieldDataType"/> values are not the same. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Indexes/FieldBuilder.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/FieldBuilder.cs
@@ -27,6 +27,8 @@ namespace Azure.Search.Documents.Indexes
                 new Dictionary<Type, SearchFieldDataType>()
                 {
                     [typeof(string)] = SearchFieldDataType.String,
+                    [typeof(sbyte)] = SearchFieldDataType.SByte,
+                    [typeof(short)] = SearchFieldDataType.Int16,
                     [typeof(int)] = SearchFieldDataType.Int32,
                     [typeof(long)] = SearchFieldDataType.Int64,
                     [typeof(double)] = SearchFieldDataType.Double,

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchFieldDataType.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchFieldDataType.cs
@@ -15,6 +15,14 @@ namespace Azure.Search.Documents.Indexes.Models
         [CodeGenMember("EdmString")]
         public static SearchFieldDataType String { get; } = new SearchFieldDataType(StringValue);
 
+        /// <summary> Indicates that a field contains a 8-bit signed integer. This is only valid when used with Collection(Edm.SByte). </summary>
+        [CodeGenMember("EdmSByte")]
+        public static SearchFieldDataType SByte { get; } = new SearchFieldDataType(SByteValue);
+
+        /// <summary> Indicates that a field contains a 16-bit signed integer. This is only valid when used with Collection(Edm.Int16). </summary>
+        [CodeGenMember("EdmInt16")]
+        public static SearchFieldDataType Int16 { get; } = new SearchFieldDataType(Int16Value);
+
         /// <summary>An <see cref="int"/> type, or something that can convert to an <see cref="int"/>.</summary>
         [CodeGenMember("EdmInt32")]
         public static SearchFieldDataType Int32 { get; } = new SearchFieldDataType(Int32Value);
@@ -47,6 +55,10 @@ namespace Azure.Search.Documents.Indexes.Models
         /// <summary>A single type.</summary>
         [CodeGenMember("EdmSingle")]
         public static SearchFieldDataType Single { get; } = new SearchFieldDataType(SingleValue);
+
+        /// <summary>Indicates that a field contains a half-precision floating point number. This is only valid when used with Collection(Edm.Half).</summary>
+        [CodeGenMember("EdmHalf")]
+        public static SearchFieldDataType Half { get; } = new SearchFieldDataType(HalfValue);
 
         /// <summary>
         /// Gets a <see cref="SearchFieldDataType"/> representing a collection of <paramref name="type"/>.

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchFieldDataType.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchFieldDataType.cs
@@ -56,10 +56,6 @@ namespace Azure.Search.Documents.Indexes.Models
         [CodeGenMember("EdmSingle")]
         public static SearchFieldDataType Single { get; } = new SearchFieldDataType(SingleValue);
 
-        /// <summary>Indicates that a field contains a half-precision floating point number. This is only valid when used with Collection(Edm.Half).</summary>
-        [CodeGenMember("EdmHalf")]
-        public static SearchFieldDataType Half { get; } = new SearchFieldDataType(HalfValue);
-
         /// <summary>
         /// Gets a <see cref="SearchFieldDataType"/> representing a collection of <paramref name="type"/>.
         /// </summary>

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/VectorSearchTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/VectorSearchTests.cs
@@ -239,6 +239,7 @@ namespace Azure.Search.Documents.Tests
         }
 
         [Test]
+        [ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2024_03_01_Preview)]
         public async Task UpdatingVectorProfileNameThrows()
         {
             await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);
@@ -519,6 +520,7 @@ namespace Azure.Search.Documents.Tests
         }
 
         [Test]
+        [ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2024_03_01_Preview)]
         public async Task CreateIndexUsingFieldBuilder()
         {
             await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);

--- a/sdk/search/Azure.Search.Documents/tests/FieldBuilderTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/FieldBuilderTests.cs
@@ -60,6 +60,8 @@ namespace Azure.Search.Documents.Tests
                 (SearchFieldDataType, string)[] primitiveFieldTestData = new[]
                 {
                     (SearchFieldDataType.String, nameof(ReflectableModel.Text)),
+                    (SearchFieldDataType.SByte, nameof(ReflectableModel.SByte)),
+                    (SearchFieldDataType.Int16, nameof(ReflectableModel.Short)),
                     (SearchFieldDataType.Int32, nameof(ReflectableModel.Id)),
                     (SearchFieldDataType.Int64, nameof(ReflectableModel.BigNumber)),
                     (SearchFieldDataType.Double, nameof(ReflectableModel.Double)),
@@ -91,6 +93,16 @@ namespace Azure.Search.Documents.Tests
                     (SearchFieldDataType.String, nameof(ReflectableModel.StringIEnumerable)),
                     (SearchFieldDataType.String, nameof(ReflectableModel.StringList)),
                     (SearchFieldDataType.String, nameof(ReflectableModel.StringICollection)),
+                    (SearchFieldDataType.SByte, nameof(ReflectableModel.SByteArray)),
+                    (SearchFieldDataType.SByte, nameof(ReflectableModel.SByteIList)),
+                    (SearchFieldDataType.SByte, nameof(ReflectableModel.SByteIEnumerable)),
+                    (SearchFieldDataType.SByte, nameof(ReflectableModel.SByteList)),
+                    (SearchFieldDataType.SByte, nameof(ReflectableModel.SByteICollection)),
+                    (SearchFieldDataType.Int16, nameof(ReflectableModel.ShortArray)),
+                    (SearchFieldDataType.Int16, nameof(ReflectableModel.ShortIList)),
+                    (SearchFieldDataType.Int16, nameof(ReflectableModel.ShortIEnumerable)),
+                    (SearchFieldDataType.Int16, nameof(ReflectableModel.ShortList)),
+                    (SearchFieldDataType.Int16, nameof(ReflectableModel.ShortICollection)),
                     (SearchFieldDataType.Int32, nameof(ReflectableModel.IntArray)),
                     (SearchFieldDataType.Int32, nameof(ReflectableModel.IntIList)),
                     (SearchFieldDataType.Int32, nameof(ReflectableModel.IntIEnumerable)),
@@ -678,7 +690,7 @@ namespace Azure.Search.Documents.Tests
             [SimpleField(IsKey = true)]
             public string ID { get; set; }
 
-            [VectorSearchField(VectorSearchDimensions = 1536, VectorSearchProfileName = "test-config")]
+            [VectorSearchField(VectorSearchDimensions = 1536, VectorSearchProfileName = "test-config", IsStored = true)]
             public IReadOnlyList<float> TitleVector { get; set; }
         }
     }

--- a/sdk/search/Azure.Search.Documents/tests/Models/ReflectableModel.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Models/ReflectableModel.cs
@@ -55,6 +55,10 @@ namespace Azure.Search.Documents.Tests
 
         public double Double { get; set; }
 
+        public sbyte SByte { get; set; }
+
+        public short Short { get; set; }
+
         public bool Flag { get; set; }
 
         public DateTimeOffset Time { get; set; }
@@ -111,6 +115,26 @@ namespace Azure.Search.Documents.Tests
         public GeoPoint GeoPoint { get; set; }
 
         public GeographyPoint GeographyPoint { get; set; }
+
+        public sbyte[] SByteArray { get; set; }
+
+        public IList<sbyte> SByteIList { get; set; }
+
+        public List<sbyte> SByteList { get; set; }
+
+        public IEnumerable<sbyte> SByteIEnumerable { get; set; }
+
+        public ICollection<sbyte> SByteICollection { get; set; }
+
+        public short[] ShortArray { get; set; }
+
+        public IList<short> ShortIList { get; set; }
+
+        public List<short> ShortList { get; set; }
+
+        public IEnumerable<short> ShortIEnumerable { get; set; }
+
+        public ICollection<short> ShortICollection { get; set; }
 
         public int[] IntArray { get; set; }
 

--- a/sdk/search/Azure.Search.Documents/tests/Models/ReflectableStructModel.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Models/ReflectableStructModel.cs
@@ -55,6 +55,10 @@ namespace Azure.Search.Documents.Tests
 
         public double Double { get; set; }
 
+        public sbyte SByte { get; set; }
+
+        public short Short { get; set; }
+
         public bool Flag { get; set; }
 
         public DateTimeOffset Time { get; set; }
@@ -108,6 +112,26 @@ namespace Azure.Search.Documents.Tests
         public GeoPoint GeoPoint { get; set; }
 
         public GeographyPoint GeographyPoint { get; set; }
+
+        public sbyte[] SByteArray { get; set; }
+
+        public IList<sbyte> SByteIList { get; set; }
+
+        public List<sbyte> SByteList { get; set; }
+
+        public IEnumerable<sbyte> SByteIEnumerable { get; set; }
+
+        public ICollection<sbyte> SByteICollection { get; set; }
+
+        public short[] ShortArray { get; set; }
+
+        public IList<short> ShortIList { get; set; }
+
+        public List<short> ShortList { get; set; }
+
+        public IEnumerable<short> ShortIEnumerable { get; set; }
+
+        public ICollection<short> ShortICollection { get; set; }
 
         public int[] IntArray { get; set; }
 

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample07_VectorSearch_UsingFieldBuilder.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample07_VectorSearch_UsingFieldBuilder.cs
@@ -7,9 +7,11 @@ using System.Threading.Tasks;
 using Azure.Search.Documents.Indexes.Models;
 using Azure.Search.Documents.Indexes;
 using NUnit.Framework;
+using Azure.Core.TestFramework;
 
 namespace Azure.Search.Documents.Tests.Samples.VectorSearch
 {
+    [ClientTestFixture(SearchClientOptions.ServiceVersion.V2024_03_01_Preview), ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2024_03_01_Preview)]
     public partial class VectorSearchUsingFieldBuilder : SearchTestBase
     {
         public VectorSearchUsingFieldBuilder(bool async, SearchClientOptions.ServiceVersion serviceVersion)


### PR DESCRIPTION
This PR adds the following:
* Support for `sbyte` and `int16` types to `FieldBuilder`.
* Fix to the [weekly pipeline failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3551203&view=results).
