### PR TITLE
[LiveMetricsExporter] Add Filtering Support part 9 - Add the DocumentStreamIds into telemetry documents

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
@@ -153,7 +153,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
 
         private Models.Trace CreateUpdatedTrace(Models.Trace trace, IList<string> documentStreamIds)
         {
-            return new Models.Trace(trace.DocumentType, documentStreamIds, trace.Properties, trace.Message + ":test7");
+            return new Models.Trace(trace.DocumentType, documentStreamIds, trace.Properties, trace.Message);
         }
 
         /// <remarks>


### PR DESCRIPTION
PR following up on #41523.

Reverting the [code change](https://github.com/Azure/azure-sdk-for-net/pull/43255/commits/93696c958da0409a059f1e38bdeb1249ad851915) which removed the `documentStreamIds`. Context: https://github.com/Azure/azure-sdk-for-net/pull/43255#discussion_r1554449776

The `documentStreamIds` are used to associate with the Sample Telemetry side panel filters. After a filter is applied, the Sample Telemetry panel will need the telemetry items in `MonitoringDataPoint.Documents` list to have the side panel filter ID, i.e. `DocumentStreams.Id`. Basically it tells the side panel that these telemetry items are sent because customer set a filter, and they are associated via this ID.

For example, after the customer set a filter in the side panel, the Distro will receive 

```
{
    "ETag": "0::A_RANDOM_LONG_ETAG_STRING::5::",
    "Metrics": [{
        "Id": "87.30d0245b",
        "TelemetryType": "Trace",
        "FilterGroups": [{
            "Filters": []
        }],
        "Projection": "Count()",
        "Aggregation": "Sum",
        "BackEndAggregation": "Sum"
    }],
    "QuotaInfo": null,
    "DocumentStreams": [{
        "Id": "66.f82c1049",
        "DocumentFilterGroups": [{
            "TelemetryType": "Trace",
            "Filters": {
                "Filters": []
            }
        }]
    }]
}
```

Later if a matching telemetry appears, the Distro needs to send Documents with DocumentStreamIds field:

```
    "Documents": [{
        "Message": "Hello {name}.",
        "DocumentType": "Trace",
        "DocumentStreamIds": ["66.f82c1049"],
    },]
```


Before this PR, the Distro sends the following object and the side panel wouldn't show it unless refreshing page (but the filter context would be lost with a refresh):

```
    "Documents": [{
        "Message": "Hello {name}.",
        "DocumentType": "Trace"
    }]
```

