### PR TITLE
Forward color information for pushpins correctly

### DIFF
--- a/sdk/maps/Azure.Maps.Rendering/src/Models/ImagePushpinStyle.cs
+++ b/sdk/maps/Azure.Maps.Rendering/src/Models/ImagePushpinStyle.cs
@@ -94,7 +94,7 @@ namespace Azure.Maps.Rendering
             if (PushpinColor != null)
             {
                 sb.AppendFormat(CultureInfo.InvariantCulture, "|co{0:X2}{1:X2}{2:X2}",
-                    PushpinColor?.R, PushpinColor?.G, PushpinColor?.A);
+                    PushpinColor?.R, PushpinColor?.G, PushpinColor?.B);
 
                 if (PushpinColor?.A != 255)
                 {

--- a/sdk/maps/Azure.Maps.Rendering/tests/ImagePushpinStyleTests.cs
+++ b/sdk/maps/Azure.Maps.Rendering/tests/ImagePushpinStyleTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Maps.Rendering.Tests
             };
 
             Assert.AreEqual("default||12.56 22.56|14.561 19.801|'A label'7.9 44|'B label'11.73 25.02", simplePinStyle.ToQueryString());
-            Assert.AreEqual("default|coF5F5FF|sc1.75|ro-47|ls1.1||'B label'11.73 25.02|14.561 19.801|12.56 22.56|'A label'7.9 44", complexPinStyle1.ToQueryString());
+            Assert.AreEqual("default|coF5F5DC|sc1.75|ro-47|ls1.1||'B label'11.73 25.02|14.561 19.801|12.56 22.56|'A label'7.9 44", complexPinStyle1.ToQueryString());
             Assert.AreEqual("custom|sc1.05|an4 -5|lc802DDF|ls0.9|la5 -6||'B label'11.73 25.02|'A label'7.9 44||http://contoso.com/pushpins/red.png", complexPinStyle2.ToQueryString());
         }
     }


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-net#38100

The problem was that the alpha value was also used for the blue component while extracting the pushpin color.

