### PR TITLE
Specify min version number for token caching in Azure.Identity

### DIFF
--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -276,16 +276,15 @@ client secret and certificate are both present, the client secret will be used.
 
 As of version 1.10.0, accessing resources protected by [Continuous Access Evaluation (CAE)][cae] is possible on a per-request basis. This behavior can be enabled by setting the `IsCaeEnabled` property of `TokenRequestContext` via its constructor. CAE isn't supported for developer and managed identity credentials.
 
-
 ## Token caching
 
-Token caching is a feature provided by the Azure Identity library that allows apps to:
+*Token caching* is a feature provided by versions 1.8.0 and later of the Azure Identity library. The feature allows apps to:
 
 * Cache tokens in memory (default) or on disk (opt-in).
 * Improve resilience and performance.
 * Reduce the number of requests made to Microsoft Entra ID to obtain access tokens.
 
-The Azure Identity library offers both in-memory and persistent disk caching. For more details, see the [token caching documentation](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/samples/TokenCache.md)
+The Azure Identity library offers both in-memory and persistent disk caching. For more details, see the [token caching documentation](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/samples/TokenCache.md).
 
 # Brokered Authentication
 

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -162,6 +162,8 @@ var eventHubProducerClient = new EventHubProducerClient("myeventhub.eventhubs.wi
 * [Azure Virtual Machines](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/how-to-use-vm-token)
 * [Azure Virtual Machines Scale Sets](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/qs-configure-powershell-windows-vmss)
 
+As of version 1.8.0, `ManagedIdentityCredential` supports [token caching](#token-caching).
+
 ### Examples
 
 These examples demonstrate authenticating the `SecretClient` from the [Azure.Security.KeyVault.Secrets][secrets_client_library] client library using the `ManagedIdentityCredential`.
@@ -278,7 +280,7 @@ As of version 1.10.0, accessing resources protected by [Continuous Access Evalua
 
 ## Token caching
 
-*Token caching* is a feature provided by versions 1.8.0 and later of the Azure Identity library. The feature allows apps to:
+*Token caching* is a feature provided by the Azure Identity library. The feature allows apps to:
 
 * Cache tokens in memory (default) or on disk (opt-in).
 * Improve resilience and performance.

--- a/sdk/identity/Azure.Identity/samples/TokenCache.md
+++ b/sdk/identity/Azure.Identity/samples/TokenCache.md
@@ -1,6 +1,6 @@
 # Token caching in the Azure Identity client library
 
-*Token caching* is a feature provided by versions 1.8.0 and later of the Azure Identity library. The feature allows apps to:
+*Token caching* is a feature provided by the Azure Identity library. The feature allows apps to:
 
 - Improve their resilience and performance.
 - Reduce the number of requests made to Microsoft Entra ID to obtain access tokens.

--- a/sdk/identity/Azure.Identity/samples/TokenCache.md
+++ b/sdk/identity/Azure.Identity/samples/TokenCache.md
@@ -1,6 +1,6 @@
 # Token caching in the Azure Identity client library
 
-*Token caching* is a feature provided by the Azure Identity library that allows apps to:
+*Token caching* is a feature provided by versions 1.8.0 and later of the Azure Identity library. The feature allows apps to:
 
 - Improve their resilience and performance.
 - Reduce the number of requests made to Microsoft Entra ID to obtain access tokens.


### PR DESCRIPTION
Call out the minimum version required, so that customers don't have to scan the changelog.
