### PR TITLE
EventHubs: report per-event process spans in processor client and turn off batch tracing

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -66,6 +66,11 @@ namespace Azure.Core.Pipeline
             _activityAdapter?.AddTag(name, value);
         }
 
+        public void AddLongAttribute(string name, long value)
+        {
+            _activityAdapter?.AddTag(name, value);
+        }
+
         public void AddAttribute<T>(string name, T value, Func<T, string> format)
         {
             if (_activityAdapter != null && value != null)
@@ -81,7 +86,7 @@ namespace Azure.Core.Pipeline
         /// <param name="traceparent">The traceparent for the link.</param>
         /// <param name="tracestate">The tracestate for the link.</param>
         /// <param name="attributes">Optional attributes to associate with the link.</param>
-        public void AddLink(string traceparent, string? tracestate, IDictionary<string, string>? attributes = null)
+        public void AddLink(string traceparent, string? tracestate, IDictionary<string, object?>? attributes = null)
         {
             _activityAdapter?.AddLink(traceparent, tracestate, attributes);
         }
@@ -179,7 +184,7 @@ namespace Azure.Core.Pipeline
 
             private ActivityTagsCollection? _tagCollection;
             private DateTimeOffset _startTime;
-            private List<Activity>? _links;
+            private List<ActivityLink>? _links;
             private string? _traceparent;
             private string? _tracestate;
             private string? _displayName;
@@ -211,50 +216,44 @@ namespace Azure.Core.Pipeline
                 }
             }
 
-            private List<ActivityLink>? GetActivitySourceLinkCollection()
+            private IEnumerable<Activity> GetDiagnosticSourceLinkCollection()
             {
                 if (_links == null)
                 {
-                    return null;
+                    return Array.Empty<Activity>();
                 }
 
-                var linkCollection = new List<ActivityLink>();
+                var linkCollection = new List<Activity>();
 
-                foreach (var activity in _links)
+                foreach (var link in _links)
                 {
-                    ActivityTagsCollection linkTagsCollection = new();
-                    foreach (var tag in activity.Tags)
+                    var activity = new Activity("LinkedActivity");
+                    if (link.Context != default) // TODO
                     {
-                        linkTagsCollection.Add(tag.Key, tag.Value!);
+                        string flags = (link.Context.TraceFlags == ActivityTraceFlags.None) ? "00" : "01";
+                        activity.SetParentId("00-" + link.Context.TraceId + "-" + link.Context.SpanId + "-" + flags);
                     }
+                    activity.TraceStateString = link.Context.TraceState;
 
-                    var contextWasParsed = ActivityContext.TryParse(activity.ParentId!, activity.TraceStateString, out var context);
-                    if (contextWasParsed)
+                    if (link.Tags != null)
                     {
-                        var link = new ActivityLink(context, linkTagsCollection);
-                        linkCollection.Add(link);
+                        foreach (var tag in link.Tags)
+                        {
+                            // old code path, only string attributes are supported
+                            activity.AddTag(tag.Key, tag.Value?.ToString());
+                        }
                     }
-            }
+                    linkCollection.Add(activity);
+                }
 
                 return linkCollection;
             }
 
-            public void AddLink(string traceparent, string? tracestate, IDictionary<string, string>? attributes)
+            public void AddLink(string traceparent, string? tracestate, IDictionary<string, object?>? attributes)
             {
-                var linkedActivity = new Activity("LinkedActivity");
-                linkedActivity.SetParentId(traceparent);
-                linkedActivity.SetIdFormat(ActivityIdFormat.W3C);
-                linkedActivity.TraceStateString = tracestate;
-
-                if (attributes != null)
-                {
-                    foreach (var kvp in attributes)
-                    {
-                        linkedActivity.AddTag(kvp.Key, kvp.Value);
-                    }
-                }
-
-                _links ??= new List<Activity>();
+                ActivityContext.TryParse(traceparent, tracestate, out var context);
+                var linkedActivity = new ActivityLink(context, attributes == null ? null : new ActivityTagsCollection(attributes));
+                _links ??= new List<ActivityLink>();
                 _links.Add(linkedActivity);
             }
 
@@ -273,7 +272,7 @@ namespace Azure.Core.Pipeline
                         return null;
                     }
 
-                    _currentActivity.AddTag(OpenTelemetrySchemaAttribute, OpenTelemetrySchemaVersion);
+                    _currentActivity.SetTag(OpenTelemetrySchemaAttribute, OpenTelemetrySchemaVersion);
                 }
                 else
                 {
@@ -303,7 +302,7 @@ namespace Azure.Core.Pipeline
 
                     _currentActivity = new DiagnosticActivity(_activityName)
                     {
-                        Links = (IEnumerable<Activity>?)_links ?? Array.Empty<Activity>(),
+                        Links = GetDiagnosticSourceLinkCollection(),
                     };
                     _currentActivity.SetIdFormat(ActivityIdFormat.W3C);
 
@@ -366,7 +365,7 @@ namespace Azure.Core.Pipeline
                 }
                 // TODO(limolkova) set isRemote to true once we switch to DiagnosticSource 7.0
                 ActivityContext.TryParse(_traceparent, _tracestate, out ActivityContext context);
-                return _activitySource.StartActivity(_activityName, _kind, context, _tagCollection, GetActivitySourceLinkCollection()!, _startTime);
+                return _activitySource.StartActivity(_activityName, _kind, context, _tagCollection, _links, _startTime);
             }
 
             public void SetStartTime(DateTime startTime)

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -260,6 +260,9 @@ namespace Azure.Core.Pipeline
 
             public void AddLink(string traceparent, string? tracestate, IDictionary<string, object?>? attributes)
             {
+                // if context is invalid, we should still add a link since it contains attributes
+                // so we let ActivityLink deal with the default context.
+                // This is otel spec requirement and default context is allowed on links.
                 ActivityContext.TryParse(traceparent, tracestate, out var context);
                 var linkedActivity = new ActivityLink(context, attributes == null ? null : new ActivityTagsCollection(attributes));
                 _links ??= new List<ActivityLink>();

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -216,7 +216,7 @@ namespace Azure.Core.Pipeline
                 }
             }
 
-            private IEnumerable<Activity> GetDiagnosticSourceLinkCollection()
+            private IReadOnlyList<Activity> GetDiagnosticSourceLinkCollection()
             {
                 if (_links == null)
                 {

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsActivitySourceTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsActivitySourceTests.cs
@@ -380,7 +380,7 @@ namespace Azure.Core.Tests
 
         [Test]
         [NonParallelizable]
-        public void StartActivitySourceActivityIgnoresInvalidLinkParent()
+        public void StartActivitySourceActivityDoesNotIgnoreInvalidLinkParent()
         {
             using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
 
@@ -388,12 +388,18 @@ namespace Azure.Core.Tests
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
 
-            scope.AddLink("test", "ignored");
+            var linkAttributes = new Dictionary<string, object>
+            {
+                { "key", "value" }
+            };
+            scope.AddLink("test", "ignored", linkAttributes);
 
             scope.Start();
             scope.Dispose();
 
-            Assert.AreEqual(0, activityListener.Activities.Single().Links.Count());
+            var links = activityListener.Activities.Single().Links;
+            Assert.AreEqual(1, links.Count());
+            Assert.AreEqual("value", links.Single().Tags.Single(o => o.Key == "key").Value);
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsActivitySourceTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsActivitySourceTests.cs
@@ -73,7 +73,7 @@ namespace Azure.Core.Tests
             scope.AddIntegerAttribute("Attribute3", 3);
 
             scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00", "foo=bar");
-            scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b2-2899ebfdbdce904b-00", null, new Dictionary<string, string>()
+            scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b2-2899ebfdbdce904b-00", null, new Dictionary<string, object>()
             {
                 {"linkAttribute", "linkAttributeValue"}
             });

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsDiagnosticSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsDiagnosticSourceTests.cs
@@ -219,7 +219,8 @@ namespace Azure.Core.Tests
                 {"key2", "value2"}
             };
 
-            scope.AddLink("id", null, expectedTags);
+            string id = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
+            scope.AddLink(id, null, expectedTags);
             scope.Start();
 
             (string Key, object Value, DiagnosticListener) startEvent = testListener.Events.Dequeue();
@@ -236,7 +237,7 @@ namespace Azure.Core.Tests
             Activity linkedActivity = activities.Single();
 
             Assert.AreEqual(ActivityIdFormat.W3C, linkedActivity.IdFormat);
-            Assert.AreEqual("id", linkedActivity.ParentId);
+            Assert.AreEqual(id, linkedActivity.ParentId);
 
             CollectionAssert.AreEquivalent(expectedTags, linkedActivity.Tags);
         }

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsDiagnosticSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsDiagnosticSourceTests.cs
@@ -213,7 +213,7 @@ namespace Azure.Core.Tests
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
 
-            var expectedTags = new Dictionary<string, string>()
+            var expectedTags = new Dictionary<string, object>()
             {
                 {"key1", "value1"},
                 {"key2", "value2"}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/api/Azure.Messaging.EventHubs.Processor.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/api/Azure.Messaging.EventHubs.Processor.netstandard2.0.cs
@@ -14,6 +14,7 @@ namespace Azure.Messaging.EventHubs
         public new string EventHubName { get { throw null; } }
         public new string FullyQualifiedNamespace { get { throw null; } }
         public new string Identifier { get { throw null; } }
+        protected override bool? IsBatchTracingEnabled { get { throw null; } }
         public new bool IsRunning { get { throw null; } protected set { } }
         public event System.Func<Azure.Messaging.EventHubs.Processor.PartitionClosingEventArgs, System.Threading.Tasks.Task> PartitionClosingAsync { add { } remove { } }
         public event System.Func<Azure.Messaging.EventHubs.Processor.PartitionInitializingEventArgs, System.Threading.Tasks.Task> PartitionInitializingAsync { add { } remove { } }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -24,6 +24,11 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--TEMP REMOVE BEFORE RELEASE -->
+    <ProjectReference Include="..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
+  </ItemGroup>
+  
   <!-- Import Event Hubs shared source -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Core.projitems" Label="Core" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Diagnostics.projitems" Label="Diagnostics" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
     <Version>5.12.0-beta.1</Version>
@@ -14,7 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" />
+    <!--TEMP UNCOMMENT BEFORE RELEASE -->
+    <!--PackageReference Include="Azure.Messaging.EventHubs" /-->
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -1121,7 +1121,7 @@ namespace Azure.Messaging.EventHubs
                     emptyBatch = false;
 
                     using var scope = StartProcessorScope(eventData);
-                    
+
                     try
                     {
                         Logger.EventBatchProcessingHandlerCall(eventData.SequenceNumber.ToString(), partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -1183,30 +1183,6 @@ namespace Azure.Messaging.EventHubs
             }
         }
 
-        private DiagnosticScope StartProcessorScope(EventData eventData)
-        {
-            var diagnosticScope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorProcessingActivityName, ActivityKind.Consumer, MessagingDiagnosticOperation.Process);
-            if (diagnosticScope.IsEnabled)
-            {
-                if (MessagingClientDiagnostics.TryExtractTraceContext(eventData.Properties, out var traceparent, out var tracestate))
-                {
-                    // set link in all cases
-                    diagnosticScope.AddLink(traceparent, tracestate);
-                    // parent is not required, but allowed and helps to correlated producer and consumers
-                    diagnosticScope.SetTraceContext(traceparent, tracestate);
-                }
-                if (eventData.EnqueuedTime != default)
-                {
-                    diagnosticScope.AddLongAttribute(
-                        DiagnosticProperty.EnqueuedTimeAttribute,
-                        eventData.EnqueuedTime.ToUnixTimeMilliseconds());
-                }
-            }
-
-            diagnosticScope.Start();
-            return diagnosticScope;
-        }
-
         /// <summary>
         ///   Performs the tasks needed when an unexpected exception occurs within the operation of the
         ///   event processor infrastructure.
@@ -1451,6 +1427,35 @@ namespace Azure.Messaging.EventHubs
                 LoadBalancingUpdateInterval = clientOptions.LoadBalancingUpdateInterval,
                 PartitionOwnershipExpirationInterval = clientOptions.PartitionOwnershipExpirationInterval
             };
+        }
+
+        /// <summary>
+        /// Creates, starts, and enriches processing diagnostics scope.
+        /// </summary>
+        /// <param name="eventData">The instance of <see cref="EventData"/> which is being processed.</param>
+        /// <returns>The instance of scope.</returns>
+        private DiagnosticScope StartProcessorScope(EventData eventData)
+        {
+            var diagnosticScope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorProcessingActivityName, ActivityKind.Consumer, MessagingDiagnosticOperation.Process);
+            if (diagnosticScope.IsEnabled)
+            {
+                if (MessagingClientDiagnostics.TryExtractTraceContext(eventData.Properties, out var traceparent, out var tracestate))
+                {
+                    // set link in all cases
+                    diagnosticScope.AddLink(traceparent, tracestate);
+                    // parent is not required, but allowed and helps to correlate producer and consumers
+                    diagnosticScope.SetTraceContext(traceparent, tracestate);
+                }
+                if (eventData.EnqueuedTime != default)
+                {
+                    diagnosticScope.AddLongAttribute(
+                        DiagnosticProperty.EnqueuedTimeAttribute,
+                        eventData.EnqueuedTime.ToUnixTimeMilliseconds());
+                }
+            }
+
+            diagnosticScope.Start();
+            return diagnosticScope;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -348,12 +348,6 @@ namespace Azure.Messaging.EventHubs
         public new string Identifier => base.Identifier;
 
         /// <summary>
-        ///   Indicates whether or not this processor should instrument batch event processing calls with distributed tracing.
-        /// </summary>
-        ///
-        protected override bool? IsBatchTracingEnabled { get => false; }
-
-        /// <summary>
         ///   The instance of <see cref="EventProcessorClientEventSource" /> which can be mocked for testing.
         /// </summary>
         ///
@@ -364,6 +358,12 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         internal MessagingClientDiagnostics ClientDiagnostics { get; }
+
+        /// <summary>
+        ///   Indicates whether or not this processor should instrument batch event processing calls with distributed tracing.
+        /// </summary>
+        ///
+        protected override bool? IsBatchTracingEnabled { get => false; }
 
         /// <summary>
         ///   Responsible for creation of checkpoints and for ownership claim.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
@@ -20,6 +20,8 @@ using Azure.Messaging.EventHubs.Processor;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
+using System.Diagnostics;
+using static Azure.Messaging.EventHubs.Tests.EventProcessorClientTests;
 
 namespace Azure.Messaging.EventHubs.Tests
 {
@@ -76,7 +78,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor.Object.Logger = mockLogger.Object;
 
-            using var listener = new TestActivitySourceListener(DiagnosticProperty.DiagnosticNamespace);
+            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
             await InvokeUpdateCheckpointAsync(mockProcessor.Object, mockContext.Object.PartitionId, 998, default);
 
             Assert.IsEmpty(listener.Activities);
@@ -121,6 +123,165 @@ namespace Azure.Messaging.EventHubs.Tests
             CollectionAssert.Contains(checkpointActivity.Tags, new KeyValuePair<string, string>(MessagingClientDiagnostics.ServerAddress, "host"));
             CollectionAssert.Contains(checkpointActivity.Tags, new KeyValuePair<string, string>(MessagingClientDiagnostics.DestinationName, "hub"));
             CollectionAssert.Contains(checkpointActivity.Tags, new KeyValuePair<string, string>(MessagingClientDiagnostics.MessagingSystem, DiagnosticProperty.EventHubsServiceContext));
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessorClient.OnProcessingEventBatchAsync" /> implementation.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventProcessorClientCreatesScopeForEachEventProcessing()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+            using var _ = SetAppConfigSwitch();
+            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
+
+            var enqueuedTime = DateTimeOffset.UtcNow;
+            var eventBatch = new[]
+            {
+                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123, enqueuedTime: enqueuedTime),
+                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456, enqueuedTime: enqueuedTime)
+            };
+
+            for (int i = 0; i < eventBatch.Length; i++)
+            {
+                eventBatch[i].Properties.Add("Diagnostic-Id", $"00-{i}0112233445566778899aabbccddeeff-0123456789abcdef-01");
+            }
+
+            var mockLogger = new Mock<EventProcessorClientEventSource>();
+            var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+
+            processorClient.Logger = mockLogger.Object;
+            processorClient.ProcessEventAsync += _ => Task.CompletedTask;
+
+            await processorClient.InvokeOnProcessingEventBatchAsync(eventBatch, new TestEventProcessorPartition("0"), cancellationSource.Token);
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            // Validate the diagnostics.
+            var expectedTags = new List<KeyValuePair<string, object>>()
+            {
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.ServerAddress, "namespace"),
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.MessagingSystem, DiagnosticProperty.EventHubsServiceContext),
+                new KeyValuePair<string, object>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeMilliseconds())
+            };
+
+            var activities = listener.Activities.ToList();
+            Assert.AreEqual(eventBatch.Length, activities.Count);
+
+            foreach (var activity in activities)
+            {
+                Assert.AreEqual(DiagnosticProperty.EventProcessorProcessingActivityName, activity.OperationName);
+                Assert.That(activity.Links, Has.Exactly(1).Items);
+                Assert.That(activity.Links.Select(a => a.Context.SpanId), Has.One.EqualTo(activity.ParentSpanId));
+                Assert.That(expectedTags, Is.SubsetOf(activity.TagObjects.ToList()));
+                Assert.AreEqual(ActivityStatusCode.Unset, activity.Status);
+                Assert.AreEqual(ActivityKind.Consumer, activity.Kind);
+            }
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessorClient.OnProcessingEventBatchAsync" /> implementation
+        ///   when processing callback throws
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventProcessorClientCreatesScopeError()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+            using var _ = SetAppConfigSwitch();
+
+            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
+            var eventBatch = new[]
+            {
+                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123),
+                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456)
+            };
+
+            var mockLogger = new Mock<EventProcessorClientEventSource>();
+            var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+
+            processorClient.Logger = mockLogger.Object;
+            processorClient.ProcessEventAsync += _ => throw new TimeoutException();
+
+            await processorClient.InvokeOnProcessingEventBatchAsync(eventBatch, new TestEventProcessorPartition("0"), cancellationSource.Token).IgnoreExceptions();
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            // Validate the diagnostics.
+            var expectedTags = new List<KeyValuePair<string, object>>()
+            {
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.ServerAddress, "namespace"),
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.MessagingSystem, DiagnosticProperty.EventHubsServiceContext),
+                new KeyValuePair<string, object>("error.type", typeof(TimeoutException).FullName),
+            };
+
+            var activities = listener.Activities.ToList();
+            Assert.AreEqual(eventBatch.Length, activities.Count);
+
+            foreach (var activity in activities)
+            {
+                Assert.AreEqual(DiagnosticProperty.EventProcessorProcessingActivityName, activity.OperationName);
+                Assert.That(expectedTags, Is.SubsetOf(activity.TagObjects.ToList()));
+                Assert.AreEqual(ActivityStatusCode.Error, activity.Status);
+                Assert.AreEqual(ActivityKind.Consumer, activity.Kind);
+                Assert.IsEmpty(activity.TagObjects.Where(t => t.Key == DiagnosticProperty.EnqueuedTimeAttribute));
+            }
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessorClient.OnProcessingEventBatchAsync" /> implementation
+        ///   when received message does not have trace context.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventProcessorClientCreatesScopeForEachEventProcessingWithoutRemoteLink()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+            using var _ = SetAppConfigSwitch();
+            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
+
+            var enqueuedTime = DateTimeOffset.UtcNow;
+            var eventBatch = new[]
+            {
+                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123, enqueuedTime: enqueuedTime),
+                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456, enqueuedTime: enqueuedTime)
+            };
+
+            var mockLogger = new Mock<EventProcessorClientEventSource>();
+            var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+
+            processorClient.Logger = mockLogger.Object;
+            processorClient.ProcessEventAsync += _ => Task.CompletedTask;
+
+            await processorClient.InvokeOnProcessingEventBatchAsync(eventBatch, new TestEventProcessorPartition("0"), cancellationSource.Token).IgnoreExceptions();
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            // Validate the diagnostics.
+            var expectedTags = new List<KeyValuePair<string, object>>()
+            {
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.ServerAddress, "namespace"),
+                new KeyValuePair<string, object>(MessagingClientDiagnostics.MessagingSystem, DiagnosticProperty.EventHubsServiceContext),
+                new KeyValuePair<string, object>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeMilliseconds())
+            };
+
+            var activities = listener.Activities.ToList();
+            Assert.AreEqual(eventBatch.Length, activities.Count);
+
+            foreach (var activity in activities)
+            {
+                Assert.AreEqual(DiagnosticProperty.EventProcessorProcessingActivityName, activity.OperationName);
+                Assert.IsEmpty(activity.Links);
+                Assert.That(expectedTags, Is.SubsetOf(activity.TagObjects.ToList()));
+                Assert.AreEqual(ActivityKind.Consumer, activity.Kind);
+            }
             cancellationSource.Cancel();
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
@@ -160,6 +160,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
+            
             var expectedTags = new List<KeyValuePair<string, object>>()
             {
                 new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),
@@ -212,6 +213,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
+            
             var expectedTags = new List<KeyValuePair<string, object>>()
             {
                 new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),
@@ -264,6 +266,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
+            
             var expectedTags = new List<KeyValuePair<string, object>>()
             {
                 new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
@@ -160,7 +160,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
-            
+
             var expectedTags = new List<KeyValuePair<string, object>>()
             {
                 new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),
@@ -213,7 +213,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
-            
+
             var expectedTags = new List<KeyValuePair<string, object>>()
             {
                 new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),
@@ -266,7 +266,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
-            
+
             var expectedTags = new List<KeyValuePair<string, object>>()
             {
                 new KeyValuePair<string, object>(MessagingClientDiagnostics.DestinationName, "eventHub"),

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Shared;
 using Azure.Core.Tests;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Diagnostics;
@@ -16,6 +19,7 @@ using Azure.Messaging.EventHubs.Processor.Diagnostics;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
+using static Azure.Messaging.EventHubs.Tests.EventProcessorClientTests;
 
 namespace Azure.Messaging.EventHubs.Tests
 {
@@ -73,6 +77,169 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(scope.Name, Is.EqualTo(DiagnosticProperty.EventProcessorCheckpointActivityName));
 
             cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessorClient.OnProcessingEventBatchAsync" /> implementation.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventProcessorClientCreatesScopeForEachEventProcessing()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
+            var enqueuedTime = DateTimeOffset.UtcNow;
+            var eventBatch = new[]
+            {
+                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123, enqueuedTime: enqueuedTime),
+                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456, enqueuedTime: enqueuedTime)
+            };
+
+            for (int i = 0; i < eventBatch.Length; i++)
+            {
+                eventBatch[i].Properties.Add("Diagnostic-Id", $"00-{i}0112233445566778899aabbccddeeff-0123456789abcdef-01");
+            }
+
+            var partitionId = "3";
+            var mockLogger = new Mock<EventProcessorClientEventSource>();
+            var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+
+            processorClient.Logger = mockLogger.Object;
+            processorClient.ProcessEventAsync += _ => Task.CompletedTask;
+
+            await processorClient.InvokeOnProcessingEventBatchAsync(eventBatch, new TestEventProcessorPartition(partitionId), cancellationSource.Token);
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            // Validate the diagnostics.
+            var expectedTags = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
+                new KeyValuePair<string, string>(MessagingClientDiagnostics.MessageBusDestination, "eventHub"),
+                new KeyValuePair<string, string>(MessagingClientDiagnostics.PeerAddress, "namespace"),
+                new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeMilliseconds().ToString())
+            };
+
+            var scopes = listener.Scopes.ToList();
+            Assert.AreEqual(eventBatch.Length, listener.Scopes.Count);
+
+            foreach (var scope in scopes)
+            {
+                Assert.AreEqual(DiagnosticProperty.EventProcessorProcessingActivityName, scope.Name);
+                Assert.That(scope.LinkedActivities, Has.Exactly(1).Items);
+                Assert.That(scope.LinkedActivities.Select(a => a.ParentId), Has.One.EqualTo(scope.Activity.ParentId));
+                Assert.That(expectedTags, Is.SubsetOf(scope.Activity.Tags.ToList()));
+                Assert.AreEqual(ActivityStatusCode.Unset, scope.Activity.Status);
+            }
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessorClient.OnProcessingEventBatchAsync" /> implementation
+        ///   when processing callback throws
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventProcessorClientCreatesScopeError()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
+            var eventBatch = new[]
+            {
+                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123),
+                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456)
+            };
+
+            var mockLogger = new Mock<EventProcessorClientEventSource>();
+            var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+
+            processorClient.Logger = mockLogger.Object;
+            processorClient.ProcessEventAsync += _ => throw new TimeoutException();
+
+            await processorClient.InvokeOnProcessingEventBatchAsync(eventBatch, new TestEventProcessorPartition("0"), cancellationSource.Token).IgnoreExceptions();
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            // Validate the diagnostics.
+            var expectedTags = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
+                new KeyValuePair<string, string>(MessagingClientDiagnostics.MessageBusDestination, "eventHub"),
+                new KeyValuePair<string, string>(MessagingClientDiagnostics.PeerAddress, "namespace"),
+            };
+
+            var scopes = listener.Scopes.ToList();
+            Assert.AreEqual(eventBatch.Length, listener.Scopes.Count);
+
+            foreach (var scope in scopes)
+            {
+                Assert.AreEqual(DiagnosticProperty.EventProcessorProcessingActivityName, scope.Name);
+                Assert.That(expectedTags, Is.SubsetOf(scope.Activity.Tags.ToList()));
+                Assert.AreEqual(ActivityStatusCode.Error, scope.Activity.Status);
+            }
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessorClient.OnProcessingEventBatchAsync" /> implementation
+        ///   when received message does not have trace context.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventProcessorClientCreatesScopeForEachEventProcessingWithoutRemoteLink()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
+            var enqueuedTime = DateTimeOffset.UtcNow;
+            var eventBatch = new[]
+            {
+                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123, enqueuedTime: enqueuedTime),
+                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456, enqueuedTime: enqueuedTime)
+            };
+
+            var mockLogger = new Mock<EventProcessorClientEventSource>();
+            var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+
+            processorClient.Logger = mockLogger.Object;
+            processorClient.ProcessEventAsync += _ => Task.CompletedTask;
+
+            await processorClient.InvokeOnProcessingEventBatchAsync(eventBatch, new TestEventProcessorPartition("0"), cancellationSource.Token).IgnoreExceptions();
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            // Validate the diagnostics.
+            var expectedTags = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
+                new KeyValuePair<string, string>(MessagingClientDiagnostics.MessageBusDestination, "eventHub"),
+                new KeyValuePair<string, string>(MessagingClientDiagnostics.PeerAddress, "namespace"),
+                new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeMilliseconds().ToString())
+            };
+
+            var scopes = listener.Scopes.ToList();
+            Assert.AreEqual(eventBatch.Length, listener.Scopes.Count);
+
+            foreach (var scope in scopes)
+            {
+                Assert.AreEqual(DiagnosticProperty.EventProcessorProcessingActivityName, scope.Name);
+                Assert.IsEmpty(scope.LinkedActivities);
+                Assert.That(expectedTags, Is.SubsetOf(scope.Activity.Tags.ToList()));
+            }
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies <see cref="EventProcessorClient" /> disables base batch tracing
+        /// </summary>
+        ///
+        [Test]
+        public void EventProcessorClientDisablesBaseBatchTracing()
+        {
+            var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+            Assert.False(processorClient.IsBaseBatchTracingEnabled);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -113,6 +113,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
+            
             var expectedTags = new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
@@ -163,6 +164,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
+            
             var expectedTags = new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
@@ -211,6 +213,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
+            
             var expectedTags = new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -113,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
-            
+
             var expectedTags = new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
@@ -164,7 +164,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
-            
+
             var expectedTags = new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
@@ -213,7 +213,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             // Validate the diagnostics.
-            
+
             var expectedTags = new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -1730,6 +1730,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public Task InvokeUpdateCheckpointAsync(string partitionId, CheckpointPosition checkpointStartingPosition, CancellationToken cancellationToken) => base.UpdateCheckpointAsync(partitionId, checkpointStartingPosition, cancellationToken);
             protected override EventHubConnection CreateConnection() => InjectedConnection;
             protected override Task ValidateProcessingPreconditions(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public bool? IsBaseBatchTracingEnabled => base.IsBatchTracingEnabled;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -394,6 +394,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string EventHubName { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
         public string Identifier { get { throw null; } }
+        protected virtual bool? IsBatchTracingEnabled { get { throw null; } set { } }
         public bool IsRunning { get { throw null; } protected set { } }
         protected Azure.Messaging.EventHubs.EventHubsRetryPolicy RetryPolicy { get { throw null; } }
         protected abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ClaimOwnershipAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership> desiredOwnership, System.Threading.CancellationToken cancellationToken);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -2299,14 +2299,14 @@ namespace Azure.Messaging.EventHubs.Primitives
                     if (MessagingClientDiagnostics.TryExtractTraceContext(eventData.Properties, out var traceparent, out var tracestate))
                     {
                         // Set link in all cases.
-                        
+
                         diagnosticScope.AddLink(traceparent, tracestate, linkAttributes);
 
                         if (!isBatch)
                         {
                             // Parent is not required, but allowed when there is just one message.
                             // It helps to correlate producer and consumers.
-                            
+
                             diagnosticScope.SetTraceContext(traceparent, tracestate);
                         }
                     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -81,13 +81,6 @@ namespace Azure.Messaging.EventHubs.Primitives
         private CancellationTokenSource _runningProcessorCancellationSource;
 
         /// <summary>
-        ///   Indicates whether or not this event processor should instrument processor calls with distributed tracing.
-        ///   Implementations that instrumentation processing themselves should set it to false.
-        /// </summary>
-        ///
-        protected virtual bool? IsBatchTracingEnabled { get; set; } = null;
-
-        /// <summary>
         ///   The fully qualified Event Hubs namespace that the processor is associated with.  This is likely
         ///   to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
         /// </summary>
@@ -212,6 +205,13 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// </summary>
         ///
         protected EventHubsRetryPolicy RetryPolicy { get; }
+
+        /// <summary>
+        ///   Indicates whether or not this event processor should instrument batch event processing calls with distributed tracing.
+        ///   Implementations that instrument event processing themselves should set this to <c>false</c>.
+        /// </summary>
+        ///
+        protected virtual bool? IsBatchTracingEnabled { get; set; }
 
         /// <summary>
         ///   The set of currently active partition processing tasks issued by this event processor and their associated
@@ -679,7 +679,6 @@ namespace Azure.Messaging.EventHubs.Primitives
             finally
             {
                 Logger.EventProcessorProcessingHandlerComplete(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation, watch.GetElapsedTime().TotalSeconds, eventBatch.Count);
-                diagnosticScope?.Dispose();
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
@@ -18,6 +18,7 @@ using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Producer;
 using Moq;
+using Moq.Protected;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -507,10 +508,10 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.AreEqual(DiagnosticProperty.DiagnosticNamespace + ".EventProcessor", processingActivity.Source.Name);
 
             var expectedTag =
-                new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute,
-                    enqueuedTime.ToUnixTimeMilliseconds().ToString());
+                new KeyValuePair<string, object>(DiagnosticProperty.EnqueuedTimeAttribute,
+                    enqueuedTime.ToUnixTimeMilliseconds());
 
-            var tags = processingActivity.Tags;
+            var tags = processingActivity.TagObjects;
             Assert.That(tags.Contains(expectedTag), Is.True, "The processing scope should have contained the enqueued time tag.");
         }
 
@@ -553,9 +554,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var linkedActivities = processingScope.Links.Where(a => a.Context.TraceId == ActivityContext.Parse(diagnosticId, null).TraceId).ToList();
             Assert.That(linkedActivities.Count, Is.EqualTo(2), "There should have been a two activities linked to the diagnostic identifier.");
 
-            var expectedTags = new List<KeyValuePair<string, string>>()
+            var expectedTags = new List<KeyValuePair<string, object>>()
             {
-                new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeMilliseconds().ToString())
+                new KeyValuePair<string, object>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeMilliseconds())
             };
 
             var tags = linkedActivities[0].Tags.ToList();
@@ -563,6 +564,38 @@ namespace Azure.Messaging.EventHubs.Tests
 
             tags = linkedActivities[1].Tags.ToList();
             Assert.That(tags, Is.EquivalentTo(expectedTags), "The second activity should have been tagged appropriately.");
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessor{TPartition}.ProcessEventBatchAsync" />
+        ///   class when base processor tracing is disabled.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventProcessorDisabledBatchTracing()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+            using var _ = SetAppConfigSwitch();
+            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
+
+            var eventBatch = new List<EventData>
+            {
+                new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: DateTimeOffset.UtcNow)
+            };
+            var partition = new EventProcessorPartition { PartitionId = "123" };
+            var fullyQualifiedNamespace = "namespace";
+            var eventHubName = "eventHub";
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(1, "consumerGroup", fullyQualifiedNamespace, eventHubName, Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+            mockProcessor.Protected().Setup<bool?>("IsBatchTracingEnabled").Returns(false);
+
+            await mockProcessor.Object.ProcessEventBatchAsync(partition, eventBatch, false, cancellationSource.Token);
+
+            // Validate the diagnostics.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.IsEmpty(listener.Activities);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -16,6 +17,7 @@ using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Producer;
 using Moq;
+using Moq.Protected;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -394,15 +396,18 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
 
+            var id0 = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
+            var id1 = "00-1123456789abcdef0123456789abcdef-0123456789abcdef-01";
+
             await producer.SendAsync(new[]
             {
-                new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, "id" } }),
-                new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, "id2" } })
+                new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, id0 } }),
+                new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, id1 } })
             });
 
             ClientDiagnosticListener.ProducedDiagnosticScope sendScope = testListener.Scopes.Single(s => s.Name == DiagnosticProperty.ProducerActivityName);
 
-            var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink("id"), new ClientDiagnosticListener.ProducedLink("id2") };
+            var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink(id0), new ClientDiagnosticListener.ProducedLink(id1) };
             var links = sendScope.Links.ToList();
 
             Assert.That(links.Count, Is.EqualTo(expectedLinks.Length), "The amount of links should be the same as the amount of events that were sent.");
@@ -445,10 +450,12 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(new ValueTask<TransportEventBatch>(Task.FromResult(batchTransportMock.Object)));
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
-
-            var eventData1 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, "id" } });
-            var eventData2 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, "id2" } });
-            var eventData3 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, "id3" } });
+            var id0 = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
+            var id1 = "00-1123456789abcdef0123456789abcdef-0123456789abcdef-01";
+            var id2 = "00-2123456789abcdef0123456789abcdef-0123456789abcdef-01";
+            var eventData1 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, id0 } });
+            var eventData2 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, id1 } });
+            var eventData3 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { MessagingClientDiagnostics.DiagnosticIdAttribute, id2 } });
             var batch = await producer.CreateBatchAsync();
 
             Assert.That(batch.TryAdd(eventData1), Is.True, "The first event should have been added to the batch.");
@@ -459,7 +466,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             ClientDiagnosticListener.ProducedDiagnosticScope sendScope = testListener.Scopes.Single(s => s.Name == DiagnosticProperty.ProducerActivityName);
 
-            var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink("id"), new ClientDiagnosticListener.ProducedLink("id2") };
+            var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink(id0), new ClientDiagnosticListener.ProducedLink(id1) };
             var links = sendScope.Links.ToList();
 
             Assert.That(links.Count, Is.EqualTo(expectedLinks.Length), "The amount of links should be the same as the amount of events that were sent.");
@@ -480,7 +487,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
 
             var enqueuedTime = DateTimeOffset.UtcNow;
-            var diagnosticId = 12;
+            var traceparents = new List<string>();
             var partition = new EventProcessorPartition { PartitionId = "123" };
             var fullyQualifiedNamespace = "namespace";
             var eventHubName = "eventHub";
@@ -492,13 +499,14 @@ namespace Azure.Messaging.EventHubs.Tests
                 new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: enqueuedTime)
             };
 
-            eventBatch.ForEach(evt => evt.Properties.Add(MessagingClientDiagnostics.DiagnosticIdAttribute, (++diagnosticId).ToString()));
+            for (int i = 0; i < eventBatch.Count; i++)
+            {
+                traceparents.Add($"00-0123456789abcdef0123456789abcde{i}-0123456789abcde{i}-01");
+                eventBatch[i].Properties.Add(MessagingClientDiagnostics.DiagnosticIdAttribute, traceparents[i]);
+            }
             await mockProcessor.Object.ProcessEventBatchAsync(partition, eventBatch, false, cancellationSource.Token);
 
             // Validate the diagnostics.
-
-            diagnosticId -= eventBatch.Count;
-
             var expectedTags = new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
@@ -513,7 +521,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             for (var index = 0; index < eventBatch.Count; ++index)
             {
-                var targetId = new ClientDiagnosticListener.ProducedLink((++diagnosticId).ToString());
+                var targetId = new ClientDiagnosticListener.ProducedLink(traceparents[index]);
                 Assert.That(scopes.SelectMany(scope => scope.Links), Has.One.EqualTo(targetId), $"There should have been a link for the diagnostic identifier: { targetId }");
             }
 
@@ -537,7 +545,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
 
             var enqueuedTime = DateTimeOffset.UtcNow;
-            var diagnosticId = "OMGHAI2U!";
+            var diagnosticId = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             var eventBatch = new List<EventData>
             {
                 new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: enqueuedTime)
@@ -559,12 +567,46 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(processingScope.Activity.ParentId, Is.EqualTo(diagnosticId), "The parent of the processing scope should have been equal to the diagnosticId.");
 
+            var targetId = new ClientDiagnosticListener.ProducedLink(diagnosticId);
+            Assert.That(processingScope.Links, Has.One.EqualTo(targetId), $"There should have been a link for the diagnostic identifier: {targetId}");
+
             var expectedTag =
                 new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute,
                     enqueuedTime.ToUnixTimeMilliseconds().ToString());
 
             var tags = processingScope.Activity.Tags;
             Assert.That(tags.Contains(expectedTag), Is.True, "The processing scope should have contained the enqueued time tag.");
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessor{TPartition}.ProcessEventBatchAsync" />
+        ///   class when processing a single event.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventProcessorDisabledBatchTracing()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+            using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
+
+            var eventBatch = new List<EventData>
+            {
+                new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: DateTimeOffset.UtcNow)
+            };
+            var partition = new EventProcessorPartition { PartitionId = "123" };
+            var fullyQualifiedNamespace = "namespace";
+            var eventHubName = "eventHub";
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(1, "consumerGroup", fullyQualifiedNamespace, eventHubName, Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+            mockProcessor.Protected().Setup<bool?>("IsBatchTracingEnabled").Returns(false);
+
+            await mockProcessor.Object.ProcessEventBatchAsync(partition, eventBatch, false, cancellationSource.Token);
+
+            // Validate the diagnostics.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.IsEmpty(listener.Scopes);
         }
 
         /// <summary>
@@ -581,7 +623,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
 
             var enqueuedTime = DateTimeOffset.UtcNow;
-            var diagnosticId = "OMGHAI2U!";
+            var diagnosticId = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             var eventBatch = new List<EventData>
             {
                 new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: enqueuedTime),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticExtensions.cs
@@ -30,6 +30,8 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                     out string traceparent,
                     out string tracestate))
             {
+                // link is required, parent is optional, but results in better experience
+                scope.AddLink(traceparent, tracestate);
                 scope.SetTraceContext(traceparent, tracestate);
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeActivitySourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeActivitySourceLiveTests.cs
@@ -269,6 +269,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     {
                         Assert.IsTrue(MessagingClientDiagnostics.TryExtractTraceContext(messages[messageProcessedCt].ApplicationProperties, out var traceparent, out var tracestate));
                         Assert.AreEqual(traceparent, activity.ParentId);
+                        Assert.AreEqual(1, activity.Links);
+                        Assert.AreEqual(activity.ParentSpanId, activity.Links.Single().Context.SpanId);
                         Assert.AreEqual(tracestate, activity.TraceStateString);
                         Assert.AreEqual(DiagnosticProperty.DiagnosticNamespace + ".ServiceBusProcessor", activity.Source.Name);
                         callbackExecuted = true;


### PR DESCRIPTION
Fixes #31922

- Adds a protected property to `EventProcessor` allowing its implementations to turn base per-batch tracing off. 
- Adds tracing to `EventProcessorClient` for individual messages

A few unrelated minor fixes:
- Adds a link to message span from processing span - it's [recommended per spec](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#:~:text=%22Process%22%20or%20%22Receive%22%20span%20SHOULD%20link%20to%20the%20message%27s%20creation%20context.) (parent is optional)
- Fixes enqueued timestamp type on the `ActivitySource` (still experimental)  path - it was string, but should be long.
- Refactors how links are recorded:
  - We used to do custom hack creating Activities (for AppInsights) and then transforming them to new `ActiviytLink` for OTel
  - Now we record them as `ActiviytLink` and transform to an old hack if AppInsights path is used. 

Todo 
- [x] Test with Otel
- [x] Test with AppInsights
