### PR TITLE
ClientModel: Add BufferResponse to RequestOptions

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `BufferResponse` property to `RequestOptions` so protocol method callers can override the client value for response content buffering.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -239,6 +239,7 @@ namespace System.ClientModel.Primitives
     public partial class RequestOptions
     {
         public RequestOptions() { }
+        public bool? BufferResponse { get { throw null; } set { } }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } set { } }
         public System.ClientModel.Primitives.ClientErrorBehaviors ErrorOptions { get { throw null; } set { } }
         public void AddHeader(string name, string value) { }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -238,6 +238,7 @@ namespace System.ClientModel.Primitives
     public partial class RequestOptions
     {
         public RequestOptions() { }
+        public bool? BufferResponse { get { throw null; } set { } }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } set { } }
         public System.ClientModel.Primitives.ClientErrorBehaviors ErrorOptions { get { throw null; } set { } }
         public void AddHeader(string name, string value) { }

--- a/sdk/core/System.ClientModel/src/Options/RequestOptions.cs
+++ b/sdk/core/System.ClientModel/src/Options/RequestOptions.cs
@@ -23,6 +23,8 @@ public class RequestOptions
 
     private List<HeadersUpdate>? _headersUpdates;
 
+    private bool? _bufferResponse;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestOptions"/> class
     /// </summary>
@@ -57,6 +59,27 @@ public class RequestOptions
             AssertNotFrozen();
 
             _errorOptions = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the response content should be
+    /// buffered in-memory by the pipeline. If specified, this value will
+    /// override any client default.
+    /// </summary>
+    /// <remarks>Please note that setting this value to <c>false</c> will result
+    /// in the <see cref="PipelineResponse.ContentStream"/> obtained from
+    /// <see cref="ClientResult.GetRawResponse"/> holding a live network stream.
+    /// It is the responsibility of the caller to ensure the stream is disposed.
+    /// </remarks>
+    public bool? BufferResponse
+    {
+        get => _bufferResponse;
+        set
+        {
+            AssertNotFrozen();
+
+            _bufferResponse = value;
         }
     }
 
@@ -150,6 +173,12 @@ public class RequestOptions
         message.PerCallPolicies = _perCallPolicies;
         message.PerTryPolicies = _perTryPolicies;
         message.BeforeTransportPolicies = _beforeTransportPolicies;
+
+        // Override any BufferResponse value set on the message.
+        if (BufferResponse.HasValue)
+        {
+            message.BufferResponse = BufferResponse.Value;
+        }
 
         // Apply adds and sets to request headers if applicable.
         if (_headersUpdates is not null)

--- a/sdk/core/System.ClientModel/tests/Options/RequestOptionsTests.cs
+++ b/sdk/core/System.ClientModel/tests/Options/RequestOptionsTests.cs
@@ -143,6 +143,7 @@ public class RequestOptionsTests
 
         Assert.Throws<InvalidOperationException>(() => options.CancellationToken = CancellationToken.None);
         Assert.Throws<InvalidOperationException>(() => options.ErrorOptions = ClientErrorBehaviors.NoThrow);
+        Assert.Throws<InvalidOperationException>(() => options.BufferResponse = true);
         Assert.Throws<InvalidOperationException>(() => options.AddHeader("A", "B"));
         Assert.Throws<InvalidOperationException>(()
             => options.AddPolicy(new ObservablePolicy("A"), PipelinePosition.PerCall));
@@ -156,8 +157,47 @@ public class RequestOptionsTests
 
         Assert.Throws<InvalidOperationException>(() => options.CancellationToken = CancellationToken.None);
         Assert.Throws<InvalidOperationException>(() => options.ErrorOptions = ClientErrorBehaviors.NoThrow);
+        Assert.Throws<InvalidOperationException>(() => options.BufferResponse = true);
         Assert.Throws<InvalidOperationException>(() => options.AddHeader("A", "B"));
         Assert.Throws<InvalidOperationException>(() => options.AddPolicy(
             new ObservablePolicy("A"), PipelinePosition.PerCall));
+    }
+
+    [Test]
+    public void OverridesBufferResponse()
+    {
+        ClientPipeline pipeline = ClientPipeline.Create();
+        PipelineMessage message = pipeline.CreateMessage();
+
+        RequestOptions bufferTrueOptions = new() { BufferResponse = true };
+        message.BufferResponse = false;
+        message.Apply(bufferTrueOptions);
+
+        Assert.IsTrue(message.BufferResponse);
+
+        RequestOptions bufferFalseOptions = new() { BufferResponse = false };
+        message.BufferResponse = true;
+        message.Apply(bufferFalseOptions);
+
+        Assert.IsFalse(message.BufferResponse);
+    }
+
+    [Test]
+    public void DoesntChangeBufferResponse()
+    {
+        RequestOptions options = new() { BufferResponse = null };
+
+        ClientPipeline pipeline = ClientPipeline.Create();
+        PipelineMessage message = pipeline.CreateMessage();
+
+        message.BufferResponse = false;
+        message.Apply(options);
+
+        Assert.IsFalse(message.BufferResponse);
+
+        message.BufferResponse = true;
+        message.Apply(options);
+
+        Assert.IsTrue(message.BufferResponse);
     }
 }


### PR DESCRIPTION
Some service endpoints such as https://platform.openai.com/docs/api-reference/chat/create can return response content in different formats based on values sent in the request.  Given the way System.ClientModel-based clients model each endpoint with a single protocol method, we want to be able to let the protocol method caller specify whether or not the pipeline should buffer the content for a given response, based on what input they sent to the service.

This PR adds an optional BufferResponse property to RequestOptions.  If a protocol-method caller sets the value for BufferResponse, it will override any value set in the client code.