### PR TITLE
[Service Bus] Reset throttle state on cancellation

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an edge case where a cancellation token signaled while waiting for a throttling delay would cause a failure to reset state and service operations would continue to apply the throttle delay going forward.  ([#42952](https://github.com/Azure/azure-sdk-for-net/issues/42952))
+
 ### Other Changes
 
 ## 7.17.4 (2024-03-05)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
@@ -227,6 +227,11 @@ namespace Azure.Messaging.ServiceBus
             {
                 // ignored
             }
+            catch (Exception ex)
+            {
+                // This is non-impactful to the operation; log as verbose and ignore.
+                Logger.RunOperationExceptionEncounteredVerbose(ex.ToString());
+            }
             finally
             {
                 // In the case of cancellation or another exception while

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
@@ -222,11 +222,16 @@ namespace Azure.Messaging.ServiceBus
             try
             {
                 await Task.Delay(ServerBusyBaseSleepTime, cancellationToken).ConfigureAwait(false);
-                ResetServerBusy();
             }
             catch (OperationCanceledException)
             {
                 // ignored
+            }
+            finally
+            {
+                // In the case of cancellation or another exception while
+                // waiting, we still want to reset the server busy state.
+                ResetServerBusy();
             }
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a bug where cancelling a service operation while a throttling delay is active would result in subsequent operations continuing to be throttled because the server busy state was not reset.

## References and resources

- [[BUG] Sometimes, after a message sent by service bus client is throttled, all messages are delayed by 10 seconds for an unlimited duration (#42952)](https://github.com/Azure/azure-sdk-for-net/issues/42952)
