### PR TITLE
Make RehydrationToken members public

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Make members of `RehydrationToken` public
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -534,7 +534,15 @@ namespace Azure.Core
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
+        public RehydrationToken(string? id, string? version, string headerSource, string nextRequestUri, string initialUri, Azure.Core.RequestMethod requestMethod, string? lastKnownLocation, string finalStateVia) { throw null; }
+        public string FinalStateVia { get { throw null; } }
+        public string HeaderSource { get { throw null; } }
         public string Id { get { throw null; } }
+        public string InitialUri { get { throw null; } }
+        public string? LastKnownLocation { get { throw null; } }
+        public string NextRequestUri { get { throw null; } }
+        public Azure.Core.RequestMethod RequestMethod { get { throw null; } }
+        public string Version { get { throw null; } }
         Azure.Core.RehydrationToken System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         object System.ClientModel.Primitives.IJsonModel<object>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -534,7 +534,15 @@ namespace Azure.Core
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
+        public RehydrationToken(string? id, string? version, string headerSource, string nextRequestUri, string initialUri, Azure.Core.RequestMethod requestMethod, string? lastKnownLocation, string finalStateVia) { throw null; }
+        public string FinalStateVia { get { throw null; } }
+        public string HeaderSource { get { throw null; } }
         public string Id { get { throw null; } }
+        public string InitialUri { get { throw null; } }
+        public string? LastKnownLocation { get { throw null; } }
+        public string NextRequestUri { get { throw null; } }
+        public Azure.Core.RequestMethod RequestMethod { get { throw null; } }
+        public string Version { get { throw null; } }
         Azure.Core.RehydrationToken System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         object System.ClientModel.Primitives.IJsonModel<object>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -534,7 +534,15 @@ namespace Azure.Core
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
+        public RehydrationToken(string? id, string? version, string headerSource, string nextRequestUri, string initialUri, Azure.Core.RequestMethod requestMethod, string? lastKnownLocation, string finalStateVia) { throw null; }
+        public string FinalStateVia { get { throw null; } }
+        public string HeaderSource { get { throw null; } }
         public string Id { get { throw null; } }
+        public string InitialUri { get { throw null; } }
+        public string? LastKnownLocation { get { throw null; } }
+        public string NextRequestUri { get { throw null; } }
+        public Azure.Core.RequestMethod RequestMethod { get { throw null; } }
+        public string Version { get { throw null; } }
         Azure.Core.RehydrationToken System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         object System.ClientModel.Primitives.IJsonModel<object>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -534,7 +534,15 @@ namespace Azure.Core
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
+        public RehydrationToken(string? id, string? version, string headerSource, string nextRequestUri, string initialUri, Azure.Core.RequestMethod requestMethod, string? lastKnownLocation, string finalStateVia) { throw null; }
+        public string FinalStateVia { get { throw null; } }
+        public string HeaderSource { get { throw null; } }
         public string Id { get { throw null; } }
+        public string InitialUri { get { throw null; } }
+        public string? LastKnownLocation { get { throw null; } }
+        public string NextRequestUri { get { throw null; } }
+        public Azure.Core.RequestMethod RequestMethod { get { throw null; } }
+        public string Version { get { throw null; } }
         Azure.Core.RehydrationToken System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         object System.ClientModel.Primitives.IJsonModel<object>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/core/Azure.Core/src/RehydrationToken.cs
+++ b/sdk/core/Azure.Core/src/RehydrationToken.cs
@@ -15,31 +15,58 @@ namespace Azure.Core
         /// </summary>
         public string Id { get; } = NextLinkOperationImplementation.NotSet;
 
-        // Version for this contract itself since we might change the members in the future.
-        internal string Version { get; } = NextLinkOperationImplementation.RehydrationTokenVersion;
+        /// <summary>
+        /// Version the <see cref="RehydrationToken"/> struct.
+        /// </summary>
+        public string Version { get; } = NextLinkOperationImplementation.RehydrationTokenVersion;
 
-        // The below members are used to re-construct <cref="NextLinkOperationImplemenation">.
-        // Value of <cref="NextLinkOperationImplemenration.HeaderSrouce">.
-        internal string HeaderSource { get; }
+        /// <summary>
+        /// The header source of the operation, could be None, OperationLocation, AzureAsyncOperation or Location.
+        /// </summary>
+        public string HeaderSource { get; }
 
-        // The polling Uri of the operation.
-        internal string NextRequestUri { get; }
+        /// <summary>
+        /// The polling Uri of the operation.
+        /// </summary>
+        public string NextRequestUri { get; }
 
-        // The initial Uri of the operation.
-        internal string InitialUri { get; }
+        /// <summary>
+        /// The initial Uri of the operation.
+        /// </summary>
+        public string InitialUri { get; }
 
-        // The Http request method of the operation.
-        internal RequestMethod RequestMethod { get; }
+        /// <summary>
+        /// The Http request method of the operation.
+        /// </summary>
+        public RequestMethod RequestMethod { get; }
 
-        // The last known location of the operation.
-        internal string? LastKnownLocation { get; }
+        /// <summary>
+        /// The last known location of the operation.
+        /// </summary>
+        public string? LastKnownLocation { get; }
 
-        // The final state of the operation, could be azure-async-operation, location, original-uri or operation-location.
-        internal string FinalStateVia { get; }
+        /// <summary>
+        /// The final state of the operation, could be AzureAsyncOperation, Location, OriginalUri, OperationLocation or LocationOverride.
+        /// </summary>
+        public string FinalStateVia { get; }
 
-        internal RehydrationToken(string id, string? version, string headerSource, string nextRequestUri, string initialUri, RequestMethod requestMethod, string? lastKnownLocation, string finalStateVia)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RehydrationToken"/> struct.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="version"></param>
+        /// <param name="headerSource"></param>
+        /// <param name="nextRequestUri"></param>
+        /// <param name="initialUri"></param>
+        /// <param name="requestMethod"></param>
+        /// <param name="lastKnownLocation"></param>
+        /// <param name="finalStateVia"></param>
+        public RehydrationToken(string? id, string? version, string headerSource, string nextRequestUri, string initialUri, RequestMethod requestMethod, string? lastKnownLocation, string finalStateVia)
         {
-            Id = id;
+            if (id is not null)
+            {
+                Id = id;
+            }
             if (version is not null)
             {
                 Version = version;

--- a/sdk/core/Azure.Core/src/RehydrationToken.cs
+++ b/sdk/core/Azure.Core/src/RehydrationToken.cs
@@ -16,7 +16,7 @@ namespace Azure.Core
         public string Id { get; } = NextLinkOperationImplementation.NotSet;
 
         /// <summary>
-        /// Version the <see cref="RehydrationToken"/> struct.
+        /// The version of the <see cref="RehydrationToken"/> struct.
         /// </summary>
         public string Version { get; } = NextLinkOperationImplementation.RehydrationTokenVersion;
 
@@ -53,14 +53,14 @@ namespace Azure.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="RehydrationToken"/> struct.
         /// </summary>
-        /// <param name="id"></param>
-        /// <param name="version"></param>
-        /// <param name="headerSource"></param>
-        /// <param name="nextRequestUri"></param>
-        /// <param name="initialUri"></param>
-        /// <param name="requestMethod"></param>
-        /// <param name="lastKnownLocation"></param>
-        /// <param name="finalStateVia"></param>
+        /// <param name="id">The id representing the operation that can be used to poll for the status of the long-running operation.</param>
+        /// <param name="version">The version of the <see cref="RehydrationToken"/> struct.</param>
+        /// <param name="headerSource">The header source of the operation, could be None, OperationLocation, AzureAsyncOperation or Location.</param>
+        /// <param name="nextRequestUri">The polling Uri of the operation.</param>
+        /// <param name="initialUri">The initial Uri of the operation.</param>
+        /// <param name="requestMethod">The Http request method of the operation.</param>
+        /// <param name="lastKnownLocation">The last known location of the operation.</param>
+        /// <param name="finalStateVia">The final state of the operation, could be AzureAsyncOperation, Location, OriginalUri, OperationLocation or LocationOverride.</param>
         public RehydrationToken(string? id, string? version, string headerSource, string nextRequestUri, string initialUri, RequestMethod requestMethod, string? lastKnownLocation, string finalStateVia)
         {
             if (id is not null)

--- a/sdk/core/Azure.Core/tests/RehydrationTokenTests.cs
+++ b/sdk/core/Azure.Core/tests/RehydrationTokenTests.cs
@@ -25,10 +25,30 @@ namespace Azure.Core.Tests
         [Test]
         public void RoundTripForRehydrationToken()
         {
-            var token = new RehydrationToken(Guid.NewGuid().ToString(), null, "headerSource", "nextRequestUri", "initialUri", RequestMethod.Get, "lastKnownLocation", OperationFinalStateVia.OperationLocation.ToString());
+            var token = new RehydrationToken(null, null, "headerSource", "nextRequestUri", "initialUri", RequestMethod.Get, "lastKnownLocation", OperationFinalStateVia.OperationLocation.ToString());
             var data = ModelReaderWriter.Write(token);
             var deserializedToken = ModelReaderWriter.Read(data, typeof(RehydrationToken));
             Assert.AreEqual(token, deserializedToken);
+        }
+
+        [Test]
+        public void VerifyPublicMembers()
+        {
+            var headerSource = "None";
+            var nextRequestUri = "nextRequestUri";
+            var initialUri = "initialUri";
+            var requestMethod = RequestMethod.Get;
+            var lastKnownLocation = "lastKnownLocation";
+            var finalStateVia = OperationFinalStateVia.OperationLocation.ToString();
+            var token = new RehydrationToken(null, null, headerSource, nextRequestUri, initialUri, requestMethod, lastKnownLocation, finalStateVia);
+            Assert.AreEqual(headerSource, token.HeaderSource);
+            Assert.AreEqual(nextRequestUri, token.NextRequestUri);
+            Assert.AreEqual(initialUri, token.InitialUri);
+            Assert.AreEqual(requestMethod, token.RequestMethod);
+            Assert.AreEqual(lastKnownLocation, token.LastKnownLocation);
+            Assert.AreEqual(finalStateVia, token.FinalStateVia);
+            Assert.AreEqual(NextLinkOperationImplementation.NotSet, token.Id);
+            Assert.AreEqual(NextLinkOperationImplementation.RehydrationTokenVersion, token.Version);
         }
 
         [Test]


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/43260

Then we can remove workaround in 
https://github.com/Azure/azure-sdk-for-net/blob/7d04683d350c0908dbc4907444e87a97a207d640/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs#L100-L112
and 
https://github.com/Azure/azure-sdk-for-net/blob/7d04683d350c0908dbc4907444e87a97a207d640/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs#L225-L226