### PR TITLE
[Functions] Event Hubs: Release prep

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 6.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 6.3.2 (2024-04-29)
 
 ### Bugs Fixed
 
-### Other Changes
-
-- Fix GetUnprocessedEventCount after changes in checkpoint format
+- Fixed an issue with scale metrics computation, potentially causing unnecessary scale-up.
 
 ## 6.3.1 (2024-04-17)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>6.4.0-beta.1</Version>
+    <Version>6.3.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>6.3.1</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636</NoWarn>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare for an out-of-band release of the Event Hubs extension to fix an issue with the scale controller's metrics calculation which is causing the scale controller
to scale out too aggressively.