### PR TITLE
ClientModel: Update BinaryContent.Create(Stream) implementation based on PR feedback

### DIFF
--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -175,7 +175,10 @@ namespace Azure.Core
             public StreamContent(Stream stream)
             {
                 if (!stream.CanSeek)
+                {
                     throw new ArgumentException("stream must be seekable", nameof(stream));
+                }
+
                 _origin = stream.Position;
                 _stream = stream;
             }

--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -207,11 +207,14 @@ namespace Azure.Core
 
             public override bool TryComputeLength(out long length)
             {
+                // CanSeek was checked in the type constructor, but it can
+                // change based on the state of the stream.
                 if (_stream.CanSeek)
                 {
                     length = _stream.Length - _origin;
                     return true;
                 }
+
                 length = 0;
                 return false;
             }

--- a/sdk/core/System.ClientModel/src/Message/BinaryContent.cs
+++ b/sdk/core/System.ClientModel/src/Message/BinaryContent.cs
@@ -219,9 +219,16 @@ public abstract class BinaryContent : IDisposable
 
         public override bool TryComputeLength(out long length)
         {
-            // CanSeek is validated in constructor - it will always be true.
-            length = _stream.Length - _origin;
-            return true;
+            // CanSeek was checked in the type constructor, but it can
+            // change based on the state of the stream.
+            if (_stream.CanSeek)
+            {
+                length = _stream.Length - _origin;
+                return true;
+            }
+
+            length = 0;
+            return false;
         }
 
         public override void WriteTo(Stream stream, CancellationToken cancellationToken)


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-for-net/pull/42696#discussion_r1529161913

We had removed a CanSeek check from the BinaryContent.TryGetLength method based on the assumption that CanSeek has the same value for the full lifetime of the Stream.

One thing to note is that, if the Stream changes from seekable to not-seekable, than calls to WriteTo will throw as well.  This just moves the problem to a different place, since most HttpContent implementations first call TryGetLength and then call WriteTo.  We should decide as part of this PR review whether we want to throw a different exception from the WriteTo methods or let the Stream implementation's exception be what gets thrown.