### PR TITLE
Monitor - fix apis

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net6.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net6.0.cs
@@ -1,0 +1,18 @@
+namespace Azure.Monitor.OpenTelemetry.AspNetCore
+{
+    public partial class AzureMonitorOptions : Azure.Core.ClientOptions
+    {
+        public AzureMonitorOptions() { }
+        public string ConnectionString { get { throw null; } set { } }
+        public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
+        public bool DisableOfflineStorage { get { throw null; } set { } }
+        public bool EnableLiveMetrics { get { throw null; } set { } }
+        public float SamplingRatio { get { throw null; } set { } }
+        public string StorageDirectory { get { throw null; } set { } }
+    }
+    public static partial class OpenTelemetryBuilderExtensions
+    {
+        public static OpenTelemetry.OpenTelemetryBuilder UseAzureMonitor(this OpenTelemetry.OpenTelemetryBuilder builder) { throw null; }
+        public static OpenTelemetry.OpenTelemetryBuilder UseAzureMonitor(this OpenTelemetry.OpenTelemetryBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.AspNetCore.AzureMonitorOptions> configureAzureMonitor) { throw null; }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/api/Azure.Monitor.OpenTelemetry.LiveMetrics.net6.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/api/Azure.Monitor.OpenTelemetry.LiveMetrics.net6.0.cs
@@ -1,0 +1,105 @@
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics
+{
+    public partial class LiveMetricsExporterOptions : Azure.Core.ClientOptions
+    {
+        public LiveMetricsExporterOptions() { }
+        public string ConnectionString { get { throw null; } set { } }
+        public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
+        public bool EnableLiveMetrics { get { throw null; } set { } }
+    }
+    public static partial class LiveMetricsExtensions
+    {
+        public static OpenTelemetry.Trace.TracerProviderBuilder AddLiveMetrics(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.LiveMetrics.LiveMetricsExporterOptions> configure = null, string name = null) { throw null; }
+    }
+}
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
+{
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct DerivedMetricInfoAggregation : System.IEquatable<Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public DerivedMetricInfoAggregation(string value) { throw null; }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation Avg { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation Max { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation Min { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation Sum { get { throw null; } }
+        public bool Equals(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation left, Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation right) { throw null; }
+        public static implicit operator Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation (string value) { throw null; }
+        public static bool operator !=(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation left, Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DerivedMetricInfoAggregation right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct DocumentFilterConjunctionGroupInfoTelemetryType : System.IEquatable<Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public DocumentFilterConjunctionGroupInfoTelemetryType(string value) { throw null; }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType Dependency { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType Event { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType Exception { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType Metric { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType PerformanceCounter { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType Request { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType Trace { get { throw null; } }
+        public bool Equals(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType left, Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType right) { throw null; }
+        public static implicit operator Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType (string value) { throw null; }
+        public static bool operator !=(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType left, Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentFilterConjunctionGroupInfoTelemetryType right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct DocumentIngressDocumentType : System.IEquatable<Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public DocumentIngressDocumentType(string value) { throw null; }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType Event { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType Exception { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType RemoteDependency { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType Request { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType Trace { get { throw null; } }
+        public bool Equals(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType left, Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType right) { throw null; }
+        public static implicit operator Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType (string value) { throw null; }
+        public static bool operator !=(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType left, Azure.Monitor.OpenTelemetry.LiveMetrics.Models.DocumentIngressDocumentType right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct FilterInfoPredicate : System.IEquatable<Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public FilterInfoPredicate(string value) { throw null; }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate Contains { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate DoesNotContain { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate Equal { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate GreaterThan { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate GreaterThanOrEqual { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate LessThan { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate LessThanOrEqual { get { throw null; } }
+        public static Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate NotEqual { get { throw null; } }
+        public bool Equals(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate left, Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate right) { throw null; }
+        public static implicit operator Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate (string value) { throw null; }
+        public static bool operator !=(Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate left, Azure.Monitor.OpenTelemetry.LiveMetrics.Models.FilterInfoPredicate right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+}


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/42426

our APIs are out of sync.
when I added net6 to these projects, I should have regenerated the api.
The following changes are from running `eng\scripts\Export-API.ps1 monitor`


### Changes
- add `net6` api file for 
  - Azure.Monitor.OpenTelemetry.AspNetCore
  - Azure.Monitor.OpenTelemetry.LiveMetrics



### Note
The LiveMetrics api is showing extra public classes. Ignore this for now, all of this will go away in my other PR updating the swagger.
THIS PR is focused on getting our build compliant again.