### PR TITLE
[Text Translation] Add support for AAD for MT endpoint

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Text/CHANGELOG.md
+++ b/sdk/translation/Azure.AI.Translation.Text/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features Added
 
 - Introduced model factory `Azure.AI.Translation.Text.TextTranslationModelFactory` for mocking.
-- Added options overloads to Translate and Transliterate.  TextTranslationTranslateOptions and TextTranslationTransliterateOptions roll up method parameters into a single object.
+- Added options overloads to Translate and Transliterate. TextTranslationTranslateOptions and TextTranslationTransliterateOptions roll up method parameters into a single object.
+- Add support for using AAD authentication.
 
 ### Breaking Changes
 

--- a/sdk/translation/Azure.AI.Translation.Text/README.md
+++ b/sdk/translation/Azure.AI.Translation.Text/README.md
@@ -73,7 +73,7 @@ Client API key authentication is used in most of the examples, but you can also 
 dotnet add package Azure.Identity
 ```
 
-Create a [custom subdomain][custom_subdomain] for your resource in order to use this type of authentication.  Use this value for the `endpoint` variable for `Text Translator Custom Endpoint`.  Only custom subdomains are supported by the SDK.  Outside of the SDK, you can use Microsoft Entra authorization for Machine Translation endpoints, as detailed [here][mt_endpoints].
+Create a [custom subdomain][custom_subdomain] for your resource in order to use this type of authentication.  Use this value for the `endpoint` variable for `Text Translator Custom Endpoint`.
 
 You will also need to [register a new Microsoft Entra application][register_aad_app] and [grant access][aad_grant_access] to your Translator resource by assigning the `"Cognitive Services User"` role to your service principal.  Additional information about Microsoft Entra authentication is available [here][custom_details].
 

--- a/sdk/translation/Azure.AI.Translation.Text/api/Azure.AI.Translation.Text.netstandard2.0.cs
+++ b/sdk/translation/Azure.AI.Translation.Text/api/Azure.AI.Translation.Text.netstandard2.0.cs
@@ -253,6 +253,7 @@ namespace Azure.AI.Translation.Text
         public TextTranslationClient(Azure.AzureKeyCredential credential, string region = "global", Azure.AI.Translation.Text.TextTranslationClientOptions options = null) { }
         public TextTranslationClient(Azure.AzureKeyCredential credential, System.Uri endpoint, string region = "global", Azure.AI.Translation.Text.TextTranslationClientOptions options = null) { }
         public TextTranslationClient(Azure.Core.TokenCredential credential, Azure.AI.Translation.Text.TextTranslationClientOptions options = null) { }
+        public TextTranslationClient(Azure.Core.TokenCredential credential, string resourceId, string region = "global", Azure.AI.Translation.Text.TextTranslationClientOptions options = null) { }
         public TextTranslationClient(Azure.Core.TokenCredential credential, System.Uri endpoint, Azure.AI.Translation.Text.TextTranslationClientOptions options = null) { }
         protected TextTranslationClient(System.Uri endpoint) { }
         protected TextTranslationClient(System.Uri endpoint, Azure.AI.Translation.Text.TextTranslationClientOptions options) { }

--- a/sdk/translation/Azure.AI.Translation.Text/assets.json
+++ b/sdk/translation/Azure.AI.Translation.Text/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/translation/Azure.AI.Translation.Text",
-  "Tag": "net/translation/Azure.AI.Translation.Text_9702e6ff9b"
+  "Tag": "net/translation/Azure.AI.Translation.Text_5e276bc39f"
 }

--- a/sdk/translation/Azure.AI.Translation.Text/src/Custom/TextTranslationClient.cs
+++ b/sdk/translation/Azure.AI.Translation.Text/src/Custom/TextTranslationClient.cs
@@ -139,6 +139,21 @@ namespace Azure.AI.Translation.Text
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextTranslationClient"/> class.
+        /// </summary>
+        /// <param name="credential">Cognitive Services Token</param>
+        /// <param name="resourceId">The value is the Resource ID for your Translator resource instance.</param>
+        /// <param name="region">Azure Resource Region</param>
+        /// <param name="options">Translate Client Options</param>
+        public TextTranslationClient(TokenCredential credential, string resourceId, string region = DEFAULT_REGION, TextTranslationClientOptions options = default) : this(DEFAULT_ENDPOINT, options)
+        {
+            var policy = new TextTranslationAADAuthenticationPolicy(credential, TOKEN_SCOPE, region, resourceId);
+            options = options ?? new TextTranslationClientOptions();
+
+            this._pipeline = HttpPipelineBuilder.Build(options, new[] { policy }, Array.Empty<HttpPipelinePolicy>(), new ResponseClassifier());
+        }
+
         /// <summary> Translate Text. </summary>
         /// <param name="targetLanguages">
         /// Specifies the language of the output text. The target language must be one of the supported languages included

--- a/sdk/translation/Azure.AI.Translation.Text/src/Custom/TextTranslationClientOptions.cs
+++ b/sdk/translation/Azure.AI.Translation.Text/src/Custom/TextTranslationClientOptions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Azure.Core;
+
+namespace Azure.AI.Translation.Text
+{
+    /// <summary> Client options for TextTranslationClient. </summary>
+    [CodeGenSuppress("TextTranslationClientOptions", typeof(ServiceVersion))]
+    public partial class TextTranslationClientOptions : ClientOptions
+    {
+        /// <summary> Initializes new instance of TextTranslationClientOptions. </summary>
+        public TextTranslationClientOptions(ServiceVersion version = LatestVersion)
+        {
+            Version = version switch
+            {
+                ServiceVersion.V3_0 => "3.0",
+                _ => throw new NotSupportedException()
+            };
+            Diagnostics.LoggedHeaderNames.Add("X-RequestId");
+        }
+    }
+}

--- a/sdk/translation/Azure.AI.Translation.Text/src/Generated/TextTranslationClientOptions.cs
+++ b/sdk/translation/Azure.AI.Translation.Text/src/Generated/TextTranslationClientOptions.cs
@@ -23,15 +23,5 @@ namespace Azure.AI.Translation.Text
         }
 
         internal string Version { get; }
-
-        /// <summary> Initializes new instance of TextTranslationClientOptions. </summary>
-        public TextTranslationClientOptions(ServiceVersion version = LatestVersion)
-        {
-            Version = version switch
-            {
-                ServiceVersion.V3_0 => "3.0",
-                _ => throw new NotSupportedException()
-            };
-        }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Text/src/TextTranslationAADAuthenticationPolicy.cs
+++ b/sdk/translation/Azure.AI.Translation.Text/src/TextTranslationAADAuthenticationPolicy.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.AI.Translation.Text
+{
+    /// <summary>
+    /// A policy that sends an <see cref="AccessToken"/> provided by a <see cref="TokenCredential"/> as an Authentication header
+    /// together with the Ocp-Apim-Subscription-Region and Ocp-Apim-ResourceId headers.
+    /// </summary>
+    internal class TextTranslationAADAuthenticationPolicy : BearerTokenAuthenticationPolicy
+    {
+        private const string RESOURCE_ID_HEADER_NAME = "Ocp-Apim-ResourceId";
+        private const string REGION_HEADER_NAME = "Ocp-Apim-Subscription-Region";
+
+        private readonly string region;
+        private readonly string resourceId;
+
+        public TextTranslationAADAuthenticationPolicy(TokenCredential credential, string scope, string region, string resourceId) : base(credential, scope)
+        {
+            this.region = region;
+            this.resourceId = resourceId;
+        }
+
+        public TextTranslationAADAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes, string region, string resourceId) : base(credential, scopes)
+        {
+            this.region = region;
+            this.resourceId = resourceId;
+        }
+
+        /// <inheritdoc />
+        public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            this.AddAuthenticationHeaders(message);
+            return base.ProcessAsync(message, pipeline);
+        }
+
+        /// <inheritdoc />
+        public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            this.AddAuthenticationHeaders(message);
+            base.Process(message, pipeline);
+        }
+
+        private void AddAuthenticationHeaders(HttpMessage message)
+        {
+            message.Request.Headers.Add(REGION_HEADER_NAME, region);
+            message.Request.Headers.Add(RESOURCE_ID_HEADER_NAME, resourceId);
+        }
+    }
+}

--- a/sdk/translation/Azure.AI.Translation.Text/tests/Infrastructure/TextTranslationTestEnvironment.cs
+++ b/sdk/translation/Azure.AI.Translation.Text/tests/Infrastructure/TextTranslationTestEnvironment.cs
@@ -30,10 +30,30 @@ namespace Azure.AI.Translation.Text.Tests
         /// <summary>The name of the environment variable from which the Text Translator resource's region will be extracted for the live tests.</summary>
         private const string RegionEnvironmentVariableName = "TEXT_TRANSLATION_REGION";
 
+        /// <summary>The name of the environment variable from which the Text Translator resource's region will be extracted for the live tests. This resource is used for AAD tests.</summary>
+        private const string AADRegionEnvironmentVariableName = "TEXT_TRANSLATION_AAD_REGION";
+
+        /// <summary>Client ID. This resource is used for AAD tests.</summary>
+        private const string AADClientIdEnvironmentVariableName = "TEXT_TRANSLATION_AAD_CLIENT_ID";
+
+        /// <summary>Tenant ID. This resource is used for AAD tests.</summary>
+        private const string AADTentantIdEnvironmentVariableName = "TEXT_TRANSLATION_AAD_TENANT_ID";
+
+        /// <summary>Secret Value. This resource is used for AAD tests.</summary>
+        private const string AADSecretEnvironmentVariableName = "TEXT_TRANSLATION_AAD_SECRET";
+
+        /// <summary>Resource ID. This resource is used for AAD tests.</summary>
+        private const string AADResourceIDEnvironmentVariableName = "TEXT_TRANSLATION_AAD_RESOURCE_ID";
+
         public string ApiKey => GetRecordedVariable(ApiKeyEnvironmentVariableName, options => options.IsSecret());
         public string Endpoint => GetRecordedVariable(EndpointEnvironmentVariableName);
         public string CustomEndpoint => GetRecordedVariable(CustomEndpointEnvironmentVariableName);
         public string Region => GetRecordedVariable(RegionEnvironmentVariableName);
+        public string AADRegion => GetRecordedVariable(AADRegionEnvironmentVariableName);
+        public string AADClientId => GetRecordedVariable(AADClientIdEnvironmentVariableName, options => options.IsSecret());
+        public string AADTenantId => GetRecordedVariable(AADTentantIdEnvironmentVariableName, options => options.IsSecret());
+        public string AADSecret => GetRecordedVariable(AADSecretEnvironmentVariableName, options => options.IsSecret());
+        public string AADResourceId => GetRecordedVariable(AADResourceIDEnvironmentVariableName, options => options.IsSecret());
 
         protected override async ValueTask<bool> IsEnvironmentReadyAsync()
         {

--- a/sdk/translation/Azure.AI.Translation.Text/tests/TranslationLiveTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Text/tests/TranslationLiveTests.cs
@@ -555,5 +555,19 @@ namespace Azure.AI.Translation.Text.Tests
             Assert.AreEqual(200, translate.GetRawResponse().Status);
             Assert.AreEqual(1, translate.Value.Count);
         }
+
+        [RecordedTest]
+        public async Task TranslateWithAADAuth()
+        {
+            TextTranslationClient client = GetClient(useAADAuth: true);
+            TextTranslationTranslateOptions options = new TextTranslationTranslateOptions(
+                targetLanguage: "cs",
+                content: "This is a test."
+            );
+            var translate = await client.TranslateAsync(options).ConfigureAwait(false);
+
+            Assert.AreEqual(200, translate.GetRawResponse().Status);
+            Assert.AreEqual(1, translate.Value.Count);
+        }
     }
 }


### PR DESCRIPTION
# Contributing to the Azure SDK

Adding a new authentication policy which is used when user is using AAD authentication and general MT endpoint. This policy is adding two required headers:
* `Ocp-Apim-ResourceId`
* `Ocp-Apim-Subscription-Region`
