### PR TITLE
[Storage] [DataMovement] Removed Upload + Download Validation Options from ShareFileStorageResourceOptions

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Improved upload and copying chunking strategy for large Share Files to improve speed
 
 ### Breaking Changes
+  - Removed `DownloadTransferValidationOptions` and `UploadTransferValidationOptions` from `ShareFileStorageResourceOptions`.
 
 ### Bugs Fixed
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
@@ -31,13 +31,11 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public ShareFileStorageResourceOptions() { }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions DestinationConditions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> DirectoryMetadata { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public string FilePermissions { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileHttpHeaders HttpHeaders { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.FileSmbProperties SmbProperties { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
 }
 namespace Azure.Storage.Files.Shares

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
@@ -31,13 +31,11 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public ShareFileStorageResourceOptions() { }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions DestinationConditions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> DirectoryMetadata { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public string FilePermissions { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileHttpHeaders HttpHeaders { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.FileSmbProperties SmbProperties { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
 }
 namespace Azure.Storage.Files.Shares

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -14,7 +14,6 @@ namespace Azure.Storage.DataMovement.Files.Shares
             => new()
             {
                 Conditions = options?.DestinationConditions,
-                TransferValidation = options?.UploadTransferValidationOptions,
             };
 
         internal static ShareFileUploadRangeOptions ToShareFileUploadRangeOptions(
@@ -22,7 +21,6 @@ namespace Azure.Storage.DataMovement.Files.Shares
             => new()
             {
                 Conditions = options?.DestinationConditions,
-                TransferValidation = options?.UploadTransferValidationOptions,
             };
 
         internal static ShareFileUploadRangeFromUriOptions ToShareFileUploadRangeFromUriOptions(
@@ -85,7 +83,6 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 Range = range,
                 Conditions = options?.SourceConditions,
-                TransferValidation = options?.DownloadTransferValidationOptions,
             };
 
         internal static StorageResourceReadStreamResult ToStorageResourceReadStreamResult(

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -64,33 +64,5 @@ namespace Azure.Storage.DataMovement.Files.Shares
 #pragma warning disable CA2227 // Collection properties should be readonly
         public Metadata FileMetadata { get; set; }
 #pragma warning restore CA2227 // Collection properties should be readonly
-
-        /// <summary>
-        /// Optional. Options for transfer validation settings on this operation.
-        /// When transfer validation options are set in the client, setting this parameter
-        /// acts as an override.
-        /// This operation does not allow <see cref="UploadTransferValidationOptions.PrecalculatedChecksum"/>
-        /// to be set.
-        ///
-        /// Applies to upload transfers.
-        /// </summary>
-        public UploadTransferValidationOptions UploadTransferValidationOptions { get; set; }
-
-        /// <summary>
-        /// Optional. Options for transfer validation settings on this operation.
-        /// When transfer validation options are set in the client, setting this parameter
-        /// acts as an override.
-        /// Set <see cref="DownloadTransferValidationOptions.AutoValidateChecksum"/> to false if you
-        /// would like to skip SDK checksum validation and validate the checksum found
-        /// in the <see cref="Response"/> object yourself.
-        /// Range must be provided explicitly, stating a range withing Azure
-        /// Storage size limits for requesting a transactional hash. See the
-        /// <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob">
-        /// REST documentation</a> for range limitation details.
-        ///
-        /// Applies to download transfers.
-        /// </summary>
-        public DownloadTransferValidationOptions DownloadTransferValidationOptions
-        { get; set; }
     }
 }


### PR DESCRIPTION
When we removed these unnecessary options for blobs, we missed it for files. This is to remove it.

Addressing it from this comment from my other PR https://github.com/Azure/azure-sdk-for-net/pull/43799#discussion_r1586965242