### PR TITLE
Use package.json for autorest in sdk repo

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
         parameters:
           Artifacts: ${{ parameters.Artifacts }}
-      
+
       - ${{ if eq(parameters.CheckAOTCompat, 'true') }}:
         - template: /eng/pipelines/templates/steps/aot-compatibility.yml
           parameters:
@@ -213,6 +213,10 @@ jobs:
           pwsh: true
           failOnStderr: false
 
+      - template: /eng/pipelines/templates/steps/dotnet-diagnostics.yml
+        parameters:
+          LogFilePath: $(Build.ArtifactStagingDirectory)/rebuild.binlog
+
       - script: >-
           dotnet build eng/service.proj -warnaserror
           /t:rebuild
@@ -225,8 +229,14 @@ jobs:
           /p:Configuration=$(BuildConfiguration)
           /p:EnableSourceLink=false
           /p:BuildSnippets=true
+          $(DiagnosticArguments)
         displayName: Build snippets
         condition: and(succeeded(), eq(${{ parameters.BuildSnippets }}, true))
+
+      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+        parameters:
+          ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: 'verify'
 
   # For some pipelines like mgmt which are tested in aggregate we want to limit the pipeline to no tests or
   # other stages that are aggregate in nature as those are tested in another aggregate pipeline

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -57,7 +57,7 @@ function Invoke-Block([scriptblock]$cmd) {
 try {
     Write-Host "Initialize npx cache"
     Invoke-Block {
-        & npx autorest --version
+        & npm ci --prefix $RepoRoot
     }
 
     if ($ProjectDirectory -and -not $ServiceDirectory)

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -55,7 +55,7 @@ function Invoke-Block([scriptblock]$cmd) {
 }
 
 try {
-    Write-Host "Initialize npx cache"
+    Write-Host "Restore ./node_modules"
     Invoke-Block {
         & npm ci --prefix $RepoRoot
     }

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -92,9 +92,13 @@ try {
                         }
             }
 
+        $debugLogging = $env:SYSTEM_DEBUG -eq "true"
+        $logsFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+        $diagnosticArguments = ($debugLogging -and $logsFolder) ? "/binarylogger:$logsFolder/generatecode.binlog" : ""
+
         Write-Host "Re-generating clients"
         Invoke-Block {
-            & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory
+            & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory $diagnosticArguments
         }
     }
 

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -3,18 +3,22 @@ param (
     [Parameter(Position=0)]
     [ValidateNotNullOrEmpty()]
     [string] $ServiceDirectory,
-    [string] $SDKType = "all", 
+    [string] $SDKType = "all",
     [switch] $SpellCheckPublicApiSurface
 )
 
-if ($SpellCheckPublicApiSurface -and -not (Get-Command 'npx')) { 
+if ($SpellCheckPublicApiSurface -and -not (Get-Command 'npx')) {
     Write-Error "Could not locate npx. Install NodeJS (includes npm and npx) https://nodejs.org/en/download/"
     exit 1
 }
 
 $servicesProj = Resolve-Path "$PSScriptRoot/../service.proj"
 
-dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /p:SDKType=$SDKType /restore $servicesProj
+$debugLogging = $env:SYSTEM_DEBUG -eq "true"
+$logsFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+$diagnosticArguments = ($debugLogging -and $logsFolder) ? "/binarylogger:$logsFolder/exportapi.binlog" : ""
+
+dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /p:SDKType=$SDKType /restore $servicesProj $diagnosticArguments
 
 if ($SpellCheckPublicApiSurface) {
     Write-Host "Spell check public API surface"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -664,7 +664,8 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    Invoke-LoggedCommand "npx autorest --version"
+    # Install autorest locally
+    Invoke-LoggedCommand "npm ci --prefix $RepoRoot"
 
     Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -623,22 +623,11 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $lines | Out-File $projectListOverrideFile -Encoding UTF8
     Write-Host "`n"
 
-    # Initialize npm and npx cache
-    Write-Host "##[group]Initializing npm and npx cache"
+    # Install autorest locally
+    Invoke-LoggedCommand "npm ci --prefix $RepoRoot"
 
-    ## Generate code in sdk/template to prime the npx and npm cache
-    Push-Location "$RepoRoot/sdk/template/Azure.Template/src"
-    try {
-      Write-Host "Building then resetting sdk/template/Azure.Template/src"
-      Invoke-LoggedCommand "dotnet build /t:GenerateCode"
-      Invoke-LoggedCommand "git restore ."
-      Invoke-LoggedCommand "git clean . --force"
-    }
-    finally {
-      Pop-Location
-    }
+    Write-Host "Running npm ci over emitter-package.json in a temp folder to prime the npm cache"
 
-    ## Run npm install over emitter-package.json in a temp folder to prime the npm cache
     $tempFolder = New-TemporaryFile
     $tempFolder | Remove-Item -Force
     New-Item $tempFolder -ItemType Directory -Force | Out-Null
@@ -658,14 +647,9 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
       $tempFolder | Remove-Item -Force -Recurse
     }
 
-    Write-Host "##[endgroup]"
-
     # Generate projects
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
-
-    # Install autorest locally
-    Invoke-LoggedCommand "npm ci --prefix $RepoRoot"
 
     Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "azure-sdk-for-net",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "azure-sdk-for-net",
+      "version": "1.0.0",
+      "dependencies": {
+        "autorest": "^3.7.1"
+      }
+    },
+    "node_modules/autorest": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.7.1.tgz",
+      "integrity": "sha512-6q17NtosQZPqBkIOUnaOPedf3PDIBF7Ha1iEGRhTqZF6TG2Q/1E3ID/D+ePIIzZDKvW01p/2pENq/oiBWH9IGQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "autorest": "entrypoints/app.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "azure-sdk-for-net",
+  "version": "1.0.0",
+  "dependencies": {
+    "autorest": "^3.7.1"
+  }
+}


### PR DESCRIPTION
Calling `npx autorest` from the GenerateCode target has been causing build breaks under heavy load in parallel.  Preempting the call with `npm ci` over a lock file is both safer for CI and makes the npx call local and pre-cached