### PR TITLE
[AppConfigutation] Updating swagger specification to point to the main branch

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.0 (2024-04-09)
+## 1.4.0 (2024-04-10)
 
 ### Features Added
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/autorest.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 > see https://aka.ms/autorest
 ``` yaml
 input-file:
-- https://github.com/Azure/azure-rest-api-specs/blob/dacba58ef1d48851ecd6ca93bc329ac63ba1f662/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/2023-10-01/appconfiguration.json
+- https://github.com/Azure/azure-rest-api-specs/blob/c77bbf822be2deaac1b690270c6cd03a52df0e37/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/2023-10-01/appconfiguration.json
 namespace: Azure.Data.AppConfiguration
 title: ConfigurationClient
 ```


### PR DESCRIPTION
Updating the swagger specification link to point to the main branch of the specs repository. This does not change code generation but it's a required condition to unblock the release pipeline.