### PR TITLE
[Storage] Added empty and null checks for storage client names

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed bug where `BlobContainerClient` and `BlobBaseClient` did not throw an exception on empty/null container names and blob names, respectively, when constructing a client. 
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -280,7 +280,6 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public new AppendBlobClient WithSnapshot(string snapshot)
         {
-            Argument.AssertNotNullOrWhiteSpace(snapshot, nameof(snapshot));
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri)
             {
                 Snapshot = snapshot
@@ -305,7 +304,6 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public new AppendBlobClient WithVersion(string versionId)
         {
-            Argument.AssertNotNullOrWhiteSpace(versionId, nameof(versionId));
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri)
             {
                 VersionId = versionId

--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -280,6 +280,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public new AppendBlobClient WithSnapshot(string snapshot)
         {
+            Argument.AssertNotNullOrWhiteSpace(snapshot, nameof(snapshot));
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri)
             {
                 Snapshot = snapshot
@@ -304,6 +305,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public new AppendBlobClient WithVersion(string versionId)
         {
+            Argument.AssertNotNullOrWhiteSpace(versionId, nameof(versionId));
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri)
             {
                 VersionId = versionId

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -195,6 +195,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         public BlobBaseClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
         {
+            Argument.AssertNotNull(blobContainerName, nameof(blobContainerName));
+            Argument.AssertNotNull(blobName, nameof(blobName));
+
             options ??= new BlobClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
             var builder =
@@ -491,6 +494,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <returns>A new <see cref="BlobBaseClient"/> instance.</returns>
         protected virtual BlobBaseClient WithSnapshotCore(string snapshot)
         {
+            Argument.AssertNotNullOrWhiteSpace(snapshot, nameof(snapshot));
             _snapshot = snapshot;
             var blobUriBuilder = new BlobUriBuilder(Uri)
             {
@@ -526,6 +530,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <returns>A new <see cref="BlobBaseClient"/> instance.</returns>
         private protected virtual BlobBaseClient WithVersionCore(string versionId)
         {
+            Argument.AssertNotNullOrWhiteSpace(versionId, nameof(versionId));
             _blobVersionId = versionId;
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri)
             {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -494,7 +494,6 @@ namespace Azure.Storage.Blobs.Specialized
         /// <returns>A new <see cref="BlobBaseClient"/> instance.</returns>
         protected virtual BlobBaseClient WithSnapshotCore(string snapshot)
         {
-            Argument.AssertNotNullOrWhiteSpace(snapshot, nameof(snapshot));
             _snapshot = snapshot;
             var blobUriBuilder = new BlobUriBuilder(Uri)
             {
@@ -530,7 +529,6 @@ namespace Azure.Storage.Blobs.Specialized
         /// <returns>A new <see cref="BlobBaseClient"/> instance.</returns>
         private protected virtual BlobBaseClient WithVersionCore(string versionId)
         {
-            Argument.AssertNotNullOrWhiteSpace(versionId, nameof(versionId));
             _blobVersionId = versionId;
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri)
             {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -186,6 +186,7 @@ namespace Azure.Storage.Blobs
         /// </param>
         public BlobContainerClient(string connectionString, string blobContainerName, BlobClientOptions options)
         {
+            Argument.AssertNotNullOrWhiteSpace(blobContainerName, nameof(blobContainerName));
             var conn = StorageConnectionString.Parse(connectionString);
             var builder = new BlobUriBuilder(conn.BlobEndpoint, options?.TrimBlobNameSlashes ?? Constants.DefaultTrimBlobNameSlashes)
             {
@@ -469,6 +470,7 @@ namespace Azure.Storage.Blobs
         /// <returns>A new <see cref="BlobBaseClient"/> instance.</returns>
         protected internal virtual BlobBaseClient GetBlobBaseClientCore(string blobName)
         {
+            Argument.AssertNotNullOrEmpty(blobName, nameof(blobName));
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri, ClientConfiguration.TrimBlobNameSlashes)
             {
                 BlobName = blobName
@@ -490,6 +492,7 @@ namespace Azure.Storage.Blobs
         /// <returns>A new <see cref="BlobClient"/> instance.</returns>
         public virtual BlobClient GetBlobClient(string blobName)
         {
+            Argument.AssertNotNullOrEmpty(blobName, nameof(blobName));
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri, ClientConfiguration.TrimBlobNameSlashes)
             {
                 BlobName = blobName
@@ -513,6 +516,7 @@ namespace Azure.Storage.Blobs
         /// <returns>A new <see cref="BlockBlobClient"/> instance.</returns>
         protected internal virtual BlockBlobClient GetBlockBlobClientCore(string blobName)
         {
+            Argument.AssertNotNullOrEmpty(blobName, nameof(blobName));
             if (ClientSideEncryption != default)
             {
                 throw Errors.ClientSideEncryption.TypeNotSupported(typeof(BlockBlobClient));
@@ -540,6 +544,7 @@ namespace Azure.Storage.Blobs
         /// <returns>A new <see cref="AppendBlobClient"/> instance.</returns>
         protected internal virtual AppendBlobClient GetAppendBlobClientCore(string blobName)
         {
+            Argument.AssertNotNullOrEmpty(blobName, nameof(blobName));
             if (ClientSideEncryption != default)
             {
                 throw Errors.ClientSideEncryption.TypeNotSupported(typeof(AppendBlobClient));
@@ -567,6 +572,7 @@ namespace Azure.Storage.Blobs
         /// <returns>A new <see cref="PageBlobClient"/> instance.</returns>
         protected internal virtual PageBlobClient GetPageBlobClientCore(string blobName)
         {
+            Argument.AssertNotNullOrEmpty(blobName, nameof(blobName));
             if (ClientSideEncryption != default)
             {
                 throw Errors.ClientSideEncryption.TypeNotSupported(typeof(PageBlobClient));

--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed bug where `DataLakeFileSystemClient` and `DatalakeFileClient` did not throw an exception on empty/null filesystem names and file names, respectively, when constructing a client.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -14,6 +13,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Common;
 using Azure.Storage.Files.DataLake.Models;
 using Azure.Storage.Sas;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
@@ -140,6 +140,7 @@ namespace Azure.Storage.Files.DataLake
             DataLakeClientOptions options)
             : base(connectionString, fileSystemName, filePath, options)
         {
+            Argument.AssertNotNullOrWhiteSpace(filePath, nameof(filePath));
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -225,6 +225,7 @@ namespace Azure.Storage.Files.DataLake
         /// </param>
         public DataLakeFileSystemClient(string connectionString, string fileSystemName, DataLakeClientOptions options)
         {
+            Argument.AssertNotNullOrWhiteSpace(fileSystemName, nameof(fileSystemName));
             StorageConnectionString conn = StorageConnectionString.Parse(connectionString);
             StorageSharedKeyCredential sharedKeyCredential = conn.Credentials as StorageSharedKeyCredential;
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(conn.BlobEndpoint)

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -282,6 +282,8 @@ namespace Azure.Storage.Files.DataLake
             string path,
             DataLakeClientOptions options)
         {
+            Argument.AssertNotNullOrWhiteSpace(fileSystemName, nameof(fileSystemName));
+            Argument.AssertNotNullOrWhiteSpace(path, nameof(path));
             StorageConnectionString conn = StorageConnectionString.Parse(connectionString);
             StorageSharedKeyCredential sharedKeyCredential = conn.Credentials as StorageSharedKeyCredential;
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(conn.BlobEndpoint)

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -283,7 +283,6 @@ namespace Azure.Storage.Files.DataLake
             DataLakeClientOptions options)
         {
             Argument.AssertNotNullOrWhiteSpace(fileSystemName, nameof(fileSystemName));
-            Argument.AssertNotNullOrWhiteSpace(path, nameof(path));
             StorageConnectionString conn = StorageConnectionString.Parse(connectionString);
             StorageSharedKeyCredential sharedKeyCredential = conn.Credentials as StorageSharedKeyCredential;
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(conn.BlobEndpoint)

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed bug where `ShareClient` and `ShareFileClient` did not throw an exception on empty/null share container names and file names, respectively, when constructing a client.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -155,6 +155,7 @@ namespace Azure.Storage.Files.Shares
             string shareName,
             ShareClientOptions options)
         {
+            Argument.AssertNotNullOrWhiteSpace(shareName, nameof(shareName));
             options ??= new ShareClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
             ShareUriBuilder uriBuilder = new ShareUriBuilder(conn.FileEndpoint) { ShareName = shareName };
@@ -369,6 +370,7 @@ namespace Azure.Storage.Files.Shares
             Uri shareUri,
             ShareClientConfiguration clientConfiguration)
         {
+            Argument.AssertNotNull(shareUri, nameof(shareUri));
             _uri = shareUri;
             _clientConfiguration = clientConfiguration;
             _shareRestClient = BuildShareRestClient(shareUri);

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -191,7 +191,6 @@ namespace Azure.Storage.Files.Shares
             ShareClientOptions options)
         {
             Argument.AssertNotNullOrWhiteSpace(shareName, nameof(shareName));
-            Argument.AssertNotNullOrWhiteSpace(directoryPath, nameof(directoryPath));
             options ??= new ShareClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
             ShareUriBuilder uriBuilder =

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -190,6 +190,8 @@ namespace Azure.Storage.Files.Shares
             string directoryPath,
             ShareClientOptions options)
         {
+            Argument.AssertNotNullOrWhiteSpace(shareName, nameof(shareName));
+            Argument.AssertNotNullOrWhiteSpace(directoryPath, nameof(directoryPath));
             options ??= new ShareClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
             ShareUriBuilder uriBuilder =

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -198,6 +198,8 @@ namespace Azure.Storage.Files.Shares
             string filePath,
             ShareClientOptions options)
         {
+            Argument.AssertNotNullOrWhiteSpace(shareName, nameof(shareName));
+            Argument.AssertNotNullOrWhiteSpace(filePath, nameof(filePath));
             options ??= new ShareClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
             ShareUriBuilder uriBuilder =

--- a/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed bug where `QueueClient` did not throw an exception on empty/null queue names when constructing a client.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -192,6 +192,7 @@ namespace Azure.Storage.Queues
         /// </param>
         public QueueClient(string connectionString, string queueName, QueueClientOptions options)
         {
+            Argument.AssertNotNullOrEmpty(queueName, nameof(queueName));
             StorageConnectionString conn = StorageConnectionString.Parse(connectionString);
             QueueUriBuilder uriBuilder = new QueueUriBuilder(conn.QueueEndpoint)
             {


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/31955
