### PR TITLE
[Core] ResponseBodyPolicy: ensure response content stream is MemoryStream if buffering is enabled

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/MockTransport.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/MockTransport.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -95,7 +96,17 @@ namespace Azure.Core.TestFramework
 
             message.Response.ClientRequestId = request.ClientRequestId;
 
-            if (message.Response.ContentStream != null && ExpectSyncPipeline != null)
+            if (message.Response.ContentStream != null && message.BufferResponse)
+            {
+                if (!(message.Response.ContentStream is MemoryStream))
+                {
+                    throw new InvalidOperationException(
+                        "Response content stream must be MemoryStream when buffering is requested"
+                    );
+                }
+            }
+
+            if (message.Response.ContentStream != null && !message.BufferResponse && ExpectSyncPipeline != null)
             {
                 message.Response.ContentStream = new AsyncValidatingStream(!ExpectSyncPipeline.Value, message.Response.ContentStream);
             }

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
@@ -68,7 +68,7 @@ namespace Azure.Core.Pipeline
             }
 
             Stream? responseContentStream = message.Response.ContentStream;
-            if (responseContentStream == null || responseContentStream.CanSeek)
+            if (responseContentStream == null || responseContentStream is MemoryStream)
             {
                 return;
             }


### PR DESCRIPTION
Provides a stronger guarantee about the behavior of the response content stream (i.e. "it is either null or a MemoryStream") if BufferResponse is true. Also, make the requirement for unit tests stricter in order to mimic the actual behavior of the response stream, and disable async stream checking in MockTransport for the case where we're guaranteed to have a MemoryStream for the buffered content (which should allow synchronous processing).

Note especially that the `responseContentStream.CanSeek` condition in ResponseBodyPolicy, which is being replaced with `responseContentStream is MemoryStream`, was added merely to accommodate unit tests (originally in this commit: https://github.com/Azure/azure-sdk-for-net/commit/96d841746e12760e87341e594fd12ffcfa12c3a0).