### PR TITLE
[CODEOWNERS] Provisioning label change over

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -175,12 +175,6 @@
 # ServiceLabel: %Bot Service
 # ServiceOwners:                                                   @sgellock
 
-# PRLabel: %CDK
-/sdk/provisioning/                                                 @JoshLove-msft @tg-msft
-
-# ServiceLabel: %CDK
-# AzureSdkOwners:                                                  @JoshLove-msft
-
 # ServiceLabel: %Cloud Shell
 # ServiceOwners:                                                   @maertendMSFT
 
@@ -759,6 +753,12 @@
 
 # ServiceLabel: %PostgreSQL
 # ServiceOwners:                                                   @sunilagarwal @lfittl-msft @sr-msft @niklarin
+
+# PRLabel: %Provisioning
+/sdk/provisioning/                                                 @JoshLove-msft @tg-msft
+
+# ServiceLabel: %Provisioning
+# AzureSdkOwners:                                                  @JoshLove-msft
 
 # PRLabel: %Quantum
 /sdk/quantum/Azure.Quantum.Jobs/                                   @xfield


### PR DESCRIPTION
# Summary

The focus of these changes is to update the `CDK` label use to `Provisioning`.  Once this merges, I'll delete the `CDK` label to complete change over.