### PR TITLE
Fix blank list items in MetricsQueryClient API ref docs

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
@@ -55,8 +55,12 @@ namespace Azure.Monitor.Query
         /// </summary>
         /// <param name="endpoint">The Azure Resource Manager service endpoint to use. Some examples include:
         /// <list type="bullet">
-        ///     <item><c>https://management.usgovcloudapi.net</c> for Azure US Government Cloud</item>
-        ///     <item><c>https://management.chinacloudapi.cn</c> for Azure China Cloud</item>
+        /// <item>
+        /// <description><c>https://management.usgovcloudapi.net</c> for Azure US Government Cloud</description>
+        /// </item>
+        /// <item>
+        /// <description><c>https://management.chinacloudapi.cn</c> for Azure China Cloud</description>
+        /// </item>
         /// </list>
         /// </param>
         /// <param name="credential">The <see cref="TokenCredential"/> instance to use for authentication.</param>


### PR DESCRIPTION
Add a missing `<description>` node so that the list item text is displayed on the Learn API ref page. Currently, the list items display as follows:

![image](https://github.com/Azure/azure-sdk-for-net/assets/10702007/51a2de09-bfbd-422c-bc95-6931e06f1a4d)

