### PR TITLE
Added support for provisioning of Azure Batch resources

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -134,6 +134,7 @@
     <PackageReference Update="Azure.ResourceManager.AppConfiguration" Version="1.3.1" />
     <PackageReference Update="Azure.ResourceManager.ApplicationInsights" Version="1.0.0" />
     <PackageReference Update="Azure.ResourceManager.Authorization" Version="1.1.1" />
+	<PackageReference Update="Azure.ResourceManager.Batch" Version="1.4.0" />
     <PackageReference Update="Azure.ResourceManager.CognitiveServices" Version="1.3.2" />
     <PackageReference Update="Azure.ResourceManager.CosmosDB" Version="1.3.2" />
     <PackageReference Update="Azure.ResourceManager.EventHubs" Version="1.0.1" />

--- a/sdk/provisioning/Azure.Provisioning.Batch.Tests/Azure.Provisioning.Batch.Tests.csproj
+++ b/sdk/provisioning/Azure.Provisioning.Batch.Tests/Azure.Provisioning.Batch.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />
+    <ProjectReference Include="..\src\Azure.Provisioning.Batch.csproj" />
+    <ProjectReference Include="..\..\Azure.Provisioning.Resources\src\Azure.Provisioning.Resources.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/provisioning/Azure.Provisioning.Batch.Tests/BatchTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Batch.Tests/BatchTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Provisioning.ResourceManager;
+using Azure.Provisioning.Tests;
+
+namespace Azure.Provisioning.Batch.Tests
+{
+    public class BatchTests : ProvisioningTestBase
+    {
+        public BatchTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        [RecordedTest]
+        public async Task BatchAccounts()
+        {
+            TestInfrastructure infrastructure =
+                new TestInfrastructure(configuration: new Configuration { UseInteractiveMode = true });
+            var account = new BatchAccount(infrastructure);
+            var pool = new BatchPool(infrastructure, parent: account);
+            infrastructure.Build(GetOutputPath());
+
+            await ValidateBicepAsync(interactiveMode true);
+        }
+
+        [RecordedTest]
+        public async Task ExistingBatchResources()
+        {
+            var infra = new TestInfrastructure();
+            var rg = infra.AddResourceGroup();
+
+            var account = BatchAccount.FromExisting(infra, "'existingAccount'", rg);
+            var pool = BatchPool.FromExisting(infra, "'existingPool'", account);
+            infra.AddResource(pool);
+
+            infra.Build(GetOutputPath());
+
+            await ValidateBicepAsync();
+        }
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning.Batch.Tests/Infrastructure/Batch/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning.Batch.Tests/Infrastructure/Batch/main.bicep
@@ -1,0 +1,19 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+resource batch_NJHADAP 'Microsoft.Batch/batchAccounts@2023-11-01' = {
+    name: toLower(take('batch${uniqueString(resourceGroup().id)}', 24))
+    location: location
+    properties: {
+    }
+}
+
+resource batchPool_KBJG233A 'Microsoft.Batch/batchAccounts/pools@2023-11-01' = {
+    parent: batch_NJHADAP
+    name: 'pool'
+    location: location
+    properties: {
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning.Batch.Tests/Infrastructure/ExistingBatchResources/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning.Batch.Tests/Infrastructure/ExistingBatchResources/main.bicep
@@ -1,0 +1,14 @@
+targetScope = 'subscription'
+
+resource resourceGroup_I6QNkoPsb 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+    name: 'rg-TEST',
+    location: 'westus'
+    tags: {
+        'azd-env-name': 'TEST'
+    }
+}
+
+module rg_TEST_module './resources/rg_TEST_module/rg_TEST_module.bicep' = {
+    name: 'rg_TEST_module'
+    scope: resourceGroup_I6QNkoPsb
+}

--- a/sdk/provisioning/Azure.Provisioning.Batch.Tests/Infrastructure/ExistingBatchResources/resources/rg_TEST_module/rg_TEST_module.bicep
+++ b/sdk/provisioning/Azure.Provisioning.Batch.Tests/Infrastructure/ExistingBatchResources/resources/rg_TEST_module/rg_TEST_module.bicep
@@ -1,0 +1,7 @@
+resource batch_ljkLJsDS 'Microsoft.Batch/batchAccounts@2023-11-01' existing = {
+    name: 'existingBatchAccount'
+}
+
+resource batchPool_JHZV2LAK 'Microsoft.Batch/batchAccounts/pools@2023-11-01' existing = {
+    name: '${batch_ljkLJsDS}/existingPool'
+}

--- a/sdk/provisioning/Azure.Provisioning.Batch.Tests/README.md
+++ b/sdk/provisioning/Azure.Provisioning.Batch.Tests/README.md
@@ -1,0 +1,81 @@
+# Azure Provisioning client library for .NET
+
+Azure.Provisioning.Batch simplifies declarative resource provisioning in >NET for Azure Batch accounts.
+
+## Getting started
+
+### Install the package
+
+Install the client library for .NET with [NuGet](https://www.nuget.org):
+
+```dotnetcli
+dotnet add package Azure.Provisioning.Batch
+```
+
+### Prerequisites
+
+> You must have an [Azure subscription](https://azure.microsoft.com/free/dotnet/).
+
+### Authenticate the Client
+
+## Key concepts
+
+This library allows you to specify your infrastructure in a declarative style using dotnet.  You can then use azd to deploy your infrastructure to Azure diretly without needing to write or maintain bicep or arm templates.
+
+## Examples
+
+Here is a simple example which creates a KeyVault.
+
+First create your Infrastructure class.
+
+```C# Snippet:SampleInfrastructure
+public class SampleInfrastructure : Infrastructure
+{
+}
+```
+
+Next add your resources into your infrastructure and then Build.
+
+```C# Snippet:BatchOnly
+// Create a new infrastructure
+var infrastructure = new SampleInfrastructure();
+
+// Add a new batch account
+var batch = infrastructure.AddBatch();
+
+// You can call Build to convert the infrastructure into bicep files
+infrastructure.Build();
+```
+
+## Troubleshooting
+
+-   File an issue via [GitHub Issues](https://github.com/Azure/azure-sdk-for-net/issues).
+-   Check [previous questions](https://stackoverflow.com/questions/tagged/azure+.net) or ask new ones on Stack Overflow using Azure and .NET tags.
+
+## Next steps
+
+## Contributing
+
+For details on contributing to this repository, see the [contributing
+guide][cg].
+
+This project welcomes contributions and suggestions. Most contributions
+require you to agree to a Contributor License Agreement (CLA) declaring
+that you have the right to, and actually do, grant us the rights to use
+your contribution. For details, visit <https://cla.microsoft.com>.
+
+When you submit a pull request, a CLA-bot will automatically determine
+whether you need to provide a CLA and decorate the PR appropriately
+(for example, label, comment). Follow the instructions provided by the
+bot. You'll only need to do this action once across all repositories
+using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For
+more information, see the [Code of Conduct FAQ][coc_faq] or contact
+<opencode@microsoft.com> with any other questions or comments.
+
+<!-- LINKS -->
+[cg]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/resourcemanager/Azure.ResourceManager/docs/CONTRIBUTING.md
+[coc]: https://opensource.microsoft.com/codeofconduct/
+[coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
+

--- a/sdk/provisioning/Azure.Provisioning.Batch/Azure.Provisioning.Batch.csproj
+++ b/sdk/provisioning/Azure.Provisioning.Batch/Azure.Provisioning.Batch.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Azure.Provisioning.Batch simplifies declarative resource provisioning in .NET for Azure Batch.</Description>
+    <Version>0.1.0-beta.1</Version>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.ResourceManager.Batch" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.Provisioning\src\Azure.Provisioning.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/provisioning/Azure.Provisioning.Batch/Batch.cs
+++ b/sdk/provisioning/Azure.Provisioning.Batch/Batch.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.Provisioning.ResourceManager;
+using Azure.ResourceManager.Batch;
+using Azure.ResourceManager.Batch.Models;
+
+namespace Azure.Provisioning.Batch
+{
+    /// <summary>
+    /// Represents an Azure Batch account.
+    /// </summary>
+    public class BatchAccount : Resource<BatchAccountData>
+    {
+        //https://learn.microsoft.com/en-us/azure/templates/microsoft.batch/batchaccounts?pivots=deployment-language-bicep
+        private const string ResourceTypeName = "Microsoft.Batch/batchAccounts";
+        internal const string DefaultVersion = "2023-11-01";
+
+        private static BatchAccountData Empty(string name) => ArmBatchModelFactory.BatchAccountData();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchAccount"/>.
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <param name="parent"></param>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <param name="location"></param>
+        public BatchAccount(
+            IConstruct scope,
+            ResourceGroup? parent = null,
+            string name = "batch",
+            string version = DefaultVersion,
+            AzureLocation? location = default)
+            : this (scope, parent, name, version, false, (name) => ArmBatchModelFactory.BatchAccountData(
+                    name: name,
+                    resourceType: ResourceTypeName,
+                    location: location ?? Environment.GetEnvironmentVariable("AZURE_LOCATION") ?? AzureLocation.WestUS))
+        {
+            AssignProperty(data => data.Name, GetAzureName(scope, name));
+        }
+
+        private BatchAccount(
+            IConstruct scope,
+            ResourceGroup? parent,
+            string name,
+            string version = DefaultVersion,
+            bool isExisting = false,
+            Func<string, BatchAccountData>? creator = null)
+            : base(scope, parent, name, ResourceTypeName, version, creator ?? Empty, isExisting)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="BatchAccount"/> class referencing an existing resource.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="name">The resource name.</param>
+        /// <param name="parent">The resource group.</param>
+        /// <returns>The Batch instance.</returns>
+        public static BatchAccount FromExisting(IConstruct scope, string name, ResourceGroup? parent = null)
+            => new BatchAccount(scope, parent: parent, name: name, isExisting: true);
+
+        protected override string GetAzureName(IConstruct scope, string resourceName) =>
+            GetGloballyUniqueName(resourceName);
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning.Batch/BatchExtensions.cs
+++ b/sdk/provisioning/Azure.Provisioning.Batch/BatchExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Provisioning.ResourceManager;
+
+namespace Azure.Provisioning.Batch
+{
+    /// <summary>
+    /// Extension methods for <see cref="IConstruct"/>.
+    /// </summary>
+    public static class BatchExtensions
+    {
+        /// <summary>
+        /// Adds a <see cref="BatchAccount"/> to the construct.
+        /// </summary>
+        /// <param name="construct">The construct.</param>
+        /// <param name="resourceGroup">The parent.</param>
+        /// <param name="name">The name.</param>
+        /// <returns></returns>
+        public static BatchAccount AddBatch(this IConstruct construct, ResourceGroup? resourceGroup = null, string name)
+        {
+            return new BatchAccount(construct, name: name, parent: resourceGroup);
+        }
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning.Batch/BatchPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.Batch/BatchPool.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.ResourceManager.Batch;
+using Azure.ResourceManager.Batch.Models;
+
+namespace Azure.Provisioning.Batch
+{
+    /// <summary>
+    /// Represents a Batch pool.
+    /// </summary>
+    public class BatchPool : Resource<BatchAccountPoolData>
+    {
+        private const string ResourceTypeName = "Microsoft.Batch/batchAccounts/pools";
+
+        private static readonly Func<string, BatchAccountPoolData> Empty = (name) =>
+            ArmBatchModelFactory.BatchAccountPoolData();
+
+        public BatchPool(IConstruct scope, BatchAccount? parent = null, string name = "pool",
+            string version = BatchAccount.DefaultVersion, AzureLocation? location = default)
+            : this(scope, parent, name, version, false, (name) => ArmBatchModelFactory.BatchAccountPoolData(
+                name: name,
+                resourceType: ResourceTypeName))
+        {
+        }
+
+        private BatchPool(IConstruct scope, BatchAccount? parent, string name,
+            string version = BatchAccount.DefaultVersion, bool isExisting = true,
+            Func<string, BatchAccountPoolData>? creator = null)
+            : base(scope, parent, name, ResourceTypeName, version, creator ?? Empty, isExisting)
+        {
+        }
+
+        public static BatchPool FromExisting(IConstruct scope, string name, BatchAccount parent)
+            => new BatchPool(scope, parent: parent, name: name, isExisting: true);
+
+        protected override Resource? FindParentInScope(IConstruct scope)
+        {
+            return scope.GetSingleResource<BatchAccount>() ?? new BatchAccount(scope);
+        }
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning.Batch/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.Batch/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Release History
+
+## 0.1.0-beta.1 (2024-05-04)
+
+### Features Added
+
+- Initial beta release of Azure.Provisioning.Batch.

--- a/sdk/provisioning/Azure.Provisioning.Batch/README.md
+++ b/sdk/provisioning/Azure.Provisioning.Batch/README.md
@@ -1,0 +1,81 @@
+# Azure Provisioning client library for .NET
+
+Azure.Provisioning.Batch simplifies declarative resource provisioning in >NET for Azure Batch accounts.
+
+## Getting started
+
+### Install the package
+
+Install the client library for .NET with [NuGet](https://www.nuget.org):
+
+```dotnetcli
+dotnet add package Azure.Provisioning.Batch
+```
+
+### Prerequisites
+
+> You must have an [Azure subscription](https://azure.microsoft.com/free/dotnet/).
+
+### Authenticate the Client
+
+## Key concepts
+
+This library allows you to specify your infrastructure in a declarative style using dotnet.  You can then use azd to deploy your infrastructure to Azure diretly without needing to write or maintain bicep or arm templates.
+
+## Examples
+
+Here is a simple example which creates a KeyVault.
+
+First create your Infrastructure class.
+
+```C# Snippet:SampleInfrastructure
+public class SampleInfrastructure : Infrastructure
+{
+}
+```
+
+Next add your resources into your infrastructure and then Build.
+
+```C# Snippet:BatchOnly
+// Create a new infrastructure
+var infrastructure = new SampleInfrastructure();
+
+// Add a new batch account
+var batch = infrastructure.AddBatch();
+
+// You can call Build to convert the infrastructure into bicep files
+infrastructure.Build();
+```
+
+## Troubleshooting
+
+-   File an issue via [GitHub Issues](https://github.com/Azure/azure-sdk-for-net/issues).
+-   Check [previous questions](https://stackoverflow.com/questions/tagged/azure+.net) or ask new ones on Stack Overflow using Azure and .NET tags.
+
+## Next steps
+
+## Contributing
+
+For details on contributing to this repository, see the [contributing
+guide][cg].
+
+This project welcomes contributions and suggestions. Most contributions
+require you to agree to a Contributor License Agreement (CLA) declaring
+that you have the right to, and actually do, grant us the rights to use
+your contribution. For details, visit <https://cla.microsoft.com>.
+
+When you submit a pull request, a CLA-bot will automatically determine
+whether you need to provide a CLA and decorate the PR appropriately
+(for example, label, comment). Follow the instructions provided by the
+bot. You'll only need to do this action once across all repositories
+using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For
+more information, see the [Code of Conduct FAQ][coc_faq] or contact
+<opencode@microsoft.com> with any other questions or comments.
+
+<!-- LINKS -->
+[cg]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/resourcemanager/Azure.ResourceManager/docs/CONTRIBUTING.md
+[coc]: https://opensource.microsoft.com/codeofconduct/
+[coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
+

--- a/sdk/provisioning/Azure.Provisioning.sln
+++ b/sdk/provisioning/Azure.Provisioning.sln
@@ -3,71 +3,75 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.7.34009.444
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning", "Azure.Provisioning\src\Azure.Provisioning.csproj", "{A2363999-F8EF-4C2F-8DDE-6777AE903BB3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning", "Azure.Provisioning\src\Azure.Provisioning.csproj", "{A2363999-F8EF-4C2F-8DDE-6777AE903BB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.AppConfiguration", "Azure.Provisioning.AppConfiguration\src\Azure.Provisioning.AppConfiguration.csproj", "{B71F9235-CFCB-40CE-B826-25F44FA42B62}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.AppConfiguration", "Azure.Provisioning.AppConfiguration\src\Azure.Provisioning.AppConfiguration.csproj", "{B71F9235-CFCB-40CE-B826-25F44FA42B62}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.ApplicationInsights", "Azure.Provisioning.ApplicationInsights\src\Azure.Provisioning.ApplicationInsights.csproj", "{DC9BB057-C5BF-4718-A858-5F05B891EE41}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.ApplicationInsights", "Azure.Provisioning.ApplicationInsights\src\Azure.Provisioning.ApplicationInsights.csproj", "{DC9BB057-C5BF-4718-A858-5F05B891EE41}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.CognitiveServices", "Azure.Provisioning.CognitiveServices\src\Azure.Provisioning.CognitiveServices.csproj", "{765BA4A0-5873-4163-9BC0-B049BC4378D9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.CognitiveServices", "Azure.Provisioning.CognitiveServices\src\Azure.Provisioning.CognitiveServices.csproj", "{765BA4A0-5873-4163-9BC0-B049BC4378D9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.CosmosDB", "Azure.Provisioning.CosmosDB\src\Azure.Provisioning.CosmosDB.csproj", "{5D3E3ECE-7A31-43B6-8656-865ED0863600}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.CosmosDB", "Azure.Provisioning.CosmosDB\src\Azure.Provisioning.CosmosDB.csproj", "{5D3E3ECE-7A31-43B6-8656-865ED0863600}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.EventHubs", "Azure.Provisioning.EventHubs\src\Azure.Provisioning.EventHubs.csproj", "{D9890E64-46E5-4A93-BDBC-189456573498}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.EventHubs", "Azure.Provisioning.EventHubs\src\Azure.Provisioning.EventHubs.csproj", "{D9890E64-46E5-4A93-BDBC-189456573498}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.KeyVault", "Azure.Provisioning.KeyVault\src\Azure.Provisioning.KeyVault.csproj", "{17D846F2-C0FE-4F9D-AB59-AC2229EB6B8C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.KeyVault", "Azure.Provisioning.KeyVault\src\Azure.Provisioning.KeyVault.csproj", "{17D846F2-C0FE-4F9D-AB59-AC2229EB6B8C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.OperationalInsights", "Azure.Provisioning.OperationalInsights\src\Azure.Provisioning.OperationalInsights.csproj", "{EB8DF0CF-21C8-45D9-8916-D74B81896E07}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.OperationalInsights", "Azure.Provisioning.OperationalInsights\src\Azure.Provisioning.OperationalInsights.csproj", "{EB8DF0CF-21C8-45D9-8916-D74B81896E07}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.PostgreSql", "Azure.Provisioning.PostgreSql\src\Azure.Provisioning.PostgreSql.csproj", "{BE180818-826C-4CD8-8005-FD2957573CE4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.PostgreSql", "Azure.Provisioning.PostgreSql\src\Azure.Provisioning.PostgreSql.csproj", "{BE180818-826C-4CD8-8005-FD2957573CE4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Redis", "Azure.Provisioning.Redis\src\Azure.Provisioning.Redis.csproj", "{225A557B-79DE-4C3B-AFDB-D4E14436B1C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Redis", "Azure.Provisioning.Redis\src\Azure.Provisioning.Redis.csproj", "{225A557B-79DE-4C3B-AFDB-D4E14436B1C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Resources", "Azure.Provisioning.Resources\src\Azure.Provisioning.Resources.csproj", "{1D58F6FC-EE13-4897-A91D-8445E7F75C86}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Resources", "Azure.Provisioning.Resources\src\Azure.Provisioning.Resources.csproj", "{1D58F6FC-EE13-4897-A91D-8445E7F75C86}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Search", "Azure.Provisioning.Search\src\Azure.Provisioning.Search.csproj", "{889C4551-4CD9-425D-8F80-99CC9E6AF730}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Search", "Azure.Provisioning.Search\src\Azure.Provisioning.Search.csproj", "{889C4551-4CD9-425D-8F80-99CC9E6AF730}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.ServiceBus", "Azure.Provisioning.ServiceBus\src\Azure.Provisioning.ServiceBus.csproj", "{2B5BA6A8-B9C8-44A9-96A3-0D9EA46F5E11}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.ServiceBus", "Azure.Provisioning.ServiceBus\src\Azure.Provisioning.ServiceBus.csproj", "{2B5BA6A8-B9C8-44A9-96A3-0D9EA46F5E11}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.SignalR", "Azure.Provisioning.SignalR\src\Azure.Provisioning.SignalR.csproj", "{68EC479D-C611-4D96-93DD-CDF2C0D4A325}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.SignalR", "Azure.Provisioning.SignalR\src\Azure.Provisioning.SignalR.csproj", "{68EC479D-C611-4D96-93DD-CDF2C0D4A325}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Sql", "Azure.Provisioning.Sql\src\Azure.Provisioning.Sql.csproj", "{5ED2D85F-6A24-4570-BBF8-886CECD759C1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Sql", "Azure.Provisioning.Sql\src\Azure.Provisioning.Sql.csproj", "{5ED2D85F-6A24-4570-BBF8-886CECD759C1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Storage", "Azure.Provisioning.Storage\src\Azure.Provisioning.Storage.csproj", "{667FED28-A029-49D9-BC22-63024B7AAEFF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Storage", "Azure.Provisioning.Storage\src\Azure.Provisioning.Storage.csproj", "{667FED28-A029-49D9-BC22-63024B7AAEFF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.AppConfiguration.Tests", "Azure.Provisioning.AppConfiguration\tests\Azure.Provisioning.AppConfiguration.Tests.csproj", "{55C03467-6BFD-424F-AF85-D769C9FCF3A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.AppConfiguration.Tests", "Azure.Provisioning.AppConfiguration\tests\Azure.Provisioning.AppConfiguration.Tests.csproj", "{55C03467-6BFD-424F-AF85-D769C9FCF3A5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.ApplicationInsights.Tests", "Azure.Provisioning.ApplicationInsights\tests\Azure.Provisioning.ApplicationInsights.Tests.csproj", "{2594F17A-3D99-4624-9EE4-2D13D43969A4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.ApplicationInsights.Tests", "Azure.Provisioning.ApplicationInsights\tests\Azure.Provisioning.ApplicationInsights.Tests.csproj", "{2594F17A-3D99-4624-9EE4-2D13D43969A4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Tests", "Azure.Provisioning\tests\Azure.Provisioning.Tests.csproj", "{38BEA83D-435F-4A71-ADCC-2F05321BC5B5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Tests", "Azure.Provisioning\tests\Azure.Provisioning.Tests.csproj", "{38BEA83D-435F-4A71-ADCC-2F05321BC5B5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.CognitiveServices.Tests", "Azure.Provisioning.CognitiveServices\tests\Azure.Provisioning.CognitiveServices.Tests.csproj", "{35F33B4F-04DF-43E3-9983-08C781865508}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.CognitiveServices.Tests", "Azure.Provisioning.CognitiveServices\tests\Azure.Provisioning.CognitiveServices.Tests.csproj", "{35F33B4F-04DF-43E3-9983-08C781865508}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.CosmosDB.Tests", "Azure.Provisioning.CosmosDB\tests\Azure.Provisioning.CosmosDB.Tests.csproj", "{50A583E5-7BBB-44C6-944F-52F6468A9ACE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.CosmosDB.Tests", "Azure.Provisioning.CosmosDB\tests\Azure.Provisioning.CosmosDB.Tests.csproj", "{50A583E5-7BBB-44C6-944F-52F6468A9ACE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.EventHubs.Tests", "Azure.Provisioning.EventHubs\tests\Azure.Provisioning.EventHubs.Tests.csproj", "{BFA2ADDC-B9B0-4387-B6D3-166A72D1BC68}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.EventHubs.Tests", "Azure.Provisioning.EventHubs\tests\Azure.Provisioning.EventHubs.Tests.csproj", "{BFA2ADDC-B9B0-4387-B6D3-166A72D1BC68}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.KeyVault.Tests", "Azure.Provisioning.KeyVault\tests\Azure.Provisioning.KeyVault.Tests.csproj", "{C8323082-D02B-4847-8D71-0F3033392359}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.KeyVault.Tests", "Azure.Provisioning.KeyVault\tests\Azure.Provisioning.KeyVault.Tests.csproj", "{C8323082-D02B-4847-8D71-0F3033392359}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.OperationalInsights.Tests", "Azure.Provisioning.OperationalInsights\tests\Azure.Provisioning.OperationalInsights.Tests.csproj", "{549264B4-16BD-4DC2-B187-1F8D4C305ED1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.OperationalInsights.Tests", "Azure.Provisioning.OperationalInsights\tests\Azure.Provisioning.OperationalInsights.Tests.csproj", "{549264B4-16BD-4DC2-B187-1F8D4C305ED1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.PostgreSql.Tests", "Azure.Provisioning.PostgreSql\tests\Azure.Provisioning.PostgreSql.Tests.csproj", "{C8649684-EC1D-4C94-B099-D7AFECCEDBC9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.PostgreSql.Tests", "Azure.Provisioning.PostgreSql\tests\Azure.Provisioning.PostgreSql.Tests.csproj", "{C8649684-EC1D-4C94-B099-D7AFECCEDBC9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Redis.Tests", "Azure.Provisioning.Redis\tests\Azure.Provisioning.Redis.Tests.csproj", "{B860EE49-1DBD-43ED-8A5F-5510955FF69D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Redis.Tests", "Azure.Provisioning.Redis\tests\Azure.Provisioning.Redis.Tests.csproj", "{B860EE49-1DBD-43ED-8A5F-5510955FF69D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Resources.Tests", "Azure.Provisioning.Resources\tests\Azure.Provisioning.Resources.Tests.csproj", "{806B09BD-0B36-4644-ACE1-A8A71608EC90}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Resources.Tests", "Azure.Provisioning.Resources\tests\Azure.Provisioning.Resources.Tests.csproj", "{806B09BD-0B36-4644-ACE1-A8A71608EC90}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Search.Tests", "Azure.Provisioning.Search\tests\Azure.Provisioning.Search.Tests.csproj", "{13D88F24-0B0F-43AA-83F5-50D7A050256C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Search.Tests", "Azure.Provisioning.Search\tests\Azure.Provisioning.Search.Tests.csproj", "{13D88F24-0B0F-43AA-83F5-50D7A050256C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.ServiceBus.Tests", "Azure.Provisioning.ServiceBus\tests\Azure.Provisioning.ServiceBus.Tests.csproj", "{000EA723-CFB7-4340-932D-69E5A0430833}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.ServiceBus.Tests", "Azure.Provisioning.ServiceBus\tests\Azure.Provisioning.ServiceBus.Tests.csproj", "{000EA723-CFB7-4340-932D-69E5A0430833}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.SignalR.Tests", "Azure.Provisioning.SignalR\tests\Azure.Provisioning.SignalR.Tests.csproj", "{2E92F7F3-5648-4948-9EAF-1DD587267782}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.SignalR.Tests", "Azure.Provisioning.SignalR\tests\Azure.Provisioning.SignalR.Tests.csproj", "{2E92F7F3-5648-4948-9EAF-1DD587267782}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Sql.Tests", "Azure.Provisioning.Sql\tests\Azure.Provisioning.Sql.Tests.csproj", "{2C7DDE49-44AF-43BD-AD6C-713DAB86C618}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Sql.Tests", "Azure.Provisioning.Sql\tests\Azure.Provisioning.Sql.Tests.csproj", "{2C7DDE49-44AF-43BD-AD6C-713DAB86C618}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Storage.Tests", "Azure.Provisioning.Storage\tests\Azure.Provisioning.Storage.Tests.csproj", "{02DC989C-9F25-42AC-BD0F-0F35FAA9684A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Provisioning.Storage.Tests", "Azure.Provisioning.Storage\tests\Azure.Provisioning.Storage.Tests.csproj", "{02DC989C-9F25-42AC-BD0F-0F35FAA9684A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.TestFramework", "..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{C2778320-ADC6-4EEE-A1D8-98590CD1223D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{C2778320-ADC6-4EEE-A1D8-98590CD1223D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Batch", "Azure.Provisioning.Batch\Azure.Provisioning.Batch.csproj", "{EFC01DE8-850F-49D6-9ECE-3EF65487F498}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Provisioning.Batch.Tests", "Azure.Provisioning.Batch.Tests\Azure.Provisioning.Batch.Tests.csproj", "{89786DEC-DD56-4CD0-8985-B66A32A0C100}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -207,6 +211,14 @@ Global
 		{C2778320-ADC6-4EEE-A1D8-98590CD1223D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C2778320-ADC6-4EEE-A1D8-98590CD1223D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C2778320-ADC6-4EEE-A1D8-98590CD1223D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFC01DE8-850F-49D6-9ECE-3EF65487F498}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFC01DE8-850F-49D6-9ECE-3EF65487F498}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFC01DE8-850F-49D6-9ECE-3EF65487F498}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFC01DE8-850F-49D6-9ECE-3EF65487F498}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89786DEC-DD56-4CD0-8985-B66A32A0C100}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89786DEC-DD56-4CD0-8985-B66A32A0C100}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89786DEC-DD56-4CD0-8985-B66A32A0C100}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89786DEC-DD56-4CD0-8985-B66A32A0C100}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds support for Azure Batch in the Azure.Provisioning.* packages as a precursor to adding such support in [Aspire](https://github.com/dotnet/aspire/issues/4084).

This specifically looks to provision both Batch accounts and pools. Additional resources can be trivially provisioned with the Azure Batch SDK, but these two resources must be deployed via ARM to capture the full surface area (e.g. in my experiments, while one can deploy Batch pools via the client SDK, they can't reference user-assigned identities - only a deployment via ARM is able to do so).

I added this in the style of the recently added EventHubs project but also added the extensions seen in the Key Vault project. Many of the READMEs for each project seem to be largely copy/pastes of the Key Vault README, so I did the same here, but updated the infrastructure example to use the Batch extension method I added (rather than referencing Key Vault as the other READMEs do).