### PR TITLE
Azure OpenAI: better image input support for gpt-4-turbo chat completions

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -9,7 +9,7 @@
   - `ChatMessageImageContent(Uri)` -- the existing constructor, used for URL-based image references
   - `ChatMessageImageContent(Stream,string)` -- (new) used with a stream and known MIME type (like `image/png`)
   - `ChatMessageImageContent(BinaryData,string)` -- (new) used with a BinaryData instance and known MIME type
-  Please see the [readme example](README.md#chat-with-images-using-gpt-4-turbo) for more details.
+  Please see the [readme example](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md#chat-with-images-using-gpt-4-turbo) for more details.
 
 ### Breaking Changes
 

--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.17 (Unreleased)
+## 1.0.0-beta.17 (2024-05-03)
 
 ### Features Added
 
@@ -16,10 +16,6 @@
 - Public visibility of the `ChatMessageImageUrl` type is removed to promote more flexible use of data sources in
   `ChatMessageImageContent`. Code that previously created a `ChatMessageImageUrl` using a `Uri` should simply provide
   the `Uri` to the `ChatMessageImageContent` constructor directly.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.0.0-beta.16 (2024-04-11)
 

--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -4,7 +4,18 @@
 
 ### Features Added
 
+- Image input support for `gpt-4-turbo` chat completions now works with image data in addition to internet URLs.
+  Images may be now be used as `gpt-4-turbo` message content items via one of three constructors:
+  - `ChatMessageImageContent(Uri)` -- the existing constructor, used for URL-based image references
+  - `ChatMessageImageContent(Stream,string)` -- (new) used with a stream and known MIME type (like `image/png`)
+  - `ChatMessageImageContent(BinaryData,string)` -- (new) used with a BinaryData instance and known MIME type
+  Please see the [readme example](README.md#chat-with-images-using-gpt-4-turbo) for more details.
+
 ### Breaking Changes
+
+- Public visibility of the `ChatMessageImageUrl` type is removed to promote more flexible use of data sources in
+  `ChatMessageImageContent`. Code that previously created a `ChatMessageImageUrl` using a `Uri` should simply provide
+  the `Uri` to the `ChatMessageImageContent` constructor directly.
 
 ### Bugs Fixed
 

--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -356,8 +356,6 @@ namespace Azure.AI.OpenAI
         public static Azure.AI.OpenAI.ChatChoiceLogProbabilityInfo ChatChoiceLogProbabilityInfo(System.Collections.Generic.IEnumerable<Azure.AI.OpenAI.ChatTokenLogProbabilityResult> tokenLogProbabilityResults = null) { throw null; }
         public static Azure.AI.OpenAI.ChatCompletions ChatCompletions(string id = null, System.DateTimeOffset created = default(System.DateTimeOffset), System.Collections.Generic.IEnumerable<Azure.AI.OpenAI.ChatChoice> choices = null, string model = null, System.Collections.Generic.IEnumerable<Azure.AI.OpenAI.ContentFilterResultsForPrompt> promptFilterResults = null, string systemFingerprint = null, Azure.AI.OpenAI.CompletionsUsage usage = null) { throw null; }
         public static Azure.AI.OpenAI.ChatCompletionsFunctionToolDefinition ChatCompletionsFunctionToolDefinition(Azure.AI.OpenAI.FunctionDefinition function = null) { throw null; }
-        public static Azure.AI.OpenAI.ChatMessageImageContentItem ChatMessageImageContentItem(Azure.AI.OpenAI.ChatMessageImageUrl imageUrl = null) { throw null; }
-        public static Azure.AI.OpenAI.ChatMessageImageUrl ChatMessageImageUrl(System.Uri url = null, Azure.AI.OpenAI.ChatMessageImageDetailLevel? detail = default(Azure.AI.OpenAI.ChatMessageImageDetailLevel?)) { throw null; }
         public static Azure.AI.OpenAI.ChatMessageTextContentItem ChatMessageTextContentItem(string text = null) { throw null; }
         public static Azure.AI.OpenAI.ChatRequestAssistantMessage ChatRequestAssistantMessage(string content = null, string name = null, System.Collections.Generic.IEnumerable<Azure.AI.OpenAI.ChatCompletionsToolCall> toolCalls = null, Azure.AI.OpenAI.FunctionCall functionCall = null) { throw null; }
         public static Azure.AI.OpenAI.ChatRequestFunctionMessage ChatRequestFunctionMessage(string name = null, string content = null) { throw null; }
@@ -613,10 +611,9 @@ namespace Azure.AI.OpenAI
     }
     public partial class ChatMessageImageContentItem : Azure.AI.OpenAI.ChatMessageContentItem, System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.ChatMessageImageContentItem>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.ChatMessageImageContentItem>
     {
-        public ChatMessageImageContentItem(Azure.AI.OpenAI.ChatMessageImageUrl imageUrl) { }
-        public ChatMessageImageContentItem(System.Uri imageUri) { }
-        public ChatMessageImageContentItem(System.Uri imageUri, Azure.AI.OpenAI.ChatMessageImageDetailLevel detailLevel) { }
-        public Azure.AI.OpenAI.ChatMessageImageUrl ImageUrl { get { throw null; } }
+        public ChatMessageImageContentItem(System.BinaryData bytes, string mimeType, Azure.AI.OpenAI.ChatMessageImageDetailLevel? detailLevel = default(Azure.AI.OpenAI.ChatMessageImageDetailLevel?)) { }
+        public ChatMessageImageContentItem(System.IO.Stream stream, string mimeType, Azure.AI.OpenAI.ChatMessageImageDetailLevel? detailLevel = default(Azure.AI.OpenAI.ChatMessageImageDetailLevel?)) { }
+        public ChatMessageImageContentItem(System.Uri imageUri, Azure.AI.OpenAI.ChatMessageImageDetailLevel? detailLevel = default(Azure.AI.OpenAI.ChatMessageImageDetailLevel?)) { }
         Azure.AI.OpenAI.ChatMessageImageContentItem System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.ChatMessageImageContentItem>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.ChatMessageImageContentItem>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.AI.OpenAI.ChatMessageImageContentItem System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.ChatMessageImageContentItem>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -641,17 +638,6 @@ namespace Azure.AI.OpenAI
         public static implicit operator Azure.AI.OpenAI.ChatMessageImageDetailLevel (string value) { throw null; }
         public static bool operator !=(Azure.AI.OpenAI.ChatMessageImageDetailLevel left, Azure.AI.OpenAI.ChatMessageImageDetailLevel right) { throw null; }
         public override string ToString() { throw null; }
-    }
-    public partial class ChatMessageImageUrl : System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.ChatMessageImageUrl>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.ChatMessageImageUrl>
-    {
-        public ChatMessageImageUrl(System.Uri url) { }
-        public Azure.AI.OpenAI.ChatMessageImageDetailLevel? Detail { get { throw null; } set { } }
-        public System.Uri Url { get { throw null; } }
-        Azure.AI.OpenAI.ChatMessageImageUrl System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.ChatMessageImageUrl>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
-        void System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.ChatMessageImageUrl>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
-        Azure.AI.OpenAI.ChatMessageImageUrl System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.ChatMessageImageUrl>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
-        string System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.ChatMessageImageUrl>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
-        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.ChatMessageImageUrl>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
     public partial class ChatMessageTextContentItem : Azure.AI.OpenAI.ChatMessageContentItem, System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.ChatMessageTextContentItem>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.ChatMessageTextContentItem>
     {

--- a/sdk/openai/Azure.AI.OpenAI/assets.json
+++ b/sdk/openai/Azure.AI.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/openai/Azure.AI.OpenAI",
-  "Tag": "net/openai/Azure.AI.OpenAI_26bdbcdaf2"
+  "Tag": "net/openai/Azure.AI.OpenAI_ee7b879bd6"
 }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatMessageImageContentItem.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatMessageImageContentItem.cs
@@ -2,29 +2,62 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 
 namespace Azure.AI.OpenAI;
 
 public partial class ChatMessageImageContentItem : ChatMessageContentItem
 {
     // CUSTOM CODE NOTE:
-    //   This addition allows the direct use of a Uri with the content item constructor rather than needing an
-    //   intervening instantiation of the Image URL type.
+    //   - Hide the ImageUrl property for easier, direct use of the content item
+    //   - Provide custom Uri, BinaryData, and Stream constructors
 
-    /// <summary> Initializes a new instance of ChatMessageImageContentItem using default detail. </summary>
-    /// <param name="imageUri"> An internet location, which must be accessible to the model,from which the image may be retrieved. </param>
-    /// <exception cref="ArgumentNullException"> <paramref name="imageUri"/> is null. </exception>
-    public ChatMessageImageContentItem(Uri imageUri)
-        : this(new ChatMessageImageUrl(imageUri))
-    { }
+    internal ChatMessageImageUrl ImageUrl { get; }
 
-    /// <summary> Initializes a new instance of ChatMessageImageContentItem. </summary>
-    /// <param name="imageUri"> An internet location, which must be accessible to the model,from which the image may be retrieved. </param>
+    /// <summary>
+    /// Initializes a new instance of ChatMessageImageContentItem that refers to an image at another location via URL.
+    /// </summary>
+    /// <remarks>
+    /// This constructor should only be used for file references. To use binary data, streams, or a file directly,
+    /// please refer to the alternate constructors.
+    /// </remarks>
+    /// <param name="imageUri"> An internet location, which must be accessible to the model, from which the image may be retrieved. </param>
     /// <param name="detailLevel"> The image detail level the model should use when evaluating the image. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="imageUri"/> is null. </exception>
-    public ChatMessageImageContentItem(Uri imageUri, ChatMessageImageDetailLevel detailLevel)
-        : this(imageUri)
+    public ChatMessageImageContentItem(Uri imageUri, ChatMessageImageDetailLevel? detailLevel = null)
+        : this(new ChatMessageImageUrl(imageUri, detailLevel))
+    {}
+
+    /// <summary>
+    /// Initializes a new instance of ChatMessageImageContentItem from a BinaryData instance containing image
+    /// information in a known format.
+    /// </summary>
+    /// <param name="bytes"> The image data to provide as content. </param>
+    /// <param name="mimeType"> The MIME type, e.g. <c>image/png</c>, matching the format of the image data. </param>
+    /// <param name="detailLevel"> The image detail level the model should use when evaluating the image. </param>
+    public ChatMessageImageContentItem(BinaryData bytes, string mimeType, ChatMessageImageDetailLevel? detailLevel = null)
+        : this(new ChatMessageImageUrl(bytes, mimeType, detailLevel))
+    {}
+
+    /// <summary>
+    /// Initializes a new instance of ChatMessageImageContentItem from a BinaryData instance containing image
+    /// information in a known format.
+    /// </summary>
+    /// <param name="stream"> The image data to provide as content. </param>
+    /// <param name="mimeType"> The MIME type, e.g. <c>image/png</c>, matching the format of the image data. </param>
+    /// <param name="detailLevel"> The image detail level the model should use when evaluating the image. </param>
+    public ChatMessageImageContentItem(Stream stream, string mimeType, ChatMessageImageDetailLevel? detailLevel = null)
+        : this(new ChatMessageImageUrl(stream, mimeType, detailLevel))
+    {}
+
+    /// <summary> Initializes a new instance of <see cref="ChatMessageImageContentItem"/>. </summary>
+    /// <param name="imageUrl"> An internet location, which must be accessible to the model,from which the image may be retrieved. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="imageUrl"/> is null. </exception>
+    internal ChatMessageImageContentItem(ChatMessageImageUrl imageUrl)
     {
-        ImageUrl.Detail = detailLevel;
+        Argument.AssertNotNull(imageUrl, nameof(imageUrl));
+
+        Type = "image_url";
+        ImageUrl = imageUrl;
     }
 }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatMessageImageUrl.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatMessageImageUrl.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+
+namespace Azure.AI.OpenAI;
+
+// CUSTOM CODE NOTE:
+//  This nested type is internalized to facilitate better abstraction of internet- vs. local-data-based images via
+//  ChatMessageImageContentItem.
+
+internal partial class ChatMessageImageUrl
+{
+    /// <summary> The URL of the image. </summary>
+    public string Url { get; }
+
+    public ChatMessageImageUrl(Uri uri, ChatMessageImageDetailLevel? detailLevel)
+    {
+        Url = uri.AbsoluteUri;
+        Detail = detailLevel;
+    }
+
+    public ChatMessageImageUrl(BinaryData bytes, string mimeType, ChatMessageImageDetailLevel? detailLevel)
+    {
+        string base64ImageData = Convert.ToBase64String(bytes.ToArray());
+        Url = $"data:{mimeType};base64,{base64ImageData}";
+        Detail = detailLevel;
+    }
+
+    public ChatMessageImageUrl(Stream stream, string mimeType, ChatMessageImageDetailLevel? detailLevel)
+        : this(BinaryData.FromStream(stream), mimeType, detailLevel)
+    { }
+}

--- a/sdk/openai/Azure.AI.OpenAI/src/Generated/AzureOpenAIModelFactory.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Generated/AzureOpenAIModelFactory.cs
@@ -673,26 +673,6 @@ namespace Azure.AI.OpenAI
             return new ChatMessageTextContentItem("text", serializedAdditionalRawData: null, text);
         }
 
-        /// <summary> Initializes a new instance of <see cref="OpenAI.ChatMessageImageContentItem"/>. </summary>
-        /// <param name="imageUrl"> An internet location, which must be accessible to the model,from which the image may be retrieved. </param>
-        /// <returns> A new <see cref="OpenAI.ChatMessageImageContentItem"/> instance for mocking. </returns>
-        public static ChatMessageImageContentItem ChatMessageImageContentItem(ChatMessageImageUrl imageUrl = null)
-        {
-            return new ChatMessageImageContentItem("image_url", serializedAdditionalRawData: null, imageUrl);
-        }
-
-        /// <summary> Initializes a new instance of <see cref="OpenAI.ChatMessageImageUrl"/>. </summary>
-        /// <param name="url"> The URL of the image. </param>
-        /// <param name="detail">
-        /// The evaluation quality setting to use, which controls relative prioritization of speed, token consumption, and
-        /// accuracy.
-        /// </param>
-        /// <returns> A new <see cref="OpenAI.ChatMessageImageUrl"/> instance for mocking. </returns>
-        public static ChatMessageImageUrl ChatMessageImageUrl(Uri url = null, ChatMessageImageDetailLevel? detail = null)
-        {
-            return new ChatMessageImageUrl(url, detail, serializedAdditionalRawData: null);
-        }
-
         /// <summary> Initializes a new instance of <see cref="OpenAI.ChatRequestSystemMessage"/>. </summary>
         /// <param name="content"> The contents of the system message. </param>
         /// <param name="name"> An optional name for the participant. </param>

--- a/sdk/openai/Azure.AI.OpenAI/src/Generated/ChatMessageImageContentItem.Serialization.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Generated/ChatMessageImageContentItem.Serialization.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.OpenAI
 
             writer.WriteStartObject();
             writer.WritePropertyName("image_url"u8);
-            writer.WriteObjectValue(ImageUrl, options);
+            writer.WriteObjectValue<ChatMessageImageUrl>(ImageUrl, options);
             writer.WritePropertyName("type"u8);
             writer.WriteStringValue(Type);
             if (options.Format != "W" && _serializedAdditionalRawData != null)

--- a/sdk/openai/Azure.AI.OpenAI/src/Generated/ChatMessageImageContentItem.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Generated/ChatMessageImageContentItem.cs
@@ -14,17 +14,6 @@ namespace Azure.AI.OpenAI
     public partial class ChatMessageImageContentItem : ChatMessageContentItem
     {
         /// <summary> Initializes a new instance of <see cref="ChatMessageImageContentItem"/>. </summary>
-        /// <param name="imageUrl"> An internet location, which must be accessible to the model,from which the image may be retrieved. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="imageUrl"/> is null. </exception>
-        public ChatMessageImageContentItem(ChatMessageImageUrl imageUrl)
-        {
-            Argument.AssertNotNull(imageUrl, nameof(imageUrl));
-
-            Type = "image_url";
-            ImageUrl = imageUrl;
-        }
-
-        /// <summary> Initializes a new instance of <see cref="ChatMessageImageContentItem"/>. </summary>
         /// <param name="type"> The discriminated object type. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         /// <param name="imageUrl"> An internet location, which must be accessible to the model,from which the image may be retrieved. </param>
@@ -37,8 +26,5 @@ namespace Azure.AI.OpenAI
         internal ChatMessageImageContentItem()
         {
         }
-
-        /// <summary> An internet location, which must be accessible to the model,from which the image may be retrieved. </summary>
-        public ChatMessageImageUrl ImageUrl { get; }
     }
 }

--- a/sdk/openai/Azure.AI.OpenAI/src/Generated/ChatMessageImageUrl.Serialization.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Generated/ChatMessageImageUrl.Serialization.cs
@@ -13,7 +13,7 @@ using Azure.Core;
 
 namespace Azure.AI.OpenAI
 {
-    public partial class ChatMessageImageUrl : IUtf8JsonSerializable, IJsonModel<ChatMessageImageUrl>
+    internal partial class ChatMessageImageUrl : IUtf8JsonSerializable, IJsonModel<ChatMessageImageUrl>
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) => ((IJsonModel<ChatMessageImageUrl>)this).Write(writer, ModelSerializationExtensions.WireOptions);
 
@@ -27,7 +27,7 @@ namespace Azure.AI.OpenAI
 
             writer.WriteStartObject();
             writer.WritePropertyName("url"u8);
-            writer.WriteStringValue(Url.AbsoluteUri);
+            writer.WriteStringValue(Url);
             if (Optional.IsDefined(Detail))
             {
                 writer.WritePropertyName("detail"u8);
@@ -71,7 +71,7 @@ namespace Azure.AI.OpenAI
             {
                 return null;
             }
-            Uri url = default;
+            string url = default;
             ChatMessageImageDetailLevel? detail = default;
             IDictionary<string, BinaryData> serializedAdditionalRawData = default;
             Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
@@ -79,7 +79,7 @@ namespace Azure.AI.OpenAI
             {
                 if (property.NameEquals("url"u8))
                 {
-                    url = new Uri(property.Value.GetString());
+                    url = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("detail"u8))

--- a/sdk/openai/Azure.AI.OpenAI/src/Generated/ChatMessageImageUrl.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Generated/ChatMessageImageUrl.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 namespace Azure.AI.OpenAI
 {
     /// <summary> An internet location from which the model may retrieve an image. </summary>
-    public partial class ChatMessageImageUrl
+    internal partial class ChatMessageImageUrl
     {
         /// <summary>
         /// Keeps track of any properties unknown to the library.
@@ -48,7 +48,7 @@ namespace Azure.AI.OpenAI
         /// <summary> Initializes a new instance of <see cref="ChatMessageImageUrl"/>. </summary>
         /// <param name="url"> The URL of the image. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="url"/> is null. </exception>
-        public ChatMessageImageUrl(Uri url)
+        public ChatMessageImageUrl(string url)
         {
             Argument.AssertNotNull(url, nameof(url));
 
@@ -62,7 +62,7 @@ namespace Azure.AI.OpenAI
         /// accuracy.
         /// </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        internal ChatMessageImageUrl(Uri url, ChatMessageImageDetailLevel? detail, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal ChatMessageImageUrl(string url, ChatMessageImageDetailLevel? detail, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Url = url;
             Detail = detail;
@@ -73,9 +73,6 @@ namespace Azure.AI.OpenAI
         internal ChatMessageImageUrl()
         {
         }
-
-        /// <summary> The URL of the image. </summary>
-        public Uri Url { get; }
         /// <summary>
         /// The evaluation quality setting to use, which controls relative prioritization of speed, token consumption, and
         /// accuracy.

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
@@ -41,6 +41,7 @@ namespace Azure.AI.OpenAI.Tests
             BodyRegexSanitizers.Add(new BodyRegexSanitizer("(\"key\" *: *\")[^ \n\"]*(\")", "$1placeholder$2"));
             HeaderRegexSanitizers.Add(new HeaderRegexSanitizer("api-key", "***********"));
             UriRegexSanitizers.Add(new UriRegexSanitizer("sig=[^\"]*", "sig=Sanitized"));
+            JsonPathSanitizers.Add("$.messages[*].content[*].image_url.url");
             SanitizedQueryParameters.Add("sig");
         }
 
@@ -117,6 +118,21 @@ namespace Azure.AI.OpenAI.Tests
                 _ => throw new NotImplementedException(),
             });
         }
+
+        protected Uri GetTestImageInternetUri()
+        {
+            return new Uri("https://www.bing.com/th?id=OHR.BradgateFallow_EN-US3932725763_1920x1080.jpg");
+        }
+
+        protected Stream GetTestImageStream(string mimeType)
+            => File.OpenRead(mimeType switch
+            {
+                "image/jpg" => TestEnvironment.TestImageJpgInputPath,
+                _ => throw new ArgumentException(nameof(mimeType)),
+            });
+
+        protected BinaryData GetTestImageData(string mimeType)
+            => BinaryData.FromStream(GetTestImageStream(mimeType));
 
         [SetUp]
         public void CreateDeployment()

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
@@ -123,7 +123,7 @@ namespace Azure.AI.OpenAI.Tests
         {
             if (Mode == RecordedTestMode.Playback)
             {
-                return new Uri("Sanitized");
+                return new Uri("https://sanitized");
             }
             return new Uri("https://www.bing.com/th?id=OHR.BradgateFallow_EN-US3932725763_1920x1080.jpg");
         }

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
@@ -121,15 +121,25 @@ namespace Azure.AI.OpenAI.Tests
 
         protected Uri GetTestImageInternetUri()
         {
+            if (Mode == RecordedTestMode.Playback)
+            {
+                return new Uri("Sanitized");
+            }
             return new Uri("https://www.bing.com/th?id=OHR.BradgateFallow_EN-US3932725763_1920x1080.jpg");
         }
 
         protected Stream GetTestImageStream(string mimeType)
-            => File.OpenRead(mimeType switch
+        {
+            if (Mode == RecordedTestMode.Playback)
+            {
+                return new MemoryStream();
+            }
+            return File.OpenRead(mimeType switch
             {
                 "image/jpg" => TestEnvironment.TestImageJpgInputPath,
                 _ => throw new ArgumentException(nameof(mimeType)),
             });
+        }
 
         protected BinaryData GetTestImageData(string mimeType)
             => BinaryData.FromStream(GetTestImageStream(mimeType));

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestEnvironment.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestEnvironment.cs
@@ -14,6 +14,8 @@ namespace Azure.AI.OpenAI.Tests
 
         public string TestAudioInputPathEnglish => GetOptionalVariable("OAI_TEST_AUDIO_INPUT_ENGLISH_PATH");
 
+        public string TestImageJpgInputPath => GetOptionalVariable("OAI_TEST_IMAGE_FILE_PATH");
+
         public Uri GetUrlVariable(string variableName) => new(GetRecordedVariable(variableName));
 
         public bool TryGetUrlVariable(string variableName, out Uri variableValue)

--- a/sdk/openai/Azure.AI.OpenAI/tests/Samples/ChatWithVision.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Samples/ChatWithVision.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Azure.Identity;
 using NUnit.Framework;
@@ -14,20 +15,23 @@ public partial class ChatWithVision
     [Ignore("Only verifying that the sample builds")]
     public async Task ChatWithVisionPreview()
     {
-        string endpoint = "https://myaccount.openai.azure.com/";
+        string endpoint = "https://myresource.openai.azure.com/";
         var client = new OpenAIClient(new Uri(endpoint), new DefaultAzureCredential());
 
         #region Snippet:AddImageToChat
         const string rawImageUri = "<URI to your image>";
+        using Stream jpegImageStream = File.OpenRead("<path to a local image file>");
+
         ChatCompletionsOptions chatCompletionsOptions = new()
         {
-            DeploymentName = "gpt-4-vision-preview",
+            DeploymentName = "gpt-4-turbo",
             Messages =
             {
                 new ChatRequestSystemMessage("You are a helpful assistant that describes images."),
                 new ChatRequestUserMessage(
-                    new ChatMessageTextContentItem("Hi! Please describe this image"),
-                    new ChatMessageImageContentItem(new Uri(rawImageUri))),
+                    new ChatMessageTextContentItem("Hi! Please describe these images"),
+                    new ChatMessageImageContentItem(new Uri(rawImageUri)),
+                    new ChatMessageImageContentItem(jpegImageStream, "image/jpg", ChatMessageImageDetailLevel.Low)),
             },
         };
         #endregion
@@ -35,7 +39,7 @@ public partial class ChatWithVision
         #region Snippet:GetResponseFromImages
         Response<ChatCompletions> chatResponse = await client.GetChatCompletionsAsync(chatCompletionsOptions);
         ChatChoice choice = chatResponse.Value.Choices[0];
-        if (choice.FinishDetails is StopFinishDetails stopDetails || choice.FinishReason == CompletionsFinishReason.Stopped)
+        if (choice.FinishReason == CompletionsFinishReason.Stopped)
         {
             Console.WriteLine($"{choice.Message.Role}: {choice.Message.Content}");
         }


### PR DESCRIPTION
## Problem

When using `gpt-4-turbo` (previously, `gpt-4-vision-preview`) image input, the `image_url` string property of image content items in messages can be used to provide a reference to an image location *or* base64-encoded image data via a `data:` URI.

The current surface only exposes the use of the `Uri` type when creating an image content item. A `Uri` instance can only hold a bit over 2,000 characters of data, so attempting to encode any substantially large image into a `Uri` results in an exception and blocks the ability to provide this local data.

## Solution

`ChatMessageImageContentItem` is augmented with two new constructors: one accepts a `BinaryData` for the image and a matching `string` for the image format's MIME type (like `image/png`); the other accepts a `Stream` and similar MIME `string`.

When using these constructors, the `data:` `Uri` will be automatically constructed from the encoded image data and MIME information; no manual encoding or formatting by the caller is necessary.

As part of this change, the `ChatMessageImageUrl` type is made internal, better facilitating the multi-purpose direct use of `ChatMessageImageContentItem`.

Please see the example in the README for more details.

## Related/acknowledgements
Fixes #40855 
Many thanks to @dersia for the `ChatMessageImageUrl` approach in #43093