### PR TITLE
[Service Bus] Test hang fix

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -630,7 +630,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         }
 
         [Test]
-        public async Task CancellingReceiveLogsVerboseCancellationEvent()
+        public async Task CancelingReceiveLogsVerboseCancellationEvent()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a typo causing a test to hang indefinitely. The assertions in this test were causing an exception that prevented the handler from running, which in turn caused the exit condition to never be met.