### PR TITLE
[DevCenter] Fix Dev Center Tests

### DIFF
--- a/sdk/devcenter/Azure.Developer.DevCenter/assets.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/devcenter/Azure.Developer.DevCenter",
-  "Tag": "net/devcenter/Azure.Developer.DevCenter_95190a8afc"
+  "Tag": "net/devcenter/Azure.Developer.DevCenter_6bd03c25ea"
 }

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DeploymentEnvironmentsClientTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DeploymentEnvironmentsClientTests.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -146,22 +144,21 @@ namespace Azure.Developer.DevCenter.Tests
         }
 
         [Test]
-        public async Task CreateAndDeleteEnvironmentSucceeds()
+        public async Task CreateGetAndDeleteEnvironmentSucceeds()
         {
-            await SetUpEnvironmentAsync();
+            await CreateEnvironmentAsync();
+            await GetEnvironmentAsync();
+            await GetEnvironmentsAsync();
+            await GetAllEnvironmentsAsync();
             await DeleteEnvironmentAsync();
         }
 
-        [Test]
-        public async Task GetEnvironmentSucceeds()
+        private async Task GetEnvironmentAsync()
         {
-            DevCenterEnvironment environment = await GetEnvironmentAsync();
-
-            if (environment == default)
-            {
-                await SetUpEnvironmentAsync();
-                environment = await GetEnvironmentAsync();
-            }
+            DevCenterEnvironment environment = (await _environmentsClient.GetEnvironmentAsync(
+                    TestEnvironment.ProjectName,
+                    TestEnvironment.MeUserId,
+                    EnvName)).Value;
 
             string envName = environment.Name;
             if (string.IsNullOrWhiteSpace(envName))
@@ -172,80 +169,40 @@ namespace Azure.Developer.DevCenter.Tests
             Assert.IsTrue(EnvName.Equals(envName, StringComparison.OrdinalIgnoreCase));
         }
 
-        [Test]
-        public async Task GetEnvironmentsSucceeds()
+        private async Task GetEnvironmentsAsync()
         {
-            var environments = await GetEnvironmentsAsync();
-
-            if (!environments.Any())
-            {
-                await SetUpEnvironmentAsync();
-                environments = await GetEnvironmentsAsync();
-            }
-
-            Assert.AreEqual(1, environments.Count);
-
-            string envName = environments[0].Name;
-            if (string.IsNullOrWhiteSpace(envName))
-            {
-                FailDueToMissingProperty("name");
-            }
-
-            Assert.IsTrue(EnvName.Equals(envName, StringComparison.OrdinalIgnoreCase));
-        }
-
-        [Test]
-        public async Task GetAllEnvironmentsSucceeds()
-        {
-            var environments = await GetAllEnvironmentsAsync();
-
-            if (!environments.Any())
-            {
-                await SetUpEnvironmentAsync();
-                environments = await GetAllEnvironmentsAsync();
-            }
-
-            Assert.AreEqual(1, environments.Count);
-
-            string envName = environments[0].Name;
-            if (string.IsNullOrWhiteSpace(envName))
-            {
-                FailDueToMissingProperty("name");
-            }
-
-            Assert.IsTrue(EnvName.Equals(envName, StringComparison.OrdinalIgnoreCase));
-        }
-
-        private async Task<DevCenterEnvironment> GetEnvironmentAsync()
-        {
-            try
-            {
-                return (await _environmentsClient.GetEnvironmentAsync(
-                    TestEnvironment.ProjectName,
-                    TestEnvironment.MeUserId,
-                    EnvName)).Value;
-            }
-            // if environment doesn't exist Get Environment will throw an error
-            catch
-            {
-                return default;
-            }
-        }
-
-        private async Task<List<DevCenterEnvironment>> GetEnvironmentsAsync()
-        {
-            return await _environmentsClient.GetEnvironmentsAsync(
+            List<DevCenterEnvironment> environments = await _environmentsClient.GetEnvironmentsAsync(
                 TestEnvironment.ProjectName,
                 TestEnvironment.MeUserId).ToEnumerableAsync();
+
+            Assert.AreEqual(1, environments.Count);
+
+            string envName = environments[0].Name;
+            if (string.IsNullOrWhiteSpace(envName))
+            {
+                FailDueToMissingProperty("name");
+            }
+
+            Assert.IsTrue(EnvName.Equals(envName, StringComparison.OrdinalIgnoreCase));
         }
 
-        private async Task<List<DevCenterEnvironment>> GetAllEnvironmentsAsync()
+        private async Task GetAllEnvironmentsAsync()
         {
-            return await _environmentsClient.GetAllEnvironmentsAsync(
+            List<DevCenterEnvironment> environments = await _environmentsClient.GetAllEnvironmentsAsync(
                 TestEnvironment.ProjectName).ToEnumerableAsync();
+
+            Assert.AreEqual(1, environments.Count);
+
+            string envName = environments[0].Name;
+            if (string.IsNullOrWhiteSpace(envName))
+            {
+                FailDueToMissingProperty("name");
+            }
+
+            Assert.IsTrue(EnvName.Equals(envName, StringComparison.OrdinalIgnoreCase));
         }
 
-        private async Task SetUpEnvironmentAsync()
+        private async Task CreateEnvironmentAsync()
         {
             var environment = new DevCenterEnvironment
             (

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DevBoxesClientTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DevBoxesClientTests.cs
@@ -31,15 +31,16 @@ namespace Azure.Developer.DevCenter.Tests
         }
 
         [SetUp]
-        public async Task SetUpAsync()
+        public void SetUp()
         {
             _devBoxesClient = GetDevBoxesClient();
-            await SetUpDevBoxAsync();
         }
 
         [Test]
-        public async Task StartAndStopDevBoxSucceeds()
+        public async Task CreateStopAndStartDevBoxSucceeds()
         {
+            await CreateDevBoxAsync();
+
             // At this point we should have a running dev box, let's stop it
             Operation devBoxStopOperation = await _devBoxesClient.StopDevBoxAsync(
                 WaitUntil.Completed,
@@ -62,6 +63,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task RestartDevBoxSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             Operation devBoxRestartOperation = await _devBoxesClient.RestartDevBoxAsync(
                 WaitUntil.Completed,
                 TestEnvironment.ProjectName,
@@ -74,6 +77,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task GetRemoteConnectionSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             RemoteConnection remoteConnection = await _devBoxesClient.GetRemoteConnectionAsync(
                 TestEnvironment.ProjectName,
                 TestEnvironment.MeUserId,
@@ -101,6 +106,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task GetDevBoxSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             DevBox devBox = await _devBoxesClient.GetDevBoxAsync(
                 TestEnvironment.ProjectName,
                 TestEnvironment.MeUserId,
@@ -118,6 +125,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task GetDevBoxesSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             List<DevBox> devBoxes = await _devBoxesClient.GetDevBoxesAsync(
                 TestEnvironment.ProjectName,
                 TestEnvironment.MeUserId).ToEnumerableAsync();
@@ -136,6 +145,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task GetAllDevBoxesSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             List<DevBox> devBoxes = await _devBoxesClient.GetAllDevBoxesAsync().ToEnumerableAsync();
 
             Assert.AreEqual(1, devBoxes.Count);
@@ -152,6 +163,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task GetAllDevBoxesByUserSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             List<DevBox> devBoxes = await _devBoxesClient.GetAllDevBoxesByUserAsync(TestEnvironment.MeUserId).ToEnumerableAsync();
 
             Assert.AreEqual(1, devBoxes.Count);
@@ -235,6 +248,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task GetAndDelayActionSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             //only perform actions if it exists and it's in the 24hrs window
             if (!await HasDefaultActionIn24hrsAsync())
             {
@@ -278,6 +293,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task GetAndDelayAllActionsSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             List<DevBoxAction> devBoxActions = await _devBoxesClient.GetDevBoxActionsAsync(
                 TestEnvironment.ProjectName,
                 TestEnvironment.MeUserId,
@@ -314,6 +331,8 @@ namespace Azure.Developer.DevCenter.Tests
         [Test]
         public async Task SkipActionAndDeleteDevBoxSucceeds()
         {
+            await EnsureDevBoxExistsAsync();
+
             if (!await HasDefaultActionIn24hrsAsync())
             {
                 return;
@@ -336,42 +355,19 @@ namespace Azure.Developer.DevCenter.Tests
             CheckLROSucceeded(devBoxDeleteOperation);
         }
 
-        private async Task SetUpDevBoxAsync()
-        {
-            DevBox devBox = await GetDevBoxAsync();
-            if (devBox == default)
-            {
-                devBox = await CreateDevBoxAsync();
-            }
-
-            string devBoxName = devBox.Name;
-            if (string.IsNullOrWhiteSpace(devBoxName))
-            {
-                FailDueToMissingProperty("name");
-            }
-
-            Assert.AreEqual(devBoxName, DevBoxName);
-
-            DevBoxProvisioningState? devBoxProvisioningState = devBox.ProvisioningState;
-
-            // Both states indicate successful provisioning
-            bool devBoxProvisionSucceeded =
-                devBoxProvisioningState.Equals(DevBoxProvisioningState.Succeeded) ||
-                devBoxProvisioningState.Equals(DevBoxProvisioningState.ProvisionedWithWarning);
-
-            Assert.IsTrue(devBoxProvisionSucceeded);
-        }
-
-        private async Task<DevBox> GetDevBoxAsync()
+        private async Task EnsureDevBoxExistsAsync()
         {
             List<DevBox> devBoxes = await _devBoxesClient.GetDevBoxesAsync(
                 TestEnvironment.ProjectName,
                 TestEnvironment.MeUserId).ToEnumerableAsync();
 
-            return devBoxes.Where(d => d.Name.Equals(DevBoxName)).FirstOrDefault();
+            if (!devBoxes.Any(d => d.Name.Equals(DevBoxName)))
+            {
+                await CreateDevBoxAsync();
+            }
         }
 
-        private async Task<DevBox> CreateDevBoxAsync()
+        private async Task CreateDevBoxAsync()
         {
             DevBox devBox = new DevBox
             (
@@ -385,7 +381,19 @@ namespace Azure.Developer.DevCenter.Tests
                 TestEnvironment.MeUserId,
                 devBox);
 
-            return devBoxCreateOperation.Value;
+            devBox = devBoxCreateOperation.Value;
+
+            Assert.NotNull(devBox);
+            Assert.AreEqual(DevBoxName, devBox.Name);
+
+            DevBoxProvisioningState? devBoxProvisioningState = devBox.ProvisioningState;
+
+            // Both states indicate successful provisioning
+            bool devBoxProvisionSucceeded =
+                devBoxProvisioningState.Equals(DevBoxProvisioningState.Succeeded) ||
+                devBoxProvisioningState.Equals(DevBoxProvisioningState.ProvisionedWithWarning);
+
+            Assert.IsTrue(devBoxProvisionSucceeded);
         }
 
         private async Task<bool> HasDefaultActionIn24hrsAsync()


### PR DESCRIPTION
* Ensure environment gets deleted in the test, since it does not allow cascade delete in the test pipeline
* Update dev box action test to run only when schedule-default exits
* Have dev box only for the tests that needs it (e.g. pool test does not require a dev box)
* Re-record tests
