### PR TITLE
Fix serialization bug for sdk maps search

### DIFF
--- a/sdk/maps/Azure.Maps.Search/api/Azure.Maps.Search.netstandard2.0.cs
+++ b/sdk/maps/Azure.Maps.Search/api/Azure.Maps.Search.netstandard2.0.cs
@@ -749,7 +749,7 @@ namespace Azure.Maps.Search.Models
     {
         internal SearchAddressResult() { }
         public int? FuzzyLevel { get { throw null; } }
-        public Azure.Core.GeoJson.GeoPosition GeoBias { get { throw null; } }
+        public Azure.Core.GeoJson.GeoPosition? GeoBias { get { throw null; } }
         public int? NumResults { get { throw null; } }
         public string Query { get { throw null; } }
         public int? QueryTime { get { throw null; } }
@@ -766,7 +766,7 @@ namespace Azure.Maps.Search.Models
         public Azure.Maps.Search.Models.AddressRanges AddressRanges { get { throw null; } }
         public string DataSourceInfo { get { throw null; } }
         public Azure.Maps.Search.Models.MapsDataSource DataSources { get { throw null; } }
-        public System.TimeSpan DetourTime { get { throw null; } }
+        public System.TimeSpan? DetourTime { get { throw null; } }
         public double? DistanceInMeters { get { throw null; } }
         public Azure.Maps.Search.GeographicEntity? EntityType { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Maps.Search.Models.FacilityEntryPoint> EntryPoints { get { throw null; } }

--- a/sdk/maps/Azure.Maps.Search/src/Models/AddressDetails.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/AddressDetails.cs
@@ -23,8 +23,14 @@ namespace Azure.Maps.Search.Models
         internal BoundingBoxCompassNotation BoundingBoxInternal { get; }
 
         /// <summary> The bounding box of the location. </summary>
-        public GeoBoundingBox BoundingBox {
-            get {
+        public GeoBoundingBox BoundingBox
+        {
+            get
+            {
+                if (BoundingBoxInternal == null)
+                {
+                    return null;
+                }
                 String northeast = BoundingBoxInternal.NorthEast;
                 String[] northEast = northeast.Split(',');
                 double north = Convert.ToDouble(northEast[0], CultureInfo.InvariantCulture.NumberFormat);

--- a/sdk/maps/Azure.Maps.Search/src/Models/SearchAddressResult.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/SearchAddressResult.cs
@@ -31,6 +31,6 @@ namespace Azure.Maps.Search.Models
         /// <summary> The maximum fuzzy level required to provide Results. </summary>
         public int? FuzzyLevel => Summary.FuzzyLevel;
         /// <summary> Indication when the internal search engine has applied a geospatial bias to improve the ranking of results.  In  some methods, this can be affected by setting the lat and lon parameters where available.  In other cases it is  purely internal. </summary>
-        public GeoPosition GeoBias => Summary.GeoBias;
+        public GeoPosition? GeoBias => Summary.GeoBias;
     }
 }

--- a/sdk/maps/Azure.Maps.Search/src/Models/SearchAddressResultItem.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/SearchAddressResultItem.cs
@@ -43,8 +43,16 @@ namespace Azure.Maps.Search.Models
         internal int? DetourTimeInternal { get; }
 
         /// <summary> Detour time in seconds. Only returned for calls to the Search Along Route API. </summary>
-        public TimeSpan DetourTime {
-            get { return TimeSpan.FromSeconds((double) DetourTimeInternal); }
+        public TimeSpan? DetourTime
+        {
+            get
+            {
+                if (DetourTimeInternal == null)
+                {
+                    return null;
+                }
+                return TimeSpan.FromSeconds((double)DetourTimeInternal);
+            }
         }
 
         /// <summary> A location represented as a latitude and longitude using short names &apos;lat&apos; &amp; &apos;lon&apos;. </summary>

--- a/sdk/maps/Azure.Maps.Search/src/Models/SearchSummary.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/SearchSummary.cs
@@ -21,8 +21,16 @@ namespace Azure.Maps.Search.Models
         internal int ResultCount { get; }
 
         /// <summary> Public GeoBias of type GeoPosition from Azure.Core.GeoJson. Indication when the internal search engine has applied a geospatial bias to improve the ranking of results.  In  some methods, this can be affected by setting the lat and lon parameters where available.  In other cases it is  purely internal. </summary>
-        public GeoPosition GeoBias {
-            get { return new GeoPosition((double) GeoBiasInternal.Lon, (double) GeoBiasInternal.Lat); }
+        public GeoPosition? GeoBias
+        {
+            get
+            {
+                if (GeoBiasInternal == null)
+                {
+                    return null;
+                }
+                return new GeoPosition((double)GeoBiasInternal.Lon, (double)GeoBiasInternal.Lat);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-net#41805
Making the properties nullable as they are not required in the REST API response for search address.
