### PR TITLE
[CODEOWNERS] Removing invalid owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,7 @@
 ##################
 # Repository root
 ##################
-
+dev
 # Catch all for loose files in the root, which are mostly global configuration and
 # should not be changed without team discussion.
 /*                                                                 @jsquire @pallavit @Azure/azure-sdk-write-net-core
@@ -449,10 +449,10 @@
 # ServiceOwners:                                                   @raedJarrar @jifems
 
 # PRLabel: %DevCenter
-/sdk/devcenter/                                                    @sebrenna @mharlan @chrissmiller @shivangireja
+/sdk/devcenter/                                                    @sebrenna @chrissmiller @shivangireja
 
 # ServiceLabel: %DevCenter
-# ServiceOwners:                                                   @sebrenna @mharlan @chrissmiller
+# ServiceOwners:                                                   @sebrenna @chrissmiller
 
 # ServiceLabel: %Dev Spaces
 # ServiceOwners:                                                   @yuzorMa @johnsta @greenie-msft

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,6 @@
 ##################
 # Repository root
 ##################
-dev
 # Catch all for loose files in the root, which are mostly global configuration and
 # should not be changed without team discussion.
 /*                                                                 @jsquire @pallavit @Azure/azure-sdk-write-net-core


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the `mharlan` handle from DevCenter ownership, as the account is no longer associated with Microsoft.