### PR TITLE
Fix bug on query expression writer logic when DataMember is present without a explict name

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue where custom models decorated with the `DataMemberAttribute` that didn't explicitly set a name caused the query filter to be malformed.
 
 ### Other Changes
 

--- a/sdk/tables/Azure.Data.Tables/assets.json
+++ b/sdk/tables/Azure.Data.Tables/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/tables/Azure.Data.Tables",
-  "Tag": "net/tables/Azure.Data.Tables_4d1f2b2c69"
+  "Tag": "net/tables/Azure.Data.Tables_4d55973aaa"
 }

--- a/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionWriter.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionWriter.cs
@@ -202,7 +202,7 @@ namespace Azure.Data.Tables.Queryable
 
         protected virtual string TranslateMemberName(MemberInfo memberInfo)
         {
-            if (memberInfo.GetCustomAttribute<DataMemberAttribute>() is DataMemberAttribute dataMemberAttribute)
+            if (memberInfo.GetCustomAttribute<DataMemberAttribute>() is DataMemberAttribute dataMemberAttribute && dataMemberAttribute.IsNameSetExplicitly)
             {
                 return dataMemberAttribute.Name;
             }

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientQueryExpressionTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientQueryExpressionTests.cs
@@ -40,6 +40,7 @@ namespace Azure.Data.Tables.Tests
         private static readonly BinaryData s_someBinaryData = new BinaryData(new byte[] { 0x01, 0x02, 0x03, 0x04, 0xFF });
         private static readonly Expression<Func<ComplexEntity, bool>> s_rename = x => x.RenamableStringProperty == "someString";
         private static readonly Expression<Func<ComplexEntity, bool>> s_renameAndNonrename = x => x.RenamableStringProperty != "someString" && x.PartitionKey == Partition;
+        private static readonly Expression<Func<ComplexEntity, bool>> s_nonRenameDataMember = x => x.DataMemberImplictNameProperty != "someString";
         private static readonly Expression<Func<TableItem, bool>> s_ne_TI = x => x.Name != TableName;
         private static readonly Expression<Func<ComplexEntity, bool>> s_ne = x => x.PartitionKey == Partition && x.RowKey != Row;
         private static readonly Expression<Func<TableEntity, bool>> s_neDE = x => x.PartitionKey == Partition && x.RowKey != Row;
@@ -98,6 +99,7 @@ namespace Azure.Data.Tables.Tests
         {
             new object[] {$"SomeNewName eq 'someString'", s_rename},
             new object[] {$"(SomeNewName ne 'someString') and (PartitionKey eq '{Partition}')", s_renameAndNonrename},
+            new object[] {$"DataMemberImplictNameProperty ne 'someString'", s_nonRenameDataMember },
             new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ne '{Row}')", s_ne },
             new object[] { $"(PartitionKey eq '{Partition}') and (RowKey gt '{Row}')", s_gt },
             new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ge '{Row}')", s_ge },

--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceLiveTestsBase.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceLiveTestsBase.cs
@@ -295,6 +295,7 @@ namespace Azure.Data.Tables.Tests
                             LongPrimitive = (long)int.MaxValue + n,
                             LongPrimitiveN = (long)int.MaxValue + n,
                             RenamableStringProperty = string.Format("{0:0000}", n),
+                            DataMemberImplictNameProperty = string.Format("{0:0000}", n)
                         };
                     })
                 .ToList();
@@ -487,6 +488,9 @@ namespace Azure.Data.Tables.Tests
 
             [DataMember(Name = "SomeNewName")]
             public string RenamableStringProperty { get; set; }
+
+            [DataMember]
+            public string DataMemberImplictNameProperty { get; set; }
 
             public Guid? GuidNull
             {


### PR DESCRIPTION
Hi, this PR https://github.com/Azure/azure-sdk-for-net/pull/35954, introduced a bug that caused the expression to be generated like this:

` ne 'someString'`

Updated the logic to consider the case that the property has a DataMember annotation but has no custom name set and expression is being generated like this:

`DataMemberImplictNameProperty ne 'someString'`

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
