### PR TITLE
[AzureMonitorDistro] upgrade OpenTelemetry for hotfix

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -147,9 +147,9 @@
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Monitor.OpenTelemetry'))">
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.8.0" />
-    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.8.0" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
+    <PackageReference Update="OpenTelemetry" Version="1.8.1" />
+    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.8.1" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Update="OpenTelemetry.PersistentStorage.FileSystem" Version="1.0.0" />
@@ -309,7 +309,7 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Update="OpenTelemetry" Version="1.8.0" />
+    <PackageReference Update="OpenTelemetry" Version="1.8.1" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -147,11 +147,11 @@
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Monitor.OpenTelemetry'))">
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.7.0" />
-    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.7.0" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
+    <PackageReference Update="OpenTelemetry" Version="1.8.0" />
+    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.8.0" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Update="OpenTelemetry.PersistentStorage.FileSystem" Version="1.0.0" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1,6.0)" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="[2.1.1,6.0)" />
@@ -309,7 +309,7 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Update="OpenTelemetry" Version="1.7.0" />
+    <PackageReference Update="OpenTelemetry" Version="1.8.0" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -8,8 +8,10 @@
   ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
   - OpenTelemetry 1.8.1
   - OpenTelemetry.Extensions.Hosting 1.8.1
-  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1 to address [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f)
-  - OpenTelemetry.Instrumentation.Http 1.8.1 to address [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f)
+  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
+	- This update is a respone to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028).
+  - OpenTelemetry.Instrumentation.Http 1.8.1
+    - This update is a respons to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028).
 
 ## 1.1.0 (2024-01-25)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+## 1.1.1 (Unreleased)
+
+* Update OpenTelemetry dependencies. This includes a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
+  ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
+  - OpenTelemetry 1.8.0
+  - OpenTelemetry.Extensions.Hosting 1.8.0
+  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
+  - OpenTelemetry.Instrumentation.Http 1.8.1
+
 ## 1.1.0 (2024-01-25)
 
 ### Other Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Other Changes
 
 * Update OpenTelemetry dependencies.
-  ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
+  ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
   - OpenTelemetry 1.8.1
   - OpenTelemetry.Extensions.Hosting 1.8.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.8.1

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -16,7 +16,8 @@
 * `OpenTelemetry.Instrumentation.AspNetCore` and `OpenTelemetry.Instrumentation.Http` include a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
   By default any values detected in the query string component of requests are replaced with the text `Redacted` when building the `url.query` tag.
   For example, `?key1=value1&key2=value2` becomes `?key1=Redacted&key2=Redacted`.
-  This is to prevent sensitive information from leaking through query strings
+  This is to prevent sensitive information from leaking through query strings.
+  ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
   You can disable this redaction by setting an environment variable:
   * For `OpenTelemetry.Instrumentation.AspNetCore` set `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION` to `true`. ([link](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md#181))
   * For `OpenTelemetry.Instrumentation.Http` set `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION ` to `true`. ([link](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md#181))

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 * Update OpenTelemetry dependencies.
   ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
-  - OpenTelemetry 1.8.0
-  - OpenTelemetry.Extensions.Hosting 1.8.0
+  - OpenTelemetry 1.8.1
+  - OpenTelemetry.Extensions.Hosting 1.8.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
   - OpenTelemetry.Instrumentation.Http 1.8.1
   - This includes a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f) which redacts the query string values by default. 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -9,9 +9,8 @@
   - OpenTelemetry 1.8.1
   - OpenTelemetry.Extensions.Hosting 1.8.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
-	- This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028).
   - OpenTelemetry.Instrumentation.Http 1.8.1
-    - This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028).
+  - This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028)
 
 ## 1.1.0 (2024-01-25)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -1,13 +1,23 @@
 # Release History
 
-## 1.1.1 (Unreleased)
+## 1.1.1 (2024-04-25)
 
-* Update OpenTelemetry dependencies. This includes a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
+### Other Changes
+
+* Update OpenTelemetry dependencies.
   ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
   - OpenTelemetry 1.8.0
   - OpenTelemetry.Extensions.Hosting 1.8.0
   - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
   - OpenTelemetry.Instrumentation.Http 1.8.1
+  - This includes a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f) which redacts the query string values by default. 
+
+### Breaking Changes
+
+* OpenTelemetry.Instrumentation.AspNetCore and OpenTelemetry.Instrumentation.Http include a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
+  By default any values detected in the query string component of requests are replaced with the text `Redacted` when building the `url.query` tag.
+  For example, `?key1=value1&key2=value2` becomes `?key1=Redacted&key2=Redacted`.
+  You can disable this redaction by setting the environment variable `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION` to `true`.
 
 ## 1.1.0 (2024-01-25)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -8,16 +8,8 @@
   ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
   - OpenTelemetry 1.8.1
   - OpenTelemetry.Extensions.Hosting 1.8.1
-  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
-  - OpenTelemetry.Instrumentation.Http 1.8.1
-* `OpenTelemetry.Instrumentation.AspNetCore` and `OpenTelemetry.Instrumentation.Http` include a [hotfix](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5532) for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
-  By default any values detected in the query string component of requests are replaced with the text `Redacted` when building the `url.query` or the `url.full` tag.
-  For example, `?key1=value1&key2=value2` becomes `?key1=Redacted&key2=Redacted`.
-  `Azure.Monitor.OpenTelemetry.AspNetCore` has chosen to disable this redaction until the OpenTelemetry Community has made a decision on the default behavior.
-  ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
-  You can re-enable this redaction by setting an environment variable:
-    - For `OpenTelemetry.Instrumentation.AspNetCore` set `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION` to `false` before calling `UseAzureMonitor()`.
-    - For `OpenTelemetry.Instrumentation.Http` set `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION` to `false` before calling `UseAzureMonitor()`.
+  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1 to address [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f)
+  - OpenTelemetry.Instrumentation.Http 1.8.1 to address [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f)
 
 ## 1.1.0 (2024-01-25)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -11,13 +11,15 @@
   - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
   - OpenTelemetry.Instrumentation.Http 1.8.1
   - This includes a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f) which redacts the query string values by default. 
-
 ### Breaking Changes
 
 * `OpenTelemetry.Instrumentation.AspNetCore` and `OpenTelemetry.Instrumentation.Http` include a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
   By default any values detected in the query string component of requests are replaced with the text `Redacted` when building the `url.query` tag.
   For example, `?key1=value1&key2=value2` becomes `?key1=Redacted&key2=Redacted`.
-  You can disable this redaction by setting the environment variable `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION` to `true`.
+  This is to prevent sensitive information from leaking through query strings
+  You can disable this redaction by setting an environment variable:
+  * For `OpenTelemetry.Instrumentation.AspNetCore` set `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION` to `true`. ([link](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md#181))
+  * For `OpenTelemetry.Instrumentation.Http` set `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION ` to `true`. ([link](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md#181))
 
 ## 1.1.0 (2024-01-25)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -9,9 +9,9 @@
   - OpenTelemetry 1.8.1
   - OpenTelemetry.Extensions.Hosting 1.8.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
-	- This update is a respone to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028).
+	- This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028).
   - OpenTelemetry.Instrumentation.Http 1.8.1
-    - This update is a respons to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028).
+    - This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028).
 
 ## 1.1.0 (2024-01-25)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.1 (2024-04-25)
+## 1.1.1 (2024-04-26)
 
 ### Other Changes
 
@@ -10,17 +10,14 @@
   - OpenTelemetry.Extensions.Hosting 1.8.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
   - OpenTelemetry.Instrumentation.Http 1.8.1
-  - This includes a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f) which redacts the query string values by default. 
-### Breaking Changes
-
-* `OpenTelemetry.Instrumentation.AspNetCore` and `OpenTelemetry.Instrumentation.Http` include a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
-  By default any values detected in the query string component of requests are replaced with the text `Redacted` when building the `url.query` tag.
+* `OpenTelemetry.Instrumentation.AspNetCore` and `OpenTelemetry.Instrumentation.Http` include a [hotfix](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5532) for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
+  By default any values detected in the query string component of requests are replaced with the text `Redacted` when building the `url.query` or the `url.full` tag.
   For example, `?key1=value1&key2=value2` becomes `?key1=Redacted&key2=Redacted`.
-  This is to prevent sensitive information from leaking through query strings.
+  `Azure.Monitor.OpenTelemetry.AspNetCore` has chosen to disable this redaction until the OpenTelemetry Community has made a decision on the default behavior.
   ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
-  You can disable this redaction by setting an environment variable:
-  * For `OpenTelemetry.Instrumentation.AspNetCore` set `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION` to `true`. ([link](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md#181))
-  * For `OpenTelemetry.Instrumentation.Http` set `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION ` to `true`. ([link](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md#181))
+  You can re-enable this redaction by setting an environment variable:
+    - For `OpenTelemetry.Instrumentation.AspNetCore` set `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION` to `false` before calling `UseAzureMonitor()`.
+    - For `OpenTelemetry.Instrumentation.Http` set `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION` to `false` before calling `UseAzureMonitor()`.
 
 ## 1.1.0 (2024-01-25)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Breaking Changes
 
-* OpenTelemetry.Instrumentation.AspNetCore and OpenTelemetry.Instrumentation.Http include a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
+* `OpenTelemetry.Instrumentation.AspNetCore` and `OpenTelemetry.Instrumentation.Http` include a hotfix for [GHSA-vh2m-22xx-q94f](https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f).
   By default any values detected in the query string component of requests are replaced with the text `Redacted` when building the `url.query` tag.
   For example, `?key1=value1&key2=value2` becomes `?key1=Redacted&key2=Redacted`.
   You can disable this redaction by setting the environment variable `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION` to `true`.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -32,6 +32,7 @@
   <!-- Shared source from Exporter -->
   <ItemGroup>
     <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\ExceptionExtensions.cs" LinkBase="Shared" />
+    <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\Platform\EnvironmentVariableConstants.cs" LinkBase="Shared" />
   </ItemGroup>
   
 </Project>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>An OpenTelemetry .NET distro that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry ASP.NET Core Distro</AssemblyTitle>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Azure Monitor OpenTelemetry Exporter Distro ApplicationInsights</PackageTags>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,7 +48,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// <item>SQL Client.</item>
         /// </list>
         /// </remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+        // Note: OpenTelemetryBuilder is obsolete because users should target
+        // IOpenTelemetryBuilder for extensions but this method is valid and
+        // expected to be called to obtain a root builder.
         public static OpenTelemetryBuilder UseAzureMonitor(this OpenTelemetryBuilder builder)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             builder.Services.TryAddSingleton<IConfigureOptions<AzureMonitorOptions>,
                         DefaultAzureMonitorOptions>();
@@ -74,7 +80,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// <item>SQL Client.</item>
         /// </list>
         /// </remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+        // Note: OpenTelemetryBuilder is obsolete because users should target
+        // IOpenTelemetryBuilder for extensions but this method is valid and
+        // expected to be called to obtain a root builder.
         public static OpenTelemetryBuilder UseAzureMonitor(this OpenTelemetryBuilder builder, Action<AzureMonitorOptions> configureAzureMonitor)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             if (builder.Services == null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -65,5 +65,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         /// When set to true, exporter will emit resources as metric telemetry.
         /// </summary>
         public const string EXPORT_RESOURCE_METRIC = "OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS";
+
+        /// <summary>
+        /// By default, OpenTelemetry.Instrumenation.AspNetCore v1.8.1 will redact query strings values from URLs.
+        /// This environment variable can be set to true to disable this behavior.
+        /// </summary>
+        /// <remarks>
+        /// <see href="https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md#181"/>.
+        /// </remarks>
+        public const string ASPNETCORE_DISABLE_URL_QUERY_REDACTION = "OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION";
+
+        /// <summary>
+        /// By default, OpenTelemetry.Instrumenation.Http v1.8.1 will redact query string values from URLs.
+        /// This environment variable can be set to true to disable this behavior.
+        /// </summary>
+        /// <remarks>
+        /// <see href="https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md#181"/>.
+        /// </remarks>
+        public const string HTTPCLIENT_DISABLE_URL_QUERY_REDACTION = "OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION";
     }
 }


### PR DESCRIPTION
I created this PR so our team can review these changes.

## Hotfix
I created a new `hotfix/azure.monitor.opentelemetry.aspnetcore_1.1.1`, forked from [tag/Azure.Monitor.OpenTelemetry.AspNetCore_1.1.0](https://github.com/Azure/azure-sdk-for-net/releases/tag/Azure.Monitor.OpenTelemetry.AspNetCore_1.1.0)
Our hotfix will release from this branch.
This PR is merging into this branch.

## Changes
This PR is upgrades the OpenTelemetry dependencies to 1.8.1.