### PR TITLE
Mark .NET package as shipped in APIView

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -167,6 +167,14 @@ stages:
                                 /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat)
                                 /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat)
                                 /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)
+                          - template: /eng/common/pipelines/templates/steps/create-apireview.yml
+                            parameters:
+                              ArtifactPath: $(Pipeline.Workspace)
+                              Artifacts: ${{parameters.Artifacts}}
+                              ConfigFileDir: $(Pipeline.Workspace)/PackageInfo
+                              MarkPackageAsShipped: true
+                              ArtifactName: ${{parameters.ArtifactName}}
+                              PackageName: ${{artifact.name}}
 
               - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
                 - deployment: PublicDocsMS

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -169,9 +169,9 @@ stages:
                                 /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)
                           - template: /eng/common/pipelines/templates/steps/create-apireview.yml
                             parameters:
-                              ArtifactPath: $(Pipeline.Workspace)
+                              ArtifactPath: $(Pipeline.Workspace)/packages
                               Artifacts: ${{parameters.Artifacts}}
-                              ConfigFileDir: $(Pipeline.Workspace)/PackageInfo
+                              ConfigFileDir: $(Pipeline.Workspace)/packages/PackageInfo
                               MarkPackageAsShipped: true
                               ArtifactName: ${{parameters.ArtifactName}}
                               PackageName: ${{artifact.name}}

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -156,7 +156,7 @@ stages:
                     runOnce:
                       deploy:
                         steps:
-                          - checkout: none
+                          - checkout: self
                           - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
                           - task: MSBuild@1
                             displayName: 'Upload Symbols for ${{artifact.name}}'


### PR DESCRIPTION
Change to mark package as shipped after releasing a package to Nuget.