### PR TITLE
Clarify when system vs. user-assigned managed identity is used

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -191,17 +191,23 @@ namespace Azure.Identity
         public string WorkloadIdentityClientId { get; set; } = EnvironmentVariables.ClientId;
 
         /// <summary>
-        /// Specifies the client id of a user assigned ManagedIdentity. If this value is configured, then <see cref="ManagedIdentityResourceId"/> should not be configured.
+        /// Specifies the client ID of a user-assigned managed identity. If this value is configured, then <see cref="ManagedIdentityResourceId"/> should not be configured.
         /// </summary>
+        /// <remarks>
+        /// If neither the <see cref="ManagedIdentityClientId"/> nor the <see cref="ManagedIdentityResourceId"/> property is set, then a system-assigned managed identity is used.
+        /// </remarks>
         public string ManagedIdentityClientId { get; set; } = EnvironmentVariables.ClientId;
 
         /// <summary>
-        /// Specifies the resource id of a user assigned ManagedIdentity. If this value is configured, then <see cref="ManagedIdentityClientId"/> should not be configured.
+        /// Specifies the resource ID of a user-assigned managed identity. If this value is configured, then <see cref="ManagedIdentityClientId"/> should not be configured.
         /// </summary>
+        /// <remarks>
+        /// If neither the <see cref="ManagedIdentityClientId"/> nor the <see cref="ManagedIdentityResourceId"/> property is set, then a system-assigned managed identity is used.
+        /// </remarks>
         public ResourceIdentifier ManagedIdentityResourceId { get; set; }
 
         /// <summary>
-        /// Specifies timeout for credentials invoked via sub-process. e.g. Visual Studio, Azure CLI, Azure Powershell.
+        /// Specifies timeout for credentials invoked via sub-process. e.g. Visual Studio, Azure CLI, Azure PowerShell.
         /// </summary>
         public TimeSpan? CredentialProcessTimeout { get; set; } = TimeSpan.FromSeconds(30);
 

--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -10,7 +10,7 @@ using Azure.Core.Pipeline;
 namespace Azure.Identity
 {
     /// <summary>
-    /// Attempts authentication using a managed identity that has been assigned to the deployment environment. This authentication type works for all Azure hosted
+    /// Attempts authentication using a managed identity that has been assigned to the deployment environment. This authentication type works for all Azure-hosted
     /// environments that support managed identity. More information about configuring managed identities can be found at
     /// <see href="https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview"/>.
     /// </summary>
@@ -33,11 +33,11 @@ namespace Azure.Identity
         { }
 
         /// <summary>
-        /// Creates an instance of the ManagedIdentityCredential capable of authenticating a resource with a managed identity.
+        /// Creates an instance of <see cref="ManagedIdentityCredential"/> capable of authenticating a resource with a user-assigned or a system-assigned managed identity.
         /// </summary>
         /// <param name="clientId">
-        /// The client ID to authenticate for a user-assigned managed identity. More information on user-assigned managed identities can be found at
-        /// <see href="https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm"/>.
+        /// The client ID to authenticate for a <see href="https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm">user-assigned managed identity</see>.
+        /// If not provided, a system-assigned managed identity is used.
         /// </param>
         /// <param name="options">Options to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ManagedIdentityCredential(string clientId = null, TokenCredentialOptions options = null)
@@ -47,11 +47,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Creates an instance of the ManagedIdentityCredential capable of authenticating a resource with a managed identity.
+        /// Creates an instance of <see cref="ManagedIdentityCredential"/> capable of authenticating a resource with a user-assigned managed identity.
         /// </summary>
         /// <param name="resourceId">
-        /// The resource ID to authenticate for a user-assigned managed identity. More information on user-assigned managed identities can be found at
-        /// <see href="https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm"/>.
+        /// The resource ID to authenticate for a <see href="https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm">user-assigned managed identity</see>.
         /// </param>
         /// <param name="options">Options to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ManagedIdentityCredential(ResourceIdentifier resourceId, TokenCredentialOptions options = null)


### PR DESCRIPTION
The XML docs don't currently say anything about system-assigned managed identity. Updating based on feedback from @dinabogdan. Also, I updated a link to a doc section that no longer existed.
