### PR TITLE
Fix for Maps.Search: Remove test delay call once service race conditi…

### DIFF
--- a/sdk/maps/Azure.Maps.Search/tests/FuzzySearchTests.cs
+++ b/sdk/maps/Azure.Maps.Search/tests/FuzzySearchTests.cs
@@ -90,8 +90,6 @@ namespace Azure.Maps.Search.Tests
                 new FuzzySearchQuery("pizza", new FuzzySearchOptions { Coordinates = new GeoPosition(121.56, 25.04) }),
             });
 
-            // delay 400 ms for the task to complete
-            await Task.Delay(400);
             var fuzzySearchBatchResp = operation.WaitForCompletion();
 
             Assert.AreEqual("CAFE_PUB", fuzzySearchBatchResp.Value.Results[0].Results[0].PointOfInterest.Classifications[0].Code);

--- a/sdk/maps/Azure.Maps.Search/tests/SearchAddressTests.cs
+++ b/sdk/maps/Azure.Maps.Search/tests/SearchAddressTests.cs
@@ -157,8 +157,6 @@ namespace Azure.Maps.Search.Tests
                 new SearchAddressQuery("Millenium", new SearchAddressOptions { CountryFilter = new[] { "US" }}),
             });
 
-            // delay 400 ms for the task to complete
-            await Task.Delay(400);
             var searchResult = operation.WaitForCompletion();
             Assert.AreEqual(2, searchResult.Value.Results.Count);
             Assert.AreEqual("Tucson", searchResult.Value.Results[1].Results[0].Address.Municipality);


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-net#31019
Remove unnecessary test delay
