### PR TITLE
Disable self-logging and self-tracing in Azure Monitor distro, exporter, and livemetrics

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+* Turned off internal spans and logs in distro HTTP pipelines
+  ([#43359](https://github.com/Azure/azure-sdk-for-net/pull/43359))
+
 ### Other Changes
 
 * Update OpenTelemetry dependencies

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
@@ -64,7 +64,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// </summary>
         public AzureMonitorOptions()
         {
-            // users can explicitly change it, but by default we don't want exporter self-diagnostics to be reporter to Azure Monitor.
+            // users can explicitly change it, but by default we don't want self-diagnostics to be reported to Azure Monitor.
             this.Diagnostics.IsDistributedTracingEnabled = false;
             this.Diagnostics.IsLoggingEnabled = false;
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
@@ -59,6 +59,16 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// </summary>
         public string StorageDirectory { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureMonitorOptions"/>.
+        /// </summary>
+        public AzureMonitorOptions()
+        {
+            // users can explicitly change it, but by default we don't want exporter self-diagnostics to be reporter to Azure Monitor.
+            this.Diagnostics.IsDistributedTracingEnabled = false;
+            this.Diagnostics.IsLoggingEnabled = false;
+        }
+
         internal void SetValueToExporterOptions(AzureMonitorExporterOptions exporterOptions)
         {
             exporterOptions.ConnectionString = ConnectionString;
@@ -70,6 +80,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             {
                 exporterOptions.Transport = Transport;
             }
+            exporterOptions.Diagnostics.IsDistributedTracingEnabled = Diagnostics.IsDistributedTracingEnabled;
+            exporterOptions.Diagnostics.IsLoggingEnabled = Diagnostics.IsLoggingEnabled;
         }
 
         internal void SetValueToLiveMetricsExporterOptions(LiveMetricsExporterOptions liveMetricsExporterOptions)
@@ -81,6 +93,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             {
                 liveMetricsExporterOptions.Transport = Transport;
             }
+            liveMetricsExporterOptions.Diagnostics.IsDistributedTracingEnabled = Diagnostics.IsDistributedTracingEnabled;
+            liveMetricsExporterOptions.Diagnostics.IsLoggingEnabled = Diagnostics.IsLoggingEnabled;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
@@ -64,7 +64,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// </summary>
         public AzureMonitorOptions()
         {
-            // users can explicitly change it, but by default we don't want self-diagnostics to be reported to Azure Monitor.
+            // users can explicitly change it, but by default we don't want internal logs to be reported to Azure Monitor.
             this.Diagnostics.IsDistributedTracingEnabled = false;
             this.Diagnostics.IsLoggingEnabled = false;
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
         public async Task DistroLogForwarderIsAdded(LogLevel eventLevel, string expectedMessage)
         {
             var builder = WebApplication.CreateBuilder();
-            var transport = new MockTransport(new MockResponse(200).SetContent("ok"));
+            var transport = new MockTransport(_ => new MockResponse(200).SetContent("ok"));
             SetUpOTelAndLogging(builder, transport, LogLevel.Information);
 
             using var app = builder.Build();
@@ -56,7 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
         public async Task PublicLogForwarderIsAdded(LogLevel eventLevel, string expectedMessage)
         {
             var builder = WebApplication.CreateBuilder();
-            var transport = new MockTransport(new MockResponse(200).SetContent("ok"));
+            var transport = new MockTransport(_ => new MockResponse(200).SetContent("ok"));
             SetUpOTelAndLogging(builder, transport, LogLevel.Information);
 
             builder.Services.TryAddSingleton<Microsoft.Extensions.Azure.AzureEventSourceLogForwarder>();
@@ -86,18 +86,62 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             }
         }
 
-        private void WaitForRequest(MockTransport transport)
+        [Fact]
+        public async Task SelfDiagnosticsIsDisabled()
         {
+            var enableLevel = LogLevel.Debug;
+
+            var builder = WebApplication.CreateBuilder();
+            var transport = new MockTransport(_ => new MockResponse(200).SetContent("ok"));
+            builder.Logging.ClearProviders();
+            bool logAzureFilterCalled = false;
+            builder.Logging.AddFilter((name, level) =>
+            {
+                if (name != null && name.StartsWith("Azure"))
+                {
+                    logAzureFilterCalled = true;
+                    return level >= enableLevel;
+                }
+                return false;
+            });
+            builder.Services.AddOpenTelemetry().UseAzureMonitor(config =>
+            {
+                config.Transport = transport;
+                config.ConnectionString = $"InstrumentationKey={Guid.NewGuid()}";
+                config.EnableLiveMetrics = true;
+                Assert.False(config.Diagnostics.IsLoggingEnabled);
+                Assert.False(config.Diagnostics.IsDistributedTracingEnabled);
+            });
+
+            using var app = builder.Build();
+            await app.StartAsync();
+
+            // let's get some live metric requests first to check that no logs were recorded for them
+            WaitForRequest(transport, r => r.Uri.Host == "rt.services.visualstudio.com");
+
+            // now let's wait for track requests
+            var trackRequests = WaitForRequest(transport, r => r.Uri.Host == "dc.services.visualstudio.com");
+            Assert.Empty(trackRequests);
+
+            // since LiveMetrics logging is disabled, we shouldn't even have logging policy trying to log anything.
+            Assert.False(logAzureFilterCalled);
+        }
+
+        private IEnumerable<MockRequest> WaitForRequest(MockTransport transport, Func<MockRequest, bool>? filter = null)
+        {
+            filter = filter ?? (_ => true);
             SpinWait.SpinUntil(
                 condition: () =>
                 {
                     Thread.Sleep(10);
-                    return transport.Requests.Count > 0;
+                    return transport.Requests.Where(filter).Any();
                 },
                 timeout: TimeSpan.FromSeconds(10));
+
+            return transport.Requests.Where(filter);
         }
 
-        private static async Task AssertContentContains(MockRequest request, string expectedMessage, LogLevel expectedLevel)
+        private static async Task<string> AssertContentContains(MockRequest request, string expectedMessage, LogLevel expectedLevel)
         {
             using var contentStream = new MemoryStream();
             await request.Content.WriteToAsync(contentStream, default);
@@ -110,6 +154,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 
             // also check that message appears just once
             Assert.Equal(content.IndexOf(jsonMessage), content.LastIndexOf(jsonMessage));
+            return content;
         }
 
         private static async Task AssertContentDoesNotContain(List<MockRequest> requests, string expectedMessage)
@@ -143,8 +188,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
                 config.Transport = transport;
                 config.ConnectionString = $"InstrumentationKey={Guid.NewGuid()}";
                 config.EnableLiveMetrics = false;
-                config.Diagnostics.IsDistributedTracingEnabled = false;
-                config.Diagnostics.IsLoggingEnabled = false;
             });
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -7,6 +7,8 @@
 * All three signals (Traces, Metrics, and Logs) now support OpenTelemetry's ["service.version"](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#service) in Resource attributes.
   This is mapped as [Application Version](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete#application-version) in Application Insights.
   ([#42174](https://github.com/Azure/azure-sdk-for-net/pull/42174))
+* Turned off internal spans and logs in exporter HTTP pipeline
+  ([#43359](https://github.com/Azure/azure-sdk-for-net/pull/43359))
 
 ### Breaking Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -58,6 +58,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorExporterOptions(ServiceVersion version = LatestVersion)
         {
             this.Version = version;
+            // users can explicitly change it, but by default we don't want exporter self-diagnostics to be reported to Azure Monitor.
+            this.Diagnostics.IsDistributedTracingEnabled = false;
+            this.Diagnostics.IsLoggingEnabled = false;
         }
 
         /// <summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -58,7 +58,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorExporterOptions(ServiceVersion version = LatestVersion)
         {
             this.Version = version;
-            // users can explicitly change it, but by default we don't want exporter self-diagnostics to be reported to Azure Monitor.
+            // users can explicitly change it, but by default we don't want exporter internal logs to be reported to Azure Monitor.
             this.Diagnostics.IsDistributedTracingEnabled = false;
             this.Diagnostics.IsLoggingEnabled = false;
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * Fix for "Comitted Memory" not updating.
   ([#42760](https://github.com/Azure/azure-sdk-for-net/pull/42760))
+* Turned off internal spans and logs in LiveMetrics HTTP pipeline
+  ([#43359](https://github.com/Azure/azure-sdk-for-net/pull/43359))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporterOptions.cs
@@ -29,4 +29,14 @@ public class LiveMetricsExporterOptions : ClientOptions
     /// Get or sets the value of <see cref="TokenCredential" />.
     /// </summary>
     public TokenCredential Credential { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LiveMetricsExporterOptions"/>.
+    /// </summary>
+    public LiveMetricsExporterOptions()
+    {
+        // users can explicitly change it, but by default we don't want live metrics self-diagnostics to be reported to Azure Monitor.
+        this.Diagnostics.IsDistributedTracingEnabled = false;
+        this.Diagnostics.IsLoggingEnabled = false;
+    }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporterOptions.cs
@@ -35,7 +35,7 @@ public class LiveMetricsExporterOptions : ClientOptions
     /// </summary>
     public LiveMetricsExporterOptions()
     {
-        // users can explicitly change it, but by default we don't want live metrics self-diagnostics to be reported to Azure Monitor.
+        // users can explicitly change it, but by default we don't want live metrics internal logs to be reported to Azure Monitor.
         this.Diagnostics.IsDistributedTracingEnabled = false;
         this.Diagnostics.IsLoggingEnabled = false;
     }


### PR DESCRIPTION
Fixes #43286

In fact it's already fixed with https://github.com/Azure/azure-sdk-for-net/pull/41858, this change prevents traces/logs creation from happening from  LiveMetrics, Exporter or Distro, i.e. serves as a small optimization.

It changes the default - disables diagnostics, but in theory users can still enable if it's ever necessary to diagnose AzMon issues.