### PR TITLE
[DocumentIntelligence] Enabling live testing

### DIFF
--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/Infrastructure/DocumentIntelligenceTestEnvironment.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/Infrastructure/DocumentIntelligenceTestEnvironment.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.DocumentIntelligence.Tests
@@ -50,6 +51,24 @@ namespace Azure.AI.DocumentIntelligence.Tests
             var bytes = File.ReadAllBytes(path);
 
             return BinaryData.FromBytes(bytes);
+        }
+
+        protected override async ValueTask<bool> IsEnvironmentReadyAsync()
+        {
+            var endpoint = new Uri(Endpoint);
+            var keyCredential = new AzureKeyCredential(ApiKey);
+            var keyCredentialClient = new DocumentIntelligenceAdministrationClient(endpoint, keyCredential);
+
+            try
+            {
+                await keyCredentialClient.GetResourceInfoAsync();
+            }
+            catch (RequestFailedException e) when (e.Status == 401)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/sdk/documentintelligence/test-resources.json
+++ b/sdk/documentintelligence/test-resources.json
@@ -11,7 +11,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "[resourceGroup().location]",
+            "defaultValue": "eastus",
             "metadata": {
                 "description": "The location of the resource. By default, this is the same as the resource group."
             }
@@ -21,13 +21,10 @@
             "type": "string"
         },
         "cognitiveServicesEndpointSuffix": {
-            "defaultValue": ".cognitiveservices.azure.com",
-            "type": "string"
-        },
-        "testApplicationOid": {
             "type": "string",
+            "defaultValue": ".cognitiveservices.azure.com",
             "metadata": {
-                "description": "The principal to assign the role to. This is application object id."
+                "description": "Endpoint suffix for the Cognitive Services resource. Defaults to '.cognitiveservices.azure.com'"
             }
         },
         "trainingDataAccount": {
@@ -44,7 +41,7 @@
         },
         "trainingDataResourceId": {
             "type": "string",
-            "defaultValue": "[resourceId('TrainingData', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
+            "defaultValue": "[resourceId('2cd617ea-1866-46b1-90e3-fffb087ebf9b', 'TrainingData', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
         },
         "trainingDataSasProperties": {
             "type": "object",
@@ -66,38 +63,28 @@
         }
     },
     "variables": {
-        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
         "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
         "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('cognitiveServicesEndpointSuffix'))]"
     },
     "resources": [
         {
             "type": "Microsoft.CognitiveServices/accounts",
-            "apiVersion": "2017-04-18",
             "name": "[variables('uniqueSubDomainName')]",
-            "location":"[parameters('location')]",
+            "apiVersion": "2023-10-01-preview",
             "sku": {
                 "name": "S0"
             },
             "kind": "FormRecognizer",
+            "location": "[parameters('location')]",
             "properties": {
                 "customSubDomainName": "[variables('uniqueSubDomainName')]"
-            }
-        },
-        {
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2018-09-01-preview",
-            "name": "[guid(resourceGroup().id)]",
-            "properties": {
-                "roleDefinitionId": "[variables('roleDefinitionId')]",
-                "principalId": "[parameters('testApplicationOid')]"
             }
         }
     ],
     "outputs": {
         "API_KEY": {
             "type": "string",
-            "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts',variables('uniqueSubDomainName')), '2017-04-18').key1]"
+            "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', variables('uniqueSubDomainName')), '2023-10-01-preview').key1]"
         },
         "ENDPOINT": {
             "type": "string",

--- a/sdk/documentintelligence/test-resources.json
+++ b/sdk/documentintelligence/test-resources.json
@@ -11,7 +11,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "eastus",
+            "defaultValue": "[resourceGroup().location]",
             "metadata": {
                 "description": "The location of the resource. By default, this is the same as the resource group."
             }
@@ -21,10 +21,13 @@
             "type": "string"
         },
         "cognitiveServicesEndpointSuffix": {
-            "type": "string",
             "defaultValue": ".cognitiveservices.azure.com",
+            "type": "string"
+        },
+        "testApplicationOid": {
+            "type": "string",
             "metadata": {
-                "description": "Endpoint suffix for the Cognitive Services resource. Defaults to '.cognitiveservices.azure.com'"
+                "description": "The principal to assign the role to. This is application object id."
             }
         },
         "trainingDataAccount": {
@@ -41,7 +44,7 @@
         },
         "trainingDataResourceId": {
             "type": "string",
-            "defaultValue": "[resourceId('2cd617ea-1866-46b1-90e3-fffb087ebf9b', 'TrainingData', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
+            "defaultValue": "[resourceId('TrainingData', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
         },
         "trainingDataSasProperties": {
             "type": "object",
@@ -63,28 +66,38 @@
         }
     },
     "variables": {
+        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
         "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
         "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('cognitiveServicesEndpointSuffix'))]"
     },
     "resources": [
         {
             "type": "Microsoft.CognitiveServices/accounts",
+            "apiVersion": "2017-04-18",
             "name": "[variables('uniqueSubDomainName')]",
-            "apiVersion": "2023-10-01-preview",
+            "location":"[parameters('location')]",
             "sku": {
                 "name": "S0"
             },
             "kind": "FormRecognizer",
-            "location": "[parameters('location')]",
             "properties": {
                 "customSubDomainName": "[variables('uniqueSubDomainName')]"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2018-09-01-preview",
+            "name": "[guid(resourceGroup().id)]",
+            "properties": {
+                "roleDefinitionId": "[variables('roleDefinitionId')]",
+                "principalId": "[parameters('testApplicationOid')]"
             }
         }
     ],
     "outputs": {
         "API_KEY": {
             "type": "string",
-            "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', variables('uniqueSubDomainName')), '2023-10-01-preview').key1]"
+            "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts',variables('uniqueSubDomainName')), '2017-04-18').key1]"
         },
         "ENDPOINT": {
             "type": "string",

--- a/sdk/documentintelligence/tests.yml
+++ b/sdk/documentintelligence/tests.yml
@@ -4,4 +4,8 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: documentintelligence
+    CloudConfig:
+      Public:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        Location: 'eastus'
     SupportedClouds: 'Public'


### PR DESCRIPTION
This PR enables live testing for the Document Intelligence SDK.

It fixes two issues that were preventing the pipeline from working:
- It changes the test resource region to `eastus` to support the latest preview REST API version.
- It overrides the `IsEnvironmentReadyAsync` method in the Test Framework to ensure that the recently created test resource is ready before starting tests. Without this step we'd get frequent 401 errors.