### PR TITLE
[Dev Center] Fix environment tests.

### DIFF
--- a/sdk/devcenter/Azure.Developer.DevCenter/assets.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/devcenter/Azure.Developer.DevCenter",
-  "Tag": "net/devcenter/Azure.Developer.DevCenter_6bd03c25ea"
+  "Tag": "net/devcenter/Azure.Developer.DevCenter_f94bb10144"
 }

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DeploymentEnvironmentsClientTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DeploymentEnvironmentsClientTests.cs
@@ -17,6 +17,7 @@ namespace Azure.Developer.DevCenter.Tests
     {
         private const string EnvName = "DevTestEnv";
         private const string EnvDefinitionName = "Sandbox";
+        private const int EnvDefinitionCount = 8;
         private DeploymentEnvironmentsClient _environmentsClient;
 
         internal DeploymentEnvironmentsClient GetEnvironmentsClient() =>
@@ -108,7 +109,7 @@ namespace Azure.Developer.DevCenter.Tests
             List<EnvironmentDefinition> envDefinitions = await _environmentsClient.GetEnvironmentDefinitionsAsync(
                 TestEnvironment.ProjectName).ToEnumerableAsync();
 
-            Assert.AreEqual(3, envDefinitions.Count);
+            Assert.AreEqual(EnvDefinitionCount, envDefinitions.Count);
 
             foreach (var envDefinition in envDefinitions)
             {
@@ -129,7 +130,7 @@ namespace Azure.Developer.DevCenter.Tests
                 TestEnvironment.ProjectName,
                 TestEnvironment.CatalogName).ToEnumerableAsync();
 
-            Assert.AreEqual(3, envDefinitions.Count);
+            Assert.AreEqual(EnvDefinitionCount, envDefinitions.Count);
 
             foreach (var envDefinition in envDefinitions)
             {


### PR DESCRIPTION
This PR fixes the failed tests: [Pipelines - Runs for net - devcenter - tests (azure.com)](https://dev.azure.com/azure-sdk/internal/_build?definitionId=5623&_a=summary)
The reason is: Environments team have updated their repo to add more definitions [deployment-environments/Environments at main · Azure/deployment-environments (github.com)](https://github.com/Azure/deployment-environments/tree/main/Environments)