### PR TITLE
[AzureMonitorDistro] update readme to describe how to configure/disable Azure Sdk logs

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
@@ -287,7 +287,7 @@ Refer to [Drop an instrument](https://github.com/open-telemetry/opentelemetry-do
 
 #### Disable Azure SDK Logs
 
-By default, the Azure Monitor Distro collects [client library requests and responses to Azure services](https://learn.microsoft.com/dotnet/azure/sdk/logging#logging-using-azuremonitoropentelemetryaspnetcore).
+By default, the Azure Monitor Distro collects [logs from Azure SDKs](https://learn.microsoft.com/dotnet/azure/sdk/logging#logging-using-azuremonitoropentelemetryaspnetcore).
 These are visible in your application's console output as well as in the Application Insights Traces.
 
 This can be configured or disabled in the appsettings.json.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
@@ -285,6 +285,34 @@ builder.Services.ConfigureOpenTelemetryMeterProvider(metrics =>
 
 Refer to [Drop an instrument](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#drop-an-instrument) for more examples.
 
+#### Disable Azure SDK Logs
+
+By default, the Azure Monitor Distro collects [client library requests and responses to Azure services](https://learn.microsoft.com/dotnet/azure/sdk/logging#logging-using-azuremonitoropentelemetryaspnetcore).
+These are visible in your application's console output as well as in the Application Insights Traces.
+
+This can be configured or disabled in the appsettings.json.
+
+- You can control the log level of individual sources
+    ```json
+    {
+      "Logging": {
+        "LogLevel": {
+          "Azure.Core": "Debug"
+        }
+      }
+    }
+    ```
+- or you can disable entirely
+    ```json
+    {
+      "Logging": {
+        "LogLevel": {
+          "Azure": "None"
+        }
+      }
+    }
+    ```
+
 ## Key concepts
 
 The Azure Monitor Distro is a distribution package that facilitates users in sending telemetry data to Azure Monitor. It encompasses the .NET OpenTelemetry SDK and instrumentation libraries for ASP.NET Core, HttpClient, and SQLClient, ensuring seamless integration and data collection.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
@@ -297,7 +297,7 @@ This can be configured or disabled in the appsettings.json.
     {
       "Logging": {
         "LogLevel": {
-          "Azure.Core": "Debug"
+          "Azure.Core": "Warning"
         }
       }
     }


### PR DESCRIPTION
Follow up to #43286.

This PR adds a section to our Readme describing how a user could disable the Azure Sdk logs.
https://learn.microsoft.com/en-us/dotnet/azure/sdk/logging#logging-using-azuremonitoropentelemetryaspnetcore

