### PR TITLE
[Search] Fix RoundtripAllSkills test

### DIFF
--- a/sdk/search/Azure.Search.Documents/assets.json
+++ b/sdk/search/Azure.Search.Documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/search/Azure.Search.Documents",
-  "Tag": "net/search/Azure.Search.Documents_b5f3720554"
+  "Tag": "net/search/Azure.Search.Documents_52c4e21bfa"
 }

--- a/sdk/search/Azure.Search.Documents/tests/SearchIndexerClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchIndexerClientTests.cs
@@ -721,7 +721,7 @@ namespace Azure.Search.Documents.Tests
                     Type _ when t == typeof(AzureMachineLearningSkill) => CreateSkill(t, new[] { "input" }, new[] { "output" }),
                     Type _ when t == typeof(AzureOpenAIEmbeddingSkill) => CreateSkill(t, new[] { "text" }, new[] { "embedding" }),
                     Type _ when t == typeof(VisionVectorizeSkill) =>
-                    TestEnvironment.Location != "usgov" ? CreateSkill(t, new[] { "image" }, new[] { "vector" }) : null,
+                    TestEnvironment.AzureEnvironment != "AzureUSGovernment" ? CreateSkill(t, new[] { "image" }, new[] { "vector" }) : null,
                     _ => throw new NotSupportedException($"{t.FullName}"),
                 })
                 .Where(skill => skill != null)


### PR DESCRIPTION
In the [previous PR](https://github.com/Azure/azure-sdk-for-net/pull/43861), I unintentionally compared `USGov` with the location. This PR resolves that issue by ensuring the comparison is between `USGov` and `AzureEnvironment`.