### PR TITLE
Fix GetUnprocessedEventCount after changes in checkpoint format - offset is always null

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Fix GetUnprocessedEventCount after changes in checkpoint format
+
 ## 6.3.1 (2024-04-17)
 
 ### Other Changes

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -109,15 +109,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
                 }
 
                 // Check for the unprocessed messages when there are messages on the Event Hub partition
-                // In that case, LastEnqueuedSequenceNumber will be >= 0
-
-                if ((partitionProperties.LastEnqueuedSequenceNumber != -1 && partitionProperties.LastEnqueuedSequenceNumber != (checkpoint?.SequenceNumber ?? -1))
-                    || (checkpoint == null && partitionProperties.LastEnqueuedSequenceNumber >= 0)
-                    || (checkpoint != null && checkpoint.Offset == null && partitionProperties.LastEnqueuedSequenceNumber >= 0))
-                {
-                    long partitionUnprocessedEventCount = GetUnprocessedEventCount(partitionProperties, checkpoint);
-                    totalUnprocessedEventCount += partitionUnprocessedEventCount;
-                }
+                long partitionUnprocessedEventCount = GetUnprocessedEventCount(partitionProperties, checkpoint);
+                totalUnprocessedEventCount += partitionUnprocessedEventCount;
             }
 
             // Only log if not all partitions are failing or it's time to log
@@ -146,8 +139,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
         private static long GetUnprocessedEventCount(PartitionProperties partitionInfo, BlobCheckpointStoreInternal.BlobStorageCheckpoint checkpoint)
         {
             // If the partition is empty, there are no events to process.
-
             if (partitionInfo.IsEmpty)
+            {
+                return 0;
+            }
+
+            // If partitionInfo.LastEnqueuedSequenceNumber, no events haven't sent to EH yet.
+            if (partitionInfo.LastEnqueuedSequenceNumber == -1)
             {
                 return 0;
             }
@@ -155,14 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             // If there is no checkpoint and the beginning and last sequence numbers for the partition are the same
             // this partition received its first event.
 
-            if (checkpoint == null
-                && partitionInfo.LastEnqueuedSequenceNumber == partitionInfo.BeginningSequenceNumber)
-            {
-                return 1;
-            }
-
-            // Legacy checkpoint support
-            if (checkpoint != null && checkpoint.Offset == null && partitionInfo.LastEnqueuedSequenceNumber == 0)
+            if (checkpoint == null && partitionInfo.LastEnqueuedSequenceNumber == partitionInfo.BeginningSequenceNumber)
             {
                 return 1;
             }
@@ -182,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             // For normal scenarios, the last sequence number will be greater than the starting number and
             // simple subtraction can be used.
 
-            if (partitionInfo.LastEnqueuedSequenceNumber > startingSequenceNumber)
+            if (partitionInfo.LastEnqueuedSequenceNumber >= startingSequenceNumber)
             {
                 return (partitionInfo.LastEnqueuedSequenceNumber - startingSequenceNumber);
             }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -162,9 +162,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             }
 
             // Legacy checkpoint support
-            if (checkpoint != null && checkpoint.Offset == null && partitionInfo.LastEnqueuedSequenceNumber >= 0)
+            if (checkpoint != null && checkpoint.Offset == null && partitionInfo.LastEnqueuedSequenceNumber == 0)
             {
-                return partitionInfo.LastEnqueuedSequenceNumber + 1;
+                return 1;
             }
 
             var startingSequenceNumber = checkpoint?.SequenceNumber switch

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             this._mockCheckpointStore = new Mock<BlobCheckpointStoreInternal>(MockBehavior.Strict);
 
             _mockCheckpointStore.Setup(s => s.GetCheckpointAsync(_namespace, _eventHubName, _consumerGroup, It.IsAny<string>(), default))
-                .Returns<string, string, string, string, CancellationToken>((ns, hub, cg, partitionId, ct) => Task.FromResult(_checkpoints.SingleOrDefault(cp => cp.PartitionId == partitionId)));
+                .Returns<string, string, string, string, CancellationToken>((ns, hub, cg, partitionId, ct) => Task.FromResult(_checkpoints == null ? null : _checkpoints.SingleOrDefault(cp => cp.PartitionId == partitionId)));
 
             _metricsProvider = new EventHubMetricsProvider(
                                     _functionId,
@@ -226,6 +226,46 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
             _loggerProvider.ClearAllLogMessages();
+        }
+
+        [TestCase(false, 0, -1, -1, 0)] // Microsoft.Azure.Functions.Worker.Extensions.EventHubs < 5.0.0, auto created checkpoint, no events sent
+        [TestCase(true, 0, -1, -1, 0)] // Microsoft.Azure.Functions.Worker.Extensions.EventHubs >= 5.0.0, no checkpoint, no events sent
+        [TestCase(false, 0, 0, 0, 0)] // Microsoft.Azure.Functions.Worker.Extensions.EventHubs < 5.0.0, auto created checkpoint, 1 event sent. Know issue: we are not scalling out in this case.
+        [TestCase(true, 0, 0, 0, 1)] // Microsoft.Azure.Functions.Worker.Extensions.EventHubs >= 5.0.0, no checkpoint, 1 event sent
+        [TestCase(false, 0, 0, 1, 1)] // Microsoft.Azure.Functions.Worker.Extensions.EventHubs < 5.0.0, auto created checkpoint, 2 events sent
+        [TestCase(false, 0, 0, 1, 1)] // Microsoft.Azure.Functions.Worker.Extensions.EventHubs >= 5.0.0, no checkpoint, 2 events sent
+        [TestCase(false, 0, 0, 1, 1)] // checkpoint for 1 event created, 1 more event sent
+        [TestCase(false, 0, 0, 2, 2)] // checkpoint for 1 event created, 2 more event sent
+        [TestCase(false, 1, 0, 2, 1)] // checkpoint for 2 events created, 1 more event sent
+        [TestCase(false, 1, 0, 3, 2)] // checkpoint for 2 events created, more event sent
+        [TestCase(false, 0, 0, 0, 0)] // checkpoint for 1 events created, no events sent
+        [TestCase(false, 1, 0, 1, 0)] // checkpoint for 2 events created, no events sent
+        public async Task CreateTriggerMetrics_DifferentCheckpointFormats_ReturnsExpectedResult(
+            bool isNullCheckpoint,
+            long checkpointSequenceNumber,
+            long partitionBeginningSequenceNumber,
+            long partitionLastSequenceNumber,
+            long expectedUprocessedMessageCount)
+        {
+            if (!isNullCheckpoint)
+            {
+                this._checkpoints = new EventProcessorCheckpoint[]
+                {
+                    new BlobCheckpointStoreInternal.BlobStorageCheckpoint { SequenceNumber = checkpointSequenceNumber, PartitionId = "0" }
+                };
+            }
+            else
+            {
+                this._checkpoints = null;
+            }
+
+            _partitions = new List<PartitionProperties>
+            {
+                new TestPartitionProperties(beginningSequenceNumber: partitionBeginningSequenceNumber, lastSequenceNumber: partitionLastSequenceNumber, partitionId: "0"),
+            };
+
+            var metrics = await _metricsProvider.GetMetricsAsync();
+            Assert.AreEqual(expectedUprocessedMessageCount, metrics.EventCount);
         }
     }
 }


### PR DESCRIPTION
There was change in checkpoint format recently - offset is always set to null:
Microsoft.Azure.Functions.Worker.Extensions.EventHubs 6.1.0 >= does not work
Microsoft.Azure.Functions.Worker.Extensions.EventHubs 6.0.1 - latest working version

**Checkpoints flow:**
**Microsoft.Azure.Functions.Worker.Extensions.EventHubs < 5.0.0**
[no events]
offset=null (created automatically on listener start)
sequencenumber=0

[1st event]
offset=0
sequencenumber=0

[2nd event]
offset=128
sequencenumber=1

**Microsoft.Azure.Functions.Worker.Extensions.EventHubs>= 5.0.0 Microsoft.Azure.Functions.Worker.Extensions.EventHubs<= 6.0.1**
[no events]
no checkpoint exists.

[1st event]
offset=0
sequencenumber=0

[2nd event]
offset=128
sequencenumber=1

**Microsoft.Azure.Functions.Worker.Extensions.EventHubs > 6.0.1**
[no events]
no checkpoint exists.

[1st event]
offset=null
sequencenumber=0

[2nd event]
offset=null
sequencenumber=1

**Partition props:**
No messages
BeginningSequenceNumber: -1
LastEnqueuedSequenceNumber: -1

1st Message
BeginningSequenceNumber: 0
LastEnqueuedSequenceNumber: 0

2nd Message
BeginningSequenceNumber: 0
LastEnqueuedSequenceNumber: 1

3rd Message
BeginningSequenceNumber: 0
LastEnqueuedSequenceNumber: 2

The logic which detects unprocessed event count should work with all the checkpoint formats without considering offset.
