### PR TITLE
updated PlaySourceInfo parameter to playSource and added overload methods with target participant for hold and unhold methos

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Core.Pipeline;
 
 namespace Azure.Communication.CallAutomation
@@ -511,7 +510,7 @@ namespace Azure.Communication.CallAutomation
                     CommunicationIdentifierSerializer.Serialize(options.TargetParticipant))
                 {
                     OperationContext = options.OperationContext,
-                    PlaySourceInfo = TranslatePlaySourceToInternal(options.PlaySourceInfo),
+                    PlaySourceInfo = TranslatePlaySourceToInternal(options.PlaySource),
                     OperationCallbackUri = options.OperationCallbackUri?.AbsoluteUri,
                 };
 
@@ -540,7 +539,7 @@ namespace Azure.Communication.CallAutomation
                     CommunicationIdentifierSerializer.Serialize(options.TargetParticipant))
                 {
                     OperationContext = options.OperationContext,
-                    PlaySourceInfo = TranslatePlaySourceToInternal(options.PlaySourceInfo),
+                    PlaySourceInfo = TranslatePlaySourceToInternal(options.PlaySource),
                     OperationCallbackUri = options.OperationCallbackUri?.AbsoluteUri,
                 };
 
@@ -599,6 +598,99 @@ namespace Azure.Communication.CallAutomation
             }
         }
 
+        /// <summary>
+        /// Hold participant from the call.
+        /// </summary>
+        /// <param name="targetParticipant">The options.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public virtual async Task<Response> HoldAsync(CommunicationIdentifier targetParticipant, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallMedia)}.{nameof(StartHoldMusicAsync)}");
+            scope.Start();
+            try
+            {
+                var request = new HoldRequestInternal(
+                    CommunicationIdentifierSerializer.Serialize(targetParticipant));
+
+                return await CallMediaRestClient.HoldAsync(CallConnectionId, request, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Hold participant from the call.
+        /// </summary>
+        /// <param name="targetParticipant">The options.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public virtual Response Hold(CommunicationIdentifier targetParticipant, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallMedia)}.{nameof(Hold)}");
+            scope.Start();
+            try
+            {
+                var request = new HoldRequestInternal(
+                    CommunicationIdentifierSerializer.Serialize(targetParticipant));
+
+                return CallMediaRestClient.Hold(CallConnectionId, request, cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Remove hold from participant.
+        /// </summary>
+        /// <param name="targetParticipant">The options.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public virtual async Task<Response> UnholdAsync(CommunicationIdentifier targetParticipant, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallMedia)}.{nameof(StopHoldMusicAsync)}");
+            scope.Start();
+            try
+            {
+                var request = new UnholdRequestInternal(CommunicationIdentifierSerializer.Serialize(targetParticipant));
+
+                return await CallMediaRestClient.UnholdAsync(CallConnectionId, request, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Remove hold from participant.
+        /// </summary>
+        /// <param name="targetParticipant">The options.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public virtual Response Unhold(CommunicationIdentifier targetParticipant, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallMedia)}.{nameof(StopHoldMusicAsync)}");
+            scope.Start();
+            try
+            {
+                var request = new UnholdRequestInternal(CommunicationIdentifierSerializer.Serialize(targetParticipant));
+
+                return CallMediaRestClient.Unhold(CallConnectionId, request, cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
         private static RecognizeRequestInternal CreateRecognizeRequest(CallMediaRecognizeOptions recognizeOptions)
         {
             if (recognizeOptions == null)

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
@@ -601,7 +601,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// Hold participant from the call.
         /// </summary>
-        /// <param name="targetParticipant">The options.</param>
+        /// <param name="targetParticipant">The target participant.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public virtual async Task<Response> HoldAsync(CommunicationIdentifier targetParticipant, CancellationToken cancellationToken = default)
@@ -625,7 +625,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// Hold participant from the call.
         /// </summary>
-        /// <param name="targetParticipant">The options.</param>
+        /// <param name="targetParticipant">The target participant.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public virtual Response Hold(CommunicationIdentifier targetParticipant, CancellationToken cancellationToken = default)
@@ -649,7 +649,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// Remove hold from participant.
         /// </summary>
-        /// <param name="targetParticipant">The options.</param>
+        /// <param name="targetParticipant">The target participant.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public virtual async Task<Response> UnholdAsync(CommunicationIdentifier targetParticipant, CancellationToken cancellationToken = default)
@@ -672,7 +672,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// Remove hold from participant.
         /// </summary>
-        /// <param name="targetParticipant">The options.</param>
+        /// <param name="targetParticipant">The target participant.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public virtual Response Unhold(CommunicationIdentifier targetParticipant, CancellationToken cancellationToken = default)

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/HoldOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/HoldOptions.cs
@@ -26,7 +26,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// Prompt to play while on hold.
         /// </summary>
-        public PlaySource PlaySourceInfo { get; set; }
+        public PlaySource PlaySource { get; set; }
 
         /// <summary>
         /// The operation context to correlate the request to the response event.

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-using NUnit.Framework;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace Azure.Communication.CallAutomation.Tests.CallMedias
 {
@@ -135,7 +135,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 VoiceKind = VoiceKind.Female,
                 VoiceName = "LULU"
             },
-            SpeechLanguage= "en-US",
+            SpeechLanguage = "en-US",
             SpeechModelEndpointId = "customModelEndpointId"
         };
 
@@ -154,7 +154,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         private static readonly HoldOptions _holdOptions = new HoldOptions(new CommunicationUserIdentifier("targetUserId"))
         {
             OperationContext = "operationContext",
-            PlaySourceInfo = _textSource,
+            PlaySource = _textSource,
             OperationCallbackUri = new Uri("https://localhost")
         };
 


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
