### PR TITLE
Set non alpha version in package properties file

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -89,6 +89,7 @@ jobs:
       - pwsh: |
           # Reset SkipDevBuildNumber as empty
           echo "##vso[task.setvariable variable=SkipDevBuildNumber]"
+          Write-Host "SkipDevBuildNumber: [$(SkipDevBuildNumber)]"
           $skipDevBuildNumber = "false"
           # For .NET builds the only case we want to not have dev build numbers on our packages is when it is manually queued and
           # the SetDevVersion property isn't set to true. All other cases should contain dev version numbers.

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -88,7 +88,8 @@ jobs:
           ServiceDirectory: ${{parameters.ServiceDirectory}}
       - pwsh: |
           # Reset SkipDevBuildNumber as empty
-          echo "##vso[task.setvariable variable=SkipDevBuildNumber]"
+          $skipDevBuildNumber = ""
+          echo "##vso[task.setvariable variable=SkipDevBuildNumber]$skipDevBuildNumber"
           Write-Host "SkipDevBuildNumber: [$(SkipDevBuildNumber)]"
           $skipDevBuildNumber = "false"
           # For .NET builds the only case we want to not have dev build numbers on our packages is when it is manually queued and

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -87,9 +87,8 @@ jobs:
         parameters:
           ServiceDirectory: ${{parameters.ServiceDirectory}}
       - pwsh: |
-          echo "##vso[task.setvariable variable=SkipDevBuildNumber]false"
-        displayName: "Reset SkipDevBuildNumber env variable"
-      - pwsh: |
+          # Reset SkipDevBuildNumber as empty
+          echo "##vso[task.setvariable variable=SkipDevBuildNumber]"
           $skipDevBuildNumber = "false"
           # For .NET builds the only case we want to not have dev build numbers on our packages is when it is manually queued and
           # the SetDevVersion property isn't set to true. All other cases should contain dev version numbers.

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -85,7 +85,7 @@ jobs:
         displayName: "Set SkipDevBuildNumber env variable"
       - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
         parameters:
-          ServiceDirectory ${{parameters.ServiceDirectory}}
+          ServiceDirectory: ${{parameters.ServiceDirectory}}
       - pwsh: |
           echo "##vso[task.setvariable variable=SkipDevBuildNumber]false"
         displayName: "Reset SkipDevBuildNumber env variable"

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -78,11 +78,15 @@ jobs:
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"
         condition: and(eq(variables['Build.SourceBranchName'],variables['DefaultBranch']),eq(variables['Build.Reason'],'Schedule'))
-      # Both 'Dump property properties' and 'Update package properties with dev version' serve the same purpose of generating package json.
-      # We decided to only run the later one (update properties) in all pipelines for the following reasons:
-      # 1. 'Update properties' happens after 'build', we will have more information at the 'update properties' step.
-      # 2. We did not find any usage of package json before 'update properties' in .NET, so it is safe to skip the 'dump properties' for now.
+      # Set env variable to Skip Dev build to generate package properties with non dev version
+      # Package version is used to create or update package work item from CI pipeline
+      - pwsh: |
+          $skipDevBuildNumber = "true"
+          echo "##vso[task.setvariable variable=SkipDevBuildNumber]$skipDevBuildNumber"
+        displayName: "Set SkipDevBuildNumber env variable"
       - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+        parameters:
+          ServiceDirectory ${{parameters.ServiceDirectory}}
       - pwsh: |
           $skipDevBuildNumber = "false"
           # For .NET builds the only case we want to not have dev build numbers on our packages is when it is manually queued and

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -78,7 +78,7 @@ jobs:
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"
         condition: and(eq(variables['Build.SourceBranchName'],variables['DefaultBranch']),eq(variables['Build.Reason'],'Schedule'))
-      # Set env variable to Skip Dev build to generate package properties with non dev version
+      # Set env variable SkipDevBuildNumber to generate package properties with non alpha version
       # Package version is used to create or update package work item from CI pipeline
       - pwsh: |
           $skipDevBuildNumber = "true"

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -81,12 +81,14 @@ jobs:
       # Set env variable SkipDevBuildNumber to generate package properties with non alpha version
       # Package version is used to create or update package work item from CI pipeline
       - pwsh: |
-          $skipDevBuildNumber = "true"
-          echo "##vso[task.setvariable variable=SkipDevBuildNumber]$skipDevBuildNumber"
+          echo "##vso[task.setvariable variable=SkipDevBuildNumber]true"
         displayName: "Set SkipDevBuildNumber env variable"
       - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
         parameters:
           ServiceDirectory ${{parameters.ServiceDirectory}}
+      - pwsh: |
+          echo "##vso[task.setvariable variable=SkipDevBuildNumber]false"
+        displayName: "Reset SkipDevBuildNumber env variable"
       - pwsh: |
           $skipDevBuildNumber = "false"
           # For .NET builds the only case we want to not have dev build numbers on our packages is when it is manually queued and


### PR DESCRIPTION
.NET CI pipeline create package properties file only after setting package version as alpha. This PR is to create package properties file before updating version as alpha so we can update correct package version in Package work item and APIView.