### PR TITLE
Update DtmiConvention to support DTDL v3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -533,7 +533,7 @@
 /sdk/modelsrepository/                                             @timtay-microsoft @abhipsaMisra @digimaun @brycewang-microsoft @andyk-ms @tmahmood-microsoft @rido-min
 
 # ServiceLabel: %IoT
-# ServiceOwners:                                                   @ethanann-ms @vighatke @timtay-microsoft @abhipsaMisra @digimaun @brycewang-microsoft @andyk-ms @tmahmood-microsoft
+# ServiceOwners:                                                   @ethanann-ms @vighatke @timtay-microsoft @abhipsaMisra @digimaun @brycewang-microsoft @andyk-ms @tmahmood-microsoft @rido-min
 
 # ServiceLabel: %IoT - CLI
 # ServiceOwners:                                                   @Azure/azure-iot-cli-triage

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -530,7 +530,7 @@
 /sdk/iot*/                                                         @ethanann-ms @vighatke
 
 # PRLabel: %Iot
-/sdk/modelsrepository/                                             @timtay-microsoft @abhipsaMisra @digimaun @brycewang-microsoft @andyk-ms @tmahmood-microsoft
+/sdk/modelsrepository/                                             @timtay-microsoft @abhipsaMisra @digimaun @brycewang-microsoft @andyk-ms @tmahmood-microsoft @rido-min
 
 # ServiceLabel: %IoT
 # ServiceOwners:                                                   @ethanann-ms @vighatke @timtay-microsoft @abhipsaMisra @digimaun @brycewang-microsoft @andyk-ms @tmahmood-microsoft

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/CHANGELOG.md
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0-preview.7
+
+- Updates the DTMI convention to be aligned with DTDL v3 requirements, to allow _versionless_ and `major.minor`
+
 ## 1.0.0-preview.6 (Unreleased)
 
 ### Features Added

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/CHANGELOG.md
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/CHANGELOG.md
@@ -1,18 +1,10 @@
 # Release History
 
-## 1.0.0-preview.7
-
-- Updates the DTMI convention to be aligned with DTDL v3 requirements, to allow _versionless_ and `major.minor`
-
 ## 1.0.0-preview.6 (Unreleased)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Updates the DTMI convention to be aligned with DTDL v3 requirements, to allow _versionless_ and `major.minor`
 
 ## 1.0.0-preview.5 (2021-11-04)
 

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/Azure.IoT.ModelsRepository.csproj
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/Azure.IoT.ModelsRepository.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <PackageTags>IoT;ModelsRepository;Pnp;DigitalTwins;$(PackageCommonTags)</PackageTags>
     <Description>SDK for the Azure IoT Models Repository</Description>
-    <Version>1.0.0-preview.6</Version>
+    <Version>1.0.0-preview.7</Version>
   </PropertyGroup>
 
 

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/Azure.IoT.ModelsRepository.csproj
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/Azure.IoT.ModelsRepository.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <PackageTags>IoT;ModelsRepository;Pnp;DigitalTwins;$(PackageCommonTags)</PackageTags>
     <Description>SDK for the Azure IoT Models Repository</Description>
-    <Version>1.0.0-preview.7</Version>
+    <Version>1.0.0-preview.6</Version>
   </PropertyGroup>
 
 

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/DtmiConventions.cs
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/DtmiConventions.cs
@@ -20,7 +20,7 @@ namespace Azure.IoT.ModelsRepository
         // The first character may not be a digit, and the last character may not be an underscore.
         // The version length is limited to nine digits, because the number 999,999,999 fits in a 32-bit signed integer value.
         // The first digit may not be zero, so there is no ambiguity regarding whether version 1 matches version 01 since the latter is invalid.
-        private static readonly Regex s_validDtmiRegex = new Regex(@"^dtmi:[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?(?::[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?)*;[1-9][0-9]{0,8}$");
+        private static readonly Regex s_validDtmiRegex = new Regex(@"^dtmi:[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?(?::[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?)*(?:;[1-9][0-9]{0,8}(?:\.[1-9][0-9]{0,5})?)?$");
 
         /// <summary>
         /// Indicates whether a given string DTMI value is well-formed.

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/DtmiConventionsTests.cs
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/DtmiConventionsTests.cs
@@ -14,6 +14,8 @@ namespace Azure.IoT.ModelsRepository.Tests
         [TestCase("dtmi:com:example:Model:1", null)]
         [TestCase("", null)]
         [TestCase(null, null)]
+        [TestCase("dtmi:com:example:Model", "dtmi/com/example/model.json")]
+        [TestCase("dtmi:com:example:Model;1.2", "dtmi/com/example/model-1.2.json")]
         public void DtmiToPath(string dtmi, string expectedPath)
         {
             DtmiConventions.DtmiToPath(dtmi).Should().Be(expectedPath);
@@ -54,6 +56,8 @@ namespace Azure.IoT.ModelsRepository.Tests
         [TestCase("com:example:Thermostat;1", false)]
         [TestCase("", false)]
         [TestCase(null, false)]
+        [TestCase("dtmi:contoso:scope:entity", true)]
+        [TestCase("dtmi:contoso:scope:entity;2.1", true)]
         public void IsValidDtmi(string dtmi, bool expected)
         {
             DtmiConventions.IsValidDtmi(dtmi).Should().Be(expected);

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/GetModelIntegrationTests.cs
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/GetModelIntegrationTests.cs
@@ -80,13 +80,12 @@ namespace Azure.IoT.ModelsRepository.Tests
 
         [TestCase(ModelsRepositoryTestBase.ClientType.Local, true)]
         [TestCase(ModelsRepositoryTestBase.ClientType.Local, false)]
-        [TestCase(ModelsRepositoryTestBase.ClientType.Remote, true)]
-        [TestCase(ModelsRepositoryTestBase.ClientType.Remote, false)]
         public async Task GetModelNoDependencies(ModelsRepositoryTestBase.ClientType clientType, bool hasMetadata)
         {
             const string dtmi1 = "dtmi:com:example:Thermostat;1";
             const string dtmi2 = "dtmi:azure:DeviceManagement:DeviceInformation;1";
-            string[] dtmis = new[] { dtmi1, dtmi2 };
+            const string dtmi3 = "dtmi:com:example:Thermostat;1.2";
+            string[] dtmis = new[] { dtmi1, dtmi2, dtmi3 };
 
             ModelsRepositoryClient client = GetClient(clientType, hasMetadata);
 

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/GetModelIntegrationTests.cs
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/GetModelIntegrationTests.cs
@@ -80,12 +80,33 @@ namespace Azure.IoT.ModelsRepository.Tests
 
         [TestCase(ModelsRepositoryTestBase.ClientType.Local, true)]
         [TestCase(ModelsRepositoryTestBase.ClientType.Local, false)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote, true)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote, false)]
         public async Task GetModelNoDependencies(ModelsRepositoryTestBase.ClientType clientType, bool hasMetadata)
         {
             const string dtmi1 = "dtmi:com:example:Thermostat;1";
             const string dtmi2 = "dtmi:azure:DeviceManagement:DeviceInformation;1";
-            const string dtmi3 = "dtmi:com:example:Thermostat;1.2";
-            string[] dtmis = new[] { dtmi1, dtmi2, dtmi3 };
+            string[] dtmis = new[] { dtmi1, dtmi2 };
+
+            ModelsRepositoryClient client = GetClient(clientType, hasMetadata);
+
+            // Multiple GetModel() execution with the same instance.
+            foreach (var dtmi in dtmis)
+            {
+                ModelResult result = await client.GetModelAsync(dtmi);
+                result.Content.Count.Should().Be(1);
+                result.Content.ContainsKey(dtmi).Should().BeTrue();
+                ModelsRepositoryTestBase.ParseRootDtmiFromJson(result.Content[dtmi]).Should().Be(dtmi);
+            }
+        }
+
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local, true)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local, false)]
+        public async Task GetModelNoDependenciesWithMinorVersion(ModelsRepositoryTestBase.ClientType clientType, bool hasMetadata)
+        {
+            const string dtmi1 = "dtmi:com:example:Boiler";
+            const string dtmi2 = "dtmi:com:example:Thermostat;1.2";
+            string[] dtmis = new[] { dtmi1, dtmi2 };
 
             ModelsRepositoryClient client = GetClient(clientType, hasMetadata);
 

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/TestModelRepo/MetadataModelRepo/dtmi/com/example/boiler.json
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/TestModelRepo/MetadataModelRepo/dtmi/com/example/boiler.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;3",
+  "@id": "dtmi:com:example:Boiler",
+  "@type": "Interface",
+  "displayName": "Boiler",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "temp",
+      "schema": "double"
+    },
+    {
+      "@type": "Property",
+      "name": "setPointTemp",
+      "writable": true,
+      "schema": "double"
+    }
+  ]
+}

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/TestModelRepo/MetadataModelRepo/dtmi/com/example/thermostat-1.2.json
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/TestModelRepo/MetadataModelRepo/dtmi/com/example/thermostat-1.2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;3",
+  "@id": "dtmi:com:example:Thermostat;1.2",
+  "@type": "Interface",
+  "displayName": "Thermostat",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "temp",
+      "schema": "double"
+    },
+    {
+      "@type": "Property",
+      "name": "setPointTemp",
+      "writable": true,
+      "schema": "double"
+    }
+  ]
+}

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/TestModelRepo/dtmi/com/example/boiler.json
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/TestModelRepo/dtmi/com/example/boiler.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;3",
+  "@id": "dtmi:com:example:Boiler",
+  "@type": "Interface",
+  "displayName": "Boiler",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "temp",
+      "schema": "double"
+    },
+    {
+      "@type": "Property",
+      "name": "setPointTemp",
+      "writable": true,
+      "schema": "double"
+    }
+  ]
+}

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/TestModelRepo/dtmi/com/example/thermostat-1.2.json
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/tests/TestModelRepo/dtmi/com/example/thermostat-1.2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;3",
+  "@id": "dtmi:com:example:Thermostat;1.2",
+  "@type": "Interface",
+  "displayName": "Thermostat",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "temp",
+      "schema": "double"
+    },
+    {
+      "@type": "Property",
+      "name": "setPointTemp",
+      "writable": true,
+      "schema": "double"
+    }
+  ]
+}


### PR DESCRIPTION
DTDL v3 updated the [DTMI spec](https://github.com/Azure/opendigitaltwins-dtdl/tree/master/DTMI) and now supports DTMI with `major.minor` and _versionless_


Address this issue https://github.com/Azure/iot-plugandplay-models-tools/issues/192