### PR TITLE
`ClientAssertionCredentialOptions` supports `TokenCachePersistenceOptions` for configuring token cache persistence.

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -56,9 +56,9 @@
 ## 1.0.0-beta.2 (2022-04-05)
 
 ### Features Added
-- Added `SharedTokenCacheCredentialBrokerOptions` to enable `SharedTokenCacheCredential` to use the authentication broker for silent authentication calls when this specicialized options type is used to construct the credential.
+- Added `SharedTokenCacheCredentialBrokerOptions` to enable `SharedTokenCacheCredential` to use the authentication broker for silent authentication calls when this specialized options type is used to construct the credential.
 
 ## 1.0.0-beta.1 (2022-02-23)
 
 ### Features Added
-- Added `InteractiveBrowserCredentialBrokerOptions` to enable `InteractiveBrowserCredential` to use the authentication broker when this specicialized options type is used to construct the credential.
+- Added `InteractiveBrowserCredentialBrokerOptions` to enable `InteractiveBrowserCredential` to use the authentication broker when this specialized options type is used to construct the credential.

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.12.0-beta.2 (Unreleased)
 
 ### Features Added
+- `ClientAssertionCredentialOptions` now supports `TokenCachePersistenceOptions` for configuring token cache persistence.
 
 ### Breaking Changes
 

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -118,6 +118,7 @@ namespace Azure.Identity
         public ClientAssertionCredentialOptions() { }
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
+        public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
     }
     public partial class ClientCertificateCredential : Azure.Core.TokenCredential
     {

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientAssertionCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientAssertionCredentialOptions.cs
@@ -8,7 +8,7 @@ namespace Azure.Identity
     /// <summary>
     /// Options used to configure the <see cref="ClientAssertionCredential"/>.
     /// </summary>
-    public class ClientAssertionCredentialOptions : TokenCredentialOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
+    public class ClientAssertionCredentialOptions : TokenCredentialOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenCachePersistenceOptions
     {
         internal CredentialPipeline Pipeline { get; set; }
 
@@ -21,5 +21,8 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        /// <inheritdoc/>
+        public TokenCachePersistenceOptions TokenCachePersistenceOptions { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/ISupportsTokenCachePersistenceOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ISupportsTokenCachePersistenceOptions.cs
@@ -9,6 +9,9 @@ namespace Azure.Identity
 {
     internal interface ISupportsTokenCachePersistenceOptions
     {
+        /// <summary>
+        /// Specifies the <see cref="TokenCachePersistenceOptions"/> to be used by the credential. If no options are specified, the token cache will not be persisted to disk.
+        /// </summary>
         TokenCachePersistenceOptions TokenCachePersistenceOptions { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredential.cs
@@ -93,6 +93,10 @@ namespace Azure.Identity
             _username = username;
             _password = password;
             _clientId = clientId;
+            if (options is UsernamePasswordCredentialOptions usernamePasswordOptions && usernamePasswordOptions.AuthenticationRecord != null)
+            {
+                _record = usernamePasswordOptions.AuthenticationRecord;
+            }
             _pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
             DefaultScope = AzureAuthorityHosts.GetDefaultScope(options?.AuthorityHost ?? AzureAuthorityHosts.GetDefault());
             Client = client ?? new MsalPublicClient(_pipeline, tenantId, clientId, null, options);

--- a/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredentialOptions.cs
@@ -22,5 +22,7 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        internal AuthenticationRecord AuthenticationRecord { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/ClientAssertionCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientAssertionCredentialLiveTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Identity.Tests
 
         [TestCase(true)]
         [TestCase(false)]
-        public async Task AuthenticateWithAssertionCallback(bool useAsyncCallback)
+        public async Task AuthnenticateWithAssertionCallback(bool useAsyncCallback)
         {
             var tenantId = TestEnvironment.ServicePrincipalTenantId;
             var clientId = TestEnvironment.ServicePrincipalClientId;

--- a/sdk/identity/Azure.Identity/tests/ClientAssertionCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientAssertionCredentialLiveTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Identity.Tests
 
         [TestCase(true)]
         [TestCase(false)]
-        public async Task AuthnenticateWithAssertionCallback(bool useAsyncCallback)
+        public async Task AuthenticateWithAssertionCallback(bool useAsyncCallback)
         {
             var tenantId = TestEnvironment.ServicePrincipalTenantId;
             var clientId = TestEnvironment.ServicePrincipalClientId;

--- a/sdk/identity/Azure.Identity/tests/ClientAssertionCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientAssertionCredentialTests.cs
@@ -36,6 +36,10 @@ namespace Azure.Identity.Tests
             {
                 options.Transport = config.Transport;
             }
+            if (config.TokenCachePersistenceOptions != null)
+            {
+                options.TokenCachePersistenceOptions = config.TokenCachePersistenceOptions;
+            }
             var pipeline = CredentialPipeline.GetInstance(options);
             options.Pipeline = pipeline;
             return InstrumentClient(new ClientAssertionCredential(config.TenantId, ClientId, () => "assertion", options));

--- a/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialTests.cs
@@ -46,6 +46,10 @@ namespace Azure.Identity.Tests
             {
                 options.Transport = config.Transport;
             }
+            if (config.TokenCachePersistenceOptions != null)
+            {
+                options.TokenCachePersistenceOptions = config.TokenCachePersistenceOptions;
+            }
             var pipeline = CredentialPipeline.GetInstance(options);
             var certificatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
             var mockCert = new X509Certificate2(certificatePath);

--- a/sdk/identity/Azure.Identity/tests/ClientSecretCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientSecretCredentialTests.cs
@@ -35,6 +35,10 @@ namespace Azure.Identity.Tests
             {
                 options.Transport = config.Transport;
             }
+            if (config.TokenCachePersistenceOptions != null)
+            {
+                options.TokenCachePersistenceOptions = config.TokenCachePersistenceOptions;
+            }
             var pipeline = CredentialPipeline.GetInstance(options);
             return InstrumentClient(new ClientSecretCredential(config.TenantId, ClientId, "secret", options, pipeline, config.MockConfidentialMsalClient));
         }

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
@@ -59,7 +59,7 @@ namespace Azure.Identity.Tests
 
         public override TokenCredential GetTokenCredential(CommonCredentialTestConfig config)
         {
-            expectedCode = Guid.NewGuid().ToString();
+            expectedCode = "some-code-created in DeviceCodeCredentialTests.GetTokenCredential";
             var options = new DeviceCodeCredentialOptions
             {
                 AdditionallyAllowedTenants = config.AdditionallyAllowedTenants,
@@ -69,6 +69,14 @@ namespace Azure.Identity.Tests
             if (config.Transport != null)
             {
                 options.Transport = config.Transport;
+            }
+            if (config.TokenCachePersistenceOptions != null)
+            {
+                options.TokenCachePersistenceOptions = config.TokenCachePersistenceOptions;
+            }
+            if (config.AuthenticationRecord != null)
+            {
+                options.AuthenticationRecord = config.AuthenticationRecord;
             }
             var pipeline = CredentialPipeline.GetInstance(options);
             return InstrumentClient(new DeviceCodeCredential((code, _) =>

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
@@ -42,6 +42,14 @@ namespace Azure.Identity.Tests
             {
                 options.Transport = config.Transport;
             }
+            if (config.TokenCachePersistenceOptions != null)
+            {
+                options.TokenCachePersistenceOptions = config.TokenCachePersistenceOptions;
+            }
+            if (config.AuthenticationRecord != null)
+            {
+                options.AuthenticationRecord = config.AuthenticationRecord;
+            }
             var pipeline = CredentialPipeline.GetInstance(options);
             return InstrumentClient(new InteractiveBrowserCredential(config.TenantId, ClientId, options, pipeline, config.MockPublicMsalClient));
         }

--- a/sdk/identity/Azure.Identity/tests/OnBehalfOfCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/OnBehalfOfCredentialTests.cs
@@ -58,6 +58,10 @@ namespace Azure.Identity.Tests
             {
                 options.Transport = config.Transport;
             }
+            if (config.TokenCachePersistenceOptions != null)
+            {
+                options.TokenCachePersistenceOptions = config.TokenCachePersistenceOptions;
+            }
             var pipeline = CredentialPipeline.GetInstance(options);
             return InstrumentClient(
                 new OnBehalfOfCredential(

--- a/sdk/identity/Azure.Identity/tests/SharedTokenCacheCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/SharedTokenCacheCredentialTests.cs
@@ -39,6 +39,14 @@ namespace Azure.Identity.Tests
             {
                 options.Transport = config.Transport;
             }
+            if (config.TokenCachePersistenceOptions != null)
+            {
+                options.TokenCachePersistenceOptions = config.TokenCachePersistenceOptions;
+            }
+            if (config.AuthenticationRecord != null)
+            {
+                options.AuthenticationRecord = config.AuthenticationRecord;
+            }
             var pipeline = CredentialPipeline.GetInstance(options);
             return InstrumentClient(new SharedTokenCacheCredential(config.TenantId, ExpectedUsername, options, pipeline, config.MockPublicMsalClient));
         }

--- a/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialTests.cs
@@ -40,6 +40,14 @@ namespace Azure.Identity.Tests
             {
                 options.Transport = config.Transport;
             }
+            if (config.TokenCachePersistenceOptions != null)
+            {
+                options.TokenCachePersistenceOptions = config.TokenCachePersistenceOptions;
+            }
+            if (config.AuthenticationRecord != null)
+            {
+                options.AuthenticationRecord = config.AuthenticationRecord;
+            }
             var pipeline = CredentialPipeline.GetInstance(options);
             return InstrumentClient(new UsernamePasswordCredential("user", "password", config.TenantId, ClientId, options, pipeline, config.MockPublicMsalClient));
         }


### PR DESCRIPTION
closes [#2099](https://github.com/Azure/azure-sdk-for-net-pr/issues/2099)