### PR TITLE
[CODEOWNERS] Removing retired library PR config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -639,9 +639,6 @@
 # ServiceLabel: %Monitor - Exporter
 # ServiceOwners:                                                   @cijothomas @reyang @rajkumar-rangaraj @TimothyMothra @vishweshbankwar
 
-# PRLabel: %Monitor - LiveMetrics
-/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/              @cijothomas @reyang @rajkumar-rangaraj @TimothyMothra @vishweshbankwar @xiang17
-
 # ServiceLabel: %Monitor - LiveMetrics
 # ServiceOwners:                                                   @cijothomas @reyang @rajkumar-rangaraj @TimothyMothra @vishweshbankwar @xiang17
 


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the PR configuration for the retired OpenTelemetry.LiveMetrics library.   Because the label still exists, the support entry has been left for now.  I'll discuss with the monitor team and see if there's a new label that should be mapped to existing/closed issues, otherwise, we will need to retain the label indefinitely for support/triage use.

## References and related

- [Linter failure](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3754968&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4)