### PR TITLE
[AppContainers] Fix for issue #42663

### DIFF
--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/assets.json
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/containerapps/Azure.ResourceManager.AppContainers",
-  "Tag": "net/containerapps/Azure.ResourceManager.AppContainers_d294f68485"
+  "Tag": "net/containerapps/Azure.ResourceManager.AppContainers_3e459fe9a9"
 }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/Models/ContainerAppVnetConfiguration.Serialization.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/Models/ContainerAppVnetConfiguration.Serialization.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.ResourceManager.AppContainers.Models
+{
+    [CodeGenSerialization(nameof(InfrastructureSubnetId), DeserializationValueHook = nameof(DeserializeInfrastructureSubnetIdValue))]
+    public partial class ContainerAppVnetConfiguration : IUtf8JsonSerializable, IJsonModel<ContainerAppVnetConfiguration>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void DeserializeInfrastructureSubnetIdValue(JsonProperty property, ref ResourceIdentifier infrastructureSubnetId)
+        {
+            if (property.Value.ValueKind != JsonValueKind.Null && !string.IsNullOrEmpty(property.Value.GetString()))
+            {
+                infrastructureSubnetId = new ResourceIdentifier(property.Value.GetString());
+            }
+            else
+            {
+                throw new ArgumentNullException("infrastructureSubnetId cannot be null or empty.");
+            }
+        }
+    }
+}

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/Models/ContainerAppVnetConfiguration.Serialization.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/Models/ContainerAppVnetConfiguration.Serialization.cs
@@ -19,10 +19,6 @@ namespace Azure.ResourceManager.AppContainers.Models
             {
                 infrastructureSubnetId = new ResourceIdentifier(property.Value.GetString());
             }
-            else
-            {
-                throw new ArgumentNullException("infrastructureSubnetId cannot be null or empty.");
-            }
         }
     }
 }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/Models/ContainerAppVnetConfiguration.Serialization.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/Models/ContainerAppVnetConfiguration.Serialization.cs
@@ -15,7 +15,10 @@ namespace Azure.ResourceManager.AppContainers.Models
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void DeserializeInfrastructureSubnetIdValue(JsonProperty property, ref ResourceIdentifier infrastructureSubnetId)
         {
-            if (property.Value.ValueKind != JsonValueKind.Null && !string.IsNullOrEmpty(property.Value.GetString()))
+            if (property.Value.ValueKind == JsonValueKind.Null)
+            	return;
+            var str = property.Value.GetString();
+            if (!string.IsNullOrEmpty(str))
             {
                 infrastructureSubnetId = new ResourceIdentifier(property.Value.GetString());
             }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Generated/Models/ContainerAppVnetConfiguration.Serialization.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Generated/Models/ContainerAppVnetConfiguration.Serialization.cs
@@ -110,11 +110,7 @@ namespace Azure.ResourceManager.AppContainers.Models
                 }
                 if (property.NameEquals("infrastructureSubnetId"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
-                    infrastructureSubnetId = new ResourceIdentifier(property.Value.GetString());
+                    DeserializeInfrastructureSubnetIdValue(property, ref infrastructureSubnetId);
                     continue;
                 }
                 if (property.NameEquals("dockerBridgeCidr"u8))

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/tests/TestCase/ManagedEnvironmentOperationTests.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/tests/TestCase/ManagedEnvironmentOperationTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Core;
+using NUnit.Framework;
+using Azure.ResourceManager.AppContainers.Models;
+
+namespace Azure.ResourceManager.AppContainers.Tests
+{
+    public class ManagedEnvironmentOperationTests : AppContainersManagementTestBase
+    {
+        public ManagedEnvironmentOperationTests(bool isAsync)
+            : base(isAsync)//, RecordedTestMode.Record)
+        {
+        }
+
+        [TestCase]
+        [RecordedTest]
+        public async Task GetContainerAppManagedEnvironmentResource()
+        {
+            var resourceGroup = await CreateResourceGroupAsync();
+            var containerAppManagedEnvironmentCollection = resourceGroup.GetContainerAppManagedEnvironments();
+            var managedEnvironmentName = Recording.GenerateAssetName("ManagedEnvironment");
+            var data = new ContainerAppManagedEnvironmentData(AzureLocation.EastUS)
+            {
+                VnetConfiguration = new ContainerAppVnetConfiguration()
+                {
+                    DockerBridgeCidr = "172.17.0.1/16"
+                },
+            };
+            var containerAppManagedEnvironment = (await containerAppManagedEnvironmentCollection.CreateOrUpdateAsync(WaitUntil.Completed, managedEnvironmentName, data)).Value;
+            var managedEnvironment = Client.GetContainerAppManagedEnvironmentResource(containerAppManagedEnvironment.Id);
+            Assert.IsNotNull(managedEnvironment);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/42663.
Modify the deserialization method of ContainerAppVnetConfiguration to prompt that infrastructureSubnetId cannot be empty or null.