### PR TITLE
Bugfix - Code Transparency 202 treated as failure

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.0-beta.2 (2024-03-27)
 
 ### Bugs Fixed
 
-### Other Changes
+- Do not fail the submission of the entry if it responds with HTTP status 202
 
 ## 1.0.0-beta.1 (2024-03-26)
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -148,5 +148,21 @@ namespace Azure.Security.CodeTransparency
                 throw;
             }
         }
+
+        internal HttpMessage CreateCreateEntryRequest(RequestContent content, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context);
+            var request = message.Request;
+            request.Method = RequestMethod.Post;
+            var uri = new RawRequestUriBuilder();
+            uri.Reset(_endpoint);
+            uri.AppendPath("/entries", false);
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            request.Headers.Add("content-type", "application/cose");
+            request.Content = content;
+            return message;
+        }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Generated/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Generated/CodeTransparencyClient.cs
@@ -910,22 +910,6 @@ namespace Azure.Security.CodeTransparency
             return GeneratorPageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "CodeTransparencyClient.GetEntryIds", "transactionIds", "nextLink", context);
         }
 
-        internal HttpMessage CreateCreateEntryRequest(RequestContent content, RequestContext context)
-        {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
-            var request = message.Request;
-            request.Method = RequestMethod.Post;
-            var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
-            uri.AppendPath("/entries", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/json");
-            request.Headers.Add("content-type", "application/cose");
-            request.Content = content;
-            return message;
-        }
-
         internal HttpMessage CreateGetEntryStatusRequest(string operationId, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -68,6 +68,27 @@ namespace Azure.Security.CodeTransparency.Tests
         }
 
         [Test]
+        public async Task CreateEntryAsync_request_accepted()
+        {
+            var mockedResponse = new MockResponse(202);
+            mockedResponse.SetContent("{\"operationId\": \"foobar\"}");
+            var mockTransport = new MockTransport(mockedResponse);
+            var options = new CodeTransparencyClientOptions
+            {
+                Transport = mockTransport,
+                IdentityClientEndpoint = "https://foo.bar.com"
+            };
+
+            CodeTransparencyClient client = new(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
+            BinaryData content = BinaryData.FromString("Hello World!");
+            Operation<GetOperationResult> response = await client.CreateEntryAsync(content);
+
+            Assert.AreEqual("https://foo.bar.com/entries?api-version=2024-01-11-preview", mockTransport.Requests[0].Uri.ToString());
+            Assert.AreEqual(false, response.HasCompleted);
+            Assert.AreEqual("foobar", response.Id);
+        }
+
+        [Test]
         public async Task CreateEntryAsync_retries_unsuccessful_post()
         {
             var mockedResponse = new MockResponse(200);


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

Success request classifier is too strict and treats 202 as a failure.