### PR TITLE
[LiveMetrics] fix for memory not updating

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 * Fix for "Comitted Memory" not updating.
-  ([]())
+  ([#42760](https://github.com/Azure/azure-sdk-for-net/pull/42760))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+* Fix for "Comitted Memory" not updating.
+  ([]())
+
 ### Other Changes
 
 ## 1.0.0-beta.3 (2024-03-08)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
@@ -115,6 +115,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         /// </remarks>
         public IEnumerable<Models.MetricPoint> CollectProcessMetrics()
         {
+            _process.Refresh();
+
             yield return new Models.MetricPoint
             {
                 Name = LiveMetricConstants.MetricId.MemoryCommittedBytesMetricIdValue,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Program.cs
@@ -17,6 +17,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Demo
 
         private static Random _random = new();
 
+        private const int chunkSizeMB = 1000;
+        private static long totalMemoryAllocated = 0;
+
         public static void Main(string[] args)
         {
             using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
@@ -40,6 +43,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Demo
 
         private static void GenerateTelemetry()
         {
+            // this will generate memory pressure
+            byte[] memoryChunk = new byte[chunkSizeMB * 1024 * 1024];
+            totalMemoryAllocated += memoryChunk.Length;
+            Console.WriteLine("Total memory allocated: " + totalMemoryAllocated / 1024 / 1024 + " MB");
+
             // Request
             if (GetRandomBool(percent: 70))
             {
@@ -85,6 +93,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Demo
                     }
                 }
             }
+
+            // Release the allocated memory
+            memoryChunk = null;
         }
     }
 }


### PR DESCRIPTION
Fix for memory not updating. 

In the original PR, we were calling `Process.GetCurrentProcess()` in the `CollectProcessMetrics` method. This guarenteed updated values. One of the last minute refactors, `GetCurrentProcess()` was moved to a class variable. We didn't catch this in testing because the CPU Process Time always updates and doesn't need to be refreshed.

> The value returned by this property represents the most recently refreshed size of memory used by the process, in bytes, that cannot be shared with other processes. To get the most up to date size, you need to call Refresh() method first.
https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.privatememorysize64?view=net-8.0#remarks

With this fix:
![image](https://github.com/Azure/azure-sdk-for-net/assets/28785781/f63a4c7f-5ad4-4be5-81e1-a25724efe625)


### Changes
- manually refresh the process before reading memory value.
- update Demo project to create memory pressure.

