### PR TITLE
Regenerate after latest .net emitter updates

### DIFF
--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -164,12 +165,15 @@ namespace Azure.Developer.DevCenter
             writer.WriteNumberValue(value.ToUnixTimeSeconds());
         }
 
-        public static void WriteObjectValue(this Utf8JsonWriter writer, object value)
+        public static void WriteObjectValue<T>(this Utf8JsonWriter writer, object value, ModelReaderWriterOptions options = null)
         {
             switch (value)
             {
                 case null:
                     writer.WriteNullValue();
+                    break;
+                case IJsonModel<T> jsonModel:
+                    jsonModel.Write(writer, options ?? new ModelReaderWriterOptions("W"));
                     break;
                 case IUtf8JsonSerializable serializable:
                     serializable.Write(writer);
@@ -225,7 +229,7 @@ namespace Azure.Developer.DevCenter
                     foreach (var pair in enumerable)
                     {
                         writer.WritePropertyName(pair.Key);
-                        writer.WriteObjectValue(pair.Value);
+                        writer.WriteObjectValue<object>(pair.Value, options);
                     }
                     writer.WriteEndObject();
                     break;
@@ -233,7 +237,7 @@ namespace Azure.Developer.DevCenter
                     writer.WriteStartArray();
                     foreach (var item in objectEnumerable)
                     {
-                        writer.WriteObjectValue(item);
+                        writer.WriteObjectValue<object>(item, options);
                     }
                     writer.WriteEndArray();
                     break;
@@ -245,7 +249,12 @@ namespace Azure.Developer.DevCenter
             }
         }
 
-        private static class TypeFormatters
+        public static void WriteObjectValue(this Utf8JsonWriter writer, object value, ModelReaderWriterOptions options = null)
+        {
+            writer.WriteObjectValue<object>(value, options);
+        }
+
+        internal static class TypeFormatters
         {
             private const string RoundtripZFormat = "yyyy-MM-ddTHH:mm:ss.fffffffZ";
             public const string DefaultNumberFormat = "G";
@@ -365,6 +374,22 @@ namespace Azure.Developer.DevCenter
             {
                 "P" => XmlConvert.ToTimeSpan(value),
                 _ => TimeSpan.ParseExact(value, format, CultureInfo.InvariantCulture)
+            };
+
+            public static string ConvertToString(object value, string format = null) => value switch
+            {
+                null => "null",
+                string s => s,
+                bool b => ToString(b),
+                int or float or double or long or decimal => ((IFormattable)value).ToString(DefaultNumberFormat, CultureInfo.InvariantCulture),
+                byte[] b0 when format != null => ToString(b0, format),
+                IEnumerable<string> s0 => string.Join(",", s0),
+                DateTimeOffset dateTime when format != null => ToString(dateTime, format),
+                TimeSpan timeSpan when format != null => ToString(timeSpan, format),
+                TimeSpan timeSpan0 => XmlConvert.ToString(timeSpan0),
+                Guid guid => guid.ToString(),
+                BinaryData binaryData => ConvertToString(binaryData.ToArray(), format),
+                _ => value.ToString()
             };
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBox.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBox.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBox>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBox)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBox)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -86,17 +86,17 @@ namespace Azure.Developer.DevCenter.Models
             if (options.Format != "W" && Optional.IsDefined(HardwareProfile))
             {
                 writer.WritePropertyName("hardwareProfile"u8);
-                writer.WriteObjectValue(HardwareProfile);
+                writer.WriteObjectValue<DevBoxHardwareProfile>(HardwareProfile, options);
             }
             if (options.Format != "W" && Optional.IsDefined(StorageProfile))
             {
                 writer.WritePropertyName("storageProfile"u8);
-                writer.WriteObjectValue(StorageProfile);
+                writer.WriteObjectValue<DevBoxStorageProfile>(StorageProfile, options);
             }
             if (options.Format != "W" && Optional.IsDefined(ImageReference))
             {
                 writer.WritePropertyName("imageReference"u8);
-                writer.WriteObjectValue(ImageReference);
+                writer.WriteObjectValue<DevBoxImageReference>(ImageReference, options);
             }
             if (options.Format != "W" && Optional.IsDefined(CreatedTime))
             {
@@ -131,7 +131,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBox>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBox)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBox)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -340,7 +340,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBox)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBox)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -356,7 +356,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBox(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBox)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBox)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -374,7 +374,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBox>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxAction.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxAction.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxAction>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxAction)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxAction)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -43,7 +43,7 @@ namespace Azure.Developer.DevCenter.Models
             if (Optional.IsDefined(NextAction))
             {
                 writer.WritePropertyName("next"u8);
-                writer.WriteObjectValue(NextAction);
+                writer.WriteObjectValue<DevBoxNextAction>(NextAction, options);
             }
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
@@ -68,7 +68,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxAction>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxAction)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxAction)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -149,7 +149,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxAction)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxAction)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -165,7 +165,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBoxAction(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxAction)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxAction)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -183,7 +183,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBoxAction>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxActionDelayResult.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxActionDelayResult.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxActionDelayResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxActionDelayResult)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxActionDelayResult)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -33,7 +33,7 @@ namespace Azure.Developer.DevCenter.Models
             if (Optional.IsDefined(Action))
             {
                 writer.WritePropertyName("action"u8);
-                writer.WriteObjectValue(Action);
+                writer.WriteObjectValue<DevBoxAction>(Action, options);
             }
             if (Optional.IsDefined(Error))
             {
@@ -63,7 +63,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxActionDelayResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxActionDelayResult)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxActionDelayResult)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -132,7 +132,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxActionDelayResult)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxActionDelayResult)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -148,7 +148,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBoxActionDelayResult(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxActionDelayResult)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxActionDelayResult)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -166,7 +166,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBoxActionDelayResult>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxHardwareProfile.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxHardwareProfile.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxHardwareProfile>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxHardwareProfile)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxHardwareProfile)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -64,7 +64,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxHardwareProfile>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxHardwareProfile)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxHardwareProfile)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -131,7 +131,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxHardwareProfile)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxHardwareProfile)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -147,7 +147,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBoxHardwareProfile(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxHardwareProfile)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxHardwareProfile)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -165,7 +165,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBoxHardwareProfile>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxImageReference.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxImageReference.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxImageReference>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxImageReference)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxImageReference)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -74,7 +74,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxImageReference>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxImageReference)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxImageReference)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -151,7 +151,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxImageReference)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxImageReference)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -167,7 +167,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBoxImageReference(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxImageReference)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxImageReference)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -185,7 +185,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBoxImageReference>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxNextAction.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxNextAction.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxNextAction>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxNextAction)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxNextAction)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -51,7 +51,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxNextAction>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxNextAction)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxNextAction)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -94,7 +94,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxNextAction)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxNextAction)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -110,7 +110,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBoxNextAction(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxNextAction)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxNextAction)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -128,7 +128,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBoxNextAction>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxPool.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxPool.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxPool>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxPool)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxPool)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -41,7 +41,7 @@ namespace Azure.Developer.DevCenter.Models
             if (Optional.IsDefined(HardwareProfile))
             {
                 writer.WritePropertyName("hardwareProfile"u8);
-                writer.WriteObjectValue(HardwareProfile);
+                writer.WriteObjectValue<DevBoxHardwareProfile>(HardwareProfile, options);
             }
             if (Optional.IsDefined(HibernateSupport))
             {
@@ -51,12 +51,12 @@ namespace Azure.Developer.DevCenter.Models
             if (Optional.IsDefined(StorageProfile))
             {
                 writer.WritePropertyName("storageProfile"u8);
-                writer.WriteObjectValue(StorageProfile);
+                writer.WriteObjectValue<DevBoxStorageProfile>(StorageProfile, options);
             }
             if (Optional.IsDefined(ImageReference))
             {
                 writer.WritePropertyName("imageReference"u8);
-                writer.WriteObjectValue(ImageReference);
+                writer.WriteObjectValue<DevBoxImageReference>(ImageReference, options);
             }
             if (Optional.IsDefined(LocalAdministratorStatus))
             {
@@ -66,7 +66,7 @@ namespace Azure.Developer.DevCenter.Models
             if (Optional.IsDefined(StopOnDisconnect))
             {
                 writer.WritePropertyName("stopOnDisconnect"u8);
-                writer.WriteObjectValue(StopOnDisconnect);
+                writer.WriteObjectValue<StopOnDisconnectConfiguration>(StopOnDisconnect, options);
             }
             writer.WritePropertyName("healthStatus"u8);
             writer.WriteStringValue(HealthStatus.ToString());
@@ -93,7 +93,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxPool>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxPool)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxPool)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -229,7 +229,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxPool)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxPool)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -245,7 +245,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBoxPool(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxPool)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxPool)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -263,7 +263,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBoxPool>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxSchedule.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxSchedule.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxSchedule>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxSchedule)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxSchedule)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -62,7 +62,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxSchedule>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxSchedule)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxSchedule)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -135,7 +135,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxSchedule)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxSchedule)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -151,7 +151,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBoxSchedule(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxSchedule)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxSchedule)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -169,7 +169,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBoxSchedule>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxStorageProfile.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevBoxStorageProfile.Serialization.cs
@@ -22,14 +22,14 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxStorageProfile>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxStorageProfile)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxStorageProfile)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
             if (Optional.IsDefined(OSDisk))
             {
                 writer.WritePropertyName("osDisk"u8);
-                writer.WriteObjectValue(OSDisk);
+                writer.WriteObjectValue<OSDisk>(OSDisk, options);
             }
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
@@ -54,7 +54,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevBoxStorageProfile>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevBoxStorageProfile)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevBoxStorageProfile)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -101,7 +101,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxStorageProfile)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxStorageProfile)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -117,7 +117,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevBoxStorageProfile(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevBoxStorageProfile)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevBoxStorageProfile)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -135,7 +135,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevBoxStorageProfile>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterCatalog.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterCatalog.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevCenterCatalog>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevCenterCatalog)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevCenterCatalog)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -54,7 +54,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevCenterCatalog>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevCenterCatalog)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevCenterCatalog)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -97,7 +97,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevCenterCatalog)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevCenterCatalog)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -113,7 +113,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevCenterCatalog(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevCenterCatalog)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevCenterCatalog)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -131,7 +131,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevCenterCatalog>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterEnvironment.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterEnvironment.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevCenterEnvironment>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevCenterEnvironment)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevCenterEnvironment)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -103,7 +103,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevCenterEnvironment>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevCenterEnvironment)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevCenterEnvironment)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -236,7 +236,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevCenterEnvironment)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevCenterEnvironment)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -252,7 +252,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevCenterEnvironment(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevCenterEnvironment)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevCenterEnvironment)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -270,7 +270,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevCenterEnvironment>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterEnvironmentType.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterEnvironmentType.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevCenterEnvironmentType>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevCenterEnvironmentType)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevCenterEnvironmentType)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -55,7 +55,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevCenterEnvironmentType>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevCenterEnvironmentType)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevCenterEnvironmentType)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -110,7 +110,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevCenterEnvironmentType)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevCenterEnvironmentType)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -126,7 +126,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevCenterEnvironmentType(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevCenterEnvironmentType)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevCenterEnvironmentType)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -144,7 +144,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevCenterEnvironmentType>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterProject.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterProject.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevCenterProject>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevCenterProject)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevCenterProject)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -64,7 +64,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<DevCenterProject>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(DevCenterProject)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(DevCenterProject)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -123,7 +123,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(DevCenterProject)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevCenterProject)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -139,7 +139,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeDevCenterProject(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(DevCenterProject)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(DevCenterProject)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -157,7 +157,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<DevCenterProject>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/EnvironmentDefinition.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/EnvironmentDefinition.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<EnvironmentDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(EnvironmentDefinition)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(EnvironmentDefinition)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -46,7 +46,7 @@ namespace Azure.Developer.DevCenter.Models
                 writer.WriteStartArray();
                 foreach (var item in Parameters)
                 {
-                    writer.WriteObjectValue(item);
+                    writer.WriteObjectValue<EnvironmentDefinitionParameter>(item, options);
                 }
                 writer.WriteEndArray();
             }
@@ -83,7 +83,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<EnvironmentDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(EnvironmentDefinition)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(EnvironmentDefinition)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -179,7 +179,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(EnvironmentDefinition)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(EnvironmentDefinition)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -195,7 +195,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeEnvironmentDefinition(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(EnvironmentDefinition)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(EnvironmentDefinition)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -213,7 +213,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<EnvironmentDefinition>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/EnvironmentDefinitionParameter.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/EnvironmentDefinitionParameter.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<EnvironmentDefinitionParameter>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(EnvironmentDefinitionParameter)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(EnvironmentDefinitionParameter)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -85,7 +85,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<EnvironmentDefinitionParameter>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(EnvironmentDefinitionParameter)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(EnvironmentDefinitionParameter)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -192,7 +192,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(EnvironmentDefinitionParameter)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(EnvironmentDefinitionParameter)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -208,7 +208,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeEnvironmentDefinitionParameter(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(EnvironmentDefinitionParameter)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(EnvironmentDefinitionParameter)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -226,7 +226,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<EnvironmentDefinitionParameter>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/OSDisk.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/OSDisk.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<OSDisk>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(OSDisk)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(OSDisk)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -54,7 +54,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<OSDisk>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(OSDisk)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(OSDisk)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -101,7 +101,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(OSDisk)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(OSDisk)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -117,7 +117,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeOSDisk(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(OSDisk)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(OSDisk)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -135,7 +135,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<OSDisk>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/RemoteConnection.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/RemoteConnection.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<RemoteConnection>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(RemoteConnection)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(RemoteConnection)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -59,7 +59,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<RemoteConnection>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(RemoteConnection)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(RemoteConnection)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -116,7 +116,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(RemoteConnection)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(RemoteConnection)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -132,7 +132,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeRemoteConnection(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(RemoteConnection)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(RemoteConnection)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -150,7 +150,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<RemoteConnection>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/StopOnDisconnectConfiguration.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/StopOnDisconnectConfiguration.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<StopOnDisconnectConfiguration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(StopOnDisconnectConfiguration)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(StopOnDisconnectConfiguration)} does not support writing '{format}' format.");
             }
 
             writer.WriteStartObject();
@@ -56,7 +56,7 @@ namespace Azure.Developer.DevCenter.Models
             var format = options.Format == "W" ? ((IPersistableModel<StopOnDisconnectConfiguration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(StopOnDisconnectConfiguration)} does not support '{format}' format.");
+                throw new FormatException($"The model {nameof(StopOnDisconnectConfiguration)} does not support reading '{format}' format.");
             }
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
@@ -109,7 +109,7 @@ namespace Azure.Developer.DevCenter.Models
                 case "J":
                     return ModelReaderWriter.Write(this, options);
                 default:
-                    throw new FormatException($"The model {nameof(StopOnDisconnectConfiguration)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(StopOnDisconnectConfiguration)} does not support writing '{options.Format}' format.");
             }
         }
 
@@ -125,7 +125,7 @@ namespace Azure.Developer.DevCenter.Models
                         return DeserializeStopOnDisconnectConfiguration(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(StopOnDisconnectConfiguration)} does not support '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(StopOnDisconnectConfiguration)} does not support reading '{options.Format}' format.");
             }
         }
 
@@ -143,7 +143,7 @@ namespace Azure.Developer.DevCenter.Models
         internal virtual RequestContent ToRequestContent()
         {
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(this);
+            content.JsonWriter.WriteObjectValue<StopOnDisconnectConfiguration>(this, new ModelReaderWriterOptions("W"));
             return content;
         }
     }


### PR DESCRIPTION
[Build](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3640377&view=results) for PR https://github.com/Azure/azure-sdk-for-net/pull/40166 failed because the PR merged was not synched with latest main. Regenerating to include the latest .net emitter updates. 