### PR TITLE
[Communication]-Sms-Added optional DeliveryReportTimeoutInSeconds to smsSendOptions

### DIFF
--- a/sdk/communication/Azure.Communication.Sms/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Sms/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
-## 1.1.0-beta.1 (2022-02-05)
-- Added support of DeliveryReportTimeoutInSeconds.
+## 1.1.0-beta.1 (2024-03-25)
+- Added optional DeliveryReportTimeoutInSeconds to smsSendOptions.
 
 ## 1.0.2 (2021-10-05)
 - Dependency versions updated.

--- a/sdk/communication/Azure.Communication.Sms/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Sms/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.1.0-beta.1 (2022-02-05)
+- Added support of DeliveryReportTimeoutInSeconds.
+
 ## 1.0.2 (2021-10-05)
 - Dependency versions updated.
 

--- a/sdk/communication/Azure.Communication.Sms/README.md
+++ b/sdk/communication/Azure.Communication.Sms/README.md
@@ -23,6 +23,7 @@ To create a new Communication Service, you can use the [Azure Portal][communicat
 ### Using statements
 ```C# Snippet:Azure_Communication_Sms_Tests_UsingStatements
 using System;
+using System.IO;
 using Azure.Communication.Sms;
 ```
 
@@ -64,6 +65,7 @@ var response = await smsClient.SendAsync(
     options: new SmsSendOptions(enableDeliveryReport: true) // OPTIONAL
     {
         Tag = "marketing", // custom tags
+        DeliveryReportTimeoutInSeconds = 90
     });
 foreach (SmsSendResult result in response.Value)
 {

--- a/sdk/communication/Azure.Communication.Sms/README.md
+++ b/sdk/communication/Azure.Communication.Sms/README.md
@@ -23,7 +23,6 @@ To create a new Communication Service, you can use the [Azure Portal][communicat
 ### Using statements
 ```C# Snippet:Azure_Communication_Sms_Tests_UsingStatements
 using System;
-using System.IO;
 using Azure.Communication.Sms;
 ```
 

--- a/sdk/communication/Azure.Communication.Sms/api/Azure.Communication.Sms.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.Sms/api/Azure.Communication.Sms.netstandard2.0.cs
@@ -18,12 +18,13 @@ namespace Azure.Communication.Sms
         public enum ServiceVersion
         {
             V2021_03_07 = 1,
-            V2024_02_05_Preview = 2
+            V2024_02_05_Preview = 2,
         }
     }
     public partial class SmsSendOptions
     {
         public SmsSendOptions(bool enableDeliveryReport) { }
+        public int? DeliveryReportTimeoutInSeconds { get { throw null; } set { } }
         public bool EnableDeliveryReport { get { throw null; } }
         public string Tag { get { throw null; } set { } }
     }

--- a/sdk/communication/Azure.Communication.Sms/api/Azure.Communication.Sms.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.Sms/api/Azure.Communication.Sms.netstandard2.0.cs
@@ -14,10 +14,11 @@ namespace Azure.Communication.Sms
     }
     public partial class SmsClientOptions : Azure.Core.ClientOptions
     {
-        public SmsClientOptions(Azure.Communication.Sms.SmsClientOptions.ServiceVersion version = Azure.Communication.Sms.SmsClientOptions.ServiceVersion.V2021_03_07) { }
+        public SmsClientOptions(Azure.Communication.Sms.SmsClientOptions.ServiceVersion version = Azure.Communication.Sms.SmsClientOptions.ServiceVersion.V2024_02_05_Preview) { }
         public enum ServiceVersion
         {
             V2021_03_07 = 1,
+            V2024_02_05_Preview = 2
         }
     }
     public partial class SmsSendOptions

--- a/sdk/communication/Azure.Communication.Sms/assets.json
+++ b/sdk/communication/Azure.Communication.Sms/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/communication/Azure.Communication.Sms",
-  "Tag": "net/communication/Azure.Communication.Sms_7cb55c85b9"
+  "Tag": "net/communication/Azure.Communication.Sms_449125c013"
 }

--- a/sdk/communication/Azure.Communication.Sms/assets.json
+++ b/sdk/communication/Azure.Communication.Sms/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/communication/Azure.Communication.Sms",
-  "Tag": "net/communication/Azure.Communication.Sms_9077b6b480"
+  "Tag": "net/communication/Azure.Communication.Sms_7cb55c85b9"
 }

--- a/sdk/communication/Azure.Communication.Sms/assets.json
+++ b/sdk/communication/Azure.Communication.Sms/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/communication/Azure.Communication.Sms",
-  "Tag": "net/communication/Azure.Communication.Sms_449125c013"
+  "Tag": "net/communication/Azure.Communication.Sms_3b274f81e7"
 }

--- a/sdk/communication/Azure.Communication.Sms/samples/Sample1_SendSms.md
+++ b/sdk/communication/Azure.Communication.Sms/samples/Sample1_SendSms.md
@@ -38,6 +38,7 @@ var response = smsClient.Send(
     options: new SmsSendOptions(enableDeliveryReport: true) // OPTIONAL
     {
         Tag = "marketing", // custom tags
+        DeliveryReportTimeoutInSeconds = 90
     });
 foreach (SmsSendResult result in response.Value)
 {

--- a/sdk/communication/Azure.Communication.Sms/samples/Sample1_SendSmsAsync.md
+++ b/sdk/communication/Azure.Communication.Sms/samples/Sample1_SendSmsAsync.md
@@ -38,6 +38,7 @@ var response = await smsClient.SendAsync(
     options: new SmsSendOptions(enableDeliveryReport: true) // OPTIONAL
     {
         Tag = "marketing", // custom tags
+        DeliveryReportTimeoutInSeconds = 90
     });
 foreach (SmsSendResult result in response.Value)
 {

--- a/sdk/communication/Azure.Communication.Sms/src/Azure.Communication.Sms.csproj
+++ b/sdk/communication/Azure.Communication.Sms/src/Azure.Communication.Sms.csproj
@@ -6,7 +6,7 @@
       Microsoft Azure Communication Sms quickstart - https://docs.microsoft.com/azure/communication-services/quickstarts/telephony-sms/send?pivots=programming-language-csharp
     </Description>
     <AssemblyTitle>Azure Communication Sms Service</AssemblyTitle>
-    <Version>1.0.2</Version>
+    <Version>1.1.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.1</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Sms Service;Microsoft;Azure;Azure Communication Service;Azure Communication Sms Service;Sms;Communication;$(PackageCommonTags)</PackageTags>

--- a/sdk/communication/Azure.Communication.Sms/src/Generated/Models/SmsSendOptions.Serialization.cs
+++ b/sdk/communication/Azure.Communication.Sms/src/Generated/Models/SmsSendOptions.Serialization.cs
@@ -22,6 +22,11 @@ namespace Azure.Communication.Sms
                 writer.WritePropertyName("tag"u8);
                 writer.WriteStringValue(Tag);
             }
+            if (Optional.IsDefined(DeliveryReportTimeoutInSeconds))
+            {
+                writer.WritePropertyName("deliveryReportTimeoutInSeconds"u8);
+                writer.WriteNumberValue(DeliveryReportTimeoutInSeconds.Value);
+            }
             writer.WriteEndObject();
         }
     }

--- a/sdk/communication/Azure.Communication.Sms/src/Generated/Models/SmsSendOptions.cs
+++ b/sdk/communication/Azure.Communication.Sms/src/Generated/Models/SmsSendOptions.cs
@@ -20,15 +20,19 @@ namespace Azure.Communication.Sms
         /// <summary> Initializes a new instance of <see cref="SmsSendOptions"/>. </summary>
         /// <param name="enableDeliveryReport"> Enable this flag to receive a delivery report for this message on the Azure Resource EventGrid. </param>
         /// <param name="tag"> Use this field to provide metadata that will then be sent back in the corresponding Delivery Report. </param>
-        internal SmsSendOptions(bool enableDeliveryReport, string tag)
+        /// <param name="deliveryReportTimeoutInSeconds"> Time to wait for a delivery report. After this time a delivery report with timeout error code is generated. </param>
+        internal SmsSendOptions(bool enableDeliveryReport, string tag, int? deliveryReportTimeoutInSeconds)
         {
             EnableDeliveryReport = enableDeliveryReport;
             Tag = tag;
+            DeliveryReportTimeoutInSeconds = deliveryReportTimeoutInSeconds;
         }
 
         /// <summary> Enable this flag to receive a delivery report for this message on the Azure Resource EventGrid. </summary>
         public bool EnableDeliveryReport { get; }
         /// <summary> Use this field to provide metadata that will then be sent back in the corresponding Delivery Report. </summary>
         public string Tag { get; set; }
+        /// <summary> Time to wait for a delivery report. After this time a delivery report with timeout error code is generated. </summary>
+        public int? DeliveryReportTimeoutInSeconds { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.Sms/src/Generated/SmsRestClient.cs
+++ b/sdk/communication/Azure.Communication.Sms/src/Generated/SmsRestClient.cs
@@ -20,7 +20,7 @@ namespace Azure.Communication.Sms
     internal partial class SmsRestClient
     {
         private readonly HttpPipeline _pipeline;
-        private readonly string _endpoint;
+        private readonly Uri _endpoint;
         private readonly string _apiVersion;
 
         /// <summary> The ClientDiagnostics is used to provide tracing support for the client library. </summary>
@@ -32,7 +32,7 @@ namespace Azure.Communication.Sms
         /// <param name="endpoint"> The communication resource, for example https://my-resource.communication.azure.com. </param>
         /// <param name="apiVersion"> Api Version. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="clientDiagnostics"/>, <paramref name="pipeline"/>, <paramref name="endpoint"/> or <paramref name="apiVersion"/> is null. </exception>
-        public SmsRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2021-03-07")
+        public SmsRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Uri endpoint, string apiVersion = "2024-02-05-preview")
         {
             ClientDiagnostics = clientDiagnostics ?? throw new ArgumentNullException(nameof(clientDiagnostics));
             _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
@@ -46,7 +46,7 @@ namespace Azure.Communication.Sms
             var request = message0.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/sms", false);
             uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;

--- a/sdk/communication/Azure.Communication.Sms/src/SmsClient.cs
+++ b/sdk/communication/Azure.Communication.Sms/src/SmsClient.cs
@@ -7,11 +7,10 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Azure.Core;
-using Azure.Core.Pipeline;
 using Azure.Communication.Pipeline;
 using Azure.Communication.Sms.Models;
+using Azure.Core;
+using Azure.Core.Pipeline;
 
 namespace Azure.Communication.Sms
 {
@@ -83,7 +82,7 @@ namespace Azure.Communication.Sms
         private SmsClient(string endpoint, HttpPipeline httpPipeline, SmsClientOptions options)
         {
             _clientDiagnostics = new ClientDiagnostics(options);
-            RestClient = new SmsRestClient(_clientDiagnostics, httpPipeline, endpoint, options.ApiVersion);
+            RestClient = new SmsRestClient(_clientDiagnostics, httpPipeline, new Uri(endpoint), options.ApiVersion);
         }
 
         #endregion

--- a/sdk/communication/Azure.Communication.Sms/src/SmsClientOptions.cs
+++ b/sdk/communication/Azure.Communication.Sms/src/SmsClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Communication.Sms
         /// <summary>
         /// The latest version of the Sms service.
         /// </summary>
-        private const ServiceVersion LatestVersion = ServiceVersion.V2021_03_07;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2024_02_05_Preview;
 
         internal string ApiVersion { get; }
 
@@ -26,6 +26,7 @@ namespace Azure.Communication.Sms
             ApiVersion = version switch
             {
                 ServiceVersion.V2021_03_07 => "2021-03-07",
+                ServiceVersion.V2024_02_05_Preview => "2024-02-05-preview",
                 _ => throw new ArgumentOutOfRangeException(nameof(version)),
             };
         }
@@ -35,11 +36,15 @@ namespace Azure.Communication.Sms
         /// </summary>
         public enum ServiceVersion
         {
-            /// <summary>
-            /// The V1 of the Sms service.
-            /// </summary>
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-            V2021_03_07 = 1
+            /// <summary>
+            /// The "2021-03-07" version of the Sms service.
+            /// </summary>
+            V2021_03_07 = 1,
+            /// <summary>
+            /// The "2024-02-05-preview" of the Sms service.
+            /// </summary>
+            V2024_02_05_Preview = 2
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
     }

--- a/sdk/communication/Azure.Communication.Sms/src/autorest.md
+++ b/sdk/communication/Azure.Communication.Sms/src/autorest.md
@@ -6,10 +6,10 @@ Run `dotnet msbuild /t:GenerateCode` to generate code.
 > see https://aka.ms/autorest
 
 ``` yaml
-tag: package-sms-2021-03-07
+tag: package-sms-2024-02-05-preview
 model-namespace: false
 require:
-    -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/896d05e37dbb00712726620b8d679cc3c3be09fb/specification/communication/data-plane/Sms/readme.md
+    -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8df53db16935b96733fda9882c3f197e2f961287/specification/communication/data-plane/Sms/readme.md
 payload-flattening-threshold: 10
 generation1-convenience-client: true
 ```

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using Azure.Core;
 using Azure.Core.TestFramework;
+using Azure.Core.TestFramework.Models;
 using Azure.Identity;
 using NUnit.Framework;
 
@@ -11,6 +12,7 @@ namespace Azure.Communication.Sms.Tests
 {
     public class SmsClientLiveTestBase : RecordedTestBase<SmsClientTestEnvironment>
     {
+        private const string URIDomainNameReplacerRegEx = @"https://([^/?]+)";
         public SmsClientLiveTestBase(bool isAsync) : base(isAsync)
         {
             JsonPathSanitizers.Add("$..from");
@@ -18,6 +20,7 @@ namespace Azure.Communication.Sms.Tests
             JsonPathSanitizers.Add("$..repeatabilityRequestId");
             JsonPathSanitizers.Add("$..repeatabilityFirstSent");
             SanitizedHeaders.Add("x-ms-content-sha256");
+            UriRegexSanitizers.Add(new UriRegexSanitizer(URIDomainNameReplacerRegEx, "https://sanitized.communication.azure.com"));
         }
 
         [OneTimeSetUp]

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTests.cs
@@ -3,13 +3,13 @@
 
 #region Snippet:Azure_Communication_Sms_Tests_UsingStatements
 using System;
-/*@@*/ using System.IO;
+/*@@*/
+using System.IO;
 //@@ using Azure.Communication.Sms;
 #endregion Snippet:Azure_Communication_Sms_Tests_UsingStatements
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Azure.Communication.Sms.Tests
@@ -109,6 +109,7 @@ namespace Azure.Communication.Sms.Tests
                    options: new SmsSendOptions(enableDeliveryReport: true) // OPTIONAL
                    {
                        Tag = "marketing", // custom tags
+                       DeliveryReportTimeoutInSeconds = 90 // OPTIONAL
                    });
                 AssertRawResponseHappyPath(response.GetRawResponse().ContentStream ?? new MemoryStream());
                 foreach (SmsSendResult result in response.Value)

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTests.cs
@@ -3,11 +3,10 @@
 
 #region Snippet:Azure_Communication_Sms_Tests_UsingStatements
 using System;
-/*@@*/
-using System.IO;
 //@@ using Azure.Communication.Sms;
 #endregion Snippet:Azure_Communication_Sms_Tests_UsingStatements
 
+using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientTest.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientTest.cs
@@ -61,7 +61,7 @@ namespace Azure.Communication.Sms.Tests
         [Test]
         public void SmsClientOptions_ThrowsWithInvalidVersion()
         {
-            var invalidServiceVersion = (SmsClientOptions.ServiceVersion)2;
+            var invalidServiceVersion = (SmsClientOptions.ServiceVersion)99;
 
             Assert.Throws<ArgumentOutOfRangeException>(() => new SmsClientOptions(invalidServiceVersion));
         }

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsRestClientTest.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsRestClientTest.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.Communication.Sms.Models;
 using Azure.Core.Pipeline;
-using Azure.Core.TestFramework;
 using NUnit.Framework;
 
 namespace Azure.Communication.Sms.Tests
@@ -17,7 +16,7 @@ namespace Azure.Communication.Sms.Tests
         public void SmsRestClient_NullClientDiagnostics_ShouldThrow()
         {
             var httpPipeline = HttpPipelineBuilder.Build(new SmsClientOptions());
-            var uri = "http://localhost";
+            var uri = new Uri("http://localhost");
 
             Assert.Throws<ArgumentNullException>(() => new SmsRestClient(null, httpPipeline, uri));
         }
@@ -26,7 +25,7 @@ namespace Azure.Communication.Sms.Tests
         public void SmsRestClient_NullHttpPipeline_ShouldThrow()
         {
             var clientDiagnostics = new ClientDiagnostics(new SmsClientOptions());
-            var endpoint = "http://localhost";
+            var endpoint = new Uri("http://localhost");
 
             Assert.Throws<ArgumentNullException>(() => new SmsRestClient(clientDiagnostics, null, endpoint));
         }
@@ -46,7 +45,7 @@ namespace Azure.Communication.Sms.Tests
             var clientOptions = new SmsClientOptions();
             var clientDiagnostics = new ClientDiagnostics(clientOptions);
             var httpPipeline = HttpPipelineBuilder.Build(clientOptions);
-            var uri = "http://localhost";
+            var uri = new Uri("http://localhost");
 
             Assert.Throws<ArgumentNullException>(() => new SmsRestClient(clientDiagnostics, httpPipeline, uri, null));
         }
@@ -170,7 +169,7 @@ namespace Azure.Communication.Sms.Tests
             var clientOptions = new SmsClientOptions();
             var clientDiagnostics = new ClientDiagnostics(clientOptions);
             var httpPipeline = HttpPipelineBuilder.Build(clientOptions);
-            var endpoint = "http://localhost";
+            var endpoint = new Uri("http://localhost");
 
             return new SmsRestClient(clientDiagnostics, httpPipeline, endpoint);
         }

--- a/sdk/communication/Azure.Communication.Sms/tests/samples/Sample1_SmsClient.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/samples/Sample1_SmsClient.cs
@@ -49,6 +49,7 @@ namespace Azure.Communication.Sms.Tests.samples
                 options: new SmsSendOptions(enableDeliveryReport: true) // OPTIONAL
                 {
                     Tag = "marketing", // custom tags
+                    DeliveryReportTimeoutInSeconds = 90
                 });
             foreach (SmsSendResult result in response.Value)
             {
@@ -90,6 +91,7 @@ namespace Azure.Communication.Sms.Tests.samples
                 options: new SmsSendOptions(enableDeliveryReport: true) // OPTIONAL
                 {
                     Tag = "marketing", // custom tags
+                    DeliveryReportTimeoutInSeconds = 90
                 });
             foreach (SmsSendResult result in response.Value)
             {


### PR DESCRIPTION
Added optional deliveryReportTimeoutInSeconds to smsSendOptions. RestApi spec is [here ](https://github.com/Azure/azure-rest-api-specs/commit/8df53db16935b96733fda9882c3f197e2f961287)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
