### PR TITLE
Update sovereign cloud heading in Monitor Query README

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -60,7 +60,7 @@ var client = new MetricsClient(
     new DefaultAzureCredential());
 ```
 
-### Configure client for Azure sovereign cloud
+#### Configure client for Azure sovereign cloud
 
 By default, `LogsQueryClient` and `MetricsQueryClient` are configured to use the Azure Public Cloud. To use a sovereign cloud instead, set the `Audience` property on the `Options` class. For example:
 


### PR DESCRIPTION
Update the heading hierarchy so that the sovereign cloud section is nested beneath "Authenticate the client". Here's what we end up with:

![image](https://github.com/Azure/azure-sdk-for-net/assets/10702007/59185557-ebeb-4266-97cb-6ba9f2403712)

