### PR TITLE
Fix file copy and credscan in aggreate-reports

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -108,7 +108,7 @@ stages:
               artifactName: reports
               path: '$(Build.ArtifactStagingDirectory)/reports'
 
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: 'Upload Dependency Report'
             inputs:
               sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
@@ -119,7 +119,7 @@ stages:
               blobPrefix: dependencies
               AdditionalArgumentsForBlobCopy: '--exclude-pattern=*data.js*'
 
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: 'Upload Dependency Graph'
             inputs:
               sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
@@ -153,7 +153,6 @@ stages:
           - template: /eng/common/pipelines/templates/steps/credscan.yml
             parameters:
               BaselineFilePath: $(Build.sourcesdirectory)/eng/dotnet.gdnbaselines
-              ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
       - job: APIScan
         timeoutInMinutes: 180


### PR DESCRIPTION
Fixing the AzureFileCopy to support workload identity federation and also fix a credscan issue that was introduced by the 1ES template change.
