### PR TITLE
Replace "npx" with "npm exec --yes --"

### DIFF
--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -57,7 +57,7 @@ function Invoke-Block([scriptblock]$cmd) {
 try {
     Write-Host "Initialize npx cache"
     Invoke-Block {
-        & npx autorest@ --version
+        & npm exec --yes -- autorest@ --version
     }
 
     if ($ProjectDirectory -and -not $ServiceDirectory)

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -57,7 +57,7 @@ function Invoke-Block([scriptblock]$cmd) {
 try {
     Write-Host "Initialize npx cache"
     Invoke-Block {
-        & npm exec --yes -- autorest --version
+        & npx autorest@ --version
     }
 
     if ($ProjectDirectory -and -not $ServiceDirectory)

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -57,7 +57,7 @@ function Invoke-Block([scriptblock]$cmd) {
 try {
     Write-Host "Initialize npx cache"
     Invoke-Block {
-        & npx autorest --version
+        & npm exec --yes -- autorest --version
     }
 
     if ($ProjectDirectory -and -not $ServiceDirectory)

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -664,7 +664,7 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    Invoke-LoggedCommand "npm exec --yes -- autorest --version"
+    Invoke-LoggedCommand "npx autorest@ --version"
 
     Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -664,7 +664,7 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    Invoke-LoggedCommand "npx autorest --version"
+    Invoke-LoggedCommand "npm exec --yes -- autorest --version"
 
     Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -664,7 +664,7 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    Invoke-LoggedCommand "npx autorest@ --version"
+    Invoke-LoggedCommand "npm exec --yes -- autorest@ --version"
 
     Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }


### PR DESCRIPTION
- Scripts should use "npm exec --" for most predictable behavior

