### PR TITLE
[AzureMonitorDistro] resync vendored code

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -1,4 +1,3 @@
-// <copyright file="SqlActivitySourceHelper.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -1,4 +1,3 @@
-// <copyright file="SqlClientDiagnosticListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
@@ -1,4 +1,3 @@
-// <copyright file="SqlClientInstrumentationEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -1,4 +1,3 @@
-// <copyright file="SqlEventSourceListener.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -1,4 +1,3 @@
-// <copyright file="SqlClientInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
@@ -1,4 +1,3 @@
-// <copyright file="SqlClientTraceInstrumentationOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.Trace;
 /// <summary>
 /// Extension methods to simplify registering of dependency instrumentation.
 /// </summary>
-internal static class SqlClient_TracerProviderBuilderExtensions
+internal static class TracerProviderBuilderExtensions
 {
     /// <summary>
     /// Enables SqlClient instrumentation.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -1,4 +1,3 @@
-// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AppServiceResourceDetector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AppServiceResourceDetector.cs
@@ -1,4 +1,3 @@
-// <copyright file="AppServiceResourceDetector.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AzureContainerAppsResourceDetector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AzureContainerAppsResourceDetector.cs
@@ -1,4 +1,3 @@
-// <copyright file="AzureContainerAppsResourceDetector.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AzureVMResourceDetector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AzureVMResourceDetector.cs
@@ -1,4 +1,3 @@
-// <copyright file="AzureVMResourceDetector.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AzureVmMetaDataRequestor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AzureVmMetaDataRequestor.cs
@@ -1,4 +1,3 @@
-// <copyright file="AzureVmMetaDataRequestor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AzureVmMetadataResponse.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/AzureVmMetadataResponse.cs
@@ -1,4 +1,3 @@
-// <copyright file="AzureVmMetadataResponse.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/ResourceAttributeConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/ResourceAttributeConstants.cs
@@ -1,4 +1,3 @@
-// <copyright file="ResourceAttributeConstants.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/SourceGenerationContext.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.ResourceDetectors.Azure/SourceGenerationContext.cs
@@ -1,4 +1,3 @@
-// <copyright file="SourceGenerationContext.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
@@ -1,4 +1,3 @@
-// <copyright file="DiagnosticSourceListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
@@ -1,4 +1,3 @@
-// <copyright file="DiagnosticSourceSubscriber.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceInstrumentation/ListenerHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceInstrumentation/ListenerHandler.cs
@@ -1,4 +1,3 @@
-// <copyright file="ListenerHandler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs
@@ -1,4 +1,3 @@
-// <copyright file="PropertyFetcher.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/ExceptionExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/ExceptionExtensions.cs
@@ -1,4 +1,3 @@
-// <copyright file="ExceptionExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/Guard.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/Guard.cs
@@ -1,4 +1,3 @@
-// <copyright file="Guard.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/SemanticConventions.cs
@@ -1,4 +1,3 @@
-// <copyright file="SemanticConventions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/Shims/IsExternalInit.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/Shims/IsExternalInit.cs
@@ -1,4 +1,3 @@
-// <copyright file="IsExternalInit.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/Shims/NullableAttributes.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/Shims/NullableAttributes.cs
@@ -1,4 +1,3 @@
-// <copyright file="NullableAttributes.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/SpanAttributeConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/SpanAttributeConstants.cs
@@ -1,4 +1,3 @@
-// <copyright file="SpanAttributeConstants.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/42479#discussion_r1515439382

Because we've been manually syncing vendored files, some of these files are out of sync with the OpenTelemetry repo. I've resynced all files.

## Explanation of Changes
- removed `// <copyright file="FILENAME" company="OpenTelemetry Authors">` from all vendored files.
  This was a mistake made when manually syncing files.
- revert class name `SqlClient_TracerProviderBuilderExtensions`. The "SqlClient_" prefix was necessary when we had multiple vendored instrumentation libraries with identical class names/namespaces. This is no longer needed.

## Steps followed to Sync Vendored code

1. Create a New Branch in azure-sdk-for-net repo. This is where changes will be committed. 
2. Sync `OpenTelemetry.Instrumentation.SqlClient`
    2a. Clone the OpenTelemetry.NET Repository
    ```bash
    git clone https://github.com/open-telemetry/opentelemetry-dotnet.git
    ```
    2b. Fetch the tags and checkout the most recent release
    ```bash
    git fetch --tags
    git checkout tags/Instrumentation.SqlClient-1.7.0-beta.1
    ```
    2c. Copy the following folders into `Azure.Monitor.OpenTelemetry.AspNetCore`'s `Vendoring` directory:
    - `OpenTelemetry.Instrumentation.SqlClient`
        - Remove the following files:
            - *.csproj
            - README.md
            - CHANGELOG.MD
            - AssemblyInfo.cs
    - `Shared`
        - Specifically copy these files:
            - DiagnosticSourceInstrumentation\DiagnosticSourceListener.cs
            - DiagnosticSourceInstrumentation\DiagnosticSourceSubscriber.cs
            - DiagnosticSourceInstrumentation\ListenerHandler.cs
            - DiagnosticSourceInstrumentation\PropertyFetcher.cs
            - Shims\IsExternalInit.cs
            - Shims\NullableAttributes.cs
            - ExceptionExtensions.cs
            - Guard.cs
            - ResourceSemanticConventions.cs
            - SemanticConventions.cs
            - SpanAttributeConstants.cs
3. Sync `OpenTelemetry.ResourceDetectors.Azure`
    3a. Clone the OpenTelemetry.NET Contrib Repository
    ```bash
    git clone https://github.com/open-telemetry/opentelemetry-dotnet-contrib.git
    ```
    3b. Fetch the tags and checkout the most recent release
    ```bash
    git fetch --tags
    git checkout tags/ResourceDetectors.Azure-1.0.0-beta.5
    ```
    3c. Copy the following folders into the `Azure.Monitor.OpenTelemetry.AspNetCore`'s `Vendoring` directory:
    - `OpenTelemetry.ResourceDetectors.Azure`
        - Remove the following files:
            - *.csproj
            - README.md
            - CHANGELOG.MD
            - AssemblyInfo.cs
    - `Shared`
        - Must do a file comparison to confirm there are no missing changes or conflicts between the two repos.
4. Additional Changes
    - Modified all instrumentation public APIs to internal.
    - Added `#nullable enable` to `OpenTelemetry.ResourceDetoctors.Azure` files. Our `Azure.Monitor.OpenTelemetry.AspNetCore` project does not yet support nullables.
    - Added `#pragma warning disable` `AZC0102` and `AZC0104` to `Azure.VmMetaDataRequestor.cs`. These are code standards that only exist in this Azure SDK reop.
    