### PR TITLE
ClientModel: Add null checks for non-nullable arguments in public methods

### DIFF
--- a/sdk/core/System.ClientModel/src/Convenience/ClientResultException.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ClientResultException.cs
@@ -4,7 +4,6 @@
 using System.ClientModel.Internal;
 using System.ClientModel.Primitives;
 using System.Globalization;
-using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/sdk/core/System.ClientModel/src/Convenience/ClientResultException.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ClientResultException.cs
@@ -4,6 +4,7 @@
 using System.ClientModel.Internal;
 using System.ClientModel.Primitives;
 using System.Globalization;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -31,6 +32,8 @@ public class ClientResultException : Exception
     /// created.</returns>
     public static async Task<ClientResultException> CreateAsync(PipelineResponse response, Exception? innerException = default)
     {
+        Argument.AssertNotNull(response, nameof(response));
+
         string message = await CreateMessageAsync(response).ConfigureAwait(false);
         return new ClientResultException(message, response, innerException);
     }
@@ -76,8 +79,10 @@ public class ClientResultException : Exception
     /// <param name="innerException">The <see cref="Exception.InnerException"/>,
     /// if any, that threw the current exception.</param>
     public ClientResultException(string message, PipelineResponse? response = default, Exception? innerException = default)
-        : base(message ?? DefaultMessage, innerException)
+        : base(message, innerException)
     {
+        Argument.AssertNotNull(message, nameof(message));
+
         _response = response;
         _status = response?.Status ?? 0;
     }
@@ -96,6 +101,8 @@ public class ClientResultException : Exception
 
     private static async ValueTask<string> CreateMessageSyncOrAsync(PipelineResponse response, bool async)
     {
+        Argument.AssertNotNull(response, nameof(response));
+
         if (async)
         {
             await response.BufferContentAsync().ConfigureAwait(false);

--- a/sdk/core/System.ClientModel/src/Message/ArrayBackedRequestHeaders.cs
+++ b/sdk/core/System.ClientModel/src/Message/ArrayBackedRequestHeaders.cs
@@ -19,6 +19,9 @@ internal class ArrayBackedRequestHeaders : PipelineRequestHeaders
 
     public override void Add(string name, string value)
     {
+        Argument.AssertNotNull(name, nameof(name));
+        Argument.AssertNotNull(name, nameof(value));
+
         if (_headers.TryAdd(new IgnoreCaseString(name), value, out object? currentValue))
         {
             return;
@@ -37,6 +40,8 @@ internal class ArrayBackedRequestHeaders : PipelineRequestHeaders
 
     public override bool TryGetValue(string name, out string? value)
     {
+        Argument.AssertNotNull(name, nameof(name));
+
         if (_headers.TryGetValue(new IgnoreCaseString(name), out object? headerValue))
         {
             value = GetHeaderValueString(name, headerValue!);
@@ -49,6 +54,8 @@ internal class ArrayBackedRequestHeaders : PipelineRequestHeaders
 
     public override bool TryGetValues(string name, out IEnumerable<string>? values)
     {
+        Argument.AssertNotNull(name, nameof(name));
+
         if (_headers.TryGetValue(new IgnoreCaseString(name), out object? value))
         {
             values = GetHeaderValueEnumerable(name, value!);

--- a/sdk/core/System.ClientModel/src/Message/ArrayBackedRequestHeaders.cs
+++ b/sdk/core/System.ClientModel/src/Message/ArrayBackedRequestHeaders.cs
@@ -19,8 +19,8 @@ internal class ArrayBackedRequestHeaders : PipelineRequestHeaders
 
     public override void Add(string name, string value)
     {
-        Argument.AssertNotNull(name, nameof(name));
-        Argument.AssertNotNull(name, nameof(value));
+        Argument.AssertNotNullOrEmpty(name, nameof(name));
+        Argument.AssertNotNullOrEmpty(value, nameof(value));
 
         if (_headers.TryAdd(new IgnoreCaseString(name), value, out object? currentValue))
         {
@@ -40,7 +40,7 @@ internal class ArrayBackedRequestHeaders : PipelineRequestHeaders
 
     public override bool TryGetValue(string name, out string? value)
     {
-        Argument.AssertNotNull(name, nameof(name));
+        Argument.AssertNotNullOrEmpty(name, nameof(name));
 
         if (_headers.TryGetValue(new IgnoreCaseString(name), out object? headerValue))
         {
@@ -54,7 +54,7 @@ internal class ArrayBackedRequestHeaders : PipelineRequestHeaders
 
     public override bool TryGetValues(string name, out IEnumerable<string>? values)
     {
-        Argument.AssertNotNull(name, nameof(name));
+        Argument.AssertNotNullOrEmpty(name, nameof(name));
 
         if (_headers.TryGetValue(new IgnoreCaseString(name), out object? value))
         {

--- a/sdk/core/System.ClientModel/src/Message/BinaryContent.cs
+++ b/sdk/core/System.ClientModel/src/Message/BinaryContent.cs
@@ -27,7 +27,11 @@ public abstract class BinaryContent : IDisposable
     /// <returns>An an instance of <see cref="BinaryContent"/> that contains the
     /// bytes held in the provided <see cref="BinaryData"/> instance.</returns>
     public static BinaryContent Create(BinaryData value)
-        => new BinaryDataBinaryContent(value.ToMemory());
+    {
+        Argument.AssertNotNull(value, nameof(value));
+
+        return new BinaryDataBinaryContent(value.ToMemory());
+    }
 
     /// <summary>
     /// Creates an instance of <see cref="BinaryContent"/> that contains the
@@ -40,7 +44,11 @@ public abstract class BinaryContent : IDisposable
     /// </param>
     /// <returns>An instance of <see cref="BinaryContent"/> that wraps a <see cref="IPersistableModel{T}"/>.</returns>
     public static BinaryContent Create<T>(T model, ModelReaderWriterOptions? options = default) where T : IPersistableModel<T>
-        => new ModelBinaryContent<T>(model, options ?? ModelWriteWireOptions);
+    {
+        Argument.AssertNotNull(model, nameof(model));
+
+        return new ModelBinaryContent<T>(model, options ?? ModelWriteWireOptions);
+    }
 
     /// <summary>
     /// Creates an instance of <see cref="BinaryContent"/> that contains the
@@ -51,7 +59,11 @@ public abstract class BinaryContent : IDisposable
     /// <returns>An an instance of <see cref="BinaryContent"/> that contains the
     /// bytes held in the provided <see cref="Stream"/> instance.</returns>
     public static BinaryContent Create(Stream stream)
-        => new StreamBinaryContent(stream);
+    {
+        Argument.AssertNotNull(stream, nameof(stream));
+
+        return new StreamBinaryContent(stream);
+    }
 
     /// <summary>
     /// Attempts to compute the length of the underlying body content, if available.
@@ -97,12 +109,18 @@ public abstract class BinaryContent : IDisposable
 
         public override void WriteTo(Stream stream, CancellationToken cancellation)
         {
+            Argument.AssertNotNull(stream, nameof(stream));
+
             byte[] buffer = _bytes.ToArray();
             stream.Write(buffer, 0, buffer.Length);
         }
 
         public override async Task WriteToAsync(Stream stream, CancellationToken cancellation)
-            => await stream.WriteAsync(_bytes, cancellation).ConfigureAwait(false);
+        {
+            Argument.AssertNotNull(stream, nameof(stream));
+
+            await stream.WriteAsync(_bytes, cancellation).ConfigureAwait(false);
+        }
 
         public override void Dispose() { }
     }
@@ -166,6 +184,8 @@ public abstract class BinaryContent : IDisposable
 
         public override void WriteTo(Stream stream, CancellationToken cancellation)
         {
+            Argument.AssertNotNull(stream, nameof(stream));
+
             if (ModelReaderWriter.ShouldWriteAsJson(_model, _options))
             {
                 SequenceReader.CopyTo(stream, cancellation);
@@ -181,6 +201,8 @@ public abstract class BinaryContent : IDisposable
 
         public override async Task WriteToAsync(Stream stream, CancellationToken cancellation)
         {
+            Argument.AssertNotNull(stream, nameof(stream));
+
             if (ModelReaderWriter.ShouldWriteAsJson(_model, _options))
             {
                 await SequenceReader.CopyToAsync(stream, cancellation).ConfigureAwait(false);
@@ -226,6 +248,8 @@ public abstract class BinaryContent : IDisposable
 
         public override void WriteTo(Stream stream, CancellationToken cancellationToken)
         {
+            Argument.AssertNotNull(stream, nameof(stream));
+
             _stream.Seek(_origin, SeekOrigin.Begin);
             _stream.CopyTo(stream, cancellationToken);
             _stream.Flush();
@@ -233,6 +257,8 @@ public abstract class BinaryContent : IDisposable
 
         public override async Task WriteToAsync(Stream stream, CancellationToken cancellationToken)
         {
+            Argument.AssertNotNull(stream, nameof(stream));
+
             _stream.Seek(_origin, SeekOrigin.Begin);
             await _stream.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
             await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);

--- a/sdk/core/System.ClientModel/src/Message/HttpClientResponseHeaders.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpClientResponseHeaders.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ClientModel.Internal;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
@@ -21,10 +22,18 @@ internal class HttpClientResponseHeaders : PipelineResponseHeaders
     }
 
     public override bool TryGetValue(string name, out string? value)
-        => TryGetHeader(_httpResponse.Headers, _httpResponseContent, name, out value);
+    {
+        Argument.AssertNotNull(name, nameof(name));
+
+        return TryGetHeader(_httpResponse.Headers, _httpResponseContent, name, out value);
+    }
 
     public override bool TryGetValues(string name, out IEnumerable<string>? values)
-        => TryGetHeader(_httpResponse.Headers, _httpResponseContent, name, out values);
+    {
+        Argument.AssertNotNull(name, nameof(name));
+
+        return TryGetHeader(_httpResponse.Headers, _httpResponseContent, name, out values);
+    }
 
     public override IEnumerator<KeyValuePair<string, string>> GetEnumerator()
         => GetHeadersStringValues(_httpResponse.Headers, _httpResponseContent).GetEnumerator();

--- a/sdk/core/System.ClientModel/src/Message/HttpClientResponseHeaders.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpClientResponseHeaders.cs
@@ -23,14 +23,14 @@ internal class HttpClientResponseHeaders : PipelineResponseHeaders
 
     public override bool TryGetValue(string name, out string? value)
     {
-        Argument.AssertNotNull(name, nameof(name));
+        Argument.AssertNotNullOrEmpty(name, nameof(name));
 
         return TryGetHeader(_httpResponse.Headers, _httpResponseContent, name, out value);
     }
 
     public override bool TryGetValues(string name, out IEnumerable<string>? values)
     {
-        Argument.AssertNotNull(name, nameof(name));
+        Argument.AssertNotNullOrEmpty(name, nameof(name));
 
         return TryGetHeader(_httpResponse.Headers, _httpResponseContent, name, out values);
     }

--- a/sdk/core/System.ClientModel/src/Message/PipelineMessage.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineMessage.cs
@@ -115,6 +115,8 @@ public class PipelineMessage : IDisposable
     /// </remarks>
     public void Apply(RequestOptions options)
     {
+        Argument.AssertNotNull(options, nameof(options));
+
         // This design moves the client-author API (options.Apply) off the
         // client-user type RequestOptions. Its only purpose is to call through to
         // the internal options.Apply method.

--- a/sdk/core/System.ClientModel/src/Options/PipelineMessageClassifier.cs
+++ b/sdk/core/System.ClientModel/src/Options/PipelineMessageClassifier.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ClientModel.Internal;
 using System.IO;
 
 namespace System.ClientModel.Primitives;
@@ -91,6 +92,7 @@ public abstract class PipelineMessageClassifier
     {
         public override bool TryClassify(PipelineMessage message, out bool isError)
         {
+            Argument.AssertNotNull(message, nameof(message));
             message.AssertResponse();
 
             int statusKind = message.Response!.Status / 100;
@@ -102,6 +104,8 @@ public abstract class PipelineMessageClassifier
 
         public override bool TryClassify(PipelineMessage message, Exception? exception, out bool isRetriable)
         {
+            Argument.AssertNotNull(message, nameof(message));
+
             isRetriable = exception is null ?
                 IsRetriable(message) :
                 IsRetriable(message, exception);

--- a/sdk/core/System.ClientModel/src/Options/RequestOptions.cs
+++ b/sdk/core/System.ClientModel/src/Options/RequestOptions.cs
@@ -136,6 +136,8 @@ public class RequestOptions
     /// options to.</param>
     protected internal virtual void Apply(PipelineMessage message)
     {
+        Argument.AssertNotNull(message, nameof(message));
+
         Freeze();
 
         // Set the cancellation token on the message so pipeline policies

--- a/sdk/core/System.ClientModel/src/Options/ResponseStatusClassifier.cs
+++ b/sdk/core/System.ClientModel/src/Options/ResponseStatusClassifier.cs
@@ -27,6 +27,7 @@ internal class ResponseStatusClassifier : PipelineMessageClassifier
 
     public override bool TryClassify(PipelineMessage message, out bool isError)
     {
+        Argument.AssertNotNull(message, nameof(message));
         message.AssertResponse();
 
         isError = !_successCodes[message.Response!.Status];
@@ -37,6 +38,8 @@ internal class ResponseStatusClassifier : PipelineMessageClassifier
 
     public override bool TryClassify(PipelineMessage message, Exception? exception, out bool isRetriable)
     {
+        Argument.AssertNotNull(message, nameof(message));
+
         bool classified = Default.TryClassify(message, exception, out isRetriable);
 
         Debug.Assert(classified);

--- a/sdk/core/System.ClientModel/src/Pipeline/ClientPipeline.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ClientPipeline.cs
@@ -193,6 +193,8 @@ public sealed partial class ClientPipeline
     /// </remarks>
     public void Send(PipelineMessage message)
     {
+        Argument.AssertNotNull(message, nameof(message));
+
         IReadOnlyList<PipelinePolicy> policies = GetProcessor(message);
         policies[0].Process(message, policies, 0);
     }
@@ -212,6 +214,8 @@ public sealed partial class ClientPipeline
     /// </remarks>
     public async ValueTask SendAsync(PipelineMessage message)
     {
+        Argument.AssertNotNull(message, nameof(message));
+
         IReadOnlyList<PipelinePolicy> policies = GetProcessor(message);
         await policies[0].ProcessAsync(message, policies, 0).ConfigureAwait(false);
     }


### PR DESCRIPTION
Even though nullability annotations are enabled in System.ClientModel, projects using the library may have annotations disabled so won't get compiler warnings/errors if they pass null to a method that takes a non-nullable parameter.

This PR adds null checks for arguments that were previously not checked, and throws ArgumentNullException where the method implementation is relying on the parameter value to be non-null.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/42964