### PR TITLE
[WebJobs][EventHubsExtension] Fix metrics when azure checkpoint container does not exist

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             }
 
             await Task.WhenAll(partitionPropertiesTasks).ConfigureAwait(false);
-            EventProcessorCheckpoint[] checkpoints;
+            EventProcessorCheckpoint[] checkpoints = null;
 
             try
             {
@@ -81,7 +81,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             catch
             {
                 // GetCheckpointsAsync would log
-                return metrics;
             }
 
             return CreateTriggerMetrics(partitionPropertiesTasks.Select(t => t.Result).ToList(), checkpoints);
@@ -103,7 +102,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             {
                 var partitionProperties = partitionRuntimeInfo[i];
 
-                var checkpoint = (BlobCheckpointStoreInternal.BlobStorageCheckpoint)checkpoints.SingleOrDefault(c => c?.PartitionId == partitionProperties.Id);
+                BlobCheckpointStoreInternal.BlobStorageCheckpoint checkpoint = null;
+                if (checkpoints != null)
+                {
+                    checkpoint = (BlobCheckpointStoreInternal.BlobStorageCheckpoint)checkpoints.SingleOrDefault(c => c?.PartitionId == partitionProperties.Id);
+                }
 
                 // Check for the unprocessed messages when there are messages on the Event Hub partition
                 // In that case, LastEnqueuedSequenceNumber will be >= 0

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var metrics = await _metricsProvider.GetMetricsAsync();
 
             Assert.AreEqual(1, metrics.PartitionCount);
-            Assert.AreEqual(0, metrics.EventCount);
+            Assert.AreEqual(1, metrics.EventCount);
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
             // Generic Exception
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             metrics = await _metricsProvider.GetMetricsAsync();
 
             Assert.AreEqual(1, metrics.PartitionCount);
-            Assert.AreEqual(0, metrics.EventCount);
+            Assert.AreEqual(1, metrics.EventCount);
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
             _loggerProvider.ClearAllLogMessages();


### PR DESCRIPTION
If the container "azure-webjobs-eventhub" does not exist - scaling logic is not able to detect new EH messages.

