### PR TITLE
Skip tagging for PR builds

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -34,6 +34,8 @@ extends:
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
     sdl:
       sourceRepositoriesToScan:
         exclude:


### PR DESCRIPTION
This looks to have been missed with the refactoring done at https://github.com/Azure/azure-sdk-for-net/pull/43049/files. Which is causing public CI builds to fail trying to add tags to the build. 