### PR TITLE
OpenAI Assistants: address bugs with FunctionToolDefinition comparisons

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI.Assistants/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI.Assistants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Several issues with direct equality comparisons of function tool definitions have been fixed
+
 ### Other Changes
 
 ## 1.0.0-beta.3 (2024-03-06)

--- a/sdk/openai/Azure.AI.OpenAI.Assistants/src/Convenience/FunctionToolDefinition.cs
+++ b/sdk/openai/Azure.AI.OpenAI.Assistants/src/Convenience/FunctionToolDefinition.cs
@@ -16,32 +16,34 @@ namespace Azure.AI.OpenAI.Assistants;
 public partial class FunctionToolDefinition
 {
     public static bool operator ==(FunctionToolDefinition functionToolDefinition, RunStepFunctionToolCall functionToolCall)
-        => functionToolDefinition.Name == functionToolDefinition.Name;
+        => functionToolDefinition.Name == functionToolCall.Name;
 
     public static bool operator !=(FunctionToolDefinition functionToolDefinition, RunStepFunctionToolCall functionToolCall)
-        => functionToolDefinition.Name != functionToolDefinition.Name;
+        => functionToolDefinition.Name != functionToolCall.Name;
 
     public static bool operator ==(RunStepFunctionToolCall functionToolCall, FunctionToolDefinition functionToolDefinition)
-    => functionToolCall.Name == functionToolDefinition.Name;
+        => functionToolCall.Name == functionToolDefinition.Name;
 
     public static bool operator !=(RunStepFunctionToolCall functionToolCall, FunctionToolDefinition functionToolDefinition)
         => functionToolCall.Name != functionToolDefinition.Name;
 
     public static bool operator ==(FunctionToolDefinition functionToolDefinition, RequiredFunctionToolCall functionToolCall)
-    => functionToolDefinition.Name == functionToolDefinition.Name;
+        => functionToolDefinition.Name == functionToolCall.Name;
 
     public static bool operator !=(FunctionToolDefinition functionToolDefinition, RequiredFunctionToolCall functionToolCall)
-        => functionToolDefinition.Name != functionToolDefinition.Name;
+        => functionToolDefinition.Name != functionToolCall.Name;
 
     public static bool operator ==(RequiredFunctionToolCall functionToolCall, FunctionToolDefinition functionToolDefinition)
-    => functionToolCall.Name == functionToolDefinition.Name;
+        => functionToolCall.Name == functionToolDefinition.Name;
 
     public static bool operator !=(RequiredFunctionToolCall functionToolCall, FunctionToolDefinition functionToolDefinition)
         => functionToolCall.Name != functionToolDefinition.Name;
 
     /// <inheritdoc/>
     public override bool Equals(object obj)
-        => ReferenceEquals(this, obj) ? true : ReferenceEquals(obj, null) ? false : throw new NotImplementedException();
+        => (obj is FunctionToolDefinition toolDefinition && Name == toolDefinition.Name)
+            || (obj is RunStepFunctionToolCall runStepToolCall && Name == runStepToolCall.Name)
+            || (obj is RequiredFunctionToolCall requiredToolCall && Name == requiredToolCall.Name);
 
     /// <inheritdoc/>
     public override int GetHashCode() => InternalFunction.GetHashCode();


### PR DESCRIPTION
The custom equality implementations for `FunctionToolDefinition`'s convenience layer currently has several pattern-induced bugs; these snuck in as oversights of misguided IDE suggestions. Most problematic, the overload of `Equals` has an incomplete implementation that enforces a reference match, which precludes other tooling like Newtonsoft.Json from working properly when serializing this data.

This change just updates the logic to match the intention.