### PR TITLE
Azure.Monitor: misc cleanup

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventListener.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventListener.cs
@@ -36,6 +36,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
+            // This method will get called for all Events.
+            // Need to check filter only the name we're interested in here to avoid spamming Debug Output.
             if (eventData.EventSource.Name == AzureMonitorExporterEventSource.EventSourceName)
             {
                 string message = EventSourceEventFormatting.Format(eventData);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -52,7 +52,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         public const string WEBSITE_HOSTNAME = "WEBSITE_HOSTNAME";
 
         /// <summary>
-        /// INTERNAL ONLY. Used by Statsbeat to get the App Service Website Name.
+        /// INTERNAL ONLY.
+        /// Used by Statsbeat to get the App Service Website Name.
+        /// Used by LiveMetrics to detect if an application is running in Azure App Service.
         /// </summary>
         public const string WEBSITE_SITE_NAME = "WEBSITE_SITE_NAME";
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
@@ -26,6 +26,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 
             if (options.EnableLiveMetrics)
             {
+                _isAzureWebApp = InitializeIsWebAppRunningInAzure(platform);
+
                 InitializeState();
             }
         }
@@ -74,6 +76,14 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             }
 
             return new QuickPulseSDKClientAPIsRestClient(new ClientDiagnostics(options), pipeline, host: connectionVars.LiveEndpoint);
+        }
+
+        /// <summary>
+        /// Searches for the environment variable specific to Azure App Service.
+        /// </summary>
+        internal static bool InitializeIsWebAppRunningInAzure(IPlatform platform)
+        {
+            return !string.IsNullOrEmpty(platform.GetEnvironmentVariable(EnvironmentVariableConstants.WEBSITE_SITE_NAME));
         }
 
         public void Dispose()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
@@ -53,7 +53,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 
                     foreach (ref readonly var tag in @event.EnumerateTagObjects())
                     {
-                        // TODO: see if these can be cached
                         if (tag.Value == null)
                         {
                             continue;


### PR DESCRIPTION
Misc cleanup


### Changes
- Exporter
  - Add a comment to Exporter EventListener. follow up to https://github.com/Azure/azure-sdk-for-net/pull/42171#discussion_r1501677587
- LiveMetrics
  - remove outdated TODO.
  - Refactor how we determine if an application is running in Azure AppService.
      - Helper method was checking the `Website_Isolation` environment variable feature for premium containers.
        The premium containers feature was retired years ago. But this check was irrelevant for determining if running in App Service.
    - Changed this to a readonly variable that is initialized in the ctor.