### PR TITLE
[LiveMetricsExporter] Add Filtering Support part 7 - Sync Model change for Duration

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
@@ -192,7 +192,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     // special case - for TimeSpan values ToString() will not result in a value convertable to double, so we must take care of that ourselves
                     if (fieldType == typeof(TimeSpan))
                     {
-                        fieldExpression = Expression.Property(fieldExpression, "TotalMilliseconds");
+                        MethodInfo? parseMethod = typeof(TimeSpan).GetMethod("Parse", new[] { typeof(string) });
+                        Expression fieldConvertedExpression = Expression.Call(parseMethod!, fieldExpression);
+                        fieldExpression = Expression.Property(fieldConvertedExpression, "TotalMilliseconds");
                     }
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
@@ -192,9 +192,12 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     // special case - for TimeSpan values ToString() will not result in a value convertable to double, so we must take care of that ourselves
                     if (fieldType == typeof(TimeSpan))
                     {
-                        MethodInfo? parseMethod = typeof(TimeSpan).GetMethod("Parse", new[] { typeof(string) });
-                        Expression fieldConvertedExpression = Expression.Call(parseMethod!, fieldExpression);
-                        fieldExpression = Expression.Property(fieldConvertedExpression, "TotalMilliseconds");
+                        if (fieldExpression.Type == typeof(string))
+                        {
+                            MethodInfo? parseMethod = typeof(TimeSpan).GetMethod("Parse", new[] { typeof(string) });
+                            fieldExpression = Expression.Call(parseMethod!, fieldExpression);
+                        }
+                        fieldExpression = Expression.Property(fieldExpression, "TotalMilliseconds");
                     }
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -286,6 +286,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                         typeof(TTelemetry),
                         (type, propertyName) => type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public).PropertyType);
 
+                if (fieldName == "Duration")
+                {
+                    propertyType = typeof(TimeSpan);
+                }
+
                 if (propertyType == null)
                 {
                     string propertyNotFoundMessage = string.Format(
@@ -555,27 +560,29 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     if (fieldType == typeof(TimeSpan))
                     {
                         this.ThrowOnInvalidFilter(fieldType, !this.comparandTimeSpan.HasValue);
+                        MethodInfo parseMethod = typeof(TimeSpan).GetMethod("Parse", new[] { typeof(string) });
+                        Expression fieldConvertedExpression = Expression.Call(parseMethod, fieldExpression);
 
                         switch (this.predicate)
                         {
                             case Predicate.Equal:
                                 Func<TimeSpan, bool> comparator = fieldValue => fieldValue == this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
                             case Predicate.NotEqual:
                                 comparator = fieldValue => fieldValue != this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
                             case Predicate.LessThan:
                                 comparator = fieldValue => fieldValue < this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
                             case Predicate.GreaterThan:
                                 comparator = fieldValue => fieldValue > this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
                             case Predicate.LessThanOrEqual:
                                 comparator = fieldValue => fieldValue <= this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
                             case Predicate.GreaterThanOrEqual:
                                 comparator = fieldValue => fieldValue >= this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
                             default:
                                 this.ThrowOnInvalidFilter(fieldType);
                                 break;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -560,29 +560,32 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     if (fieldType == typeof(TimeSpan))
                     {
                         this.ThrowOnInvalidFilter(fieldType, !this.comparandTimeSpan.HasValue);
-                        MethodInfo parseMethod = typeof(TimeSpan).GetMethod("Parse", new[] { typeof(string) });
-                        Expression fieldConvertedExpression = Expression.Call(parseMethod, fieldExpression);
+                        if (fieldExpression.Type == typeof(string))
+                        {
+                            MethodInfo parseMethod = typeof(TimeSpan).GetMethod("Parse", new[] { typeof(string) });
+                            fieldExpression = Expression.Call(parseMethod, fieldExpression);
+                        }
 
                         switch (this.predicate)
                         {
                             case Predicate.Equal:
                                 Func<TimeSpan, bool> comparator = fieldValue => fieldValue == this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
                             case Predicate.NotEqual:
                                 comparator = fieldValue => fieldValue != this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
                             case Predicate.LessThan:
                                 comparator = fieldValue => fieldValue < this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
                             case Predicate.GreaterThan:
                                 comparator = fieldValue => fieldValue > this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
                             case Predicate.LessThanOrEqual:
                                 comparator = fieldValue => fieldValue <= this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
                             case Predicate.GreaterThanOrEqual:
                                 comparator = fieldValue => fieldValue >= this.comparandTimeSpan.Value;
-                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldConvertedExpression);
+                                return Expression.Call(Expression.Constant(comparator.Target), comparator.GetMethodInfo(), fieldExpression);
                             default:
                                 this.ThrowOnInvalidFilter(fieldType);
                                 break;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
@@ -47,7 +47,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     ////errorList.Add(
                     ////    CollectionConfigurationError.CreateError(
                     ////        CollectionConfigurationErrorType.FilterFailureToRun,
-                    ////        string.Format(CultureInfo.InvariantCulture, "Failter failed to run: {0}.", filter),
+                    ////        string.Format(CultureInfo.InvariantCulture, "Filter failed to run: {0}.", filter),
                     ////        e));
                     filterPassed = false;
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/DerivedMetricTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/DerivedMetricTests.cs
@@ -277,6 +277,32 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Tests
             Assert.Equal(120, projection);
         }
 
+        [Fact]
+        public void DerivedMetricProjectsCorrectlyWhenDurationIsString()
+        {
+            // ARRANGE
+            var metricInfo = new DerivedMetricInfo(
+                id: "Metric1",
+                telemetryType: TelemetryType.Request,
+                filterGroups: new FilterConjunctionGroupInfo[0],
+                projection: "Duration",
+                aggregation: DerivedMetricInfoAggregation.Avg
+            );
+
+            var durationString = TimeSpan.FromMilliseconds(120).ToString();
+            var telemetry = new DocumentMockWithStringDuration(durationString);
+
+            // ACT
+            CollectionConfigurationError[] errors;
+            var metric = new DerivedMetric<DocumentMockWithStringDuration>(metricInfo, out errors);
+            double projection = metric.Project(telemetry);
+
+            // ASSERT
+            Assert.Equal(DerivedMetricInfoAggregation.Avg, metric.AggregationType);
+            Assert.Empty(errors);
+            Assert.Equal(120, projection);
+        }
+
         [Fact(Skip = "Unknown failure.")]
         public void DerivedMetricReportsErrorsForInvalidFilters()
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/DocumentMockWithStringDuration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/DocumentMockWithStringDuration.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Tests
+{
+    using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
+
+    internal class DocumentMockWithStringDuration : DocumentIngress
+    {
+        internal DocumentMockWithStringDuration(string duration)
+        {
+            Duration = duration;
+        }
+
+        public string Duration { get; set; }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/FilterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/FilterTests.cs
@@ -912,6 +912,20 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => new Filter<DocumentMock>(equalsValue));
         }
 
+        [Fact]
+        public void FilterDurationAsString()
+        {
+            // ARRANGE
+            var equalsValue = new FilterInfo("Duration", FilterInfoPredicate.Equal, "123");
+
+            // ACT
+            bool result1 = new Filter<DocumentMockWithStringDuration>(equalsValue).Check(new DocumentMockWithStringDuration(TimeSpan.Parse("123", CultureInfo.InvariantCulture).ToString()));
+            bool result2 = new Filter<DocumentMockWithStringDuration>(equalsValue).Check(new DocumentMockWithStringDuration(TimeSpan.Parse("124", CultureInfo.InvariantCulture).ToString()));
+
+            // ASSERT
+            Assert.True(result1);
+            Assert.False(result2);
+        }
         #endregion
 
         #region String


### PR DESCRIPTION
PR following up on #41523.

Models for all telemetry's `Duration` field changed from `TimeSpan` to `string`. Changing the code to parse the field to `TimeSpan` to facilitate comparisons actions later.

To be specific, these two `DocumentIngress` implementations have `Duration` field but is of type `string`:
https://github.com/Azure/azure-sdk-for-net/blob/9ce35d5370ddef0707776075d855c6b290bbc0d3/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Request.cs#L45
https://github.com/Azure/azure-sdk-for-net/blob/9ce35d5370ddef0707776075d855c6b290bbc0d3/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/RemoteDependency.cs#L45