### PR TITLE
Do not fail scope and log an exception for existing container within CreateIfNotExistsAsync

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -1155,6 +1155,9 @@ namespace Azure.Storage.Blobs
         /// <param name="operationName">
         /// Optional. To indicate if the name of the operation.
         /// </param>
+        /// <param name="failScopeOnAlreadyExists">
+        /// Optional. To indicate if the logging scope should fail upon an container already exists exception.
+        /// </param>
         /// <returns>
         /// A <see cref="Response{ContainerInfo}"/> describing the newly
         /// created container.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -1098,13 +1098,9 @@ namespace Azure.Storage.Blobs
                         encryptionScopeOptions,
                         async,
                         cancellationToken,
-                        operationName)
+                        operationName,
+                        false)
                         .ConfigureAwait(false);
-                }
-                catch (RequestFailedException storageRequestFailedException)
-                when (storageRequestFailedException.ErrorCode == BlobErrorCode.ContainerAlreadyExists)
-                {
-                    response = default;
                 }
                 catch (Exception ex)
                 {
@@ -1174,8 +1170,9 @@ namespace Azure.Storage.Blobs
             bool async,
             CancellationToken cancellationToken,
 #pragma warning disable CA1801 // Review unused parameters
-            string operationName = null)
+            string operationName = null,
 #pragma warning restore CA1801 // Review unused parameters
+            bool failScopeOnAlreadyExists = true)
         {
             using (ClientConfiguration.Pipeline.BeginLoggingScope(nameof(BlobContainerClient)))
             {
@@ -1215,6 +1212,11 @@ namespace Azure.Storage.Blobs
                     return Response.FromValue(
                         response.ToBlobContainerInfo(),
                         response.GetRawResponse());
+                }
+                catch (RequestFailedException storageRequestFailedException)
+                when (storageRequestFailedException.ErrorCode == BlobErrorCode.ContainerAlreadyExists && !failScopeOnAlreadyExists)
+                {
+                    return default;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This is a fix for the underlying dependency of CreateIfNotExistsAsync showing up as failed within Application Insights when a container already exists, as the issue described within #28549

![image](https://github.com/Azure/azure-sdk-for-net/assets/784475/85bf7a41-916d-40fb-bc32-bd1c34eac62c)
