### PR TITLE
[Event Hubs] Fix stress references for release

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
+    <!--ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" /-->
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the direct reference to the core Event Hubs project due to conflicts and temporarily use the implicit dependnecy from the Processor project.   Once the processor has been released, this will be reverted.

## References and resources

- [Build failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3684044&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=45862c6e-83c5-515f-73e2-e7009eff9f9b)