### PR TITLE
[AzureMonitorExporter] refactor resource attribute truncation

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -122,9 +122,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         private void SetResourceSdkVersionAndIkey(AzureMonitorResource? resource, string instrumentationKey)
         {
             InstrumentationKey = instrumentationKey;
-            Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName.Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength);
-            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance.Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength);
-            Tags[ContextTagKeys.AiApplicationVer.ToString()] = resource?.ServiceVersion.Truncate(SchemaConstants.Tags_AiApplicationVer_MaxLength);
+            Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName_Truncated;
+            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance_Truncated;
+            Tags[ContextTagKeys.AiApplicationVer.ToString()] = resource?.ServiceVersion_Truncated;
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -7,12 +7,28 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
     internal sealed class AzureMonitorResource
     {
-        internal string? RoleName { get; set; }
+        public AzureMonitorResource(
+            string? roleName,
+            string? roleInstance,
+            string? serviceVersion,
+            MonitorBase? monitorBaseData)
+        {
+            RoleName = roleName;
+            RoleName_Truncated = roleName.Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength);
+            RoleInstance = roleInstance;
+            RoleInstance_Truncated = roleInstance.Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength);
+            ServiceVersion_Truncated = serviceVersion.Truncate(SchemaConstants.Tags_AiApplicationVer_MaxLength);
+            MonitorBaseData = monitorBaseData;
+        }
 
-        internal string? RoleInstance { get; set; }
+        internal string? RoleName { get; }
+        internal string? RoleName_Truncated { get; }
 
-        internal string? ServiceVersion { get; set; }
+        internal string? RoleInstance { get; }
+        internal string? RoleInstance_Truncated { get; }
 
-        internal MonitorBase? MonitorBaseData { get; set; }
+        internal string? ServiceVersion_Truncated { get; }
+
+        internal MonitorBase? MonitorBaseData { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -7,6 +7,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
     internal sealed class AzureMonitorResource
     {
+        public AzureMonitorResource()
+        {
+        }
+
         public AzureMonitorResource(
             string? roleName,
             string? roleInstance,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -26,7 +26,6 @@ internal static class ResourceExtensions
             return null;
         }
 
-        AzureMonitorResource azureMonitorResource = new AzureMonitorResource();
         MetricsData? metricsData = null;
         AksResourceProcessor? aksResourceProcessor = null;
         string? serviceName = null;
@@ -88,29 +87,26 @@ internal static class ResourceExtensions
             }
         }
 
+        string? roleName = null, roleInstance = null;
+
         // TODO: Check if service.name as unknown_service should be sent.
         // (2023-07) we need to drop the "unknown_service."
         if (serviceName != null && serviceNamespace != null)
         {
-            azureMonitorResource.RoleName = string.Concat(serviceNamespace, "/", serviceName);
+            roleName = string.Concat(serviceNamespace, "/", serviceName);
         }
         else
         {
-            azureMonitorResource.RoleName = serviceName;
+            roleName = serviceName;
         }
 
         try
         {
-            azureMonitorResource.RoleInstance = serviceInstance ?? Dns.GetHostName();
+            roleInstance = serviceInstance ?? Dns.GetHostName();
         }
         catch (Exception ex)
         {
             AzureMonitorExporterEventSource.Log.ErrorInitializingRoleInstanceToHostName(ex);
-        }
-
-        if (serviceVersion != null)
-        {
-            azureMonitorResource.ServiceVersion = serviceVersion;
         }
 
         if (aksResourceProcessor != null)
@@ -120,19 +116,19 @@ internal static class ResourceExtensions
 
             if (hasDefaultServiceName != false && aksRoleName != null)
             {
-                azureMonitorResource.RoleName = aksRoleName;
+                roleName = aksRoleName;
             }
 
             if (serviceInstance == null && aksRoleInstanceName != null)
             {
-                azureMonitorResource.RoleInstance = aksRoleInstanceName;
+                roleInstance = aksRoleInstanceName;
             }
         }
 
         bool shouldReportMetricTelemetry = false;
         try
         {
-            var exportResource = Environment.GetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC);
+            var exportResource = Environment.GetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC); // TODO: CAN THIS BE CHANGED TO USE THE PLATFORM ABSTRACTION?
             if (exportResource != null && exportResource.Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 shouldReportMetricTelemetry = true;
@@ -142,15 +138,21 @@ internal static class ResourceExtensions
         {
         }
 
+        MonitorBase? monitorBaseData = null;
+
         if (shouldReportMetricTelemetry && metricsData != null)
         {
-            azureMonitorResource.MonitorBaseData = new MonitorBase
+            monitorBaseData = new MonitorBase
             {
                 BaseType = "MetricData",
                 BaseData = metricsData
             };
         }
 
-        return azureMonitorResource;
+        return new AzureMonitorResource(
+            roleName: roleName,
+            roleInstance: roleInstance,
+            serviceVersion: serviceVersion,
+            monitorBaseData: monitorBaseData);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -220,11 +220,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 logger.LogWarning(new Exception("Test Exception"), "Test Exception");
             }
 
-            var logResource = new AzureMonitorResource()
-            {
-                RoleName = "roleName",
-                RoleInstance = "roleInstance"
-            };
+            var logResource = new AzureMonitorResource(
+                roleName: "testRoleName",
+                roleInstance: "testRoleInstance",
+                serviceVersion: null,
+                monitorBaseData: null);
             var telemetryItem = LogsHelper.OtelToAzureMonitorLogs(new Batch<LogRecord>(logRecords.ToArray(), logRecords.Count), logResource, "Ikey");
 
             Assert.Equal(type, telemetryItem[0].Data.BaseType);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricHelperTests.cs
@@ -32,11 +32,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             doubleCounter.Add(123.45);
             provider.ForceFlush();
 
-            var metricResource = new AzureMonitorResource()
-            {
-                RoleName = "testRoleName",
-                RoleInstance = "testRoleInstance"
-            };
+            var metricResource = new AzureMonitorResource(
+                roleName: "testRoleName",
+                roleInstance: "testRoleInstance",
+                serviceVersion: null,
+                monitorBaseData: null);
             var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(new Batch<Metric>(metrics.ToArray(), 1), metricResource, "00000000-0000-0000-0000-000000000000");
             Assert.Single(telemetryItems);
             Assert.Equal("MetricData", telemetryItems[0].Data.BaseType);


### PR DESCRIPTION
The Exporter creates an instance of `AzureMonitorResource` at initialization and uses that to set Tags on `TelemetryItems`.
Currently, we apply truncation rules every time we create a new instance of `TelemetryItem`.
This PR moves those truncation rules to the `AzureMonitorResource` initialization.

## Changes
- refactor `AzureMonitorResource`
  - move truncation operations to the ctor.
  - rename properties with a "_Truncated" suffix and change to readonly. This indicates to any consumer that they've already been truncated and are safe to set on TelemetryItems.





## Notes
- StandardMetrics uses RoleName and RoleInstance without truncation.
    https://github.com/Azure/azure-sdk-for-net/blob/7aacf4280f2e7db25f54d1029d3dd44d5b19d6e4/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs#L79-L80

- The Truncate extension method safely handles null values.
    https://github.com/Azure/azure-sdk-for-net/blob/7aacf4280f2e7db25f54d1029d3dd44d5b19d6e4/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StringExtensions.cs#L19-L35