### PR TITLE
[Search] Fix VisionVectorizeSkill Test Case for USGov Region

### DIFF
--- a/sdk/search/Azure.Search.Documents/assets.json
+++ b/sdk/search/Azure.Search.Documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/search/Azure.Search.Documents",
-  "Tag": "net/search/Azure.Search.Documents_1748f3593d"
+  "Tag": "net/search/Azure.Search.Documents_b5f3720554"
 }

--- a/sdk/search/Azure.Search.Documents/tests/SearchIndexerClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchIndexerClientTests.cs
@@ -720,9 +720,11 @@ namespace Azure.Search.Documents.Tests
                     Type _ when t == typeof(WebApiSkill) => CreateSkill(t, new[] { "input" }, new[] { "output" }),
                     Type _ when t == typeof(AzureMachineLearningSkill) => CreateSkill(t, new[] { "input" }, new[] { "output" }),
                     Type _ when t == typeof(AzureOpenAIEmbeddingSkill) => CreateSkill(t, new[] { "text" }, new[] { "embedding" }),
-                    Type _ when t == typeof(VisionVectorizeSkill) => CreateSkill(t, new[] { "image" }, new[] { "vector" }),
+                    Type _ when t == typeof(VisionVectorizeSkill) =>
+                    TestEnvironment.Location != "usgov" ? CreateSkill(t, new[] { "image" }, new[] { "vector" }) : null,
                     _ => throw new NotSupportedException($"{t.FullName}"),
                 })
+                .Where(skill => skill != null)
                 .ToList();
 
             skills.Add(CreateEntityRecognitionSkill(EntityRecognitionSkill.SkillVersion.V3));


### PR DESCRIPTION
This PR addresses an issue where creating VisionVectorizeSkill test case fails in the USGov region due to unavailability. As per the documentation [here](https://learn.microsoft.com/en-us/azure/ai-services/computer-vision/overview-image-analysis?tabs=4-0#multimodal-embeddings-v40-only), VisionVectorizeSkill is not supported in USGov. This PR modifies the test case to accommodate this limitation and ensures that VisionVectorizeSkill is not created for the USGov region.

Fixes failure in the weekly pipeline - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3760189&view=logs&j=8202aa58-244c-5614-d0df-1d06f4ac1fb7&t=a320f648-9d95-5152-4598-216de8a7b95f&l=2292