### PR TITLE
System.ClientModel: add a nullable struct overload for ModelReaderWriter.Write

### DIFF
--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
@@ -82,6 +82,25 @@ public static class ModelReaderWriter
     }
 
     /// <summary>
+    /// Converts the value of a model into a <see cref="BinaryData"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    /// <param name="model">The model to convert.</param>
+    /// <param name="options">The <see cref="ModelReaderWriterOptions"/> to use.</param>
+    /// <returns>A <see cref="BinaryData"/> representation of the model in the <see cref="ModelReaderWriterOptions.Format"/> specified by the <paramref name="options"/>.</returns>
+    /// <exception cref="FormatException">If the model does not support the requested <see cref="ModelReaderWriterOptions.Format"/>.</exception>
+    /// <exception cref="ArgumentNullException">If <paramref name="model"/> is null.</exception>
+    public static BinaryData Write<T>(T? model, ModelReaderWriterOptions? options = default)
+        where T : struct, IPersistableModel<T>
+    {
+        if (!model.HasValue)
+        {
+            throw new ArgumentNullException(nameof(model));
+        }
+        return Write<T>(model!, options);
+    }
+
+    /// <summary>
     /// Converts the <see cref="BinaryData"/> into a <typeparamref name="T"/>.
     /// </summary>
     /// <param name="data">The <see cref="BinaryData"/> to convert.</param>


### PR DESCRIPTION
## What's the problem?

tl;dr: `ModelReaderWriter.Write(model)` cryptically fails when `model` is a nullable struct.

Client models may frequently have nullable value types -- e.g. generated extensible enum structs -- as constituents. Consider, as a contrived example:

```csharp
public partial class MyRequestModel : IJsonModel<MyRequestModel>
{
    ...
    MyExtensibleEnum? OptionalEnumThing { get; }
    ...
}

public readonly partial struct MyExtensibleEnum : IJsonModel<MyExtensibleEnum> { ... }
```

With the above, serialization logic may want to invoke (directly or indirectly) `ModelReaderWriter.Write()`. In that situation, this code works:
```csharp
BinaryData enumPayload = ModelReaderWriter.Write(requestModel.OptionalEnumThing.Value);
```
...while this code cryptically fails at runtime:
```csharp
BinaryData enumPayload = ModelReaderWriter.Write(requestModel.OptionalEnumThing);
// System.InvalidOperationException: OptionalEnumThing does not implement IPersistableModel
```

This falls into a confusing path because:
- The typed generic `Write<T>(T model,...)` isn't invoked, as the fully qualified nullable of `T?` *does not* implement `IPersistableModel`
- The implementation thus falls back into the `Write(object model,...)` implementation, which *should* work, except that a limitation of covariance makes `obj as IPersistableModel<object>` `null` for (and only for) value types -- making it indistinguishable from the target type *actually* not implementing the interface

The following program is a min repro of the language issue that parallels the SCM conundrum:
```csharp
using System;

public interface IFoo<out T> {}
public class BarClass : IFoo<BarClass> {}
public struct BazStruct : IFoo<BazStruct> {}

public static class Program
{
	public static void PrintViaType<T>(T instance, string label) where T : IFoo<T>
		=> Console.WriteLine($"{label}: {instance as IFoo<T>}");
	public static void PrintViaObject(object instance, string label)
		=> Console.WriteLine($"{label}: {instance as IFoo<object>}");

	public static void Main(string[] _)
	{
		// Covariant use of IFoo<object> works for classes
		BarClass barClassInstance = new();
		PrintViaType(barClassInstance, "BarClass used via IFoo<BarClass>");
		PrintViaObject(barClassInstance, "BarClass used via IFoo<object>");

		// Covariant use of IFoo<object> fails confusingly for structs
		BazStruct bazStructInstance = new();
		PrintViaType(bazStructInstance, "BazStruct used via IFoo<BazStruct>");
		PrintViaObject(bazStructInstance, "BazStruct used via IFoo<object>");
	}

	// OUTPUT:
	// BarClass used via IFoo<BarClass>: BarClass
	// BarClass used via IFoo<object>: BarClass
	// BazStruct used via IFoo<BazStruct>: BazStruct
	// BazStruct used via IFoo<object>: 
}
```

Speaking as a customer, I can vouch for this causing some potential confusion!

## Approach

I'm not positive this is the right or ideal way to achieve things, but adding a new overload specifically for `T?` when `T : struct` appears to address the above by letting us redirect the call to avoid confusion and make things work.

Augmenting the above demo code, it's parallel to adding this:
```csharp
	public static void PrintViaType<T>(T? instance, string label) where T : struct, IFoo<T>
		=> PrintViaType(instance.Value, label);
```

More concretely in SCM, a `Write<T>(T? model,...) where T : struct, IPersistableModel<T>` appears to let us catch structs and other nullable value types in a non-covariance-dependent overload that really doesn't need to do anything other than check and unbox the nullable.