### PR TITLE
[DevCenter] Fix Test Resource Clean Up

### DIFF
--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DeploymentEnvironmentsClientTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DeploymentEnvironmentsClientTests.cs
@@ -146,13 +146,6 @@ namespace Azure.Developer.DevCenter.Tests
         }
 
         [Test]
-        public async Task CreateAndDeleteEnvironmentSucceeds()
-        {
-            await SetUpEnvironmentAsync();
-            await DeleteEnvironmentAsync();
-        }
-
-        [Test]
         public async Task GetEnvironmentSucceeds()
         {
             DevCenterEnvironment environment = await GetEnvironmentAsync();
@@ -216,6 +209,16 @@ namespace Azure.Developer.DevCenter.Tests
             Assert.IsTrue(EnvName.Equals(envName, StringComparison.OrdinalIgnoreCase));
         }
 
+        [OneTimeTearDown]
+        public async Task TearDownAsync()
+        {
+             await _environmentsClient.DeleteEnvironmentAsync(
+                WaitUntil.Completed,
+                TestEnvironment.ProjectName,
+                TestEnvironment.MeUserId,
+                EnvName);
+        }
+
         private async Task<DevCenterEnvironment> GetEnvironmentAsync()
         {
             try
@@ -263,17 +266,6 @@ namespace Azure.Developer.DevCenter.Tests
 
             EnvironmentProvisioningState? provisioningState = environmentCreateOperation.Value.ProvisioningState;
             Assert.IsTrue(provisioningState.Equals(EnvironmentProvisioningState.Succeeded));
-        }
-
-        private async Task DeleteEnvironmentAsync()
-        {
-            Operation environmentDeleteOperation = await _environmentsClient.DeleteEnvironmentAsync(
-                WaitUntil.Completed,
-                TestEnvironment.ProjectName,
-                TestEnvironment.MeUserId,
-                EnvName);
-
-            CheckLROSucceeded(environmentDeleteOperation);
         }
 
         private void CheckLROSucceeded(Operation finalOperationResponse)

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DevBoxesClientTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DevBoxesClientTests.cs
@@ -322,14 +322,16 @@ namespace Azure.Developer.DevCenter.Tests
                 "schedule-default");
 
             Assert.AreEqual((int)HttpStatusCode.NoContent, skipActionResponse.Status);
+        }
 
-            Operation devBoxDeleteOperation = await _devBoxesClient.DeleteDevBoxAsync(
+        [OneTimeTearDown]
+        public async Task TearDownAsync()
+        {
+            await _devBoxesClient.DeleteDevBoxAsync(
                WaitUntil.Completed,
                TestEnvironment.ProjectName,
                TestEnvironment.MeUserId,
                DevBoxName);
-
-            CheckLROSucceeded(devBoxDeleteOperation);
         }
 
         private async Task SetUpDevBoxAsync()


### PR DESCRIPTION
DevCenter test pipeline was failing due to reaching quota limit for the region.  That happened because the `Remove test resources` step in all previous tests were failing to delete the resource groups. The underlying reason is that `environments` blocks cascade delete, so we should delete that ourselves in the end of the tests, instead of relying on RG deletion for that. 

Adding the `TearDown` to fix the issue. 