### PR TITLE
[AzureMonitorDistro] Update OpenTelemetryBuilderExtensions.cs

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -131,7 +131,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                     builderOptions.SetResourceBuilder(resourceBuilder);
 
                     builderOptions.IncludeFormattedMessage = true;
-                    builderOptions.IncludeScopes = false;
                 });
             });
 


### PR DESCRIPTION
Removing this line `IncludeScopes = false`.
This is not necessary because the default is already false in [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/logs/customizing-the-sdk#includescopes). 