### PR TITLE
[Schema Registry] Bump Avro serializer version

### DIFF
--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/CHANGELOG.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Release History
+## 1.0.1 (2024-03-29)
+
+### Other changes
+
+- Added a direct reference to `Newtonsoft.Json` v13.0.3 to hoist up the version used by `Apache.Avro`, which has known security vulnerabilities.
 
 ## 1.0.0 (2022-05-11)
 

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.csproj
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Microsoft Azure Schema Registry Apache Avro SDK</Description>
     <AssemblyTitle>Microsoft Azure Schema Registry Apache Avro SDK</AssemblyTitle>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageTags>Azure;Schema Registry;SchemaRegistry;.NET;Data;Apache;Avro;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -11,6 +11,7 @@
     <PackageReference Include="Apache.Avro" />
     <PackageReference Include="Azure.Data.SchemaRegistry" />
     <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.3" />
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->


### PR DESCRIPTION
# Summary

The focus of these changes is to add a direct reference to `Newtonsoft.Json` v13.0.3 to hoist up the version used by `Apache.Avro`, which has known security vulnerabilities.