### PR TITLE
Exclude successful response content from the message of RequestFailedException

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+- `RequestFailedException` will not include the response content or headers in the message when the `IsError` property of the response is false.
 
 ## 1.38.0 (2024-02-26)
 

--- a/sdk/core/Azure.Core/src/Pipeline/RequestFailedDetailsParser.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RequestFailedDetailsParser.cs
@@ -15,7 +15,7 @@ namespace Azure.Core
         /// Parses the error details from the provided <see cref="Response"/>.
         /// </summary>
         /// <remarks>
-        /// In various scenarios, parsers can get called for successful responses. Implementations should not populate <paramref name="error"/> or <paramref name="data"/> with sensitive information, as these values may be logged as part of the exception.
+        /// In various scenarios, parsers may be called for successful responses. Implementations should not populate <paramref name="error"/> or <paramref name="data"/> with sensitive information, as these values may be logged as part of the exception.
         /// </remarks>
         /// <param name="response">The <see cref="Response"/> to parse. The <see cref="Response.ContentStream"/> will already be buffered.</param>
         /// <param name="error">The <see cref="ResponseError"/> describing the parsed error details.</param>

--- a/sdk/core/Azure.Core/src/Pipeline/RequestFailedDetailsParser.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RequestFailedDetailsParser.cs
@@ -14,6 +14,9 @@ namespace Azure.Core
         /// <summary>
         /// Parses the error details from the provided <see cref="Response"/>.
         /// </summary>
+        /// <remarks>
+        /// In various scenarios, parsers can get called for successful responses. Implementations should not populate <paramref name="error"/> or <paramref name="data"/> with sensitive information, as these values may be logged as part of the exception.
+        /// </remarks>
         /// <param name="response">The <see cref="Response"/> to parse. The <see cref="Response.ContentStream"/> will already be buffered.</param>
         /// <param name="error">The <see cref="ResponseError"/> describing the parsed error details.</param>
         /// <param name="data">Data to be applied to the <see cref="Exception.Data"/> property.</param>

--- a/sdk/core/Azure.Core/src/RequestFailedException.cs
+++ b/sdk/core/Azure.Core/src/RequestFailedException.cs
@@ -21,6 +21,7 @@ namespace Azure
     public class RequestFailedException : Exception, ISerializable
     {
         private const string DefaultMessage = "Service request failed.";
+        internal const string NoContentOnSuccessMessage = "Service request succeeded. Response content will not be included to avoid logging sensitive data.";
 
         /// <summary>
         /// Gets the HTTP status code of the response. Returns. <code>0</code> if response was not received.
@@ -172,55 +173,64 @@ namespace Azure
                 .Append("Status: ")
                 .Append(response.Status.ToString(CultureInfo.InvariantCulture));
 
-            if (!string.IsNullOrEmpty(response.ReasonPhrase))
+            if (response.IsError)
             {
-                messageBuilder.Append(" (")
-                    .Append(response.ReasonPhrase)
-                    .AppendLine(")");
+                if (!string.IsNullOrEmpty(response.ReasonPhrase))
+                {
+                    messageBuilder.Append(" (")
+                        .Append(response.ReasonPhrase)
+                        .AppendLine(")");
+                }
+                else
+                {
+                    messageBuilder.AppendLine();
+                }
+
+                if (!string.IsNullOrWhiteSpace(error?.Code))
+                {
+                    messageBuilder.Append("ErrorCode: ")
+                        .Append(error?.Code)
+                        .AppendLine();
+                }
+
+                if (additionalInfo is { Count: > 0 })
+                {
+                    messageBuilder
+                        .AppendLine()
+                        .AppendLine("Additional Information:");
+                    foreach (KeyValuePair<string, string> info in additionalInfo)
+                    {
+                        messageBuilder
+                            .Append(info.Key)
+                            .Append(": ")
+                            .AppendLine(info.Value);
+                    }
+                }
+
+                if (response.ContentStream is MemoryStream && ContentTypeUtilities.TryGetTextEncoding(response.Headers.ContentType, out Encoding _))
+                {
+                    messageBuilder
+                        .AppendLine()
+                        .AppendLine("Content:")
+                        .AppendLine(response.Content.ToString());
+                }
+
+                messageBuilder
+                    .AppendLine()
+                    .AppendLine("Headers:");
+
+                foreach (HttpHeader responseHeader in response.Headers)
+                {
+                    string headerValue = response.Sanitizer.SanitizeHeader(responseHeader.Name, responseHeader.Value);
+                    string header = $"{responseHeader.Name}: {headerValue}";
+                    messageBuilder.AppendLine(header);
+                }
             }
             else
             {
-                messageBuilder.AppendLine();
-            }
-
-            if (!string.IsNullOrWhiteSpace(error?.Code))
-            {
-                messageBuilder.Append("ErrorCode: ")
-                    .Append(error?.Code)
-                    .AppendLine();
-            }
-
-            if (additionalInfo is { Count: > 0 })
-            {
                 messageBuilder
                     .AppendLine()
-                    .AppendLine("Additional Information:");
-                foreach (KeyValuePair<string, string> info in additionalInfo)
-                {
-                    messageBuilder
-                        .Append(info.Key)
-                        .Append(": ")
-                        .AppendLine(info.Value);
-                }
-            }
-
-            if (response.ContentStream is MemoryStream && ContentTypeUtilities.TryGetTextEncoding(response.Headers.ContentType, out Encoding _))
-            {
-                messageBuilder
-                    .AppendLine()
-                    .AppendLine("Content:")
-                    .AppendLine(response.Content.ToString());
-            }
-
-            messageBuilder
-                .AppendLine()
-                .AppendLine("Headers:");
-
-            foreach (HttpHeader responseHeader in response.Headers)
-            {
-                string headerValue = response.Sanitizer.SanitizeHeader(responseHeader.Name, responseHeader.Value);
-                string header = $"{responseHeader.Name}: {headerValue}";
-                messageBuilder.AppendLine(header);
+                    .AppendLine(NoContentOnSuccessMessage);
             }
 
             var formatMessage = messageBuilder.ToString();

--- a/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
+++ b/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
@@ -23,17 +23,23 @@ namespace Azure.Core.Tests
         private static HttpMessageSanitizer Sanitizer = new TestClientOption().Sanitizer;
 
         [Test]
-        public void FormatsResponse()
+        public void FormatsResponse(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Custom-Header: Value" + s_nl +
-                "x-ms-requestId: 123" + s_nl;
+                "x-ms-requestId: 123" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Custom-Header", "Value"));
             response.AddHeader(new HttpHeader("x-ms-requestId", "123"));
             response.Sanitizer = Sanitizer;
@@ -50,17 +56,23 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void FormatsResponse_ResponseCtor()
+        public void FormatsResponse_ResponseCtor(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Custom-Header: Value" + s_nl +
-                "x-ms-requestId: 123" + s_nl;
+                "x-ms-requestId: 123" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Custom-Header", "Value"));
             response.AddHeader(new HttpHeader("x-ms-requestId", "123"));
             response.Sanitizer = Sanitizer;
@@ -77,17 +89,23 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void FormatsResponseWithoutSanitizer_ResponseCtor()
+        public void FormatsResponseWithoutSanitizer_ResponseCtor(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Custom-Header: REDACTED" + s_nl +
-                "x-ms-requestId: REDACTED" + s_nl;
+                "x-ms-requestId: REDACTED" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Custom-Header", "Value"));
             response.AddHeader(new HttpHeader("x-ms-requestId", "123"));
 
@@ -103,17 +121,23 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void HeadersAreSanitized()
+        public void HeadersAreSanitized(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Custom-Header-2: REDACTED" + s_nl +
-                "x-ms-requestId-2: REDACTED" + s_nl;
+                "x-ms-requestId-2: REDACTED" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Custom-Header-2", "Value"));
             response.AddHeader(new HttpHeader("x-ms-requestId-2", "123"));
 
@@ -122,17 +146,23 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void HeadersAreSanitized_ResponseCtor()
+        public void HeadersAreSanitized_ResponseCtor(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Custom-Header-2: REDACTED" + s_nl +
-                "x-ms-requestId-2: REDACTED" + s_nl;
+                "x-ms-requestId-2: REDACTED" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Custom-Header-2", "Value"));
             response.AddHeader(new HttpHeader("x-ms-requestId-2", "123"));
 
@@ -141,9 +171,10 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void FormatsResponseContentForTextContentTypes()
+        public void FormatsResponseContentForTextContentTypes(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
@@ -152,9 +183,14 @@ namespace Azure.Core.Tests
                 s_nl +
                 "Headers:" + s_nl +
                 "Content-Type: text/json" + s_nl +
-                "x-ms-requestId: 123" + s_nl;
+                "x-ms-requestId: 123" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.AddHeader(new HttpHeader("x-ms-requestId", "123"));
             response.SetContent("{\"errorCode\": 1}");
@@ -174,16 +210,22 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void DoesntFormatsResponseContentForNonTextContentTypes()
+        public void DoesntFormatsResponseContentForNonTextContentTypes(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
-                "Content-Type: binary" + s_nl;
+                "Content-Type: binary" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Content-Type", "binary"));
             response.SetContent("{\"errorCode\": 1}");
             response.Sanitizer = Sanitizer;
@@ -198,18 +240,24 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void IncludesErrorCodeInMessageIfAvailable()
+        public void IncludesErrorCodeInMessageIfAvailable(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 "ErrorCode: CUSTOM CODE" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Custom-Header: Value" + s_nl +
-                "x-ms-requestId: 123" + s_nl;
+                "x-ms-requestId: 123" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Custom-Header", "Value"));
             response.AddHeader(new HttpHeader("x-ms-requestId", "123"));
             response.SetContent("{ \"error\": { \"code\":\"CUSTOM CODE\" }}");
@@ -220,9 +268,10 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void IncludesAdditionalInformationIfAvailable()
+        public void IncludesAdditionalInformationIfAvailable(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
@@ -232,9 +281,14 @@ namespace Azure.Core.Tests
                 s_nl +
                 "Headers:" + s_nl +
                 "Custom-Header: Value" + s_nl +
-                "x-ms-requestId: 123" + s_nl;
+                "x-ms-requestId: 123" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Custom-Header", "Value"));
             response.AddHeader(new HttpHeader("x-ms-requestId", "123"));
             response.SetContent("{ \"a\": \"a-value\", \"b\": \"b-value\" }");
@@ -249,17 +303,23 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void IncludesInnerException()
+        public void IncludesInnerException(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Custom-Header: Value" + s_nl +
-                "x-ms-requestId: 123" + s_nl;
+                "x-ms-requestId: 123" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.AddHeader(new HttpHeader("Custom-Header", "Value"));
             response.AddHeader(new HttpHeader("x-ms-requestId", "123"));
             response.Sanitizer = Sanitizer;
@@ -271,7 +331,8 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void RequestFailedExceptionIsSerializeable()
+        public void RequestFailedExceptionIsSerializeable(
+            [Values(true, false)] bool responseIsError)
         {
             var dataContractSerializer = new DataContractSerializer(typeof(RequestFailedException));
             var exception = new RequestFailedException(201, "Message", "Error", null);
@@ -288,9 +349,10 @@ namespace Azure.Core.Tests
 
         [Test]
         public void ParsesJsonErrors(
+            [Values(true, false)] bool responseIsError,
             [Values(true, false)] bool hasErrorWrapper)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Custom message" + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 "ErrorCode: StatusCode" + s_nl +
@@ -300,9 +362,14 @@ namespace Azure.Core.Tests
                 "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }") + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
-                "Content-Type: text/json" + s_nl;
+                "Content-Type: text/json" + s_nl
+                :
+                "Custom message" + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             var errorContent = hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
                 "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }";
             response.SetContent(errorContent);
@@ -316,9 +383,10 @@ namespace Azure.Core.Tests
 
         [Test]
         public void ParsesJsonErrors_ResponseCtor(
+            [Values(true, false)] bool responseIsError,
             [Values(true, false)] bool hasErrorWrapper)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Custom message" + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 "ErrorCode: StatusCode" + s_nl +
@@ -328,9 +396,14 @@ namespace Azure.Core.Tests
                 "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }") + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
-                "Content-Type: text/json" + s_nl;
+                "Content-Type: text/json" + s_nl
+                :
+                "Custom message" + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             var errorContent = hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
                 "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }";
             response.SetContent(errorContent);
@@ -344,10 +417,11 @@ namespace Azure.Core.Tests
 
         [Test]
         public void ParsesJsonErrors_ResponseCtor_Stream(
+            [Values(true, false)] bool responseIsError,
             [Values(true, false)] bool canSeek,
             [Values(true, false)] bool hasErrorWrapper)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Custom message" + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 "ErrorCode: StatusCode" + s_nl +
@@ -357,9 +431,14 @@ namespace Azure.Core.Tests
                 "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }") + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
-                "Content-Type: text/json" + s_nl;
+                "Content-Type: text/json" + s_nl
+                :
+                "Custom message" + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             var errorContent = hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
                 "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }";
             response.ContentStream = GetStream(canSeek, errorContent);
@@ -378,11 +457,12 @@ namespace Azure.Core.Tests
 
         [Test]
         public async Task ParsesJsonErrors_ResponseCtor_StreamAsync(
+            [Values(true, false)] bool responseIsError,
             [Values(true, false)] bool canSeek,
             [Values(true, false)] bool hasErrorWrapper)
         {
             await Task.Yield();
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Custom message" + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 "ErrorCode: StatusCode" + s_nl +
@@ -392,9 +472,14 @@ namespace Azure.Core.Tests
                 "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }") + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
-                "Content-Type: text/json" + s_nl;
+                "Content-Type: text/json" + s_nl
+                :
+                "Custom message" + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             var errorContent = hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
                 "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }";
             response.ContentStream = GetStream(canSeek, errorContent);
@@ -412,9 +497,10 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void IgnoresInvalidJsonErrors()
+        public void IgnoresInvalidJsonErrors(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
@@ -422,9 +508,14 @@ namespace Azure.Core.Tests
                 "{ \"error\": { \"code\":\"StatusCode\"" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
-                "Content-Type: text/json" + s_nl;
+                "Content-Type: text/json" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.SetContent("{ \"error\": { \"code\":\"StatusCode\"");
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.Sanitizer = Sanitizer;
@@ -434,9 +525,10 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void IgnoresNonStandardJson()
+        public void IgnoresNonStandardJson(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
@@ -444,9 +536,14 @@ namespace Azure.Core.Tests
                 "{ \"customCode\":\"StatusCode\" }" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
-                "Content-Type: text/json" + s_nl;
+                "Content-Type: text/json" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.SetContent("{ \"customCode\":\"StatusCode\" }");
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.Sanitizer = Sanitizer;
@@ -456,9 +553,10 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void IgnoresUnexpectedNestedJson()
+        public void IgnoresUnexpectedNestedJson(
+            [Values(true, false)] bool responseIsError)
         {
-            var formattedResponse =
+            var formattedResponse = responseIsError ?
                 "Service request failed." + s_nl +
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
@@ -466,9 +564,14 @@ namespace Azure.Core.Tests
                 "{ \"error\": { \"error\": { \"code\":\"StatusCode\" }}}" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
-                "Content-Type: text/json" + s_nl;
+                "Content-Type: text/json" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210" + s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
             response.SetContent("{ \"error\": { \"error\": { \"code\":\"StatusCode\" }}}");
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.Sanitizer = Sanitizer;

--- a/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
+++ b/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
@@ -35,7 +35,8 @@ namespace Azure.Core.Tests
                 "x-ms-requestId: 123" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -68,7 +69,8 @@ namespace Azure.Core.Tests
                 "x-ms-requestId: 123" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -101,7 +103,8 @@ namespace Azure.Core.Tests
                 "x-ms-requestId: REDACTED" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -133,7 +136,8 @@ namespace Azure.Core.Tests
                 "x-ms-requestId-2: REDACTED" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -158,7 +162,8 @@ namespace Azure.Core.Tests
                 "x-ms-requestId-2: REDACTED" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -186,7 +191,8 @@ namespace Azure.Core.Tests
                 "x-ms-requestId: 123" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -221,7 +227,8 @@ namespace Azure.Core.Tests
                 "Content-Type: binary" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -253,7 +260,9 @@ namespace Azure.Core.Tests
                 "x-ms-requestId: 123" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                "ErrorCode: CUSTOM CODE" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -284,7 +293,12 @@ namespace Azure.Core.Tests
                 "x-ms-requestId: 123" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
+                "Additional Information:" + s_nl +
+                "a: a-value" + s_nl +
+                "b: b-value" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -315,7 +329,8 @@ namespace Azure.Core.Tests
                 "x-ms-requestId: 123" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -365,7 +380,9 @@ namespace Azure.Core.Tests
                 "Content-Type: text/json" + s_nl
                 :
                 "Custom message" + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                "ErrorCode: StatusCode" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -399,7 +416,9 @@ namespace Azure.Core.Tests
                 "Content-Type: text/json" + s_nl
                 :
                 "Custom message" + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                "ErrorCode: StatusCode" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -434,7 +453,9 @@ namespace Azure.Core.Tests
                 "Content-Type: text/json" + s_nl
                 :
                 "Custom message" + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                "ErrorCode: StatusCode" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -475,7 +496,9 @@ namespace Azure.Core.Tests
                 "Content-Type: text/json" + s_nl
                 :
                 "Custom message" + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                "ErrorCode: StatusCode" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -511,7 +534,8 @@ namespace Azure.Core.Tests
                 "Content-Type: text/json" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -539,7 +563,8 @@ namespace Azure.Core.Tests
                 "Content-Type: text/json" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");
@@ -567,7 +592,8 @@ namespace Azure.Core.Tests
                 "Content-Type: text/json" + s_nl
                 :
                 "Service request failed." + s_nl +
-                "Status: 210" + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
                 RequestFailedException.NoContentOnSuccessMessage + s_nl;
 
             var response = new MockResponse(210, "Reason");

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
@@ -383,7 +383,14 @@ namespace Azure.Storage.DataMovement
                 ex is not TaskCanceledException &&
                 !ex.Message.Contains("The request was canceled."))
             {
-                SetFailureType(ex.Message);
+                if (ex is RequestFailedException requestFailedException)
+                {
+                    SetFailureType(requestFailedException.ErrorCode);
+                }
+                else
+                {
+                    SetFailureType(ex.Message);
+                }
                 if (TransferFailedEventHandler != null)
                 {
                     await TransferFailedEventHandler.RaiseAsync(

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
@@ -124,7 +124,7 @@ namespace Azure.Storage.DataMovement.Tests
                 It.IsAny<CancellationToken>()),
                 Times.Once());
             destMock.Verify(b => b.DeleteIfExistsAsync(It.IsAny<CancellationToken>()),
-                Times.Once());
+                Times.Never());
             destMock.VerifyNoOtherCalls();
             await testEventsRaised.AssertSingleFailedCheck(1);
         }
@@ -163,9 +163,9 @@ namespace Azure.Storage.DataMovement.Tests
                 It.IsAny<CancellationToken>()),
                 Times.Once());
             destMock.Verify(b => b.DeleteIfExistsAsync(It.IsAny<CancellationToken>()),
-                Times.Once());
+                Times.Never());
             destMock.VerifyNoOtherCalls();
-            await testEventsRaised.AssertSingleFailedCheck(2);
+            await testEventsRaised.AssertSingleFailedCheck(1);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferCopyTestBase.cs
@@ -658,8 +658,16 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(true, transfer.TransferStatus.HasFailedItems);
             Assert.IsTrue(await DestinationExistsAsync(destinationClient));
             await testEventsRaised.AssertSingleFailedCheck(1);
-            Assert.NotNull(testEventsRaised.FailedEvents.First().Exception, "Excepted failure: Overwrite failure was supposed to be raised during the test");
-            Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage));
+            var testException = testEventsRaised.FailedEvents.First().Exception;
+            Assert.NotNull(testException, "Excepted failure: Overwrite failure was supposed to be raised during the test");
+            if (testException is RequestFailedException rfe)
+            {
+                Assert.That(rfe.ErrorCode, Does.Contain(_expectedOverwriteExceptionMessage));
+            }
+            else
+            {
+                Assert.IsTrue(testException.Message.Contains(_expectedOverwriteExceptionMessage));
+            }
             // Verify Copy - That we skipped over and didn't reupload something new.
             using Stream destinationStream = await DestinationOpenReadAsync(destinationClient);
             Assert.AreEqual(originalStream, destinationStream);
@@ -772,7 +780,15 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(DataTransferState.Completed, transfer.TransferStatus.State);
             Assert.AreEqual(true, transfer.TransferStatus.HasFailedItems);
             await testEventsRaised.AssertSingleFailedCheck(1);
-            Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage));
+            var testException = testEventsRaised.FailedEvents.First().Exception;
+            if (testException is RequestFailedException rfe)
+            {
+                Assert.That(rfe.ErrorCode, Does.Contain(_expectedOverwriteExceptionMessage));
+            }
+            else
+            {
+                Assert.IsTrue(testException.Message.Contains(_expectedOverwriteExceptionMessage));
+            }
         }
 
         [RecordedTest]
@@ -877,7 +893,15 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(DataTransferState.Completed, transfer.TransferStatus.State);
             Assert.AreEqual(true, transfer.TransferStatus.HasFailedItems);
-            Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage));
+            var testException = testEventsRaised.FailedEvents.First().Exception;
+            if (testException is RequestFailedException rfe)
+            {
+                Assert.That(rfe.ErrorCode, Does.Contain(_expectedOverwriteExceptionMessage));
+            }
+            else
+            {
+                Assert.IsTrue(testException.Message.Contains(_expectedOverwriteExceptionMessage));
+            }
         }
 
         [RecordedTest]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferUploadTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferUploadTestBase.cs
@@ -227,7 +227,16 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(DataTransferState.Completed, transfer.TransferStatus.State);
             Assert.AreEqual(true, transfer.TransferStatus.HasFailedItems);
-            Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage));
+            var testException = testEventsRaised.FailedEvents.First().Exception;
+            Assert.NotNull(testException, "Excepted failure: Overwrite failure was supposed to be raised during the test");
+            if (testException is RequestFailedException rfe)
+            {
+                Assert.That(rfe.ErrorCode, Does.Contain(_expectedOverwriteExceptionMessage));
+            }
+            else
+            {
+                Assert.IsTrue(testException.Message.Contains(_expectedOverwriteExceptionMessage));
+            }
         }
 
         [RecordedTest]
@@ -624,8 +633,16 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(true, transfer.TransferStatus.HasFailedItems);
             Assert.IsTrue(await ExistsAsync(objectClient));
             await testEventRaised.AssertSingleFailedCheck(1);
-            Assert.NotNull(testEventRaised.FailedEvents.First().Exception, "Excepted failure: Overwrite failure was supposed to be raised during the test");
-            Assert.IsTrue(testEventRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage));
+            var testException = testEventRaised.FailedEvents.First().Exception;
+            Assert.NotNull(testException, "Excepted failure: Overwrite failure was supposed to be raised during the test");
+            if (testException is RequestFailedException rfe)
+            {
+                Assert.That(rfe.ErrorCode, Does.Contain(_expectedOverwriteExceptionMessage));
+            }
+            else
+            {
+                Assert.IsTrue(testException.Message.Contains(_expectedOverwriteExceptionMessage));
+            }
             // Verify Upload - That we skipped over and didn't reupload something new.
             using Stream stream = await OpenReadAsync(objectClient);
             Assert.AreEqual(originalStream, stream);


### PR DESCRIPTION
Do not add response content to the exception message if the response was successful.