### PR TITLE
Initialize autorest before calling GenerateCode

### DIFF
--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -55,6 +55,11 @@ function Invoke-Block([scriptblock]$cmd) {
 }
 
 try {
+    Write-Host "Initialize npx cache"
+    Invoke-Block {
+        & npx autorest --version
+    }
+
     if ($ProjectDirectory -and -not $ServiceDirectory)
     {
         if ($ProjectDirectory -match "sdk[\\/](?<projectdir>.*)[\\/]src")

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -664,7 +664,9 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj" -GroupOutput
+    Invoke-LoggedCommand "npx autorest --version"
+
+    Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }
   finally {
     Pop-Location


### PR DESCRIPTION
calling `dotnet build /t:GenerateCode` on service.proj or a solution that generates multiple clients causes a race condition where multiple client projects invoke `npx autorest` concurrently.   npx doesn't seem to be concurrency safe, so we call `npx autorest --version` before making any msbuild calls that may go parallel.