### PR TITLE
Document how to use user-assigned MI resource ID with DefaultAzureCre…

### DIFF
--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -125,18 +125,47 @@ var eventHubClient = new EventHubProducerClient("myeventhub.eventhubs.windows.ne
 
 ### Specify a user-assigned managed identity with `DefaultAzureCredential`
 
-Many Azure hosts allow the assignment of a user-assigned managed identity. This example demonstrates configuring the `DefaultAzureCredential` to authenticate a user-assigned identity when deployed to an Azure host. It then authenticates a `BlobClient` from the [Azure.Storage.Blobs][blobs_client_library] client library with credential.
+Many Azure hosts allow the assignment of a user-assigned managed identity. The following examples demonstrate configuring `DefaultAzureCredential` to authenticate a user-assigned managed identity when deployed to an Azure host. The sample code uses the credential to authenticate a `BlobClient` from the [Azure.Storage.Blobs][blobs_client_library] client library. To do this, you can specify a user-assigned managed identity either by a client ID or a resource ID.
 
-```C# Snippet:UserAssignedManagedIdentity
-// When deployed to an azure host, the default azure credential will authenticate the specified user assigned managed identity.
+#### Client ID
 
-string userAssignedClientId = "<your managed identity client Id>";
-var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = userAssignedClientId });
+To use a client ID, take one of the following approaches:
 
-var blobClient = new BlobClient(new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"), credential);
+1. Set the [DefaultAzureCredentialOptions.ManagedIdentityClientId](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredentialoptions.managedidentityclientid?view=azure-dotnet) property. For example:
+
+    ```C# Snippet:UserAssignedManagedIdentityWithClientId
+    // When deployed to an Azure host, DefaultAzureCredential will authenticate the specified user-assigned managed identity.
+
+    string userAssignedClientId = "<your managed identity client ID>";
+    var credential = new DefaultAzureCredential(
+        new DefaultAzureCredentialOptions
+        {
+            ManagedIdentityClientId = userAssignedClientId
+        });
+
+    var blobClient = new BlobClient(
+        new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"),
+        credential);
+    ```
+
+1. Set the `AZURE_CLIENT_ID` environment variable.
+
+#### Resource ID
+
+To use a resource ID, set the [DefaultAzureCredentialOptions.ManagedIdentityResourceId](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredentialoptions.managedidentityresourceid?view=azure-dotnet) property. The resource ID takes the form `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}`. For example:
+
+```C# Snippet:UserAssignedManagedIdentityWithResourceId
+string userAssignedResourceId = "<your managed identity resource ID>";
+var credential = new DefaultAzureCredential(
+    new DefaultAzureCredentialOptions
+    {
+        ManagedIdentityResourceId = new ResourceIdentifier(userAssignedResourceId)
+    });
+
+var blobClient = new BlobClient(
+    new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"),
+    credential);
 ```
-
-In addition to configuring the `ManagedIdentityClientId` via code, it can also be set using the `AZURE_CLIENT_ID` environment variable. These two approaches are equivalent when using the `DefaultAzureCredential`.
 
 ### Define a custom authentication flow with `ChainedTokenCredential`
 

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -133,20 +133,20 @@ To use a client ID, take one of the following approaches:
 
 1. Set the [DefaultAzureCredentialOptions.ManagedIdentityClientId](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredentialoptions.managedidentityclientid?view=azure-dotnet) property. For example:
 
-    ```C# Snippet:UserAssignedManagedIdentityWithClientId
-    // When deployed to an Azure host, DefaultAzureCredential will authenticate the specified user-assigned managed identity.
+```C# Snippet:UserAssignedManagedIdentityWithClientId
+// When deployed to an Azure host, DefaultAzureCredential will authenticate the specified user-assigned managed identity.
 
-    string userAssignedClientId = "<your managed identity client ID>";
-    var credential = new DefaultAzureCredential(
-        new DefaultAzureCredentialOptions
-        {
-            ManagedIdentityClientId = userAssignedClientId
-        });
+string userAssignedClientId = "<your managed identity client ID>";
+var credential = new DefaultAzureCredential(
+    new DefaultAzureCredentialOptions
+    {
+        ManagedIdentityClientId = userAssignedClientId
+    });
 
-    var blobClient = new BlobClient(
-        new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"),
-        credential);
-    ```
+var blobClient = new BlobClient(
+    new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"),
+    credential);
+```
 
 1. Set the `AZURE_CLIENT_ID` environment variable.
 

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
@@ -12,8 +12,8 @@ using Azure.Core.Pipeline;
 namespace Azure.Identity
 {
     /// <summary>
-    /// Provides a default <see cref="TokenCredential"/> authentication flow for applications that will be deployed to Azure.  The following credential
-    /// types if enabled will be tried, in order:
+    /// Provides a default <see cref="TokenCredential"/> authentication flow for applications that will be deployed to Azure. The following credential
+    /// types, if enabled, will be tried, in order:
     /// <list type="bullet">
     /// <item><description><see cref="EnvironmentCredential"/></description></item>
     /// <item><description><see cref="WorkloadIdentityCredential"/></description></item>
@@ -36,15 +36,21 @@ namespace Azure.Identity
     /// <example>
     /// <para>
     /// This example demonstrates authenticating the BlobClient from the Azure.Storage.Blobs client library using the DefaultAzureCredential,
-    /// deployed to an Azure resource with a user assigned managed identity configured.
+    /// deployed to an Azure resource with a user-assigned managed identity configured.
     /// </para>
-    /// <code snippet="Snippet:UserAssignedManagedIdentity" language="csharp">
-    /// // When deployed to an azure host, the default azure credential will authenticate the specified user assigned managed identity.
+    /// <code snippet="Snippet:UserAssignedManagedIdentityWithClientId" language="csharp">
+    /// // When deployed to an Azure host, DefaultAzureCredential will authenticate the specified user-assigned managed identity.
     ///
-    /// string userAssignedClientId = &quot;&lt;your managed identity client Id&gt;&quot;;
-    /// var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = userAssignedClientId });
+    /// string userAssignedClientId = &quot;&lt;your managed identity client ID&gt;&quot;;
+    /// var credential = new DefaultAzureCredential(
+    ///     new DefaultAzureCredentialOptions
+    ///     {
+    ///         ManagedIdentityClientId = userAssignedClientId
+    ///     });
     ///
-    /// var blobClient = new BlobClient(new Uri(&quot;https://myaccount.blob.core.windows.net/mycontainer/myblob&quot;), credential);
+    /// var blobClient = new BlobClient(
+    ///     new Uri(&quot;https://myaccount.blob.core.windows.net/mycontainer/myblob&quot;),
+    ///     credential);
     /// </code>
     /// </example>
     public class DefaultAzureCredential : TokenCredential

--- a/sdk/identity/Azure.Identity/tests/samples/ReadmeSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/ReadmeSnippets.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Azure.Core;
 using Azure.Messaging.EventHubs.Producer;
 using Azure.Security.KeyVault.Secrets;
 using Azure.Storage.Blobs;
@@ -36,19 +37,42 @@ namespace Azure.Identity.Samples
         }
 
         [Test]
-        public void UserAssignedManagedIdentity()
+        public void UserAssignedManagedIdentityWithClientId()
         {
             string userAssignedClientId = "";
 
-            #region Snippet:UserAssignedManagedIdentity
+            #region Snippet:UserAssignedManagedIdentityWithClientId
 
-            // When deployed to an azure host, the default azure credential will authenticate the specified user assigned managed identity.
+            // When deployed to an Azure host, DefaultAzureCredential will authenticate the specified user-assigned managed identity.
 
-            //@@string userAssignedClientId = "<your managed identity client Id>";
-            var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = userAssignedClientId });
+            //@@string userAssignedClientId = "<your managed identity client ID>";
+            var credential = new DefaultAzureCredential(
+                new DefaultAzureCredentialOptions
+                {
+                    ManagedIdentityClientId = userAssignedClientId
+                });
 
-            var blobClient = new BlobClient(new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"), credential);
+            var blobClient = new BlobClient(
+                new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"),
+                credential);
 
+            #endregion
+        }
+
+        [Test]
+        public void UserAssignedManagedIdentityWithResourceId()
+        {
+            #region Snippet:UserAssignedManagedIdentityWithResourceId
+            string userAssignedResourceId = "<your managed identity resource ID>";
+            var credential = new DefaultAzureCredential(
+                new DefaultAzureCredentialOptions
+                {
+                    ManagedIdentityResourceId = new ResourceIdentifier(userAssignedResourceId)
+                });
+
+            var blobClient = new BlobClient(
+                new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"),
+                credential);
             #endregion
         }
 


### PR DESCRIPTION
The changes in https://github.com/Azure/azure-sdk-for-net/pull/26595 enabled the use of a user-assigned managed identity resource ID with DAC. This PR raises more awareness of that capability.