### PR TITLE
Add UpdateState to IOperation

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CreateEntryOperation.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CreateEntryOperation.cs
@@ -70,6 +70,18 @@ namespace Azure.Security.CodeTransparency
                     .ConfigureAwait(false)
                 : _client.GetEntryStatus(Id, new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow });
 
+            return GetOperateState(response);
+        }
+
+        public OperationState UpdateState(CancellationToken cancellationToken)
+        {
+            Response response = _client.GetEntryStatus(Id, new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow });
+
+            return GetOperateState(response);
+        }
+
+        private OperationState GetOperateState(Response response)
+        {
             if (response.Status != (int)HttpStatusCode.OK)
             {
                 RequestFailedException ex = new(response);
@@ -80,10 +92,12 @@ namespace Azure.Security.CodeTransparency
             if (result.Value.Status == OperationStatus.Failed)
             {
                 return OperationState.Failure(response, new RequestFailedException(result.Value.Error));
-            } else if (result.Value.Status == OperationStatus.Succeeded)
+            }
+            else if (result.Value.Status == OperationStatus.Succeeded)
             {
                 return OperationState.Success(response);
-            } else
+            }
+            else
             {
                 return OperationState.Pending(response);
             }

--- a/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
@@ -150,6 +150,35 @@ namespace Azure.Core
         /// must be manually updated by the operation implementing this method.
         /// <example>Usage example:
         /// <code>
+        ///   OperationState IOperation.UpdateStateAsync(CancellationToken cancellationToken)<br/>
+        ///   {<br/>
+        ///     Response&lt;R&gt; response = &lt;sync service call&gt;;<br/>
+        ///     if (&lt;operation succeeded&gt;) return OperationState.Success(response.GetRawResponse(), &lt;parse response&gt;);<br/>
+        ///     if (&lt;operation failed&gt;) return OperationState.Failure(response.GetRawResponse());<br/>
+        ///     return OperationState.Pending(response.GetRawResponse());<br/>
+        ///   }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
+        /// <returns>
+        /// A structure indicating the current operation state. The <see cref="OperationState"/> structure must be instantiated by one of
+        /// its static methods:
+        /// <list type="bullet">
+        ///   <item>Use <see cref="OperationState.Success"/> when the operation has completed successfully.</item>
+        ///   <item>Use <see cref="OperationState.Failure"/> when the operation has completed with failures.</item>
+        ///   <item>Use <see cref="OperationState.Pending"/> when the operation has not completed yet.</item>
+        /// </list>
+        /// </returns>
+        OperationState UpdateState(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Calls the service and updates the state of the long-running operation. Properties directly handled by the
+        /// <see cref="OperationInternal"/> class, such as <see cref="OperationInternalBase.RawResponse"/>
+        /// don't need to be updated. Operation-specific properties, such as "<c>CreateOn</c>" or "<c>LastModified</c>",
+        /// must be manually updated by the operation implementing this method.
+        /// <example>Usage example:
+        /// <code>
         ///   async ValueTask&lt;OperationState&gt; IOperation.UpdateStateAsync(bool async, CancellationToken cancellationToken)<br/>
         ///   {<br/>
         ///     Response&lt;R&gt; response = async ? &lt;async service call&gt; : &lt;sync service call&gt;;<br/>

--- a/sdk/core/Azure.Core/tests/OperationPollerTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationPollerTests.cs
@@ -56,6 +56,8 @@ namespace Azure.Core.Tests.DelayStrategies
 
         private class EndlessOperation : IOperation
         {
+            public OperationState UpdateState(CancellationToken cancellationToken) => OperationState.Pending(new MockResponse(200));
+
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(OperationState.Pending(new MockResponse(200)));
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/DeleteCertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/DeleteCertificateOperation.cs
@@ -42,7 +42,7 @@ namespace Azure.Security.KeyVault.Certificates
         }
 
         /// <summary> Initializes a new instance of <see cref="DeleteCertificateOperation" /> for mocking. </summary>
-        protected DeleteCertificateOperation() {}
+        protected DeleteCertificateOperation() { }
 
         /// <inheritdoc/>
         public override string Id => _value.Id.AbsoluteUri;
@@ -101,6 +101,18 @@ namespace Azure.Security.KeyVault.Certificates
                 ? await _pipeline.GetResponseAsync(RequestMethod.Get, cancellationToken, CertificateClient.DeletedCertificatesPath, _value.Name).ConfigureAwait(false)
                 : _pipeline.GetResponse(RequestMethod.Get, cancellationToken, CertificateClient.DeletedCertificatesPath, _value.Name);
 
+            return GetOperationState(response);
+        }
+
+        OperationState IOperation.UpdateState(CancellationToken cancellationToken)
+        {
+            Response response = _pipeline.GetResponse(RequestMethod.Get, cancellationToken, CertificateClient.DeletedCertificatesPath, _value.Name);
+
+            return GetOperationState(response);
+        }
+
+        private static OperationState GetOperationState(Response response)
+        {
             switch (response.Status)
             {
                 case 200:

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/RecoverDeletedCertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/RecoverDeletedCertificateOperation.cs
@@ -91,6 +91,18 @@ namespace Azure.Security.KeyVault.Certificates
                 ? await _pipeline.GetResponseAsync(RequestMethod.Get, cancellationToken, CertificateClient.CertificatesPath, _value.Name).ConfigureAwait(false)
                 : _pipeline.GetResponse(RequestMethod.Get, cancellationToken, CertificateClient.CertificatesPath, _value.Name);
 
+            return GetOperationState(response);
+        }
+
+        OperationState IOperation.UpdateState(CancellationToken cancellationToken)
+        {
+            Response response = _pipeline.GetResponse(RequestMethod.Get, cancellationToken, CertificateClient.CertificatesPath, _value.Name);
+
+            return GetOperationState(response);
+        }
+
+        private static OperationState GetOperationState(Response response)
+        {
             switch (response.Status)
             {
                 case 200:

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
@@ -101,6 +101,18 @@ namespace Azure.Security.KeyVault.Keys
                 ? await _pipeline.GetResponseAsync(RequestMethod.Get, cancellationToken, KeyClient.DeletedKeysPath, _value.Name).ConfigureAwait(false)
                 : _pipeline.GetResponse(RequestMethod.Get, cancellationToken, KeyClient.DeletedKeysPath, _value.Name);
 
+            return GetOperationState(response);
+        }
+
+        OperationState IOperation.UpdateState(CancellationToken cancellationToken)
+        {
+            Response response = _pipeline.GetResponse(RequestMethod.Get, cancellationToken, KeyClient.DeletedKeysPath, _value.Name);
+
+            return GetOperationState(response);
+        }
+
+        private static OperationState GetOperationState(Response response)
+        {
             switch (response.Status)
             {
                 case 200:

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RecoverDeletedKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RecoverDeletedKeyOperation.cs
@@ -91,6 +91,18 @@ namespace Azure.Security.KeyVault.Keys
                 ? await _pipeline.GetResponseAsync(RequestMethod.Get, cancellationToken, KeyClient.KeysPath, _value.Name).ConfigureAwait(false)
                 : _pipeline.GetResponse(RequestMethod.Get, cancellationToken, KeyClient.KeysPath, _value.Name);
 
+            return GetOperationState(response);
+        }
+
+        OperationState IOperation.UpdateState(CancellationToken cancellationToken)
+        {
+            Response response = _pipeline.GetResponse(RequestMethod.Get, cancellationToken, KeyClient.KeysPath, _value.Name);
+
+            return GetOperationState(response);
+        }
+
+        private static OperationState GetOperationState(Response response)
+        {
             switch (response.Status)
             {
                 case 200:

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
@@ -97,6 +97,18 @@ namespace Azure.Security.KeyVault.Secrets
                 ? await _pipeline.GetResponseAsync(RequestMethod.Get, cancellationToken, SecretClient.DeletedSecretsPath, _value.Name).ConfigureAwait(false)
                 : _pipeline.GetResponse(RequestMethod.Get, cancellationToken, SecretClient.DeletedSecretsPath, _value.Name);
 
+            return GetOperationState(response);
+        }
+
+        OperationState IOperation.UpdateState(CancellationToken cancellationToken)
+        {
+            Response response = _pipeline.GetResponse(RequestMethod.Get, cancellationToken, SecretClient.DeletedSecretsPath, _value.Name);
+
+            return GetOperationState(response);
+        }
+
+        private static OperationState GetOperationState(Response response)
+        {
             switch (response.Status)
             {
                 case 200:

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/RecoverDeletedSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/RecoverDeletedSecretOperation.cs
@@ -87,6 +87,18 @@ namespace Azure.Security.KeyVault.Secrets
                 ? await _pipeline.GetResponseAsync(RequestMethod.Get, cancellationToken, SecretClient.SecretsPath, _value.Name).ConfigureAwait(false)
                 : _pipeline.GetResponse(RequestMethod.Get, cancellationToken, SecretClient.SecretsPath, _value.Name);
 
+            return GetOperationState(response);
+        }
+
+        OperationState IOperation.UpdateState(CancellationToken cancellationToken)
+        {
+            Response response = _pipeline.GetResponse(RequestMethod.Get, cancellationToken, SecretClient.SecretsPath, _value.Name);
+
+            return GetOperationState(response);
+        }
+
+        private static OperationState GetOperationState(Response response)
+        {
             switch (response.Status)
             {
                 case 200:


### PR DESCRIPTION
To avoid sync-over-async in https://github.com/Azure/azure-sdk-for-net/pull/42686#discussion_r1539497852, we need to add `UpdateState` to `IOperation`.
Ideally, we should update the existing
```csharp
ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken)
```
to 
```csharp
ValueTask<OperationState> UpdateStateAsync(CancellationToken cancellationToken)
```
But there are public types implemented this already, we can't have breaking changes for them, just keep the signature for `UpdateStateAsync`.

Ideally, we should add the sync method to `IOperation<T>` as well, just to minimize the change to existing contracts. 