### PR TITLE
[AppConfiguration] Test fix: GetBatchSettingPagination

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/appconfiguration/Azure.Data.AppConfiguration",
-  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_d5e84cbb97"
+  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_40b7825d94"
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -86,16 +87,15 @@ namespace Azure.Data.AppConfiguration.Tests
             return CreateSetting($"{specialChars}", $"value-{specialChars}", $"label-{specialChars}");
         }
 
-        private async Task<string> SetMultipleKeys(ConfigurationClient service, int expectedEvents)
+        private async Task<string> SetMultipleKeys(ConfigurationClient service, int expectedEvents, [CallerMemberName] string batchKey = null)
         {
             string key = GenerateKeyId("key-");
 
             /*
              * The configuration store contains a KV with the Key
              * that represents {expectedEvents} data points.
-             * If not set, create the {expectedEvents} data points and the "BatchKey"
+             * If not set, create the {expectedEvents} data points and the "batchKey"
             */
-            const string batchKey = "BatchKey";
 
             try
             {


### PR DESCRIPTION
`GetBatchSettingPagination` started failing after new unit tests were introduced. These new tests also make use of the `SetMultipleKeys` test helper method, which is interfering with the `GetBatchSettingPagination` validation.

To ensure that tests create independent configurations when calling `SetMultipleKeys`, we're now using the `CallerMemberName` attribute to set the test name as a unique identifier for different sets of keys.