### PR TITLE
Cleanup BitVector640 and remove incorrect comments

### DIFF
--- a/sdk/core/System.ClientModel/src/Internal/BitVector640.cs
+++ b/sdk/core/System.ClientModel/src/Internal/BitVector640.cs
@@ -5,7 +5,7 @@ namespace System.ClientModel.Internal;
 
 /// <summary>
 /// This type effectively stores 640 bool values, but compresses their storage
-/// into ten ulongs, where each bit of the ulong represents a single bool value.
+/// into ten unsigned long fields, where each bit of the ulong represents a single bool value.
 ///
 /// It exposes a public indexer so that the bool values can be accessed as a
 /// standard .NET collection API.
@@ -16,7 +16,7 @@ namespace System.ClientModel.Internal;
 /// </summary>
 internal struct BitVector640
 {
-    // Keeping ulongs as fields puts them on the stack.
+    // Ten unsigned long brackets to keep 640 bits.
     private ulong _bits0;
     private ulong _bits1;
     private ulong _bits2;
@@ -28,136 +28,66 @@ internal struct BitVector640
     private ulong _bits8;
     private ulong _bits9;
 
+    // To get or set the correct bit, we need to find a bracket and an offset inside bracket
+    // For that, we have GetBracket and GetOffset methods.
+    // ===================================================
+    // Example: find the bracket and the offset for index 621
+    // In binary form, 621 is 0b1001101101.
+    // First 4 bits represent the bracket number, while the last 6 bits represent the offset in the bracket
+    // (ulong is 64-bit type, hence offset is in the [0, 63] range)
+    //
+    //    9 - bracket number
+    // ╔══╩══╗
+    // 1 0 0 1 1 0 1 1 0 1
+    //         ╚════╦════╝
+    //              45 - offset in the bracket
+    // ╔════════════╩════════════════════════════════════════════════════════╗
+    // 00000000 00000000 00100000 00000000 00000000 00000000 00000000 00000000
+    //                     ↑
+    //      bit #45 in 64-bit mask (indexing starts with 0)
+    //
+    // To get the bracket number, we right shift the index by 6
+    //    (6 bits required to represent value in [0, 63] range)
+    // To get the offset, we apply the 0b111111 mask to the index to get value from the last 6 bits,
+    //    then shift left a single bit by that value to get mask for the bracket,
+    //    then apply mask to the bracket
+
+    private static ref ulong GetBracket(ref BitVector640 vector, int index)
+    {
+        switch (index >> 6)
+        {
+            case 0: return ref vector._bits0;
+            case 1: return ref vector._bits1;
+            case 2: return ref vector._bits2;
+            case 3: return ref vector._bits3;
+            case 4: return ref vector._bits4;
+            case 5: return ref vector._bits5;
+            case 6: return ref vector._bits6;
+            case 7: return ref vector._bits7;
+            case 8: return ref vector._bits8;
+            case 9: return ref vector._bits9;
+            default: throw new InvalidOperationException();
+        }
+    }
+
+    private static ulong GetOffset(int index)
+        => 1ul << (index & 0b111_111);
+
     public bool this[int i]
     {
-        readonly get
+        get
         {
-            // "Index" of the ulong the bit is stored in.
-            int index = i >> 6;
-
-            // i % 6, i.e. the offset of the bit in the ulong.
-            int mod = i & 0b111111;
-
-            // A mask that lets us access the single bit
-            ulong mask = 1ul << mod;
-
-            // The storage ulong and the mask
-            ulong bit = Get(index) & mask;
-
-            // If the bit equals the mask, the bit was set to true.
-            return bit == mask;
+            var bracket = GetBracket(ref this, i);
+            var offset = GetOffset(i);
+            return (bracket & offset) != 0;
         }
         set
         {
-            // "Index" of the ulong the bit is stored in.
-            int index = i >> 6;
-
-            // i % 6, i.e. the offset of the bit in the ulong.
-            int mod = i & 0b111111;
-
-            // A mask that lets us access the single bit
-            ulong mask = 1ul << mod;
-
-            // Set the bit in question to the passed-in value
-            Set(index, mask, value);
-        }
-    }
-
-    private readonly ulong Get(int index)
-    {
-        return index switch
-        {
-            0 => _bits0,
-            1 => _bits1,
-            2 => _bits2,
-            3 => _bits3,
-            4 => _bits4,
-            5 => _bits5,
-            6 => _bits6,
-            7 => _bits7,
-            8 => _bits8,
-            9 => _bits9,
-            _ => throw new InvalidOperationException(),
-        };
-    }
-
-    private void Set(int index, ulong mask, bool value)
-    {
-        if (value)
-        {
-            switch (index)
-            {
-                case 0:
-                    _bits0 |= mask;
-                    break;
-                case 1:
-                    _bits1 |= mask;
-                    break;
-                case 2:
-                    _bits2 |= mask;
-                    break;
-                case 3:
-                    _bits3 |= mask;
-                    break;
-                case 4:
-                    _bits4 |= mask;
-                    break;
-                case 5:
-                    _bits5 |= mask;
-                    break;
-                case 6:
-                    _bits6 |= mask;
-                    break;
-                case 7:
-                    _bits7 |= mask;
-                    break;
-                case 8:
-                    _bits8 |= mask;
-                    break;
-                case 9:
-                    _bits9 |= mask;
-                    break;
-                default:
-                    throw new InvalidOperationException();
-            }
-        }
-        else
-        {
-            switch (index)
-            {
-                case 0:
-                    _bits0 &= ~mask;
-                    break;
-                case 1:
-                    _bits1 &= ~mask;
-                    break;
-                case 2:
-                    _bits2 &= ~mask;
-                    break;
-                case 3:
-                    _bits3 &= ~mask;
-                    break;
-                case 4:
-                    _bits4 &= ~mask;
-                    break;
-                case 5:
-                    _bits5 &= ~mask;
-                    break;
-                case 6:
-                    _bits6 &= ~mask;
-                    break;
-                case 7:
-                    _bits7 &= ~mask;
-                    break;
-                case 8:
-                    _bits8 &= ~mask;
-                    break;
-                case 9:
-                    _bits9 &= ~mask;
-                    break;
-                default:
-                    throw new InvalidOperationException();
-            }
+            ref ulong bracket = ref GetBracket(ref this, i);
+            var offset = GetOffset(i);
+            bracket = value
+                ? bracket | offset
+                : bracket & ~offset;
         }
     }
 }

--- a/sdk/core/System.ClientModel/src/Internal/BitVector640.cs
+++ b/sdk/core/System.ClientModel/src/Internal/BitVector640.cs
@@ -18,18 +18,6 @@ namespace System.ClientModel.Internal;
 /// </summary>
 internal struct BitVector640
 {
-    // Ten unsigned long field to keep 640 bits.
-    private ulong _bits0;
-    private ulong _bits1;
-    private ulong _bits2;
-    private ulong _bits3;
-    private ulong _bits4;
-    private ulong _bits5;
-    private ulong _bits6;
-    private ulong _bits7;
-    private ulong _bits8;
-    private ulong _bits9;
-
     // To get or set the correct bit, we need to find a field and an offset inside field
     // For that, we have GetField and GetOffset methods.
     // ===================================================
@@ -54,23 +42,29 @@ internal struct BitVector640
     //    then shift left a single bit by that value to get mask for the field,
     //    then apply mask to the field
 
+    // Ten unsigned long field to keep 640 bits.
+#pragma warning disable CS0169 // Fields are used via Unsafe.As / Unsafe.Add in GetField
+    private ulong _bits0;
+    private ulong _bits1;
+    private ulong _bits2;
+    private ulong _bits3;
+    private ulong _bits4;
+    private ulong _bits5;
+    private ulong _bits6;
+    private ulong _bits7;
+    private ulong _bits8;
+    private ulong _bits9;
+#pragma warning restore CS0169 // Fields are used via Unsafe.As / Unsafe.Add in GetField
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref ulong GetField(ref BitVector640 vector, int index)
     {
-        switch (index >> 6)
+        if (index is < 0 or > 640)
         {
-            case 0: return ref vector._bits0;
-            case 1: return ref vector._bits1;
-            case 2: return ref vector._bits2;
-            case 3: return ref vector._bits3;
-            case 4: return ref vector._bits4;
-            case 5: return ref vector._bits5;
-            case 6: return ref vector._bits6;
-            case 7: return ref vector._bits7;
-            case 8: return ref vector._bits8;
-            case 9: return ref vector._bits9;
-            default: throw new InvalidOperationException();
+            throw new ArgumentOutOfRangeException(nameof(index), "Index must be in the range [0, 639]");
         }
+
+        return ref Unsafe.Add(ref Unsafe.As<BitVector640, ulong>(ref vector), index >> 6);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/sdk/core/System.ClientModel/src/Internal/BitVector640.cs
+++ b/sdk/core/System.ClientModel/src/Internal/BitVector640.cs
@@ -56,10 +56,9 @@ internal struct BitVector640
     private ulong _bits9;
 #pragma warning restore CS0169 // Fields are used via Unsafe.As / Unsafe.Add in GetField
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref ulong GetField(ref BitVector640 vector, int index)
     {
-        if (index is < 0 or > 640)
+        if (index is < 0 or > 639)
         {
             throw new ArgumentOutOfRangeException(nameof(index), "Index must be in the range [0, 639]");
         }

--- a/sdk/core/System.ClientModel/tests/internal/Internal/BitVectorTests.cs
+++ b/sdk/core/System.ClientModel/tests/internal/Internal/BitVectorTests.cs
@@ -56,4 +56,14 @@ public class BitVectorTests
             Assert.IsFalse(vector[i]);
         }
     }
+
+    [Test]
+    public void IndexerOutOfRange()
+    {
+        BitVector640 vector = new();
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = vector[-1]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = vector[640]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = vector[int.MinValue]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = vector[int.MaxValue]);
+    }
 }


### PR DESCRIPTION
Performance improvements:

| Method                        | Mean       | Error    | StdDev   |
|------------------------------ |-----------:|---------:|---------:|
| Read before change            | 1,042.3 ns | 10.16 ns |  9.50 ns |
| Read ref switch               |   741.7 ns |  9.52 ns |  8.44 ns |
| Read Unsafe                   |   409.8 ns |  4.20 ns |  3.93 ns |
| Read Unsafe with check        |   557.6 ns | 10.90 ns | 11.20 ns |

| Method                         | Mean       | Error    | StdDev   |
|------------------------------- |-----------:|---------:|---------:|
| Write before change            | 1,094.5 ns | 11.27 ns | 10.54 ns |
| Write ref switch               |   863.3 ns |  6.35 ns |  5.94 ns |
| Write Unsafe                   |   725.3 ns |  4.48 ns |  3.97 ns |
| Write Unsafe with check        |   733.0 ns |  5.13 ns |  4.55 ns |