### PR TITLE
[LiveMetricsExporter] Add Filtering Support part 6 - Sync Model change

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -60,8 +60,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
         private static readonly MethodInfo DictionaryStringDoubleTryGetValueMethodInfo = typeof(IDictionary<string, double>).GetMethod("TryGetValue");
 
-        private static readonly MethodInfo DictionaryStringStringScanMethodInfo =
-            GetMethodInfo<IDictionary<string, string>, string, bool>((dict, searchValue) => Filter<int>.ScanDictionary(dict, searchValue));
+        private static readonly MethodInfo ListKeyValuePairStringScanMethodInfo =
+            GetMethodInfo<IList<KeyValuePairString>, string, bool>((list, searchValue) => Filter<int>.ScanList(list, searchValue));
 
         private static readonly MethodInfo DictionaryStringDoubleScanMethodInfo =
            GetMethodInfo<IDictionary<string, double>, string, bool>((dict, searchValue) => Filter<int>.ScanDictionary(dict, searchValue));
@@ -240,7 +240,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
         {
             // return Filter<int>.TryGetString(document.listName, keyValue)
             MemberExpression properties = Expression.Property(documentExpression, listName);
-            return Expression.Call(ListStringTryGetValueMethodInfo, properties, Expression.Constant(keyValue));
+            return Expression.Call(tryGetValueMethodInfo, properties, Expression.Constant(keyValue));
         }
 
         private static Expression CreateDictionaryAccessExpression(ParameterExpression documentExpression, string dictionaryName, MethodInfo tryGetValueMethodInfo, Type valueType, string keyValue)
@@ -338,9 +338,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
             return null;
         }
 
-        private static bool ScanDictionary(IDictionary<string, string> dict, string searchValue)
+        private static bool ScanList(IList<KeyValuePairString> list, string searchValue)
         {
-            return dict?.Values.Any(val => (val ?? string.Empty).IndexOf(searchValue ?? string.Empty, StringComparison.OrdinalIgnoreCase) != -1)
+            return list?.Any(val => (val.Value ?? string.Empty).IndexOf(searchValue ?? string.Empty, StringComparison.OrdinalIgnoreCase) != -1)
                    ?? false;
         }
 
@@ -642,11 +642,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     Expression propertyComparatorExpression;
                     if (string.Equals(propertyInfo.Name, CustomDimensionsPropertyName, StringComparison.Ordinal))
                     {
-                        // ScanDictionary(document.<CustomDimensionsPropertyName>, <this.comparand>)
+                        // ScanList(document.<CustomDimensionsPropertyName>, <this.comparand>)
                         MemberExpression customDimensionsProperty = Expression.Property(documentExpression, CustomDimensionsPropertyName);
                         propertyComparatorExpression = Expression.Call(
                             null,
-                            DictionaryStringStringScanMethodInfo,
+                            ListKeyValuePairStringScanMethodInfo,
                             customDimensionsProperty,
                             Expression.Constant(this.comparand));
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/FilterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/FilterTests.cs
@@ -1511,7 +1511,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Tests
         //TODO: Removed TelemetryContext related tests. Confirm they are not needed.
 
         #region Custom dimensions
-        [Fact(Skip = "CustomDimensions not working yet.")]
+        [Fact]
         public void FilterCustomDimensions()
         {
             // ARRANGE

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/FilterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/FilterTests.cs
@@ -1508,8 +1508,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Tests
 
         #endregion
 
-        //TODO: Removed TelemetryContext related tests. Confirm they are not needed.
-
         #region Custom dimensions
         [Fact]
         public void FilterCustomDimensions()
@@ -1642,7 +1640,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Tests
             Assert.True(result9);
         }
 
-        [Fact(Skip = "Asterisk CustomDimensions not working yet.")]
+        [Fact]
         public void FilterAsteriskCustomDimensionContains()
         {
             // ARRANGE
@@ -1680,7 +1678,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Tests
             Assert.False(result3);
         }
 
-        [Fact(Skip = "Asterisk CustomDimensions not working yet.")]
+        [Fact]
         public void FilterAsteriskCustomDimensionDoesNotContain()
         {
             // ARRANGE


### PR DESCRIPTION
PR following up on #41523.

The type of field `CustomDimensions` in Model definition changed from `IDictionary<string, string>` to `IList<KeyValuePairString>`. Corresponding code needs to be updated to reflect this change.