### PR TITLE
Update typo in modelsRepo README

### DIFF
--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/samples/readme.md
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/samples/readme.md
@@ -171,7 +171,7 @@ called `DtmiConventions` which exposes utility functions supporting these conven
 DtmiConventions.IsValidDtmi("dtmi:com:example:Thermostat;1");
 
 // Returns false
-DtmiConventions.IsValidDtmi("dtmi:com:example:Thermostat");
+DtmiConventions.IsValidDtmi("dtmi:com:example;Thermostat");
 ```
 
 ```C# Snippet:ModelsRepositorySamplesDtmiConventionsGetModelUri


### PR DESCRIPTION
With https://github.com/Azure/azure-sdk-for-net/pull/43014 DTMIs can be versionless, updating the README to show a invalid DTMI using `;` without a `major.minor`.

