### PR TITLE
OpenAI Assistants: changelog update for beta.4 bug patch

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI.Assistants/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI.Assistants/CHANGELOG.md
@@ -1,16 +1,15 @@
 # Release History
 
-## 1.0.0-beta.4 (Unreleased)
+## 1.0.0-beta.4 (2024-04-30)
 
-### Features Added
-
-### Breaking Changes
+This small, out-of-band version addresses a couple of critical blocking bugs. It does not yet include any of the latest
+features. Streaming support and Assistants v2 will come soon, in a future update.
 
 ### Bugs Fixed
 
 - Several issues with direct equality comparisons of function tool definitions have been fixed
-
-### Other Changes
+- The mistaken, remain instance of an "Azure not supported" exception has been removed, along with its related
+  mentions. This should unblock the use of the the token-based client constructor.
 
 ## 1.0.0-beta.3 (2024-03-06)
 


### PR DESCRIPTION
This change just updates the `changelog.md` file with final details for a `prepare-release.ps1` snap. We'd originally intended to batch these into a bigger feature update soon, but we've heard from several blocked customers and want to expedite availability of the pending fixes.