### PR TITLE
[LiveMetrics] update process metrics

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/LiveMetricConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/LiveMetricConstants.cs
@@ -27,9 +27,13 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             // EXCEPTIONS
             internal const string ExceptionsPerSecondMetricIdValue = @"\ApplicationInsights\Exceptions/Sec";
 
-            // PROCESS METRICS
+            // PROCESS METRICS (OLD) // TODO: Remove these after the UX is updated to use the new metrics
             internal const string MemoryCommittedBytesMetricIdValue = @"\Memory\Committed Bytes";
             internal const string ProcessorTimeMetricIdValue = @"\Processor(_Total)\% Processor Time";
+
+            // PROCESS METRICS (NEW)
+            internal const string ProcessPhysicalBytesMetricIdValue = @"\Process\Physical Bytes";
+            internal const string ProcessProcessorTimeNormalizedMetricIdValue = @"\% Process\Processor Time Normalized";
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
@@ -131,18 +131,34 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         {
             _process.Refresh();
 
+            // OLD METRIC NAME. TODO: Remove this after the UX is updated to use the new metrics
             yield return new Models.MetricPoint
             {
                 Name = LiveMetricConstants.MetricId.MemoryCommittedBytesMetricIdValue,
-                Value = _process.PrivateMemorySize64,
+                Value = _process.WorkingSet64,
+                Weight = 1
+            };
+
+            yield return new Models.MetricPoint
+            {
+                Name = LiveMetricConstants.MetricId.ProcessPhysicalBytesMetricIdValue,
+                Value = _process.WorkingSet64,
                 Weight = 1
             };
 
             if (TryCalculateCPUCounter(out var processorValue))
             {
+                // OLD METRIC NAME. TODO: Remove this after the UX is updated to use the new metrics
                 yield return new Models.MetricPoint
                 {
                     Name = LiveMetricConstants.MetricId.ProcessorTimeMetricIdValue,
+                    Value = Convert.ToSingle(processorValue),
+                    Weight = 1
+                };
+
+                yield return new Models.MetricPoint
+                {
+                    Name = LiveMetricConstants.MetricId.ProcessProcessorTimeNormalizedMetricIdValue,
                     Value = Convert.ToSingle(processorValue),
                     Weight = 1
                 };


### PR DESCRIPTION
Our teams agreed on a migration plan for Process Metrics.
The spec was updated today (ping me for internal link).

This PR updates our Process Metrics.
We will emit the Process Metrics using both the old and new names.
This will ensure that users will not be impacted by the change.
After the UX is updated, we can drop the old name.
