### PR TITLE
Fix for GeographyEntity.Neighborhood causes RequestFailedException

### DIFF
--- a/sdk/maps/Azure.Maps.Search/src/Models/GeographicEntity.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/GeographicEntity.cs
@@ -20,6 +20,6 @@ namespace Azure.Maps.Search
         public static GeographicEntity Neighborhood { get; } = new GeographicEntity(NeighborhoodValue);
 
         /// <summary> NeighborhoodValue. </summary>
-        private const string NeighborhoodValue = "Neighborhood";
+        private const string NeighborhoodValue = "Neighbourhood";
     }
 }


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-net#40183

Correct spelling of the Neighborhood property.
