### PR TITLE
[AzureMonitorExporter][AzureMonitorDistro] Update OpenTelemetry packages to 1.8.0

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -168,9 +168,9 @@
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Monitor.OpenTelemetry'))">
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.7.0" />
-    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.7.0" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Update="OpenTelemetry" Version="1.8.0" />
+    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.8.0" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
     <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
     <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
     <PackageReference Update="OpenTelemetry.PersistentStorage.FileSystem" Version="1.0.0" />
@@ -334,7 +334,7 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Update="OpenTelemetry" Version="1.7.0" />
+    <PackageReference Update="OpenTelemetry" Version="1.8.0" />
     <PackageReference Update="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -11,8 +11,16 @@
 ### Other Changes
 
 * Update OpenTelemetry dependencies
-  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+  ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
   - OpenTelemetry 1.8.0
+  - OpenTelemetry.Extensions.Hosting 1.8.0
+  - OpenTelemetry.Exporter.InMemory 1.8.0
+  
+* Removed the necessity for custom resource attributes configuration in
+  OpenTelemetry logging setup, as the OpenTelemetry .NET SDK's enhancements to
+  the builder.ConfigureResource method now uniformly set resource attributes
+  across logs, metrics, and traces.
+  ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
 
 ## 1.2.0-beta.2 (2024-03-12)
 
@@ -29,7 +37,7 @@
     documentation.
   ([#42307](https://github.com/Azure/azure-sdk-for-net/pull/42307))
 
-- Enabled support for log collection from Azure SDKs via `Microsoft.Extensions.Logging`. See [Logging with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/logging)
+* Enabled support for log collection from Azure SDKs via `Microsoft.Extensions.Logging`. See [Logging with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/logging)
   for the details.
   ([#42374](https://github.com/Azure/azure-sdk-for-net/pull/42374))
 
@@ -68,7 +76,7 @@
   property can be set to `false` to disable live metrics.
   ([#41872](https://github.com/Azure/azure-sdk-for-net/pull/41872))
 
-- Added an experimental feature for logs emitted within an active tracing
+* Added an experimental feature for logs emitted within an active tracing
   context to follow the Activity's sampling decision. The feature can be enabled
   by setting `OTEL_DOTNET_AZURE_MONITOR_EXPERIMENTAL_ENABLE_LOG_SAMPLING`
   environment variable to `true`.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Other Changes
 
+* Update OpenTelemetry dependencies
+  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+  - OpenTelemetry 1.8.0
+
 ## 1.2.0-beta.2 (2024-03-12)
 
 ### Features Added

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -14,8 +14,7 @@
   ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
   - OpenTelemetry 1.8.0
   - OpenTelemetry.Extensions.Hosting 1.8.0
-  - OpenTelemetry.Exporter.InMemory 1.8.0
-  
+
 * Removed the necessity for custom resource attributes configuration in
   OpenTelemetry logging setup, as the OpenTelemetry .NET SDK's enhancements to
   the builder.ConfigureResource method now uniformly set resource attributes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -49,7 +49,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// <item>SQL Client.</item>
         /// </list>
         /// </remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+        // Note: OpenTelemetryBuilder is obsolete because users should target
+        // IOpenTelemetryBuilder for extensions but this method is valid and
+        // expected to be called to obtain a root builder.
         public static OpenTelemetryBuilder UseAzureMonitor(this OpenTelemetryBuilder builder)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             builder.Services.TryAddSingleton<IConfigureOptions<AzureMonitorOptions>,
                         DefaultAzureMonitorOptions>();
@@ -76,7 +81,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// <item>SQL Client.</item>
         /// </list>
         /// </remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+        // Note: OpenTelemetryBuilder is obsolete because users should target
+        // IOpenTelemetryBuilder for extensions but this method is valid and
+        // expected to be called to obtain a root builder.
         public static OpenTelemetryBuilder UseAzureMonitor(this OpenTelemetryBuilder builder, Action<AzureMonitorOptions> configureAzureMonitor)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             if (builder.Services == null)
             {
@@ -126,10 +136,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             {
                 logging.AddOpenTelemetry(builderOptions =>
                 {
-                    var resourceBuilder = ResourceBuilder.CreateDefault();
-                    configureResource(resourceBuilder);
-                    builderOptions.SetResourceBuilder(resourceBuilder);
-
                     builderOptions.IncludeFormattedMessage = true;
                 });
             });
@@ -205,30 +211,16 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
 
         private static TracerProviderBuilder AddVendorInstrumentationIfPackageNotReferenced(this TracerProviderBuilder tracerProviderBuilder)
         {
-            var vendorInstrumentationActions = new Dictionary<string, Action>
+            try
             {
-                { SqlClientInstrumentationPackageName, () => tracerProviderBuilder.AddSqlClientInstrumentation() },
-            };
-
-            foreach (var packageActionPair in vendorInstrumentationActions)
+                var instrumentationAssembly = Assembly.Load(SqlClientInstrumentationPackageName);
+                AzureMonitorAspNetCoreEventSource.Log.FoundInstrumentationPackageReference(SqlClientInstrumentationPackageName);
+            }
+            catch
             {
-                Assembly? instrumentationAssembly = null;
-
-                try
-                {
-                    instrumentationAssembly = Assembly.Load(packageActionPair.Key);
-                    AzureMonitorAspNetCoreEventSource.Log.FoundInstrumentationPackageReference(packageActionPair.Key);
-                }
-                catch
-                {
-                    AzureMonitorAspNetCoreEventSource.Log.NoInstrumentationPackageReference(packageActionPair.Key);
-                }
-
-                if (instrumentationAssembly == null)
-                {
-                    packageActionPair.Value.Invoke();
-                    AzureMonitorAspNetCoreEventSource.Log.VendorInstrumentationAdded(packageActionPair.Key);
-                }
+                AzureMonitorAspNetCoreEventSource.Log.NoInstrumentationPackageReference(SqlClientInstrumentationPackageName);
+                tracerProviderBuilder.AddSqlClientInstrumentation();
+                AzureMonitorAspNetCoreEventSource.Log.VendorInstrumentationAdded(SqlClientInstrumentationPackageName);
             }
 
             return tracerProviderBuilder;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -15,8 +15,10 @@
 ### Other Changes
 
 * Update OpenTelemetry dependencies
-  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+  ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
   - OpenTelemetry 1.8.0
+  - OpenTelemetry.Extensions.Hosting 1.8.0
+  - OpenTelemetry.Exporter.InMemory 1.8.0
 
 ## 1.3.0-beta.1 (2024-02-08)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -17,7 +17,6 @@
 * Update OpenTelemetry dependencies
   ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
   - OpenTelemetry 1.8.0
-  - OpenTelemetry.Extensions.Hosting 1.8.0
 
 ## 1.3.0-beta.1 (2024-02-08)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### Other Changes
 
+* Update OpenTelemetry dependencies
+  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+  - OpenTelemetry 1.8.0
+
 ## 1.3.0-beta.1 (2024-02-08)
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -18,7 +18,6 @@
   ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
   - OpenTelemetry 1.8.0
   - OpenTelemetry.Extensions.Hosting 1.8.0
-  - OpenTelemetry.Exporter.InMemory 1.8.0
 
 ## 1.3.0-beta.1 (2024-02-08)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsActivityProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsActivityProcessor.cs
@@ -11,7 +11,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 {
     internal sealed class LiveMetricsActivityProcessor : BaseProcessor<Activity>
     {
-        private bool _disposed;
         private LiveMetricsResource? _resource;
         private readonly Manager _manager;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsActivityProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsActivityProcessor.cs
@@ -75,27 +75,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
             }
         }
 
-        protected override void Dispose(bool disposing)
-        {
-            if (!_disposed)
-            {
-                if (disposing)
-                {
-                    try
-                    {
-                        _manager.Dispose();
-                    }
-                    catch (System.Exception)
-                    {
-                    }
-                }
-
-                _disposed = true;
-            }
-
-            base.Dispose(disposing);
-        }
-
         private void AddExceptionDocument(string exceptionType, string exceptionMessage)
         {
             var exceptionDocumentIngress = DocumentHelper.CreateException(exceptionType, exceptionMessage);


### PR DESCRIPTION
### Changes
- Update all OpenTelemetry .NET SDK, hosting and in-memory exporter dependencies to v1.8.0
- OpenTelemetry hosting has marked `OpenTelemetryBuilder` as obsolete. We are following the same approach as hosting, by suppressing the obsolete message in the `UseAzureMonitor` API. Ref: https://github.com/open-telemetry/opentelemetry-dotnet/blob/b0c95307dd4bb0cab17f07c177773592816ddc09/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs#L39
- The dictionary iteration in `AddVendorInstrumentationIfPackageNotReferenced` was removed since it only looks for one assembly.
- Add a `Manager` instance to the singleton service collection. This can be retrieved later using Logging Extensions.
- Solves #42756