### PR TITLE
Add clarity to Monitor Query client XML docs

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClient.cs
@@ -26,7 +26,7 @@ namespace Azure.Monitor.Query
         private readonly HttpPipeline _pipeline;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="LogsQueryClient"/>. Uses the default 'https://api.loganalytics.io' endpoint.
+        /// Creates an instance of <see cref="LogsQueryClient"/> for Azure Public Cloud usage. Uses the default 'https://api.loganalytics.io' endpoint.
         /// <example snippet="Snippet:CreateLogsClient">
         /// <code language="csharp">
         /// var client = new LogsQueryClient(new DefaultAzureCredential());
@@ -39,7 +39,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="LogsQueryClient"/>. Uses the default 'https://api.loganalytics.io' endpoint if Audience is not set in LogsQueryClientOptions.
+        /// Creates an instance of <see cref="LogsQueryClient"/> for Azure Public Cloud usage. Uses the default 'https://api.loganalytics.io' endpoint, unless <see cref="LogsQueryClientOptions.Audience"/> is set to an Azure sovereign cloud.
         /// </summary>
         /// <param name="credential">The <see cref="TokenCredential"/> instance to use for authentication.</param>
         /// <param name="options">The <see cref="LogsQueryClientOptions"/> instance to use as client configuration.</param>
@@ -48,7 +48,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="LogsQueryClient"/>.
+        /// Creates an instance of <see cref="LogsQueryClient"/> for the Azure cloud represented by <paramref name="endpoint"/>.
         /// </summary>
         /// <param name="endpoint">The service endpoint to use.</param>
         /// <param name="credential">The <see cref="TokenCredential"/> instance to use for authentication.</param>
@@ -57,7 +57,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="LogsQueryClient"/>.
+        /// Creates an instance of <see cref="LogsQueryClient"/> for the Azure cloud represented by <paramref name="endpoint"/>.
         /// </summary>
         /// <param name="endpoint">The service endpoint to use.</param>
         /// <param name="credential">The <see cref="TokenCredential"/> instance to use for authentication.</param>

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsClient.cs
@@ -13,7 +13,7 @@ using Azure.Monitor.Query.Models;
 namespace Azure.Monitor.Query
 {
     /// <summary>
-    /// The <see cref="MetricsClient"/> allows you to query multiple Azure Monitor Metric services.
+    /// The <see cref="MetricsClient"/> allows you to query the Azure Monitor Metrics service for multiple Azure resources in a single request.
     /// </summary>
     public class MetricsClient
     {
@@ -21,11 +21,11 @@ namespace Azure.Monitor.Query
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="MetricsClient"/>.
+        /// Creates an instance of <see cref="MetricsClient"/>.
         /// </summary>
-        /// <param name="endpoint">The data plane service endpoint to use. For example <c>https://metrics.monitor.azure.com/.default</c> for public cloud.</param>
+        /// <param name="endpoint">The data plane service endpoint to use. For example, <c>https://metrics.monitor.azure.com/.default</c> for Azure Public Cloud.</param>
         /// <param name="credential">The <see cref="TokenCredential"/> instance to use for authentication.</param>
-        /// <param name="options">The <see cref="MetricsQueryClientOptions"/> instance to as client configuration.</param>
+        /// <param name="options">The <see cref="MetricsClientOptions"/> instance to use as client configuration.</param>
         public MetricsClient(Uri endpoint, TokenCredential credential, MetricsClientOptions options = null)
         {
             Argument.AssertNotNull(credential, nameof(credential));
@@ -44,7 +44,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="MetricsClient"/> for mocking.
+        /// Creates an instance of <see cref="MetricsClient"/> to support <see href="https://aka.ms/azsdk/net/mocking">mocking</see>.
         /// </summary>
         protected MetricsClient()
         {
@@ -63,7 +63,7 @@ namespace Azure.Monitor.Query
         /// <param name="metricNamespace">The namespace of the metrics to query.</param>
         /// <param name="options">The <see cref="MetricsClientOptions"/> to configure the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <returns>A time-series metrics result for the requested metric names.</returns>
+        /// <returns>A time series metrics result for the requested metric names.</returns>
         public virtual Response<MetricsQueryResourcesResult> QueryResources(IEnumerable<ResourceIdentifier> resourceIds, List<string> metricNames, string metricNamespace, MetricsQueryResourcesOptions options = null, CancellationToken cancellationToken = default)
         {
             if (resourceIds.Count() == 0 || metricNames.Count == 0)
@@ -92,12 +92,12 @@ namespace Azure.Monitor.Query
         /// <summary>
         /// Returns all the Azure Monitor metrics requested for the batch of resources.
         /// </summary>
-        /// <param name="resourceIds">The resource URIs for which the metrics is requested.</param>
+        /// <param name="resourceIds">The resource URIs for which the metrics are requested.</param>
         /// <param name="metricNames">The names of the metrics to query.</param>
         /// <param name="metricNamespace">The namespace of the metrics to query.</param>
         /// <param name="options">The <see cref="MetricsClientOptions"/> to configure the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <returns>A time-series metrics result for the requested metric names.</returns>
+        /// <returns>A time series metrics result for the requested metric names.</returns>
         public virtual async Task<Response<MetricsQueryResourcesResult>> QueryResourcesAsync(IEnumerable<ResourceIdentifier> resourceIds, List<string> metricNames, string metricNamespace, MetricsQueryResourcesOptions options = null, CancellationToken cancellationToken = default)
         {
             if (resourceIds.Count() == 0 || metricNames.Count == 0)

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
@@ -12,7 +12,7 @@ using Azure.Monitor.Query.Models;
 namespace Azure.Monitor.Query
 {
     /// <summary>
-    /// The <see cref="MetricsQueryClient"/> allows you to query the Azure Monitor Metrics service.
+    /// The <see cref="MetricsQueryClient"/> allows you to query the Azure Monitor Metrics service for a single Azure resource.
     /// </summary>
     public class MetricsQueryClient
     {
@@ -24,8 +24,10 @@ namespace Azure.Monitor.Query
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="MetricsQueryClient"/>. Uses the default 'https://management.azure.com' endpoint.
-        /// <code snippet="Snippet:CreateMetricsClient" language="csharp">
+        /// Creates an instance of <see cref="MetricsQueryClient"/> for Azure Public Cloud usage. Uses the default 'https://management.azure.com' endpoint.
+        /// To access an Azure sovereign cloud, use the following constructor overload:
+        /// <see cref="MetricsQueryClient.MetricsQueryClient(TokenCredential, MetricsQueryClientOptions)"/>
+        /// <code snippet="Snippet:CreateMetricsQueryClient" language="csharp">
         /// var client = new MetricsQueryClient(new DefaultAzureCredential());
         /// </code>
         /// </summary>
@@ -35,20 +37,25 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="MetricsQueryClient"/>. Uses the default 'https://management.azure.com' endpoint if Audience is not set in MetricsQueryClientOptions.
+        /// Creates an instance of <see cref="MetricsQueryClient"/> for Azure Public Cloud usage. Uses the default 'https://management.azure.com' endpoint, unless <see cref="MetricsQueryClientOptions.Audience"/> is set to an Azure sovereign cloud.
         /// </summary>
         /// <param name="credential">The <see cref="TokenCredential"/> instance to use for authentication.</param>
-        /// <param name="options">The <see cref="MetricsQueryClientOptions"/> instance to as client configuration.</param>
+        /// <param name="options">The <see cref="MetricsQueryClientOptions"/> instance to use as client configuration.</param>
         public MetricsQueryClient(TokenCredential credential, MetricsQueryClientOptions options) : this(string.IsNullOrEmpty(options.Audience?.ToString()) ? _defaultEndpoint : new Uri(options.Audience.ToString()), credential, options)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="MetricsQueryClient"/>.
+        /// Creates an instance of <see cref="MetricsQueryClient"/> for the Azure cloud represented by <paramref name="endpoint"/>.
         /// </summary>
-        /// <param name="endpoint">The resource manager service endpoint to use. For example <c>https://management.azure.com/</c> for public cloud.</param>
+        /// <param name="endpoint">The Azure Resource Manager service endpoint to use. Some examples include:
+        /// <list type="bullet">
+        ///     <item><c>https://management.usgovcloudapi.net</c> for Azure US Government Cloud</item>
+        ///     <item><c>https://management.chinacloudapi.cn</c> for Azure China Cloud</item>
+        /// </list>
+        /// </param>
         /// <param name="credential">The <see cref="TokenCredential"/> instance to use for authentication.</param>
-        /// <param name="options">The <see cref="MetricsQueryClientOptions"/> instance to as client configuration.</param>
+        /// <param name="options">The <see cref="MetricsQueryClientOptions"/> instance to use as client configuration.</param>
         public MetricsQueryClient(Uri endpoint, TokenCredential credential, MetricsQueryClientOptions options = null)
         {
             Argument.AssertNotNull(credential, nameof(credential));

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
@@ -27,7 +27,7 @@ namespace Azure.Monitor.Query
         /// Creates an instance of <see cref="MetricsQueryClient"/> for Azure Public Cloud usage. Uses the default 'https://management.azure.com' endpoint.
         /// To access an Azure sovereign cloud, use the following constructor overload:
         /// <see cref="MetricsQueryClient.MetricsQueryClient(TokenCredential, MetricsQueryClientOptions)"/>
-        /// <code snippet="Snippet:CreateMetricsQueryClient" language="csharp">
+        /// <code snippet="Snippet:CreateMetricsClient" language="csharp">
         /// var client = new MetricsQueryClient(new DefaultAzureCredential());
         /// </code>
         /// </summary>

--- a/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientSamples.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientSamples.cs
@@ -24,7 +24,7 @@ namespace Azure.Monitor.Query.Tests
 #else
             string resourceId = TestEnvironment.MetricsResource;
 #endif
-            #region Snippet:CreateMetricsClient
+            #region Snippet:CreateMetricsQueryClient
 #if SNIPPET
             var client = new MetricsQueryClient(new DefaultAzureCredential());
 #else

--- a/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientSamples.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientSamples.cs
@@ -24,7 +24,7 @@ namespace Azure.Monitor.Query.Tests
 #else
             string resourceId = TestEnvironment.MetricsResource;
 #endif
-            #region Snippet:CreateMetricsQueryClient
+            #region Snippet:CreateMetricsClient
 #if SNIPPET
             var client = new MetricsQueryClient(new DefaultAzureCredential());
 #else


### PR DESCRIPTION
Reacting to feedback received from a recent IcM regarding sovereign cloud usage with `MetricsQueryClient`.

/cc: @scschneider