### PR TITLE
[Functions] Allow disabling Event Hubs checkpoints

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added a new setting to `EventHubOptions` to allow checkpointing to be disabled for applications that always want to use their `initialOffsetOptions` when starting to process a new partition.
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -16,7 +18,7 @@
 
 - Adjusted checkpointing logic to no longer write a checkpoint when the listener is shutting down.  This was necessary to prevent potential data loss from occurring when shutting down Function retries.  Because the trigger cannot know if the Function host would have retried a failure if it were not shutting down, we cannot assume that it is safe to checkpoint. This change ensures that the batch of events being processed when shut down was requested will be retried by another instance or the next time the Function app is run.
 
-- Updated the `Azure.Messaging.EventHubs`, which includes a new build of the AMQP transport library.  The notable bug fix addresses an obscure race condition when a cancellation token is signaled while service operations are being invoked concurrently which caused those operations to hang.
+- Updated the `Azure.Messaging.EventHubs`, which includes a new build of the AMQP transport library. The notable bug fix addresses an obscure race condition when a cancellation token is signaled while service operations are being invoked concurrently which caused those operations to hang.
 
 ## 6.1.0 (2024-02-13)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         /// <summary>
         /// Gets or sets the number of batches to process before creating an EventHub cursor checkpoint. Default 1.
         /// </summary>
+        /// <remarks>If <see cref="EnableCheckpointing"/> is set to <c>false</c>, this value is ignored.</remarks>
         public int BatchCheckpointFrequency
         {
             get => _batchCheckpointFrequency;
@@ -218,6 +219,17 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         /// </summary>
         public InitialOffsetOptions InitialOffsetOptions { get; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the trigger will create
+        /// checkpoints as events are being processed.  The default value is <c>true</c>.
+        /// </summary>
+        /// <value><c>true</c> if checkpoints will be written; otherwise, <c>false</c>.</value>
+        /// <remarks>
+        /// This value takes precedence over <see cref="BatchCheckpointFrequency"/>, which will be
+        /// ignored if this property is set to <c>false</c>.
+        /// </remarks>
+        public bool EnableCheckpointing { get; set; } = true;
+
         /// <inheritdoc cref="EventProcessorOptions.TrackLastEnqueuedEventProperties"/>
         public bool TrackLastEnqueuedEventProperties
         {
@@ -282,6 +294,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                     { nameof(PartitionOwnershipExpirationInterval), PartitionOwnershipExpirationInterval },
                     { nameof(LoadBalancingUpdateInterval), LoadBalancingUpdateInterval },
                     { nameof(InitialOffsetOptions), ConstructInitialOffsetOptions() },
+                    { nameof(EnableCheckpointing), EnableCheckpointing },
                 };
             // Only include if not null since it would otherwise not round-trip correctly due to
             // https://github.com/dotnet/runtime/issues/36510. Once this issue is fixed, it can be included

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Processor;
 using Azure.Messaging.EventHubs.Tests;
@@ -337,6 +338,97 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(eventProcessor.CachedEventsManager.CachedEvents.Count, 0);
         }
 
+        [TestCase(1)]
+        [TestCase(4)]
+        [TestCase(8)]
+        [TestCase(32)]
+        [TestCase(128)]
+        public async Task ProcessEvents_SingleDispatch_RespectsDisabledCheckpointing(int batchCheckpointFrequency)
+        {
+            var partitionContext = EventHubTests.GetPartitionContext();
+            var options = new EventHubOptions
+            {
+                EnableCheckpointing = false,
+                BatchCheckpointFrequency = batchCheckpointFrequency
+            };
+            var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
+            processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            partitionContext.ProcessorHost = processor.Object;
+
+            var loggerMock = new Mock<ILogger>();
+            var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+            executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default, default);
+
+            for (int i = 0; i < 100; i++)
+            {
+                List<EventData> events = new List<EventData>() { new EventData(new byte[0]) };
+                await eventProcessor.ProcessEventsAsync(partitionContext, events);
+
+                // This value should never be set.
+                Assert.False(partitionContext.PartitionContext.IsCheckpointingAfterInvocation);
+            }
+
+            try
+            {
+                eventProcessor.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected; ignore.
+            }
+
+            processor.Verify(
+                p => p.CheckpointAsync(It.IsAny<string>(), It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestCase(1)]
+        [TestCase(4)]
+        [TestCase(8)]
+        [TestCase(32)]
+        [TestCase(128)]
+        public async Task ProcessEvents_MultipleDispatch_RespectsDisabledCheckpointing(int batchCheckpointFrequency)
+        {
+            var partitionContext = EventHubTests.GetPartitionContext();
+            var options = new EventHubOptions
+            {
+                EnableCheckpointing = false,
+                BatchCheckpointFrequency = batchCheckpointFrequency
+            };
+
+            var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
+            processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            partitionContext.ProcessorHost = processor.Object;
+
+            var loggerMock = new Mock<ILogger>();
+            var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+            executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default, default);
+
+            for (int i = 0; i < 100; i++)
+            {
+                List<EventData> events = new List<EventData>() { new EventData(new byte[0]), new EventData(new byte[0]), new EventData(new byte[0]) };
+                await eventProcessor.ProcessEventsAsync(partitionContext, events);
+
+                // This value should never be set.
+                Assert.False(partitionContext.PartitionContext.IsCheckpointingAfterInvocation);
+            }
+
+            try
+            {
+                eventProcessor.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected; ignore.
+            }
+
+            processor.Verify(
+                p => p.CheckpointAsync(It.IsAny<string>(), It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
         /// <summary>
         /// Even if some events in a batch fail, we still checkpoint. Event error handling
         /// is the responsibility of user function code.
@@ -611,7 +703,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [Test]
         public async Task ProcessErrorsAsync_LoggedAsError()
         {
-            var partitionContext = EventHubTests.GetPartitionContext(partitionId: "123", eventHubPath: "abc", owner: "def");
+            var partitionContext = EventHubTests.GetPartitionContext(partitionId: "123", eventHubPath: "abc");
             var options = new EventHubOptions();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");
@@ -629,7 +721,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [Test]
         public async Task ProcessErrorsAsync_RebalancingExceptions_LoggedAsInformation()
         {
-            var partitionContext = EventHubTests.GetPartitionContext(partitionId: "123", eventHubPath: "abc", owner: "def");
+            var partitionContext = EventHubTests.GetPartitionContext(partitionId: "123", eventHubPath: "abc");
             var options = new EventHubOptions();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Text;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Consumer;
@@ -311,7 +310,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         }
 
         internal static EventProcessorHostPartition GetPartitionContext(string partitionId = "0", string eventHubPath = "path",
-            string consumerGroupName = "group", string owner = null)
+            string consumerGroupName = "group")
         {
             var processor = new EventProcessorHost(consumerGroupName,
                 "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123=",

--- a/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/tests/shared/TestHelpers.cs
+++ b/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/tests/shared/TestHelpers.cs
@@ -12,13 +12,11 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Timers;
-using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Microsoft.Azure.WebJobs.Host.TestCommon


### PR DESCRIPTION
# Summary

The focus of these changes is to add an option to allow disabling Event Hubs checkpoints. This is useful for scenarios where applications always wish to use their `initialOffsetProvider` configuration when starting to process a partition.
