### PR TITLE
[OpenAI Assistants] Clarify Azure support by removing old compatibility warnings

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI.Assistants/README.md
+++ b/sdk/openai/Azure.AI.OpenAI.Assistants/README.md
@@ -1,7 +1,5 @@
 # Azure OpenAI: OpenAI Assistants client library for .NET
 
-> **NOTE**: This is a preview version of the Azure SDK library for OpenAI Assistants. [OpenAI's Assistants API](https://platform.openai.com/docs/api-reference/assistants) is tagged as beta and both the API surface as well as this library's representation are subject to change. For other OpenAI features like Chat Completions, please see the [Azure SDK for .NET Azure.AI.OpenAI library](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/openai/Azure.AI.OpenAI).
-
 The Azure OpenAI Assistants client library for .NET is an adaptation of OpenAI's REST APIs that provides an idiomatic interface
 and rich integration with the rest of the Azure SDK ecosystem. It will connect to Azure OpenAI resources *or* to the
 non-Azure OpenAI inference endpoint, making it a great choice for even non-Azure OpenAI development.
@@ -19,7 +17,7 @@ Use this library to:
 To use Assistants capabilities, you'll need service API access through OpenAI or Azure OpenAI:
 
 - To use OpenAI (api.openai.com), you'll need an API key obtained from a developer account at https://platform.openai.com
-- (Not yet supported) If you'd like to use an Azure OpenAI resource, you must have an [Azure subscription](https://azure.microsoft.com/free/dotnet/) and [Azure OpenAI access](https://learn.microsoft.com/azure/cognitive-services/openai/overview#how-do-i-get-access-to-azure-openai). This will allow you to create an Azure OpenAI resource and get both a connection URL as well as API keys. For more information, see [Quickstart: Get started generating text using Azure OpenAI Service](https://learn.microsoft.com/azure/cognitive-services/openai/quickstart).
+- To use an Azure OpenAI resource, you must have an [Azure subscription](https://azure.microsoft.com/free/dotnet/) and [Azure OpenAI access](https://learn.microsoft.com/azure/cognitive-services/openai/overview#how-do-i-get-access-to-azure-openai). This will allow you to create an Azure OpenAI resource and get both a connection URL as well as API keys. For more information, see [Quickstart: Get started generating text using Azure OpenAI Service](https://learn.microsoft.com/azure/cognitive-services/openai/quickstart).
 
 ### Install the package
 
@@ -42,6 +40,8 @@ AssistantsClient client = isAzureOpenAI
     ? new AssistantsClient(new Uri(azureResourceUrl), new AzureKeyCredential(azureApiKey))
     : new AssistantsClient(nonAzureApiKey);
 ```
+
+> **NOTE**: The Assistants API should always be used from a trusted device. Because the same authentication mechanism for running threads also allows changing persistent resources like Assistant instructions, a malicious user could extract an API key and modify Assistant behavior for other customers.
 
 ## Key concepts
 

--- a/sdk/openai/Azure.AI.OpenAI.Assistants/src/Custom/AssistantsClient.cs
+++ b/sdk/openai/Azure.AI.OpenAI.Assistants/src/Custom/AssistantsClient.cs
@@ -22,7 +22,6 @@ public partial class AssistantsClient
      */
 
     private static readonly string s_openAIEndpoint = "https://api.openai.com/v1";
-    private static readonly string s_aoaiNotYetSupportedMessage = "Azure OpenAI does not yet support Assistants.";
 
     private readonly string _apiVersion;
     private bool _isConfiguredForAzure;
@@ -35,9 +34,6 @@ public partial class AssistantsClient
     /// <param name="options"> Additional options for customizing the behavior of the client. </param>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="endpoint"/> or <paramref name="keyCredential"/> is null.
-    /// </exception>
-    /// <exception cref="NotSupportedException">
-    ///     Always thrown until Azure OpenAI support for /assistants is available.
     /// </exception>
     public AssistantsClient(Uri endpoint, AzureKeyCredential keyCredential, AssistantsClientOptions options)
     {
@@ -68,9 +64,6 @@ public partial class AssistantsClient
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="endpoint"/> or <paramref name="keyCredential"/> is null.
     /// </exception>
-    /// <exception cref="NotSupportedException">
-    ///     Always thrown until Azure OpenAI support for /assistants is available.
-    /// </exception>
     public AssistantsClient(Uri endpoint, AzureKeyCredential keyCredential)
         : this(endpoint, keyCredential, new AssistantsClientOptions())
     {
@@ -84,9 +77,6 @@ public partial class AssistantsClient
     /// <param name="options"> Additional options for customizing the behavior of the client. </param>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="endpoint"/> or <paramref name="tokenCredential"/> is null.
-    /// </exception>
-    /// <exception cref="NotSupportedException">
-    ///     Always thrown until Azure OpenAI support for /assistants is available.
     /// </exception>
     public AssistantsClient(Uri endpoint, TokenCredential tokenCredential, AssistantsClientOptions options)
     {
@@ -106,8 +96,6 @@ public partial class AssistantsClient
             new ResponseClassifier());
         _endpoint = endpoint;
         _apiVersion = options.Version;
-
-        throw new NotSupportedException(s_aoaiNotYetSupportedMessage);
     }
 
     /// <summary>
@@ -117,9 +105,6 @@ public partial class AssistantsClient
     /// <param name="tokenCredential"> The authentication information for the Azure OpenAI resource. </param>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="endpoint"/> is null.
-    /// </exception>
-    /// <exception cref="NotSupportedException">
-    ///     Always thrown until Azure OpenAI support for /assistants is available.
     /// </exception>
     public AssistantsClient(Uri endpoint, TokenCredential tokenCredential)
         : this(endpoint, tokenCredential, new AssistantsClientOptions())


### PR DESCRIPTION
At its release, the Assistants library could not use Azure OpenAI because the AOAI service had not yet released official, public support. Functionality and test coverage were verified as soon as support became available, but a few lingering references to Azure OpenAI "not yet being supported," including the very content line of the README, weren't removed. This is misleading.

This change cleans up those lingering references:

- README updated to remove "not yet supported"
- `NotImplementedException` references removed from the client

Opportunistically, a small security note about considerations related to trusted devices was added in the authentication section of the README.