### PR TITLE
ServiceBusSessionMessageActions management APIs

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Update proto for support for `ServiceBusSessionMessageActions` and `RenewMessageLock` method.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/Proto/settlement.proto
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/Proto/settlement.proto
@@ -21,17 +21,20 @@ service Settlement {
   // Defers a message
   rpc Defer (DeferRequest) returns (google.protobuf.Empty) {}
 
-  // Get
-  rpc Get (GetRequest) returns (GetResponse) {}
+  // Renew message lock
+  rpc RenewMessageLock (RenewMessageLockRequest) returns (google.protobuf.Empty) {}
 
-  // Set
-  rpc Set (SetRequest) returns (google.protobuf.Empty) {}
+  // Get session state
+  rpc GetSessionState (GetSessionStateRequest) returns (GetSessionStateResponse) {}
 
-  // Release
-  rpc Release (ReleaseSession) returns (google.protobuf.Empty) {}
+  // Set session state
+  rpc SetSessionState (SetSessionStateRequest) returns (google.protobuf.Empty) {}
 
-  // Renew
-  rpc Renew (RenewSessionLock) returns (RenewSessionLockResponse) {}
+  // Release session
+  rpc ReleaseSession (ReleaseSessionRequest) returns (google.protobuf.Empty) {}
+
+  // Renew session lock
+  rpc RenewSessionLock (RenewSessionLockRequest) returns (RenewSessionLockResponse) {}
 }
 
 // The complete message request containing the locktoken.
@@ -59,29 +62,34 @@ message DeferRequest {
   bytes propertiesToModify = 2;
 }
 
+// The renew message lock request containing the locktoken.
+message RenewMessageLockRequest {
+  string locktoken = 1;
+}
+
 // The get message request.
-message GetRequest {
+message GetSessionStateRequest {
   string sessionId = 1;
 }
 
 // The set message request.
-message SetRequest {
+message SetSessionStateRequest {
   string sessionId = 1;
   bytes sessionState = 2;
 }
 
 // Get response containing the session state.
-message GetResponse {
+message GetSessionStateResponse {
   bytes sessionState = 1;
 }
 
 // Release session.
-message ReleaseSession {
+message ReleaseSessionRequest {
   string sessionId = 1;
 }
 
 // Renew session lock.
-message RenewSessionLock {
+message RenewSessionLockRequest {
   string sessionId = 1;
 }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/Proto/settlement.proto
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/Proto/settlement.proto
@@ -31,10 +31,7 @@ service Settlement {
   rpc Release (ReleaseSession) returns (google.protobuf.Empty) {}
 
   // Renew
-  rpc Renew (RenewSessionLock) returns (google.protobuf.Empty) {}
-
-  // SessionLockedUntil property
-  rpc SessionLocked (SessionLockedUntil) returns (SessionLockedUntilResponse) {}
+  rpc Renew (RenewSessionLock) returns (RenewSessionLockResponse) {}
 }
 
 // The complete message request containing the locktoken.
@@ -88,12 +85,7 @@ message RenewSessionLock {
   string sessionId = 1;
 }
 
-// Session locked until property response.
-message SessionLockedUntil {
-  string sessionId = 1;
-}
-
-// Session locked until property response.
-message SessionLockedUntilResponse {
+// Renew session lock.
+message RenewSessionLockResponse {
   google.protobuf.Timestamp lockedUntil = 1;
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/Proto/settlement.proto
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/Proto/settlement.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/timestamp.proto";
 
 // this namespace will be shared between isolated worker and WebJobs extension so make it somewhat generic
 option csharp_namespace = "Microsoft.Azure.ServiceBus.Grpc";
@@ -32,7 +33,8 @@ service Settlement {
   // Renew
   rpc Renew (RenewSessionLock) returns (google.protobuf.Empty) {}
 
-
+  // SessionLockedUntil property
+  rpc SessionLocked (SessionLockedUntil) returns (SessionLockedUntilResponse) {}
 }
 
 // The complete message request containing the locktoken.
@@ -71,14 +73,27 @@ message SetRequest {
   bytes sessionState = 2;
 }
 
+// Get response containing the session state.
 message GetResponse {
-	bytes sessionState = 1;
+  bytes sessionState = 1;
 }
 
 // Release session.
 message ReleaseSession {
+  string sessionId = 1;
 }
 
 // Renew session lock.
 message RenewSessionLock {
+  string sessionId = 1;
+}
+
+// Session locked until property response.
+message SessionLockedUntil {
+  string sessionId = 1;
+}
+
+// Session locked until property response.
+message SessionLockedUntilResponse {
+  google.protobuf.Timestamp lockedUntil = 1;
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/Proto/settlement.proto
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/Proto/settlement.proto
@@ -19,6 +19,20 @@ service Settlement {
 
   // Defers a message
   rpc Defer (DeferRequest) returns (google.protobuf.Empty) {}
+
+  // Get
+  rpc Get (GetRequest) returns (GetResponse) {}
+
+  // Set
+  rpc Set (SetRequest) returns (google.protobuf.Empty) {}
+
+  // Release
+  rpc Release (ReleaseSession) returns (google.protobuf.Empty) {}
+
+  // Renew
+  rpc Renew (RenewSessionLock) returns (google.protobuf.Empty) {}
+
+
 }
 
 // The complete message request containing the locktoken.
@@ -44,4 +58,27 @@ message DeadletterRequest {
 message DeferRequest {
   string locktoken = 1;
   bytes propertiesToModify = 2;
+}
+
+// The get message request.
+message GetRequest {
+  string sessionId = 1;
+}
+
+// The set message request.
+message SetRequest {
+  string sessionId = 1;
+  bytes sessionState = 2;
+}
+
+message GetResponse {
+	bytes sessionState = 1;
+}
+
+// Release session.
+message ReleaseSession {
+}
+
+// Renew session lock.
+message RenewSessionLock {
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/SettlementService.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/SettlementService.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Grpc
             {
                 if (_provider.SessionActionsCache.TryGetValue(request.SessionId, out var actions))
                 {
-                    await actions.SetSessionStateAsync(BinaryData.FromString(request.SessionState.ToStringUtf8()),
+                    await actions.SetSessionStateAsync(BinaryData.FromBytes(request.SessionState.ToByteArray()),
                                                        context.CancellationToken).ConfigureAwait(false);
                     return new Empty();
                 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/SettlementService.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Grpc/SettlementService.cs
@@ -185,36 +185,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Grpc
             throw new RpcException(new Status(StatusCode.FailedPrecondition, $"SessionId {request.SessionId} not found."));
         }
 
-        public override async Task<Empty> Renew(RenewSessionLock request, ServerCallContext context)
+        public override async Task<RenewSessionLockResponse> Renew(RenewSessionLock request, ServerCallContext context)
         {
             try
             {
                 if (_provider.SessionActionsCache.TryGetValue(request.SessionId, out var actions))
                 {
                     await actions.RenewSessionLockAsync().ConfigureAwait(false);
-                    return new Empty();
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new RpcException(new Status(StatusCode.Unknown, ex.ToString()));
-            }
-
-            throw new RpcException(new Status(StatusCode.FailedPrecondition, $"SessionId {request.SessionId} not found."));
-        }
-
-        public override Task<SessionLockedUntilResponse> SessionLocked(SessionLockedUntil request, ServerCallContext context)
-        {
-            try
-            {
-                if (_provider.SessionActionsCache.TryGetValue(request.SessionId, out var actions))
-                {
-                    return Task.FromResult(
-                        new SessionLockedUntilResponse
-                        {
-                            LockedUntil = actions.SessionLockedUntil.ToTimestamp()
-                        }
-                    );
+                    return new RenewSessionLockResponse
+                    {
+                        LockedUntil = actions.SessionLockedUntil.ToTimestamp()
+                    };
                 }
             }
             catch (Exception ex)

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -384,7 +384,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             {
                 var actions = new ServiceBusSessionMessageActions(args);
                 _messagingProvider.ActionsCache.TryAdd(args.Message.LockToken, (args.Message, actions));
-                _messagingProvider.SessionActionsCache.TryAdd(args.Message.SessionId, actions);
+                if (_isSessionsEnabled)
+                {
+                    _messagingProvider.SessionActionsCache.TryAdd(args.Message.SessionId, actions);
+                }
 
                 if (!await _sessionMessageProcessor.Value.BeginProcessingMessageAsync(actions, args.Message, linkedCts.Token)
                     .ConfigureAwait(false))
@@ -729,7 +732,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 foreach (var message in input.Messages)
                 {
                     _messagingProvider.ActionsCache.TryRemove(message.LockToken, out _);
-                    _messagingProvider.ActionsCache.TryRemove(message.SessionId, out _);
+                    if (_isSessionsEnabled)
+                    {
+                        _messagingProvider.SessionActionsCache.TryRemove(message.SessionId, out _);
+                    }
                 }
             }
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -412,7 +412,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 {
                     receiveActions.EndExecutionScope();
                     _messagingProvider.ActionsCache.TryRemove(args.Message.LockToken, out _);
-                    _messagingProvider.SessionActionsCache.TryRemove(args.Message.SessionId, out _);
+                    if (_isSessionsEnabled)
+                    {
+                        _messagingProvider.SessionActionsCache.TryRemove(args.Message.SessionId, out _);
+                    }
                 }
             }
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessagingProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessagingProvider.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         internal ConcurrentDictionary<string, ServiceBusReceiver> MessageReceiverCache { get; } = new();
         internal ConcurrentDictionary<string, ServiceBusClient> ClientCache { get; } = new();
         internal ConcurrentDictionary<string, (ServiceBusReceivedMessage Message, ServiceBusMessageActions Actions)> ActionsCache { get; } = new();
+        internal ConcurrentDictionary<string, ServiceBusSessionMessageActions> SessionActionsCache { get; } = new();
 
         /// <summary>
         /// Initializes a new instance of <see cref="MessagingProvider"/>.

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcEndToEndTests.cs
@@ -492,8 +492,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     new RenewMessageLockRequest { Locktoken = message.LockToken },
                     new MockServerCallContext());
                 _waitHandle1.Set();
-
-                Assert.True(message.LockedUntil > lockedBefore);
             }
         }
     }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcEndToEndTests.cs
@@ -232,6 +232,27 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.IsEmpty(provider.ActionsCache);
         }
 
+        [Test]
+        public async Task BindToMessageAndRenewMessageLock()
+        {
+            var host = BuildHost<ServiceBusBindToMessageAndRenewMessageLock>();
+            var settlementImpl = host.Services.GetRequiredService<SettlementService>();
+            var provider = host.Services.GetRequiredService<MessagingProvider>();
+            ServiceBusBindToMessageAndRenewMessageLock.SettlementService = settlementImpl;
+            await using ServiceBusClient client = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
+
+            using (host)
+            {
+                var message = new ServiceBusMessage("foobar");
+                var sender = client.CreateSender(FirstQueueScope.QueueName);
+                await sender.SendMessageAsync(message);
+
+                bool result = _waitHandle1.WaitOne(SBTimeoutMills);
+                Assert.True(result);
+            }
+            Assert.IsEmpty(provider.ActionsCache);
+        }
+
         public class ServiceBusBindToMessageAndComplete
         {
             internal static SettlementService SettlementService { get; set; }
@@ -456,6 +477,23 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     },
                     new MockServerCallContext());
                 _waitHandle1.Set();
+            }
+        }
+
+        public class ServiceBusBindToMessageAndRenewMessageLock
+        {
+            internal static SettlementService SettlementService { get; set; }
+            public static async Task BindToMessage(
+                [ServiceBusTrigger(FirstQueueNameKey)] ServiceBusReceivedMessage message, ServiceBusReceiveActions receiveActions)
+            {
+                Assert.AreEqual("foobar", message.Body.ToString());
+                var lockedBefore = message.LockedUntil;
+                await SettlementService.RenewMessageLock(
+                    new RenewMessageLockRequest { Locktoken = message.LockToken },
+                    new MockServerCallContext());
+                _waitHandle1.Set();
+
+                Assert.True(message.LockedUntil > lockedBefore);
             }
         }
     }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcSessionEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcSessionEndToEndTests.cs
@@ -357,7 +357,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     new SetSessionStateRequest
                     {
                         SessionId = message.SessionId,
-                        SessionState = ByteString.CopyFromUtf8(message.Body.ToString())
+                        SessionState = ByteString.CopyFrom(predefinedData)
                     },
                     new MockServerCallContext()
                  );

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcSessionEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcSessionEndToEndTests.cs
@@ -364,8 +364,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     new MockServerCallContext()
                 );
                 _waitHandle1.Set();
-
-                Assert.True(lockedUntil < message.LockedUntil);
             }
         }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcSessionEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcSessionEndToEndTests.cs
@@ -287,14 +287,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 [ServiceBusTrigger(FirstQueueNameKey, IsSessionsEnabled = true)] ServiceBusReceivedMessage message, ServiceBusReceiveActions receiveActions)
             {
                 Assert.AreEqual("foobar", message.Body.ToString());
-                var lockBefore = message.LockedUntil;
                 await SettlementService.RenewMessageLock(
                     new RenewMessageLockRequest
                     {
                         Locktoken = message.LockToken,
                     },
                     new MockServerCallContext());
-                Assert.True(lockBefore < message.LockedUntil);
                 _waitHandle1.Set();
             }
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcSessionEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Grpc/ServiceBusGrpcSessionEndToEndTests.cs
@@ -166,6 +166,26 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        public async Task BindToSessionMessageAndSetAndGetBinaryData()
+        {
+            var host = BuildHost<ServiceBusBindToSessionMessageAndSetAndGet>();
+            var settlementImpl = host.Services.GetRequiredService<SettlementService>();
+            var provider = host.Services.GetRequiredService<MessagingProvider>();
+            ServiceBusBindToSessionMessageAndSetAndGet.SettlementService = settlementImpl;
+            await using ServiceBusClient client = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
+
+            using (host)
+            {
+                var message = new ServiceBusMessage(new BinaryData("foobar")) { SessionId = "sessionId" };
+                var sender = client.CreateSender(FirstQueueScope.QueueName);
+                await sender.SendMessageAsync(message);
+
+                bool result = _waitHandle1.WaitOne(SBTimeoutMills);
+                Assert.True(result);
+            }
+        }
+
+        [Test]
         public async Task BindToSessionMessageAndReleaseSession()
         {
             var host = BuildHost<ServiceBusBindToSessionMessageAndReleaseSession>();


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-functions-dotnet-worker/issues/2374

This PR has the web jobs changes needed to support ServiceBusSessionMessageActions and its APIs. I've added the grpc contracts to the existing settlement.proto so that the worker can use the same RPC protocol.