### PR TITLE
Fix for Method 'GetMapStaticImageAsync' throws 'NullReferenceExceptio…

### DIFF
--- a/sdk/maps/Azure.Maps.Rendering/src/MapsRenderingClient.cs
+++ b/sdk/maps/Azure.Maps.Rendering/src/MapsRenderingClient.cs
@@ -182,7 +182,7 @@ namespace Azure.Maps.Rendering
                 List<string> paths = null;
                 if (options?.ImagePathStyles != null)
                 {
-                    pushpins = new List<string>();
+                    paths = new List<string>();
                     foreach (var path in options?.ImagePathStyles)
                     {
                         paths.Add(path.ToQueryString());


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-net#38587
Instantiate paths variable.
