### PR TITLE
Don't bootstrap if no resource group env var

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -303,12 +303,12 @@ namespace Azure.Core.TestFramework
 
         private async Task ExtendResourceGroupExpirationAsync()
         {
-            if (Mode is not (RecordedTestMode.Live or RecordedTestMode.Record) || DisableBootstrapping)
+            string resourceGroup = GetOptionalVariable("RESOURCE_GROUP");
+
+            if (Mode is not (RecordedTestMode.Live or RecordedTestMode.Record) || DisableBootstrapping || string.IsNullOrEmpty(resourceGroup))
             {
                 return;
             }
-
-            string resourceGroup = GetVariable("RESOURCE_GROUP");
 
             string subscription = GetVariable("SUBSCRIPTION_ID");
 


### PR DESCRIPTION
Mgmt libraries won't have resource_group env var. Also, if there is no resource group env var we don't really need to bootstrap at this point in the test.