### PR TITLE
[Communication][PhoneNumbers] Fix paging issue in get areacodes

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/PhoneNumbersClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/PhoneNumbersClient.cs
@@ -748,10 +748,6 @@ namespace Azure.Communication.PhoneNumbers
                 try
                 {
                     int skip = int.Parse(HttpUtility.ParseQueryString(nextLink).Get("skip"));
-                    if (skip > pageSizeHint)
-                    {
-                        return null;
-                    }
 
                     return RestClient.CreateListAreaCodesNextPageRequest(nextLink, twoLetterIsoCountryName, phoneNumberType, skip, pageSizeHint, phoneNumberAssignmentType, locality, administrativeDivision, null);
                 }
@@ -805,10 +801,6 @@ namespace Azure.Communication.PhoneNumbers
                 try
                 {
                     int skip = int.Parse(HttpUtility.ParseQueryString(nextLink).Get("skip"));
-                    if (skip > pageSizeHint)
-                    {
-                        return null;
-                    }
 
                     return RestClient.CreateListAreaCodesNextPageRequest(nextLink, twoLetterIsoCountryName, phoneNumberType, skip, pageSizeHint, phoneNumberAssignmentType, locality, administrativeDivision, null);
                 }


### PR DESCRIPTION
Removing an if statement that would cause the areacodes pageable to stop returning pages.