### PR TITLE
[AppConfiguration] Bug fix: GetConfigurationSetting logs 304 as failures

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 1.5.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.4.1 (2024-04-17)
 
 ### Bugs Fixed
-
-### Other Changes
+- Fixed a bug introduced in version 1.3.0 where the `GetConfigurationSetting` method incorrectly logged 304 responses as failures in distributed tracing.
 
 ## 1.4.0 (2024-04-10)
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/appconfiguration/Azure.Data.AppConfiguration",
-  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_6f9a3b2b43"
+  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_cd95303075"
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Application Configuration Service client library</Description>
     <AssemblyTitle>Microsoft Azure.Data.AppConfiguration client library</AssemblyTitle>
-    <Version>1.5.0-beta.1</Version>
+    <Version>1.4.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.4.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Application Configuration;Data;AppConfig;$(PackageCommonTags)</PackageTags>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -587,6 +587,7 @@ namespace Azure.Data.AppConfiguration
             try
             {
                 RequestContext context = CreateRequestContext(ErrorOptions.NoThrow, cancellationToken);
+                context.AddClassifier(304, isError: false);
 
                 var dateTime = acceptDateTime.HasValue ? acceptDateTime.Value.UtcDateTime.ToString(AcceptDateTimeFormat, CultureInfo.InvariantCulture) : null;
                 using Response response = await GetConfigurationSettingAsync(key, label, dateTime, null, conditions, context).ConfigureAwait(false);
@@ -623,6 +624,7 @@ namespace Azure.Data.AppConfiguration
             try
             {
                 RequestContext context = CreateRequestContext(ErrorOptions.NoThrow, cancellationToken);
+                context.AddClassifier(304, isError: false);
 
                 var dateTime = acceptDateTime.HasValue ? acceptDateTime.Value.UtcDateTime.ToString(AcceptDateTimeFormat, CultureInfo.InvariantCulture) : null;
                 using Response response = GetConfigurationSetting(key, label, dateTime, null, conditions, context);


### PR DESCRIPTION
When requesting a setting with the `onlyIfChanged` flag enabled, `GetConfigurationSetting` will return a 304 HTTP response if the setting has not been changed since the last call. This is a response we consider successful, so we throw no exceptions in this scenario.

In version 1.3.0, we accidentally introduced a change in behavior where distributed tracing logs 304 responses as failures for the `GetConfigurationSetting` method. This is the output we see when printing logs to the console:
```
[Warning] Azure-Core: Error response [a8d58310-8822-4c37-9942-9b150c1a848b] 304 Not Modified (00.1s)
```

This PR:
- Fixes the bug for the `GetConfigurationSetting` method.
- Adds unit tests for `GetConfigurationSetting` to ensure the bug won't be introduced again.
- Adds unit tests for `GetConfigurationSettings`, which could face the same bug if its code changes in the future.