### PR TITLE
[TestFramework] Make ClientSecret optional

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -189,7 +189,7 @@ namespace Azure.Core.TestFramework
         /// <summary>
         ///   The client secret of the Azure Active Directory service principal to use during Live tests. Not recorded.
         /// </summary>
-        public string ClientSecret => GetVariable("CLIENT_SECRET");
+        public string ClientSecret => GetOptionalVariable("CLIENT_SECRET");
 
         public virtual TokenCredential Credential
         {

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -184,7 +184,7 @@ namespace Azure.Core.TestFramework
         /// <summary>
         ///   The client id of the Azure Active Directory service principal to use during Live tests. Recorded.
         /// </summary>
-        public string ClientId => GetRecordedVariable("CLIENT_ID");
+        public string ClientId => GetRecordedOptionalVariable("CLIENT_ID");
 
         /// <summary>
         ///   The client secret of the Azure Active Directory service principal to use during Live tests. Not recorded.


### PR DESCRIPTION
# Summary

The focus of these changes is to make the `ClientSecret` environment variable optional.  This is to support scenarios where using `DefaultAzureCredential` is
preferred, such as local runs for live tests.