### PR TITLE
[Event Hubs] Changelogs and trace member rename

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- The `EventProcessorClient` will now create a unique span for each event emitted to the handler for processing.  Previously a single span was created for all events in a batch.  ([#31922](https://github.com/Azure/azure-sdk-for-net/issues/31922))
+
 ### Other Changes
 
 ## 5.11.1 (2024-03-05)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/api/Azure.Messaging.EventHubs.Processor.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/api/Azure.Messaging.EventHubs.Processor.netstandard2.0.cs
@@ -14,7 +14,6 @@ namespace Azure.Messaging.EventHubs
         public new string EventHubName { get { throw null; } }
         public new string FullyQualifiedNamespace { get { throw null; } }
         public new string Identifier { get { throw null; } }
-        protected override bool? IsBatchTracingEnabled { get { throw null; } }
         public new bool IsRunning { get { throw null; } protected set { } }
         public event System.Func<Azure.Messaging.EventHubs.Processor.PartitionClosingEventArgs, System.Threading.Tasks.Task> PartitionClosingAsync { add { } remove { } }
         public event System.Func<Azure.Messaging.EventHubs.Processor.PartitionInitializingEventArgs, System.Threading.Tasks.Task> PartitionInitializingAsync { add { } remove { } }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -360,12 +360,6 @@ namespace Azure.Messaging.EventHubs
         internal MessagingClientDiagnostics ClientDiagnostics { get; }
 
         /// <summary>
-        ///   Indicates whether or not this processor should instrument batch event processing calls with distributed tracing.
-        /// </summary>
-        ///
-        protected override bool? IsBatchTracingEnabled { get => false; }
-
-        /// <summary>
         ///   Responsible for creation of checkpoints and for ownership claim.
         /// </summary>
         ///
@@ -491,6 +485,8 @@ namespace Azure.Messaging.EventHubs
 
             _containerClient = checkpointStore;
             CheckpointStore = new BlobCheckpointStoreInternal(checkpointStore);
+
+            EnableBatchTracing = false;
             ClientDiagnostics = new MessagingClientDiagnostics(
                 DiagnosticProperty.DiagnosticNamespace,
                 DiagnosticProperty.ResourceProviderNamespace,
@@ -527,6 +523,8 @@ namespace Azure.Messaging.EventHubs
 
             _containerClient = checkpointStore;
             CheckpointStore = new BlobCheckpointStoreInternal(checkpointStore);
+
+            EnableBatchTracing = false;
             ClientDiagnostics = new MessagingClientDiagnostics(
                 DiagnosticProperty.DiagnosticNamespace,
                 DiagnosticProperty.ResourceProviderNamespace,
@@ -563,6 +561,8 @@ namespace Azure.Messaging.EventHubs
 
             _containerClient = checkpointStore;
             CheckpointStore = new BlobCheckpointStoreInternal(checkpointStore);
+
+            EnableBatchTracing = false;
             ClientDiagnostics = new MessagingClientDiagnostics(
                 DiagnosticProperty.DiagnosticNamespace,
                 DiagnosticProperty.ResourceProviderNamespace,
@@ -599,6 +599,8 @@ namespace Azure.Messaging.EventHubs
 
             _containerClient = checkpointStore;
             CheckpointStore = new BlobCheckpointStoreInternal(checkpointStore);
+
+            EnableBatchTracing = false;
             ClientDiagnostics = new MessagingClientDiagnostics(
                 DiagnosticProperty.DiagnosticNamespace,
                 DiagnosticProperty.ResourceProviderNamespace,
@@ -635,6 +637,8 @@ namespace Azure.Messaging.EventHubs
 
             DefaultStartingPosition = (clientOptions?.DefaultStartingPosition ?? DefaultStartingPosition);
             CheckpointStore = checkpointStore;
+
+            EnableBatchTracing = false;
             ClientDiagnostics = new MessagingClientDiagnostics(
                 DiagnosticProperty.DiagnosticNamespace,
                 DiagnosticProperty.ResourceProviderNamespace,
@@ -671,6 +675,8 @@ namespace Azure.Messaging.EventHubs
 
             DefaultStartingPosition = (clientOptions?.DefaultStartingPosition ?? DefaultStartingPosition);
             CheckpointStore = checkpointStore;
+
+            EnableBatchTracing = false;
             ClientDiagnostics = new MessagingClientDiagnostics(
                 DiagnosticProperty.DiagnosticNamespace,
                 DiagnosticProperty.ResourceProviderNamespace,
@@ -707,6 +713,8 @@ namespace Azure.Messaging.EventHubs
 
             DefaultStartingPosition = (clientOptions?.DefaultStartingPosition ?? DefaultStartingPosition);
             CheckpointStore = checkpointStore;
+
+            EnableBatchTracing = false;
             ClientDiagnostics = new MessagingClientDiagnostics(
                 DiagnosticProperty.DiagnosticNamespace,
                 DiagnosticProperty.ResourceProviderNamespace,
@@ -721,6 +729,7 @@ namespace Azure.Messaging.EventHubs
         ///
         protected EventProcessorClient() : base()
         {
+            EnableBatchTracing = false;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -235,14 +235,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies <see cref="EventProcessorClient" /> disables base batch tracing
+        ///   Verifies <see cref="EventProcessorClient" /> disables base batch tracing.
         /// </summary>
         ///
         [Test]
         public void EventProcessorClientDisablesBaseBatchTracing()
         {
             var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
-            Assert.False(processorClient.IsBaseBatchTracingEnabled);
+            Assert.That(processorClient.IsBaseBatchTracingEnabled, Is.False);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -1730,7 +1730,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public Task InvokeUpdateCheckpointAsync(string partitionId, CheckpointPosition checkpointStartingPosition, CancellationToken cancellationToken) => base.UpdateCheckpointAsync(partitionId, checkpointStartingPosition, cancellationToken);
             protected override EventHubConnection CreateConnection() => InjectedConnection;
             protected override Task ValidateProcessingPreconditions(CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public bool? IsBaseBatchTracingEnabled => base.IsBatchTracingEnabled;
+            public bool? IsBaseBatchTracingEnabled => EnableBatchTracing;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+  - It is now possible for processors extending `EventProcessor<T>` to disable the batch-level tracing emitted when processing events.  This is intended to allow derived processors dispatching single events or partial batches to emit their own trace information that more accurately correlates to the set of events being processed.  Previously all events in a batch were tracked under a single span regardless of how they were dispatched for processing.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -391,10 +391,10 @@ namespace Azure.Messaging.EventHubs.Primitives
         protected EventProcessor(int eventBatchMaximumCount, string consumerGroup, string fullyQualifiedNamespace, string eventHubName, Azure.Core.TokenCredential credential, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
         protected EventProcessor(int eventBatchMaximumCount, string consumerGroup, string connectionString, string eventHubName, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
         public string ConsumerGroup { get { throw null; } }
+        protected bool EnableBatchTracing { get { throw null; } set { } }
         public string EventHubName { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
         public string Identifier { get { throw null; } }
-        protected virtual bool? IsBatchTracingEnabled { get { throw null; } set { } }
         public bool IsRunning { get { throw null; } protected set { } }
         protected Azure.Messaging.EventHubs.EventHubsRetryPolicy RetryPolicy { get { throw null; } }
         protected abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ClaimOwnershipAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership> desiredOwnership, System.Threading.CancellationToken cancellationToken);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -591,17 +591,14 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
 
-            var eventBatch = new List<EventData>
-            {
-                new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: DateTimeOffset.UtcNow)
-            };
+            var eventBatch = new[] { new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: DateTimeOffset.UtcNow) };
             var partition = new EventProcessorPartition { PartitionId = "123" };
             var fullyQualifiedNamespace = "namespace";
             var eventHubName = "eventHub";
-            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(1, "consumerGroup", fullyQualifiedNamespace, eventHubName, Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
-            mockProcessor.Protected().Setup<bool?>("IsBatchTracingEnabled").Returns(false);
+            var mockProcessor = new MockEventProcessor(1, "consumerGroup", fullyQualifiedNamespace, eventHubName, Mock.Of<TokenCredential>(), default);
 
-            await mockProcessor.Object.ProcessEventBatchAsync(partition, eventBatch, false, cancellationSource.Token);
+            mockProcessor.EnableBatchTracing = false;
+            await mockProcessor.ProcessEventBatchAsync(partition, eventBatch, false, cancellationSource.Token);
 
             // Validate the diagnostics.
 
@@ -679,6 +676,36 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                     EventHubTokenCredential credential,
                                                                     EventHubConnectionOptions options,
                                                                     bool useTls = true) => Mock.Of<TransportClient>();
+        }
+
+        /// <summary>
+        ///   A minimal mock processor that allows toggling the batch tracing
+        ///   flag.
+        /// </summary>
+        ///
+        private class MockEventProcessor : EventProcessor<EventProcessorPartition>
+        {
+            public MockEventProcessor(int identifier,
+                                      string consumerGroup,
+                                      string fullyQualifiedNamespace,
+                                      string eventHubName,
+                                      TokenCredential credential,
+                                      EventProcessorOptions options) : base(identifier, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options)
+            {
+            }
+
+            public new bool EnableBatchTracing
+            {
+                get => base.EnableBatchTracing;
+                set => base.EnableBatchTracing = value;
+            }
+
+            protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+            protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            protected override Task OnProcessingEventBatchAsync(IEnumerable<EventData> events, EventProcessorPartition partition, CancellationToken cancellationToken) => Task.CompletedTask;
+
+            protected override Task OnProcessingErrorAsync(Exception exception, EventProcessorPartition partition, string operationDescription, CancellationToken cancellationToken) => Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to add change log entries for the recent event processor batch tracing fix and to rename the new member to better align with existing names in the package.  This also changes the form of the member slightly, as it does not need to virtual to be set by derived processors, nor does a null value have meaning.