### PR TITLE
Sas preservation fix

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.20.0-beta.2 (Unreleased)
 - Added support for service version 2024-05-04.
 - Fixed bug where BlockBlobClient.Upload() and .UploadAsync() would throw an exception if BlobUploadOptions was null.
+- Fixed a bug where some valid shared access signatures were improperly parsed, throwing an exception.
 
 ## 12.20.0-beta.1 (2023-12-05)
 - Added support for service version 2024-02-04.

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -3289,6 +3291,55 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(blobName, pageBlobClientFromContainer.Name);
             Assert.AreEqual(expectedUri, pageBlobClientFromConnectionString.Uri);
             Assert.AreEqual(blobName, pageBlobClientFromConnectionString.Name);
+        }
+
+        [Test]
+        [Sequential]
+        public void GetBlobClient_PreserveSas(
+            [Values("https,http", "http,https", "https")] string protocol)
+        {
+            string version = _serviceVersion.ToVersionString();
+            string service = "b";
+            string resourceType = "c";
+            string startTime = DateTimeOffset.Now.ToString(Constants.SasTimeFormatSeconds, CultureInfo.InvariantCulture);
+            string expiryTime = DateTimeOffset.Now.AddDays(1).ToString(Constants.SasTimeFormatSeconds, CultureInfo.InvariantCulture);
+            string identifier = "foo";
+            string resource = "bar";
+            string permissions = "rw";
+            string cacheControl = "no-store";
+            string contentDisposition = "inline";
+            string contentEncoding = "identity";
+            string contentLanguage = "en-US";
+            string contentType = "text/html";
+            string signature = "a+b=";
+
+            Dictionary<string, string> original = new()
+            {
+                { "sv", version },
+                { "ss", service },
+                { "srt", resourceType },
+                { "spr", protocol },
+                { "st", startTime },
+                { "se", expiryTime },
+                { "si", identifier },
+                { "sr", resource },
+                { "sp", permissions },
+                { "rscc", cacheControl },
+                { "rscd", contentDisposition },
+                { "rsce", contentEncoding },
+                { "rscl", contentLanguage },
+                { "rsct", contentType },
+                { "sig", signature },
+            };
+
+            string sas = SasQueryParametersInternals.Create(new Dictionary<string, string>(original)).ToString();
+
+            BlobContainerClient containerFromUri = new(new Uri($"https://myaccount.blob.core.windows.net/mycontainer?{sas}"));
+            BlobClient blob = containerFromUri.GetBlobClient("myblob");
+            Dictionary<string, string> blobQueryParams = blob.Uri.Query.Trim('?').Split('&').ToDictionary(
+                s => s.Split('=')[0],
+                s => WebUtility.UrlDecode(s.Split('=')[1]));
+            Assert.That(original, Is.EquivalentTo(blobQueryParams));
         }
 
         #region GenerateSasTests

--- a/sdk/storage/Azure.Storage.Blobs/tests/SasQueryParametersTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SasQueryParametersTests.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
 using Azure.Storage.Sas;
 using NUnit.Framework;
 
@@ -56,6 +60,57 @@ namespace Azure.Storage.Blobs.Test
             var roundTripSas = SasQueryParametersInternals.Create(new UriQueryParamsCollection(sasString));
 
             Assert.AreEqual(sasQueryParameters.ToString(), roundTripSas.ToString());
+        }
+
+        [Test]
+        [Sequential]
+        public void SasQueryParameters_RoundTrip_String(
+            [Values("https", "https,http", "http,https")] string protocol)
+        {
+            string version = "2018-03-28";
+            string service = AccountSasServices.Blobs.ToPermissionsString();
+            string resourceType = AccountSasResourceTypes.Container.ToPermissionsString();
+            string startTime = DateTimeOffset.Now.ToString(Constants.SasTimeFormatSeconds, CultureInfo.InvariantCulture);
+            string expiryTime = DateTimeOffset.Now.AddDays(1).ToString(Constants.SasTimeFormatSeconds, CultureInfo.InvariantCulture);
+            string identifier = "foo";
+            string resource = "bar";
+            string permissions = "rw";
+            string signature = "a+b=";
+            string cacheControl = "no-store";
+            string contentDisposition = "inline";
+            string contentEncoding = "identity";
+            string contentLanguage = "en-US";
+            string contentType = "text/html";
+
+            Dictionary<string, string> original = new()
+            {
+                { "sv", version },
+                { "ss", service },
+                { "srt", resourceType },
+                { "spr", protocol },
+                { "st", startTime },
+                { "se", expiryTime },
+                { "si", identifier },
+                { "sr", resource },
+                { "sp", permissions },
+                { "rscc", cacheControl },
+                { "rscd", contentDisposition },
+                { "rsce", contentEncoding },
+                { "rscl", contentLanguage },
+                { "rsct", contentType },
+                { "sig", signature },
+            };
+
+            var sasQueryParameters = SasQueryParametersInternals.Create(new Dictionary<string, string>(original));
+
+            Assert.AreEqual(signature, sasQueryParameters.Signature);
+
+            Dictionary<string, string> roundtrip = sasQueryParameters.ToString().Trim('?').Split('&')
+                .ToDictionary(
+                    s => s.Split('=')[0],
+                    s => WebUtility.UrlDecode(s.Split('=')[1]));
+
+            Assert.That(original, Is.EquivalentTo(roundtrip));
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/SasExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/SasExtensions.cs
@@ -75,6 +75,7 @@ namespace Azure.Storage.Sas
         private const string NoneName = null;
         private const string HttpsName = "https";
         private const string HttpsAndHttpName = "https,http";
+        private const string HttpAndHttpsName = "http,https";
 
         /// <summary>
         /// Gets a string representation of the protocol.
@@ -109,6 +110,7 @@ namespace Azure.Storage.Sas
                 case HttpsName:
                     return SasProtocol.Https;
                 case HttpsAndHttpName:
+                case HttpAndHttpsName:
                     return SasProtocol.HttpsAndHttp;
                 default:
                     throw Errors.InvalidSasProtocol(nameof(s), nameof(SasProtocol));


### PR DESCRIPTION
Hardcoded values in SAS parsing don't cover the full valid range of values. Fix preserves valid signed protocol that was previously unsupported while preserving BlobUriBuilder behavior.