### PR TITLE
Fix for RehydrationToken serialization

### DIFF
--- a/sdk/core/Azure.Core/src/RehydrationToken.Serialization.cs
+++ b/sdk/core/Azure.Core/src/RehydrationToken.Serialization.cs
@@ -105,7 +105,7 @@ namespace Azure.Core
             writer.WritePropertyName("version"u8);
             writer.WriteStringValue(Version);
             writer.WritePropertyName("headerSource"u8);
-            writer.WriteStringValue(HeaderSource.ToString());
+            writer.WriteStringValue(HeaderSource);
             writer.WritePropertyName("nextRequestUri"u8);
             writer.WriteStringValue(NextRequestUri);
             writer.WritePropertyName("initialUri"u8);
@@ -115,7 +115,7 @@ namespace Azure.Core
             writer.WritePropertyName("lastKnownLocation"u8);
             writer.WriteStringValue(LastKnownLocation);
             writer.WritePropertyName("finalStateVia"u8);
-            writer.WriteStringValue(FinalStateVia.ToString());
+            writer.WriteStringValue(FinalStateVia);
             writer.WriteEndObject();
         }
 

--- a/sdk/core/Azure.Core/tests/RehydrationTokenTests.cs
+++ b/sdk/core/Azure.Core/tests/RehydrationTokenTests.cs
@@ -30,5 +30,12 @@ namespace Azure.Core.Tests
             var deserializedToken = ModelReaderWriter.Read(data, typeof(RehydrationToken));
             Assert.AreEqual(token, deserializedToken);
         }
+
+        [Test]
+        public void SerializeDefaultValue()
+        {
+            var data = ModelReaderWriter.Write(default(RehydrationToken));
+            Assert.NotNull(data);
+        }
     }
 }


### PR DESCRIPTION

It throws on serialize default of `RehydrationToken`, remove the unnecessary `ToString` since the value is string already.