### PR TITLE
Only determine success of request based on statuscode when the Activity Status is Unset

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-* The success or failure of an HTTP request is only determined by the statuscode when the Activity Status is Unset
+* The success or failure of an incoming HTTP request is now determined by the status code only when the Activity Status is `Unset`
   ([#43594](https://github.com/Azure/azure-sdk-for-net/pull/43594), based on [#41993](https://github.com/Azure/azure-sdk-for-net/issues/41993))
 
 ### Other Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* The success or failure of an HTTP request is only determined by the statuscode when the Activity Status is Unset
+  ([#43594](https://github.com/Azure/azure-sdk-for-net/pull/43594), based on [#41993](https://github.com/Azure/azure-sdk-for-net/issues/41993))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
@@ -53,12 +53,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsSuccess(Activity activity, string? responseCode, OperationType operationType)
         {
-            if (operationType.HasFlag(OperationType.Http)
+            if (activity.Status == ActivityStatusCode.Unset
+                && operationType.HasFlag(OperationType.Http)
                 && responseCode != null
                 && int.TryParse(responseCode, out int statusCode))
             {
-                bool isSuccessStatusCode = statusCode != 0 && statusCode < 400;
-                return activity.Status != ActivityStatusCode.Error && isSuccessStatusCode;
+                return statusCode != 0 && statusCode < 400;
             }
             else
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
@@ -95,11 +95,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Theory]
-        [InlineData("200", true)]
-        [InlineData("400", false)]
-        [InlineData("500", false)]
-        [InlineData("0", false)]
-        public void ValidateHttpRequestSuccess(string httpStatusCode, bool isSuccess)
+        [InlineData("200", ActivityStatusCode.Unset, true)]
+        [InlineData("200", ActivityStatusCode.Ok, true)]
+        [InlineData("200", ActivityStatusCode.Error, false)]
+        [InlineData("400", ActivityStatusCode.Unset, false)]
+        [InlineData("400", ActivityStatusCode.Ok, true)]
+        [InlineData("400", ActivityStatusCode.Error, false)]
+        [InlineData("500", ActivityStatusCode.Unset, false)]
+        [InlineData("500", ActivityStatusCode.Ok, true)]
+        [InlineData("500", ActivityStatusCode.Error, false)]
+        [InlineData("0", ActivityStatusCode.Unset, false)]
+        [InlineData("0", ActivityStatusCode.Ok, true)]
+        [InlineData("0", ActivityStatusCode.Error, false)]
+        public void ValidateHttpRequestSuccess(string httpStatusCode, ActivityStatusCode activityStatus, bool isSuccess)
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
@@ -113,6 +121,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");
             activity.SetTag(SemanticConventions.AttributeHttpStatusCode, httpStatusCode);
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
+            activity.SetStatus(activityStatus);
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 


### PR DESCRIPTION
Fixes #41993

When a non-2xx response from a web request should not be marked as an error in OpenTelemetry, you can set the `Activity`'s status to `ActivityStatusCode.Ok` manually.

```cs
builder
    .AddAspNetCoreInstrumentation(options =>
    {
        options.EnrichWithHttpResponse = (activity, response) =>
        {
            if (response.StatusCode == 404)
            {
                activity.SetStatus(ActivityStatusCode.Ok);
            }
        };
    })
    .AddConsoleExporter()
    .AddAzureMonitorTraceExporter(options =>
    {
        options.ConnectionString = "<my connection string>";
    });
```

However, even though the status was set to `Ok`, the ApplicationInsights exporter still treats it like an error because of the response code being `>= 400`. This should only happen in cases where `activity.Status == ActivityStatusCode.Unset`.

Added to the `RequestData.IsSuccess` function is this extra check. Also, inside the `if` now the expression `activity.Status != ActivityStatusCode.Error` becomes always `true` and can hence be removed.