### PR TITLE
[Search] Disable flaky test

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/Batching/BatchingTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Batching/BatchingTests.cs
@@ -213,6 +213,7 @@ namespace Azure.Search.Documents.Tests
 
         #region Champion
         [Test]
+        [Ignore(Consistently exceeding global timeout in Core runs.  Tracked by #43540")]
         public async Task Champion_OneShotUpload()
         {
             await using SearchResources resources = await SearchResources.CreateWithEmptyIndexAsync<SimpleDocument>(this);

--- a/sdk/search/Azure.Search.Documents/tests/Batching/BatchingTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Batching/BatchingTests.cs
@@ -213,7 +213,7 @@ namespace Azure.Search.Documents.Tests
 
         #region Champion
         [Test]
-        [Ignore(Consistently exceeding global timeout in Core runs.  Tracked by #43540")]
+        [Ignore("Consistently exceeding global timeout in Core runs.  Tracked by #43540")]
         public async Task Champion_OneShotUpload()
         {
             await using SearchResources resources = await SearchResources.CreateWithEmptyIndexAsync<SimpleDocument>(this);


### PR DESCRIPTION
# Summary

The focus of these changes is to ignore a flaky test that is consistently exceeding the global timeout in Azure.Core runs.

## References and resources

- [[Search] Flaky test: Champion_OneShotUpload (#43540)](https://github.com/Azure/azure-sdk-for-net/issues/43540)