### PR TITLE
[Core] Release Prep: LRO Rehydration

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,17 +1,14 @@
 # Release History
 
-## 1.39.0-beta.1 (Unreleased)
+## 1.39.0 (2024-04-18)
 
 ### Features Added
 
 - Add `Operation.Rehydrate` and `Operation.Rehydrate<T>` static methods to rehydrate a long-running operation.
 
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
-- `RequestFailedException` will not include the response content or headers in the message when the `IsError` property of the response is false.
+
+- `RequestFailedException` will not include the response content or headers in the message when the `IsError` property of the response is `false`.
 
 ## 1.38.0 (2024-02-26)
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.39.0-beta.1</Version>
+    <Version>1.39.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.38.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare for an out-of-band release of Azure.Core to make the new LRO rehydration feature available.