### PR TITLE
[EngSys] Update central Core version

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -108,7 +108,7 @@
     <!-- Azure SDK packages -->
     <PackageReference Update="Azure.Communication.Identity" Version="1.3.1" />
     <PackageReference Update="Azure.Communication.Common" Version="1.3.0" />
-    <PackageReference Update="Azure.Core" Version="1.38.0" />
+    <PackageReference Update="Azure.Core" Version="1.39.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.3.0" />
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.32" />
     <PackageReference Update="Azure.Core.Expressions.DataFactory" Version="1.0.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the central version for Azure.Core references to the latest release.