### PR TITLE
[AppConfiguration] Implemented Etag/page feature with an AsPages extension method

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 1.4.0-beta.2 (Unreleased)
+## 1.4.0 (2024-04-09)
 
 ### Features Added
 
+- Added `ConfigurationSettingPageableExtensions` class to support new `Pageable<ConfigurationSetting>.AsPages` and `AsyncPageable<ConfigurationSetting>.AsPages` extension methods. This replaces `SettingSelector.MatchConditions`.
+
 ### Breaking Changes
 
-### Bugs Fixed
-
-### Other Changes
+- Removed property `MatchConditions` from `SettingSelector`.
 
 ## 1.4.0-beta.1 (2024-03-07)
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -64,6 +64,11 @@ namespace Azure.Data.AppConfiguration
         public override string ToString() { throw null; }
         public virtual void UpdateSyncToken(string token) { }
     }
+    public static partial class ConfigurationClientExtensions
+    {
+        public static System.Collections.Generic.IAsyncEnumerable<Azure.Page<Azure.Data.AppConfiguration.ConfigurationSetting>> AsPages(this Azure.AsyncPageable<Azure.Data.AppConfiguration.ConfigurationSetting> pageable, System.Collections.Generic.IEnumerable<Azure.MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = default(int?)) { throw null; }
+        public static System.Collections.Generic.IEnumerable<Azure.Page<Azure.Data.AppConfiguration.ConfigurationSetting>> AsPages(this Azure.Pageable<Azure.Data.AppConfiguration.ConfigurationSetting> pageable, System.Collections.Generic.IEnumerable<Azure.MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = default(int?)) { throw null; }
+    }
     public partial class ConfigurationClientOptions : Azure.Core.ClientOptions
     {
         public ConfigurationClientOptions(Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion version = Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion.V2023_10_01) { }
@@ -97,11 +102,6 @@ namespace Azure.Data.AppConfiguration
         public override int GetHashCode() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
-    }
-    public static partial class ConfigurationSettingPageableExtensions
-    {
-        public static System.Collections.Generic.IAsyncEnumerable<Azure.Page<Azure.Data.AppConfiguration.ConfigurationSetting>> AsPages(this Azure.AsyncPageable<Azure.Data.AppConfiguration.ConfigurationSetting> pageable, System.Collections.Generic.IList<Azure.MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = default(int?)) { throw null; }
-        public static System.Collections.Generic.IEnumerable<Azure.Page<Azure.Data.AppConfiguration.ConfigurationSetting>> AsPages(this Azure.Pageable<Azure.Data.AppConfiguration.ConfigurationSetting> pageable, System.Collections.Generic.IList<Azure.MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = default(int?)) { throw null; }
     }
     public partial class ConfigurationSettingsFilter
     {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -98,6 +98,11 @@ namespace Azure.Data.AppConfiguration
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }
+    public static partial class ConfigurationSettingPageableExtensions
+    {
+        public static System.Collections.Generic.IAsyncEnumerable<Azure.Page<Azure.Data.AppConfiguration.ConfigurationSetting>> AsPages(this Azure.AsyncPageable<Azure.Data.AppConfiguration.ConfigurationSetting> pageable, System.Collections.Generic.IList<Azure.MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = default(int?)) { throw null; }
+        public static System.Collections.Generic.IEnumerable<Azure.Page<Azure.Data.AppConfiguration.ConfigurationSetting>> AsPages(this Azure.Pageable<Azure.Data.AppConfiguration.ConfigurationSetting> pageable, System.Collections.Generic.IList<Azure.MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = default(int?)) { throw null; }
+    }
     public partial class ConfigurationSettingsFilter
     {
         public ConfigurationSettingsFilter(string key) { }
@@ -197,7 +202,6 @@ namespace Azure.Data.AppConfiguration
         public Azure.Data.AppConfiguration.SettingFields Fields { get { throw null; } set { } }
         public string KeyFilter { get { throw null; } set { } }
         public string LabelFilter { get { throw null; } set { } }
-        public System.Collections.Generic.IList<Azure.MatchConditions> MatchConditions { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/appconfiguration/Azure.Data.AppConfiguration",
-  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_40b7825d94"
+  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_6f9a3b2b43"
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Application Configuration Service client library</Description>
     <AssemblyTitle>Microsoft Azure.Data.AppConfiguration client library</AssemblyTitle>
-    <Version>1.4.0-beta.2</Version>
+    <Version>1.4.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Application Configuration;Data;AppConfig;$(PackageCommonTags)</PackageTags>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -656,23 +656,22 @@ namespace Azure.Data.AppConfiguration
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
             IEnumerable<string> fieldsString = selector.Fields.Split();
-            int nextConditionsIndex = 0;
 
             context.AddClassifier(304, false);
 
-            HttpMessage FirstPageRequest(int? pageSizeHint)
+            HttpMessage FirstPageRequest(MatchConditions conditions, int? pageSizeHint)
             {
-                MatchConditions conditions = (nextConditionsIndex < selector.MatchConditions.Count) ? selector.MatchConditions[nextConditionsIndex++] : null;
                 return CreateGetConfigurationSettingsRequest(key, label, null, dateTime, fieldsString, null, conditions, context);
             };
 
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink)
+            HttpMessage NextPageRequest(MatchConditions conditions, int? pageSizeHint, string nextLink)
             {
-                MatchConditions conditions = (nextConditionsIndex < selector.MatchConditions.Count) ? selector.MatchConditions[nextConditionsIndex++] : null;
                 return CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, null, conditions, context);
             }
 
-            return PageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, ParseGetConfigurationSettingsResponse, ClientDiagnostics, _pipeline, "ConfigurationClient.GetConfigurationSettings", context);
+            var pageableImplementation = new ConditionalPageableImplementation(FirstPageRequest, NextPageRequest, ParseGetConfigurationSettingsResponse, _pipeline, ClientDiagnostics, "ConfigurationClient.GetConfigurationSettings", context);
+
+            return new AsyncConditionalPageable(pageableImplementation);
         }
 
         /// <summary>
@@ -689,23 +688,22 @@ namespace Azure.Data.AppConfiguration
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
             IEnumerable<string> fieldsString = selector.Fields.Split();
-            int nextConditionsIndex = 0;
 
             context.AddClassifier(304, false);
 
-            HttpMessage FirstPageRequest(int? pageSizeHint)
+            HttpMessage FirstPageRequest(MatchConditions conditions, int? pageSizeHint)
             {
-                MatchConditions conditions = (nextConditionsIndex < selector.MatchConditions.Count) ? selector.MatchConditions[nextConditionsIndex++] : null;
                 return CreateGetConfigurationSettingsRequest(key, label, null, dateTime, fieldsString, null, conditions, context);
             };
 
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink)
+            HttpMessage NextPageRequest(MatchConditions conditions, int? pageSizeHint, string nextLink)
             {
-                MatchConditions conditions = (nextConditionsIndex < selector.MatchConditions.Count) ? selector.MatchConditions[nextConditionsIndex++] : null;
                 return CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, null, conditions, context);
             }
 
-            return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, ParseGetConfigurationSettingsResponse, ClientDiagnostics, _pipeline, "ConfigurationClient.GetConfigurationSettings", context);
+            var pageableImplementation = new ConditionalPageableImplementation(FirstPageRequest, NextPageRequest, ParseGetConfigurationSettingsResponse, _pipeline, ClientDiagnostics, "ConfigurationClient.GetConfigurationSettings", context);
+
+            return new ConditionalPageable(pageableImplementation);
         }
 
         /// <summary>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientExtensions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientExtensions.cs
@@ -8,9 +8,9 @@ using System.Threading;
 namespace Azure.Data.AppConfiguration
 {
     /// <summary>
-    /// Extension methods to support <see cref="Pageable{T}"/> and <see cref="AsyncPageable{T}"/> features.
+    /// Extension methods for <see cref="ConfigurationClient"/> and its related models.
     /// </summary>
-    public static class ConfigurationSettingPageableExtensions
+    public static class ConfigurationClientExtensions
     {
         /// <summary>
         /// Enumerate the values a <see cref="Page{T}"/> at a time. This may make multiple service requests.
@@ -28,7 +28,7 @@ namespace Azure.Data.AppConfiguration
         /// <see cref="ConfigurationClient.GetConfigurationSettingsAsync(SettingSelector, CancellationToken)"/>
         /// support it.
         /// </exception>
-        public static IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(this AsyncPageable<ConfigurationSetting> pageable, IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null)
+        public static IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(this AsyncPageable<ConfigurationSetting> pageable, IEnumerable<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null)
         {
             var conditionalPageable = pageable as AsyncConditionalPageable;
 
@@ -56,7 +56,7 @@ namespace Azure.Data.AppConfiguration
         /// <see cref="ConfigurationClient.GetConfigurationSettings(SettingSelector, CancellationToken)"/>
         /// support it.
         /// </exception>
-        public static IEnumerable<Page<ConfigurationSetting>> AsPages(this Pageable<ConfigurationSetting> pageable, IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null)
+        public static IEnumerable<Page<ConfigurationSetting>> AsPages(this Pageable<ConfigurationSetting> pageable, IEnumerable<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null)
         {
             var conditionalPageable = pageable as ConditionalPageable;
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientExtensions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientExtensions.cs
@@ -13,10 +13,12 @@ namespace Azure.Data.AppConfiguration
     public static class ConfigurationClientExtensions
     {
         /// <summary>
-        /// Enumerate the values a <see cref="Page{T}"/> at a time. This may make multiple service requests.
+        /// Enumerate the values a <see cref="Page{T}"/> at a time, if they satisfy the match conditions for each page.
+        /// This can be used to efficiently check for changes to a cache of pages of settings. This may make multiple
+        /// service requests.
         /// </summary>
         /// <param name="pageable">The pageable object.</param>
-        /// <param name="conditions">The match conditions. Conditions are applied to pages one by one in the order specified.</param>
+        /// <param name="conditions">The match conditions. Conditions are applied to pages one by one in enumeration order.</param>
         /// <param name="continuationToken"> A continuation token indicating where to resume paging or null to begin paging from the beginning.</param>
         /// <param name="pageSizeHint">
         /// The number of items per <see cref="Page{T}"/> that should be requested (from service operations that support it). It's not guaranteed
@@ -30,6 +32,8 @@ namespace Azure.Data.AppConfiguration
         /// </exception>
         public static IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(this AsyncPageable<ConfigurationSetting> pageable, IEnumerable<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null)
         {
+            Argument.AssertNotNull(conditions, nameof(conditions));
+
             var conditionalPageable = pageable as AsyncConditionalPageable;
 
             if (conditionalPageable is null)
@@ -41,10 +45,12 @@ namespace Azure.Data.AppConfiguration
         }
 
         /// <summary>
-        /// Enumerate the values a <see cref="Page{T}"/> at a time. This may make multiple service requests.
+        /// Enumerate the values a <see cref="Page{T}"/> at a time, if they satisfy the match conditions for each page.
+        /// This can be used to efficiently check for changes to a cache of pages of settings. This may make multiple
+        /// service requests.
         /// </summary>
         /// <param name="pageable">The pageable object.</param>
-        /// <param name="conditions">The match conditions. Conditions are applied to pages one by one in the order specified.</param>
+        /// <param name="conditions">The match conditions. Conditions are applied to pages one by one in enumeration order.</param>
         /// <param name="continuationToken"> A continuation token indicating where to resume paging or null to begin paging from the beginning.</param>
         /// <param name="pageSizeHint">
         /// The number of items per <see cref="Page{T}"/> that should be requested (from service operations that support it). It's not guaranteed
@@ -58,6 +64,8 @@ namespace Azure.Data.AppConfiguration
         /// </exception>
         public static IEnumerable<Page<ConfigurationSetting>> AsPages(this Pageable<ConfigurationSetting> pageable, IEnumerable<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null)
         {
+            Argument.AssertNotNull(conditions, nameof(conditions));
+
             var conditionalPageable = pageable as ConditionalPageable;
 
             if (conditionalPageable is null)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingSelector.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingSelector.cs
@@ -49,12 +49,6 @@ namespace Azure.Data.AppConfiguration
         public DateTimeOffset? AcceptDateTime { get; set; }
 
         /// <summary>
-        /// The match conditions of <see cref="ConfigurationClient.GetConfigurationSettings(SettingSelector, CancellationToken)"/>
-        /// requests. Conditions are applied to pages one by one in the order specified.
-        /// </summary>
-        public IList<MatchConditions> MatchConditions { get; } = new ChangeTrackingList<MatchConditions>();
-
-        /// <summary>
         /// Creates a default <see cref="SettingSelector"/> that will retrieve all <see cref="ConfigurationSetting"/> entities in the configuration store.
         /// </summary>
         public SettingSelector() { }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/AsyncConditionalPageable.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/AsyncConditionalPageable.cs
@@ -16,7 +16,7 @@ namespace Azure.Data.AppConfiguration
         }
 
         public override IAsyncEnumerator<ConfigurationSetting> GetAsyncEnumerator(CancellationToken cancellationToken = default) => _implementation.GetAsyncEnumerator(cancellationToken);
-        public override IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync([], continuationToken, pageSizeHint, default);
-        public IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(conditions, continuationToken, pageSizeHint, default);
+        public override IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(new List<MatchConditions>(), continuationToken, pageSizeHint, default);
+        public IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(IEnumerable<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(conditions, continuationToken, pageSizeHint, default);
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/AsyncConditionalPageable.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/AsyncConditionalPageable.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Azure.Data.AppConfiguration
+{
+    internal class AsyncConditionalPageable : AsyncPageable<ConfigurationSetting>
+    {
+        private readonly ConditionalPageableImplementation _implementation;
+
+        public AsyncConditionalPageable(ConditionalPageableImplementation implementation)
+        {
+            _implementation = implementation;
+        }
+
+        public override IAsyncEnumerator<ConfigurationSetting> GetAsyncEnumerator(CancellationToken cancellationToken = default) => _implementation.GetAsyncEnumerator(cancellationToken);
+        public override IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(new List<MatchConditions>(), continuationToken, pageSizeHint, default);
+        public IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(conditions, continuationToken, pageSizeHint, default);
+    }
+}

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/AsyncConditionalPageable.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/AsyncConditionalPageable.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -16,7 +17,7 @@ namespace Azure.Data.AppConfiguration
         }
 
         public override IAsyncEnumerator<ConfigurationSetting> GetAsyncEnumerator(CancellationToken cancellationToken = default) => _implementation.GetAsyncEnumerator(cancellationToken);
-        public override IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(new List<MatchConditions>(), continuationToken, pageSizeHint, default);
+        public override IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(Array.Empty<MatchConditions>(), continuationToken, pageSizeHint, default);
         public IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(IEnumerable<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(conditions, continuationToken, pageSizeHint, default);
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/AsyncConditionalPageable.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/AsyncConditionalPageable.cs
@@ -16,7 +16,7 @@ namespace Azure.Data.AppConfiguration
         }
 
         public override IAsyncEnumerator<ConfigurationSetting> GetAsyncEnumerator(CancellationToken cancellationToken = default) => _implementation.GetAsyncEnumerator(cancellationToken);
-        public override IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(new List<MatchConditions>(), continuationToken, pageSizeHint, default);
+        public override IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync([], continuationToken, pageSizeHint, default);
         public IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPagesAsync(conditions, continuationToken, pageSizeHint, default);
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageable.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageable.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Azure.Data.AppConfiguration
@@ -14,7 +15,7 @@ namespace Azure.Data.AppConfiguration
             _implementation = implementation;
         }
 
-        public override IEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPages(new List<MatchConditions>(), continuationToken, pageSizeHint);
+        public override IEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPages(Array.Empty<MatchConditions>(), continuationToken, pageSizeHint);
         public IEnumerable<Page<ConfigurationSetting>> AsPages(IEnumerable<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPages(conditions, continuationToken, pageSizeHint);
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageable.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageable.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.Data.AppConfiguration
+{
+    internal class ConditionalPageable : Pageable<ConfigurationSetting>
+    {
+        private readonly ConditionalPageableImplementation _implementation;
+
+        public ConditionalPageable(ConditionalPageableImplementation implementation)
+        {
+            _implementation = implementation;
+        }
+
+        public override IEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPages(new List<MatchConditions>(), continuationToken, pageSizeHint);
+        public IEnumerable<Page<ConfigurationSetting>> AsPages(IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPages(conditions, continuationToken, pageSizeHint);
+    }
+}

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageable.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageable.cs
@@ -15,6 +15,6 @@ namespace Azure.Data.AppConfiguration
         }
 
         public override IEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPages(new List<MatchConditions>(), continuationToken, pageSizeHint);
-        public IEnumerable<Page<ConfigurationSetting>> AsPages(IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPages(conditions, continuationToken, pageSizeHint);
+        public IEnumerable<Page<ConfigurationSetting>> AsPages(IEnumerable<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null) => _implementation.AsPages(conditions, continuationToken, pageSizeHint);
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
@@ -73,7 +73,7 @@ namespace Azure.Data.AppConfiguration
             string nextLink = null;
             do
             {
-                var response = GetNextResponse(null, null, nextLink);
+                var response = GetNextResponse(conditions: null, pageSizeHint: null, nextLink);
                 if (!TryGetItemsFromResponse(response, out nextLink, out var items))
                 {
                     continue;

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
@@ -153,9 +153,9 @@ namespace Azure.Data.AppConfiguration
         }
 
         private HttpMessage CreateMessage(MatchConditions conditions, int? pageSizeHint, string nextLink) =>
-            string.IsNullOrEmpty(nextLink) ?
-                _createFirstPageRequest(conditions, pageSizeHint) :
-                _createNextPageRequest(conditions, pageSizeHint, nextLink);
+            string.IsNullOrEmpty(nextLink)
+                ? _createFirstPageRequest(conditions, pageSizeHint)
+                : _createNextPageRequest(conditions, pageSizeHint, nextLink);
 
         private Response GetResponse(HttpMessage message)
         {
@@ -175,21 +175,18 @@ namespace Azure.Data.AppConfiguration
                 items = default;
                 return false;
             }
-
-            var parsedResponse = _responseParser(response);
-            items = parsedResponse.Values;
-            nextLink = parsedResponse.NextLink;
-            return items is not null;
-        }
-
-        private Page<ConfigurationSetting> CreatePage(Response response, out string nextLink)
-        {
-            if (!TryGetItemsFromResponse(response, out nextLink, out var items))
+            else
             {
-                return Page<ConfigurationSetting>.FromValues(Array.Empty<ConfigurationSetting>(), nextLink, response);
+                var parsedResponse = _responseParser(response);
+                items = parsedResponse.Values;
+                nextLink = parsedResponse.NextLink;
+                return items is not null;
             }
-
-            return Page<ConfigurationSetting>.FromValues(items, nextLink, response);
         }
+
+        private Page<ConfigurationSetting> CreatePage(Response response, out string nextLink) =>
+            TryGetItemsFromResponse(response, out nextLink, out var items)
+                ? Page<ConfigurationSetting>.FromValues(items, nextLink, response)
+                : Page<ConfigurationSetting>.FromValues(Array.Empty<ConfigurationSetting>(), nextLink, response);
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Data.AppConfiguration
+{
+    internal class ConditionalPageableImplementation
+    {
+        private readonly Func<MatchConditions, int?, HttpMessage> _createFirstPageRequest;
+        private readonly Func<MatchConditions, int?, string, HttpMessage> _createNextPageRequest;
+        private readonly HttpPipeline _pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly Func<Response, (List<ConfigurationSetting> Values, string NextLink)> _responseParser;
+        private readonly string _scopeName;
+        private readonly CancellationToken _cancellationToken;
+        private readonly ErrorOptions? _errorOptions;
+
+        public ConditionalPageableImplementation(Func<MatchConditions, int?, HttpMessage> createFirstPageRequest, Func<MatchConditions, int?, string, HttpMessage> createNextPageRequest, Func<Response, (List<ConfigurationSetting> Values, string NextLink)> responseParser, HttpPipeline pipeline, ClientDiagnostics clientDiagnostics, string scopeName, RequestContext requestContext)
+        {
+            _createFirstPageRequest = createFirstPageRequest;
+            _createNextPageRequest = createNextPageRequest;
+            _responseParser = responseParser;
+            _pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _scopeName = scopeName;
+            _cancellationToken = requestContext?.CancellationToken ?? default;
+            _errorOptions = requestContext?.ErrorOptions ?? ErrorOptions.Default;
+        }
+
+        public async IAsyncEnumerator<ConfigurationSetting> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            string nextLink = null;
+            do
+            {
+                var response = await GetNextResponseAsync(null, null, nextLink, cancellationToken).ConfigureAwait(false);
+                if (!TryGetItemsFromResponse(response, out nextLink, out var items))
+                {
+                    continue;
+                }
+
+                foreach (var item in items)
+                {
+                    yield return item;
+                }
+            } while (!string.IsNullOrEmpty(nextLink));
+        }
+
+        public async IAsyncEnumerable<Page<ConfigurationSetting>> AsPagesAsync(IList<MatchConditions> conditionsList, string continuationToken, int? pageSizeHint, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            string nextLink = continuationToken;
+            int nextConditionsIndex = 0;
+            do
+            {
+                var conditions = (nextConditionsIndex < conditionsList.Count) ? conditionsList[nextConditionsIndex++] : null;
+                var response = await GetNextResponseAsync(conditions, pageSizeHint, nextLink, cancellationToken).ConfigureAwait(false);
+                if (response is null)
+                {
+                    yield break;
+                }
+                yield return CreatePage(response, out nextLink);
+            } while (!string.IsNullOrEmpty(nextLink));
+        }
+
+        public IEnumerator<ConfigurationSetting> GetEnumerator()
+        {
+            string nextLink = null;
+            do
+            {
+                var response = GetNextResponse(null, null, nextLink);
+                if (!TryGetItemsFromResponse(response, out nextLink, out var items))
+                {
+                    continue;
+                }
+
+                foreach (var item in items)
+                {
+                    yield return item;
+                }
+            } while (!string.IsNullOrEmpty(nextLink));
+        }
+
+        public IEnumerable<Page<ConfigurationSetting>> AsPages(IList<MatchConditions> conditionsList, string continuationToken, int? pageSizeHint)
+        {
+            string nextLink = continuationToken;
+            int nextConditionsIndex = 0;
+            do
+            {
+                var conditions = (nextConditionsIndex < conditionsList.Count) ? conditionsList[nextConditionsIndex++] : null;
+                var response = GetNextResponse(conditions, pageSizeHint, nextLink);
+                if (response is null)
+                {
+                    yield break;
+                }
+                yield return CreatePage(response, out nextLink);
+            } while (!string.IsNullOrEmpty(nextLink));
+        }
+
+        private Response GetNextResponse(MatchConditions conditions, int? pageSizeHint, string nextLink)
+        {
+            var message = CreateMessage(conditions, pageSizeHint, nextLink);
+            if (message == null)
+            {
+                return null;
+            }
+
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope(_scopeName);
+            scope.Start();
+            try
+            {
+                _pipeline.Send(message, _cancellationToken);
+                return GetResponse(message);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        private async ValueTask<Response> GetNextResponseAsync(MatchConditions conditions, int? pageSizeHint, string nextLink, CancellationToken cancellationToken)
+        {
+            var message = CreateMessage(conditions, pageSizeHint, nextLink);
+            if (message == null)
+            {
+                return null;
+            }
+
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope(_scopeName);
+            scope.Start();
+            try
+            {
+                if (cancellationToken.CanBeCanceled && _cancellationToken.CanBeCanceled)
+                {
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancellationToken);
+                    await _pipeline.SendAsync(message, cts.Token).ConfigureAwait(false);
+                }
+                else
+                {
+                    var ct = cancellationToken.CanBeCanceled ? cancellationToken : _cancellationToken;
+                    await _pipeline.SendAsync(message, ct).ConfigureAwait(false);
+                }
+
+                return GetResponse(message);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        private HttpMessage CreateMessage(MatchConditions conditions, int? pageSizeHint, string nextLink)
+        {
+            if (!string.IsNullOrEmpty(nextLink))
+            {
+                return _createNextPageRequest(conditions, pageSizeHint, nextLink);
+            }
+
+            return _createFirstPageRequest(conditions, pageSizeHint);
+        }
+
+        private Response GetResponse(HttpMessage message)
+        {
+            if (message.Response.IsError && _errorOptions != ErrorOptions.NoThrow)
+            {
+                throw new RequestFailedException(message.Response);
+            }
+
+            return message.Response;
+        }
+
+        private bool TryGetItemsFromResponse(Response response, out string nextLink, out List<ConfigurationSetting> items)
+        {
+            if (response is null)
+            {
+                nextLink = default;
+                items = default;
+                return false;
+            }
+
+            var parsedResponse = _responseParser(response);
+            items = parsedResponse.Values;
+            nextLink = parsedResponse.NextLink;
+            return items is not null;
+        }
+
+        private Page<ConfigurationSetting> CreatePage(Response response, out string nextLink)
+        {
+            if (!TryGetItemsFromResponse(response, out nextLink, out var items))
+            {
+                return Page<ConfigurationSetting>.FromValues(Array.Empty<ConfigurationSetting>(), nextLink, response);
+            }
+
+            return Page<ConfigurationSetting>.FromValues(items, nextLink, response);
+        }
+    }
+}

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
@@ -152,15 +152,10 @@ namespace Azure.Data.AppConfiguration
             }
         }
 
-        private HttpMessage CreateMessage(MatchConditions conditions, int? pageSizeHint, string nextLink)
-        {
-            if (!string.IsNullOrEmpty(nextLink))
-            {
-                return _createNextPageRequest(conditions, pageSizeHint, nextLink);
-            }
-
-            return _createFirstPageRequest(conditions, pageSizeHint);
-        }
+        private HttpMessage CreateMessage(MatchConditions conditions, int? pageSizeHint, string nextLink) =>
+            string.IsNullOrEmpty(nextLink) ?
+                _createFirstPageRequest(conditions, pageSizeHint) :
+                _createNextPageRequest(conditions, pageSizeHint, nextLink);
 
         private Response GetResponse(HttpMessage message)
         {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
@@ -20,7 +20,7 @@ namespace Azure.Data.AppConfiguration
         private readonly Func<Response, (List<ConfigurationSetting> Values, string NextLink)> _responseParser;
         private readonly string _scopeName;
         private readonly CancellationToken _cancellationToken;
-        private readonly ErrorOptions? _errorOptions;
+        private readonly ErrorOptions _errorOptions;
 
         public ConditionalPageableImplementation(Func<MatchConditions, int?, HttpMessage> createFirstPageRequest, Func<MatchConditions, int?, string, HttpMessage> createNextPageRequest, Func<Response, (List<ConfigurationSetting> Values, string NextLink)> responseParser, HttpPipeline pipeline, ClientDiagnostics clientDiagnostics, string scopeName, RequestContext requestContext)
         {
@@ -127,10 +127,6 @@ namespace Azure.Data.AppConfiguration
         private async ValueTask<Response> GetNextResponseAsync(MatchConditions conditions, int? pageSizeHint, string nextLink, CancellationToken cancellationToken)
         {
             var message = CreateMessage(conditions, pageSizeHint, nextLink);
-            if (message == null)
-            {
-                return null;
-            }
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope(_scopeName);
             scope.Start();
@@ -168,7 +164,7 @@ namespace Azure.Data.AppConfiguration
 
         private Response GetResponse(HttpMessage message)
         {
-            if (message.Response.IsError && _errorOptions != ErrorOptions.NoThrow)
+            if (message.Response.IsError && !_errorOptions.HasFlag(ErrorOptions.NoThrow))
             {
                 throw new RequestFailedException(message.Response);
             }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConditionalPageableImplementation.cs
@@ -52,13 +52,13 @@ namespace Azure.Data.AppConfiguration
             } while (!string.IsNullOrEmpty(nextLink));
         }
 
-        public async IAsyncEnumerable<Page<ConfigurationSetting>> AsPagesAsync(IList<MatchConditions> conditionsList, string continuationToken, int? pageSizeHint, [EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<Page<ConfigurationSetting>> AsPagesAsync(IEnumerable<MatchConditions> conditionsEnumerable, string continuationToken, int? pageSizeHint, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
+            var enumerator = conditionsEnumerable.GetEnumerator();
             string nextLink = continuationToken;
-            int nextConditionsIndex = 0;
             do
             {
-                var conditions = (nextConditionsIndex < conditionsList.Count) ? conditionsList[nextConditionsIndex++] : null;
+                var conditions = enumerator.MoveNext() ? enumerator.Current : null;
                 var response = await GetNextResponseAsync(conditions, pageSizeHint, nextLink, cancellationToken).ConfigureAwait(false);
                 if (response is null)
                 {
@@ -86,13 +86,13 @@ namespace Azure.Data.AppConfiguration
             } while (!string.IsNullOrEmpty(nextLink));
         }
 
-        public IEnumerable<Page<ConfigurationSetting>> AsPages(IList<MatchConditions> conditionsList, string continuationToken, int? pageSizeHint)
+        public IEnumerable<Page<ConfigurationSetting>> AsPages(IEnumerable<MatchConditions> conditionsEnumerable, string continuationToken, int? pageSizeHint)
         {
+            var enumerator = conditionsEnumerable.GetEnumerator();
             string nextLink = continuationToken;
-            int nextConditionsIndex = 0;
             do
             {
-                var conditions = (nextConditionsIndex < conditionsList.Count) ? conditionsList[nextConditionsIndex++] : null;
+                var conditions = enumerator.MoveNext() ? enumerator.Current : null;
                 var response = GetNextResponse(conditions, pageSizeHint, nextLink);
                 if (response is null)
                 {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConfigurationSettingPageableExtensions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Pageable/ConfigurationSettingPageableExtensions.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Azure.Data.AppConfiguration
+{
+    /// <summary>
+    /// Extension methods to support <see cref="Pageable{T}"/> and <see cref="AsyncPageable{T}"/> features.
+    /// </summary>
+    public static class ConfigurationSettingPageableExtensions
+    {
+        /// <summary>
+        /// Enumerate the values a <see cref="Page{T}"/> at a time. This may make multiple service requests.
+        /// </summary>
+        /// <param name="pageable">The pageable object.</param>
+        /// <param name="conditions">The match conditions. Conditions are applied to pages one by one in the order specified.</param>
+        /// <param name="continuationToken"> A continuation token indicating where to resume paging or null to begin paging from the beginning.</param>
+        /// <param name="pageSizeHint">
+        /// The number of items per <see cref="Page{T}"/> that should be requested (from service operations that support it). It's not guaranteed
+        /// that the value will be respected.
+        /// </param>
+        /// <returns>An async sequence of <see cref="Page{T}"/>s.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the pageable used does not support this operation. Only objects returned by the
+        /// <see cref="ConfigurationClient.GetConfigurationSettingsAsync(SettingSelector, CancellationToken)"/>
+        /// support it.
+        /// </exception>
+        public static IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(this AsyncPageable<ConfigurationSetting> pageable, IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null)
+        {
+            var conditionalPageable = pageable as AsyncConditionalPageable;
+
+            if (conditionalPageable is null)
+            {
+                throw new InvalidOperationException("Operation not supported by this pageable object.");
+            }
+
+            return conditionalPageable.AsPages(conditions, continuationToken, pageSizeHint);
+        }
+
+        /// <summary>
+        /// Enumerate the values a <see cref="Page{T}"/> at a time. This may make multiple service requests.
+        /// </summary>
+        /// <param name="pageable">The pageable object.</param>
+        /// <param name="conditions">The match conditions. Conditions are applied to pages one by one in the order specified.</param>
+        /// <param name="continuationToken"> A continuation token indicating where to resume paging or null to begin paging from the beginning.</param>
+        /// <param name="pageSizeHint">
+        /// The number of items per <see cref="Page{T}"/> that should be requested (from service operations that support it). It's not guaranteed
+        /// that the value will be respected.
+        /// </param>
+        /// <returns>A sequence of <see cref="Page{T}"/>s.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the pageable used does not support this operation. Only objects returned by the
+        /// <see cref="ConfigurationClient.GetConfigurationSettings(SettingSelector, CancellationToken)"/>
+        /// support it.
+        /// </exception>
+        public static IEnumerable<Page<ConfigurationSetting>> AsPages(this Pageable<ConfigurationSetting> pageable, IList<MatchConditions> conditions, string continuationToken = null, int? pageSizeHint = null)
+        {
+            var conditionalPageable = pageable as ConditionalPageable;
+
+            if (conditionalPageable is null)
+            {
+                throw new InvalidOperationException("Operation not supported by this pageable object.");
+            }
+
+            return conditionalPageable.AsPages(conditions, continuationToken, pageSizeHint);
+        }
+    }
+}

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -38,14 +38,21 @@ namespace Azure.Data.AppConfiguration.Tests
             return prefix + Recording.GenerateId();
         }
 
-        private ConfigurationClient GetClient()
+        private ConfigurationClient GetClient(bool skipClientInstrumentation = false)
         {
             if (string.IsNullOrEmpty(TestEnvironment.ConnectionString))
             {
                 throw new TestRecordingMismatchException();
             }
             var options = InstrumentClientOptions(new ConfigurationClientOptions(_serviceVersion));
-            return InstrumentClient(new ConfigurationClient(TestEnvironment.ConnectionString, options));
+            var client = new ConfigurationClient(TestEnvironment.ConnectionString, options);
+
+            if (!skipClientInstrumentation)
+            {
+                client = InstrumentClient(client);
+            }
+
+            return client;
         }
 
         private ConfigurationClient GetAADClient()
@@ -925,10 +932,11 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [AsyncOnly]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task GetBatchSettingIfChangedWithUnmodifiedPage()
         {
-            ConfigurationClient service = GetClient();
+            ConfigurationClient service = GetClient(skipClientInstrumentation: true);
 
             const int expectedEvents = 105;
             var key = await SetMultipleKeys(service, expectedEvents);
@@ -947,14 +955,9 @@ namespace Azure.Data.AppConfiguration.Tests
                 matchConditionsList.Add(matchConditions);
             }
 
-            foreach (MatchConditions matchConditions in matchConditionsList)
-            {
-                selector.MatchConditions.Add(matchConditions);
-            }
-
             int pagesCount = 0;
 
-            await foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettingsAsync(selector).AsPages())
+            await foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettingsAsync(selector).AsPages(matchConditionsList))
             {
                 Response response = page.GetRawResponse();
 
@@ -968,10 +971,50 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [SyncOnly]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
+        public async Task GetBatchSettingIfChangedWithUnmodifiedPageSync()
+        {
+            ConfigurationClient service = GetClient(skipClientInstrumentation: true);
+
+            const int expectedEvents = 105;
+            var key = await SetMultipleKeys(service, expectedEvents);
+
+            SettingSelector selector = new SettingSelector { KeyFilter = key };
+            var matchConditionsList = new List<MatchConditions>();
+
+            foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettings(selector).AsPages())
+            {
+                Response response = page.GetRawResponse();
+                var matchConditions = new MatchConditions()
+                {
+                    IfNoneMatch = response.Headers.ETag
+                };
+
+                matchConditionsList.Add(matchConditions);
+            }
+
+            int pagesCount = 0;
+
+            foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettings(selector).AsPages(matchConditionsList))
+            {
+                Response response = page.GetRawResponse();
+
+                Assert.AreEqual(304, response.Status);
+                Assert.IsEmpty(page.Values);
+
+                pagesCount++;
+            }
+
+            Assert.AreEqual(2, pagesCount);
+        }
+
+        [RecordedTest]
+        [AsyncOnly]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task GetBatchSettingIfChangedWithModifiedPage()
         {
-            ConfigurationClient service = GetClient();
+            ConfigurationClient service = GetClient(skipClientInstrumentation: true);
 
             const int expectedEvents = 105;
             var key = await SetMultipleKeys(service, expectedEvents);
@@ -992,9 +1035,56 @@ namespace Azure.Data.AppConfiguration.Tests
                 lastSetting = page.Values.Last();
             }
 
-            foreach (MatchConditions matchConditions in matchConditionsList)
+            lastSetting.Value += "1";
+            await service.SetConfigurationSettingAsync(lastSetting);
+
+            int pagesCount = 0;
+
+            await foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettingsAsync(selector).AsPages(matchConditionsList))
             {
-                selector.MatchConditions.Add(matchConditions);
+                Response response = page.GetRawResponse();
+
+                if (pagesCount == 0)
+                {
+                    Assert.AreEqual(304, response.Status);
+                    Assert.IsEmpty(page.Values);
+                }
+                else
+                {
+                    Assert.AreEqual(200, response.Status);
+                    Assert.IsNotEmpty(page.Values);
+                }
+
+                pagesCount++;
+            }
+
+            Assert.AreEqual(2, pagesCount);
+        }
+
+        [RecordedTest]
+        [SyncOnly]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
+        public async Task GetBatchSettingIfChangedWithModifiedPageSync()
+        {
+            ConfigurationClient service = GetClient(skipClientInstrumentation: true);
+
+            const int expectedEvents = 105;
+            var key = await SetMultipleKeys(service, expectedEvents);
+
+            SettingSelector selector = new SettingSelector { KeyFilter = key };
+            var matchConditionsList = new List<MatchConditions>();
+            ConfigurationSetting lastSetting = null;
+
+            foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettings(selector).AsPages())
+            {
+                Response response = page.GetRawResponse();
+                var matchConditions = new MatchConditions()
+                {
+                    IfNoneMatch = response.Headers.ETag
+                };
+
+                matchConditionsList.Add(matchConditions);
+                lastSetting = page.Values.Last();
             }
 
             lastSetting.Value += "1";
@@ -1002,7 +1092,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             int pagesCount = 0;
 
-            await foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettingsAsync(selector).AsPages())
+            foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettings(selector).AsPages(matchConditionsList))
             {
                 Response response = page.GetRawResponse();
 


### PR DESCRIPTION
Based on architect feedback, the `SettingSelector.MatchConditions` property was removed and replaced with an `AsPages` extension method.

New usage is:
```cs
foreach (Page<ConfigurationSetting> page in service.GetConfigurationSettings(selector).AsPages(matchConditionsList))
{
}
```