### PR TITLE
[Communication][PhoneNumbers] Fix update capabilities test

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/assets.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/communication/Azure.Communication.PhoneNumbers",
-  "Tag": "net/communication/Azure.Communication.PhoneNumbers_862930fd40"
+  "Tag": "net/communication/Azure.Communication.PhoneNumbers_ab86664f5c"
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/Infrastructure/PhoneNumbersClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/Infrastructure/PhoneNumbersClientLiveTestBase.cs
@@ -20,7 +20,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
         public PhoneNumbersClientLiveTestBase(bool isAsync) : base(isAsync)
         {
-            SanitizedHeaders.Add("location");
+            HeaderRegexSanitizers.Add(new HeaderRegexSanitizer("location", SanitizeValue)
+            {
+                Regex = PhoneNumberRegEx
+            });
             BodyRegexSanitizers.Add(new BodyRegexSanitizer(PhoneNumberRegEx, SanitizeValue));
             UriRegexSanitizers.Add(new UriRegexSanitizer(PhoneNumberRegEx, SanitizeValue));
             UriRegexSanitizers.Add(new UriRegexSanitizer(URIDomainNameReplacerRegEx, "https://sanitized.communication.azure.com"));

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
@@ -604,7 +604,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
         [Test]
         [AsyncOnly]
-        [Ignore("Test is failing in playback mode due to an issue with LRO not completing")]
         public async Task UpdateCapabilitiesAsync()
         {
             if (TestEnvironment.ShouldIgnorePhoneNumbersTests || SkipUpdateCapabilitiesLiveTest)
@@ -629,7 +628,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
         [Test]
         [SyncOnly]
-        [Ignore("Test is failing in playback mode due to an issue with LRO not completing")]
         public void UpdateCapabilities()
         {
             if (TestEnvironment.ShouldIgnorePhoneNumbersTests || SkipUpdateCapabilitiesLiveTest)
@@ -721,7 +719,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
         [Test]
         [AsyncOnly]
-        [Ignore("Test is failing in playback mode due to an infinite loop")]
         public async Task GetTollFreeAreaCodesAsyncAsPages()
         {
             var client = CreateClient();
@@ -758,7 +755,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
         [Test]
         [SyncOnly]
-        [Ignore("Test is failing in playback mode due to an infinite loop")]
         public void GetTollFreeAreaCodesAsPages()
         {
             var client = CreateClient();
@@ -832,7 +828,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
         [Test]
         [AsyncOnly]
-        [Ignore("Test is failing in playback mode due to an infinite loop")]
         public async Task GetGeographicAreaCodesAsyncAsPages()
         {
             var client = CreateClient();
@@ -870,7 +865,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
         [Test]
         [SyncOnly]
-        [Ignore("Test is failing in playback mode due to an infinite loop")]
         public void GetGeographicAreaCodesAsPages()
         {
             var client = CreateClient();


### PR DESCRIPTION
The sanitization of the whole location attribute in the response headers was preventing the UpdateCapabilities test to fetch the correct request URI after waiting for the LRO to complete. 

It was updated to just sanitize the phonenumber and the ignore flags have been removed.
