### PR TITLE
[Event Hubs] Post-release updates

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -245,7 +245,7 @@
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Identity" Version="1.10.4" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.17.0" />
-		<PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.11.1" />
+		<PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.11.2" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.2.0" />
     <PackageReference Update="Azure.ResourceManager.CognitiveServices" Version="1.3.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the central package version for the processor and to restore the explicit stress references.