### PR TITLE
[Messaging Functions Extensions] Release Prep for April 2024

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/CHANGELOG.md
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 3.4.1 (2024-04-17)
 
 ### Other Changes
+
+- To mitigate a [disclosure vulnerability](https://github.com/advisories/GHSA-wvxc-855f-jvrv), updating the transitive dependency for `Azure.Identity` to v1.11.1 via version bump to `Microsoft.Extensions.Azure`. 
 
 ## 3.3.1 (2023-11-13)
 

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>This extension adds bindings for EventGrid</Description>
-    <Version>3.4.0-beta.1</Version>
+    <Version>3.4.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>3.3.1</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS1591</NoWarn>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 6.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 6.3.1 (2024-04-17)
 
 ### Other Changes
+
+- To mitigate a [disclosure vulnerability](https://github.com/advisories/GHSA-wvxc-855f-jvrv), updating the transitive dependency for `Azure.Identity` to v1.11.1 via version bump to `Microsoft.Extensions.Azure`. 
 
 ## 6.3.0 (2024-04-10)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>6.4.0-beta.1</Version>
+    <Version>6.3.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>6.3.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636</NoWarn>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.15.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 5.15.1 (2024-04-17)
 
 ### Other Changes
+
+- To mitigate a [disclosure vulnerability](https://github.com/advisories/GHSA-wvxc-855f-jvrv), updating the transitive dependency for `Azure.Identity` to v1.11.1 via version bump to `Microsoft.Extensions.Azure`. 
 
 ## 5.14.0 (2024-03-14)
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK ServiceBus Extension</Description>
-    <Version>5.15.0-beta.1</Version>
+    <Version>5.15.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <!--Since we are adding a new target for net6.0, we need to temporarily condition on netstandard-->
     <ApiCompatVersion>5.14.0</ApiCompatVersion>

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/CHANGELOG.md
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.1 (2024-04-17)
 
 ### Other Changes
+
+- To mitigate a [disclosure vulnerability](https://github.com/advisories/GHSA-wvxc-855f-jvrv), updating the transitive dependency for `Azure.Identity` to v1.11.1 via version bump to `Microsoft.Extensions.Azure`. 
 
 ## 1.2.1 (2023-11-13)
 

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/Microsoft.Azure.WebJobs.Extensions.Tables.csproj
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/Microsoft.Azure.WebJobs.Extensions.Tables.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>1.3.0-beta.1</Version>
+        <Version>1.3.1</Version>
         <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
         <ApiCompatVersion>1.2.1</ApiCompatVersion>
         <Description>This package extends the Microsoft.Azure.WebJobs library with Table triggers using Azure Table service.</Description>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the messaging-related Azure Functions extensions packages for an out-of-band release to bump the transitive Azure.Identity dependency version due to a recent
CVE.
