### PR TITLE
Reduce memory allocation in HttpMessageSanitizer

### DIFF
--- a/sdk/core/Azure.Core/perf/HttpMessageSanitizerBenchmark.cs
+++ b/sdk/core/Azure.Core/perf/HttpMessageSanitizerBenchmark.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Azure.Core.Perf;
+
+[MemoryDiagnoser]
+public class HttpMessageSanitizerBenchmark
+{
+    private HttpMessageSanitizer _sanitizer;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _sanitizer = new HttpMessageSanitizer(
+            allowedQueryParameters: new[] { "api-version" },
+            allowedHeaders: Array.Empty<string>()
+            );
+    }
+
+    [Benchmark]
+    public string SanitizeHeader()
+    {
+        return _sanitizer.SanitizeHeader("header", "value");
+    }
+
+    [Benchmark]
+    public string SanitizeUrl()
+    {
+        return _sanitizer.SanitizeUrl("https://www.example.com");
+    }
+
+    [Benchmark]
+    public string SanitizeUrlWithQueryNoValue()
+    {
+        return _sanitizer.SanitizeUrl("https://www.example.com?param1");
+    }
+
+    [Benchmark]
+    public string SanitizeUrlWithAllowedQuery()
+    {
+        return _sanitizer.SanitizeUrl("https://www.example.com?api-version=2024-05-01");
+    }
+
+    [Benchmark]
+    public string SanitizeUrlWithDisallowedQuery()
+    {
+        return _sanitizer.SanitizeUrl("https://www.example.com?param1=value1");
+    }
+}

--- a/sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs
+++ b/sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs
@@ -1,140 +1,198 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#nullable enable
 
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 
-namespace Azure.Core
+namespace Azure.Core;
+
+internal class HttpMessageSanitizer
 {
-    internal class HttpMessageSanitizer
+    private const string LogAllValue = "*";
+    private readonly bool _logAllHeaders;
+    private readonly bool _logFullQueries;
+    private readonly string[] _allowedQueryParameters;
+    private readonly string _redactedPlaceholder;
+    private readonly HashSet<string> _allowedHeaders;
+
+    [ThreadStatic]
+    private static StringBuilder? s_cachedStringBuilder;
+    private const int MaxCachedStringBuilderCapacity = 1024;
+
+    internal static HttpMessageSanitizer Default = new HttpMessageSanitizer(Array.Empty<string>(), Array.Empty<string>());
+
+    public HttpMessageSanitizer(string[] allowedQueryParameters, string[] allowedHeaders, string redactedPlaceholder = "REDACTED")
     {
-        private const string LogAllValue = "*";
-        private readonly bool _logAllHeaders;
-        private readonly bool _logFullQueries;
-        private readonly string[] _allowedQueryParameters;
-        private readonly string _redactedPlaceholder;
-        private readonly HashSet<string> _allowedHeaders;
+        _logAllHeaders = allowedHeaders.Contains(LogAllValue);
+        _logFullQueries = allowedQueryParameters.Contains(LogAllValue);
 
-        internal static HttpMessageSanitizer Default = new HttpMessageSanitizer(Array.Empty<string>(), Array.Empty<string>());
+        _allowedQueryParameters = allowedQueryParameters;
+        _redactedPlaceholder = redactedPlaceholder;
+        _allowedHeaders = new HashSet<string>(allowedHeaders, StringComparer.InvariantCultureIgnoreCase);
+    }
 
-        public HttpMessageSanitizer(string[] allowedQueryParameters, string[] allowedHeaders, string redactedPlaceholder = "REDACTED")
+    public string SanitizeHeader(string name, string value)
+    {
+        if (_logAllHeaders || _allowedHeaders.Contains(name))
         {
-            _logAllHeaders = allowedHeaders.Contains(LogAllValue);
-            _logFullQueries = allowedQueryParameters.Contains(LogAllValue);
-
-            _allowedQueryParameters = allowedQueryParameters;
-            _redactedPlaceholder = redactedPlaceholder;
-            _allowedHeaders = new HashSet<string>(allowedHeaders, StringComparer.InvariantCultureIgnoreCase);
+            return value;
         }
 
-        public string SanitizeHeader(string name, string value)
-        {
-            if (_logAllHeaders || _allowedHeaders.Contains(name))
-            {
-                return value;
-            }
+        return _redactedPlaceholder;
+    }
 
-            return _redactedPlaceholder;
+    public string SanitizeUrl(string url)
+    {
+        if (_logFullQueries)
+        {
+            return url;
         }
-
-        public string SanitizeUrl(string url)
-        {
-            if (_logFullQueries)
-            {
-                return url;
-            }
 
 #if NET5_0_OR_GREATER
-            int indexOfQuerySeparator = url.IndexOf('?', StringComparison.Ordinal);
+        int indexOfQuerySeparator = url.IndexOf('?', StringComparison.Ordinal);
 #else
-            int indexOfQuerySeparator = url.IndexOf('?');
+        int indexOfQuerySeparator = url.IndexOf('?');
 #endif
 
-            if (indexOfQuerySeparator == -1)
+        if (indexOfQuerySeparator == -1)
+        {
+            return url;
+        }
+
+        // PERF: Avoid allocations in this heavily-used method:
+        // 1. Use ReadOnlySpan<char> to avoid creating substrings.
+        // 2. Defer creating a StringBuilder until absolutely necessary.
+        // 3. Use a rented StringBuilder to avoid allocating a new one
+        //    each time.
+
+        // Create the StringBuilder only when necessary (when we encounter
+        // a query parameter that needs to be redacted)
+        StringBuilder? stringBuilder = null;
+
+        // Keeps track of the number of characters we've processed so far
+        // so that, if we need to create a StringBuilder, we know how many
+        // characters to copy over from the original URL.
+        int lengthSoFar = indexOfQuerySeparator + 1;
+
+        ReadOnlySpan<char> query = url.AsSpan(indexOfQuerySeparator + 1); // +1 to skip the '?'
+
+        while (query.Length > 0)
+        {
+            int endOfParameterValue = query.IndexOf('&');
+            int endOfParameterName = query.IndexOf('=');
+            bool noValue = false;
+
+            // Check if we have parameter without value
+            if ((endOfParameterValue == -1 && endOfParameterName == -1) ||
+                (endOfParameterValue != -1 && (endOfParameterName == -1 || endOfParameterName > endOfParameterValue)))
             {
-                return url;
+                endOfParameterName = endOfParameterValue;
+                noValue = true;
             }
 
-            StringBuilder stringBuilder = new StringBuilder(url.Length);
-            stringBuilder.Append(url, 0, indexOfQuerySeparator);
-
-            string query = url.Substring(indexOfQuerySeparator);
-
-            int queryIndex = 1;
-            stringBuilder.Append('?');
-
-            do
+            if (endOfParameterName == -1)
             {
-                int endOfParameterValue = query.IndexOf('&', queryIndex);
-                int endOfParameterName = query.IndexOf('=', queryIndex);
-                bool noValue = false;
+                endOfParameterName = query.Length;
+            }
 
-                // Check if we have parameter without value
-                if ((endOfParameterValue == -1 && endOfParameterName == -1) ||
-                    (endOfParameterValue != -1 && (endOfParameterName == -1 || endOfParameterName > endOfParameterValue)))
+            if (endOfParameterValue == -1)
+            {
+                endOfParameterValue = query.Length;
+            }
+            else
+            {
+                // include the separator
+                endOfParameterValue++;
+            }
+
+            ReadOnlySpan<char> parameterName = query.Slice(0, endOfParameterName);
+
+            bool isAllowed = false;
+            foreach (string name in _allowedQueryParameters)
+            {
+                if (parameterName.Equals(name.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
-                    endOfParameterName = endOfParameterValue;
-                    noValue = true;
+                    isAllowed = true;
+                    break;
                 }
+            }
 
-                if (endOfParameterName == -1)
+            int valueLength = endOfParameterValue;
+            int nameLength = endOfParameterName;
+
+            if (isAllowed || noValue)
+            {
+                if (stringBuilder is null)
                 {
-                    endOfParameterName = query.Length;
-                }
-
-                if (endOfParameterValue == -1)
-                {
-                    endOfParameterValue = query.Length;
-                }
-                else
-                {
-                    // include the separator
-                    endOfParameterValue++;
-                }
-
-                ReadOnlySpan<char> parameterName = query.AsSpan(queryIndex, endOfParameterName - queryIndex);
-
-                bool isAllowed = false;
-                foreach (string name in _allowedQueryParameters)
-                {
-                    if (parameterName.Equals(name.AsSpan(), StringComparison.OrdinalIgnoreCase))
-                    {
-                        isAllowed = true;
-                        break;
-                    }
-                }
-
-                int valueLength = endOfParameterValue - queryIndex;
-                int nameLength = endOfParameterName - queryIndex;
-
-                if (isAllowed)
-                {
-                    stringBuilder.Append(query, queryIndex, valueLength);
+                    lengthSoFar += valueLength;
                 }
                 else
                 {
-                    if (noValue)
-                    {
-                        stringBuilder.Append(query, queryIndex, valueLength);
-                    }
-                    else
-                    {
-                        stringBuilder.Append(query, queryIndex, nameLength);
-                        stringBuilder.Append('=');
-                        stringBuilder.Append(_redactedPlaceholder);
-                        if (query[endOfParameterValue - 1] == '&')
-                        {
-                            stringBuilder.Append('&');
-                        }
-                    }
+                    AppendReadOnlySpan(stringBuilder, query.Slice(0, valueLength));
                 }
+            }
+            else
+            {
+                // Encountered a query value that needs to be redacted.
+                // Create the StringBuilder if we haven't already.
+                stringBuilder ??= RentStringBuilder(url.Length).Append(url, 0, lengthSoFar);
 
-                queryIndex += valueLength;
-            } while (queryIndex < query.Length);
+                AppendReadOnlySpan(stringBuilder, query.Slice(0, nameLength))
+                    .Append('=')
+                    .Append(_redactedPlaceholder);
 
-            return stringBuilder.ToString();
+                if (query[endOfParameterValue - 1] == '&')
+                {
+                    stringBuilder.Append('&');
+                }
+            }
+
+            query = query.Slice(valueLength);
         }
+
+        return stringBuilder is null ? url : ToStringAndReturnStringBuilder(stringBuilder);
+
+        static StringBuilder AppendReadOnlySpan(StringBuilder builder, ReadOnlySpan<char> span)
+        {
+#if NET6_0_OR_GREATER
+            return builder.Append(span);
+#else
+            foreach (char c in span)
+            {
+                builder.Append(c);
+            }
+
+            return builder;
+#endif
+        }
+    }
+
+    private static StringBuilder RentStringBuilder(int capacity)
+    {
+        if (capacity <= MaxCachedStringBuilderCapacity)
+        {
+            StringBuilder? builder = s_cachedStringBuilder;
+            if (builder is not null && builder.Capacity >= capacity)
+            {
+                s_cachedStringBuilder = null;
+                return builder;
+            }
+        }
+
+        return new StringBuilder(capacity);
+    }
+
+    private static string ToStringAndReturnStringBuilder(StringBuilder builder)
+    {
+        string result = builder.ToString();
+        if (builder.Capacity <= MaxCachedStringBuilderCapacity)
+        {
+            s_cachedStringBuilder = builder.Clear();
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
This is a performance optimization in HttpMessageSanitizer to reduce the memory allocated in common cases.

There are three optimization techniques:
1. Use `url.AsSpan(...)` instead of `url.Substring(...)` to create the query part of the URL.
2. Defer creation of the `StringBuilder` until/unless absolutely necessary (when there's a redacted query value)
3. Use a cached StringBuilder.

I added benchmarks to show the difference:

#### Baseline

|                         Method |       Mean |     Error |    StdDev |   Gen0 | Allocated |
|------------------------------- |-----------:|----------:|----------:|-------:|----------:|
|                 SanitizeHeader |   3.890 ns | 0.3120 ns | 0.3468 ns |      - |         - |
|                    SanitizeUrl |   8.218 ns | 0.7272 ns | 0.8375 ns |      - |         - |
|    SanitizeUrlWithQueryNoValue | 110.411 ns | 4.3084 ns | 4.7888 ns | 0.0004 |     264 B |
|    SanitizeUrlWithAllowedQuery | 137.150 ns | 7.0172 ns | 7.7996 ns | 0.0005 |     360 B |
| SanitizeUrlWithDisallowedQuery | 185.949 ns | 7.9072 ns | 9.1060 ns | 0.0007 |     464 B |

#### Candidate

|                         Method |      Mean |     Error |    StdDev | Allocated |
|------------------------------- |----------:|----------:|----------:|----------:|
|                 SanitizeHeader |  4.148 ns | 0.5924 ns | 0.6822 ns |         - |
|                    SanitizeUrl |  7.978 ns | 0.9843 ns | 1.1336 ns |         - |
|    SanitizeUrlWithQueryNoValue | 21.698 ns | 1.9727 ns | 2.2717 ns |         - |
|    SanitizeUrlWithAllowedQuery | 27.414 ns | 2.7250 ns | 3.1381 ns |         - |
| SanitizeUrlWithDisallowedQuery | 84.632 ns | 5.9402 ns | 6.8407 ns |     104 B |

As you can see, we avoid memory allocations (and potential garbage collections) in common cases where there are no query parameters or where all the query parameters are allowed. In the case where we have to redact query values, the bytes allocated is one fourth of the baseline.