### PR TITLE
Update Azure Pipelines credential sample

### DIFF
--- a/sdk/identity/Azure.Identity/samples/OtherCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/OtherCredentialSamples.md
@@ -15,4 +15,4 @@ var credential = new AzurePipelinesCredential(tenantId, clientId, serviceConnect
 var client = new SecretClient(new Uri("https://keyvault-name.vault.azure.net/"), credential);
 ```
 
-***Note:*** This credential is **not** included in the `DefaultAzureCredential` chain and must be used explicitly.
+***Note:*** This credential is **not** included in the `DefaultAzureCredential` chain.


### PR DESCRIPTION
Now that `AzurePipelinesCredential` can throw a `CredentialUnavailableException`, update the sample verbiage accordingly. The phrase "and must be used explicitly" could be interpreted as this credential must be used as a standalone credential and not inside a `ChainedTokenCredential`.
