### PR TITLE
Switch ApiScan to use Azure CLI auth

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -17,142 +17,142 @@ variables:
   - template: templates/variables/globals.yml
 
 stages:
-  # - stage: AggregateReports
-  #   displayName: Aggregate Reports
+  - stage: AggregateReports
+    displayName: Aggregate Reports
 
-  #   jobs:
-  #     - job: GenerateReports
-  #       timeoutInMinutes: 120
-  #       steps:
-  #         - template: /eng/pipelines/templates/steps/install-dotnet.yml
+    jobs:
+      - job: GenerateReports
+        timeoutInMinutes: 120
+        steps:
+          - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
-  #         - task: PowerShell@2
-  #           displayName: Download Latest Dev Packages
-  #           inputs:
-  #             pwsh: true
-  #             filePath: 'eng/scripts/DownloadDevPackages.ps1'
-  #             arguments: >
-  #               -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
-  #               -NupkgFilesDestination 'nupkgFiles'
+          - task: PowerShell@2
+            displayName: Download Latest Dev Packages
+            inputs:
+              pwsh: true
+              filePath: 'eng/scripts/DownloadDevPackages.ps1'
+              arguments: >
+                -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
+                -NupkgFilesDestination 'nupkgFiles'
 
-  #         - pwsh: |
-  #             ."eng/common/spelling/Invoke-Cspell.ps1" `
-  #               -CSpellConfigPath "./.vscode/cspell.json" `
-  #               -ScanGlobs "sdk/*/*/api/*.cs"
-  #           displayName: Check spelling of public API surface
-  #           # Spelling errors in public api surface are not blockers yet but will
-  #           # become blockers when this is rolled out to all services. For now, turn
-  #           # the pipeline yellow if spelling errors are detected but do not block.
-  #           continueOnError: true
+          - pwsh: |
+              ."eng/common/spelling/Invoke-Cspell.ps1" `
+                -CSpellConfigPath "./.vscode/cspell.json" `
+                -ScanGlobs "sdk/*/*/api/*.cs"
+            displayName: Check spelling of public API surface
+            # Spelling errors in public api surface are not blockers yet but will
+            # become blockers when this is rolled out to all services. For now, turn
+            # the pipeline yellow if spelling errors are detected but do not block.
+            continueOnError: true
 
-  #         - template: /eng/common/pipelines/templates/steps/verify-links.yml
-  #           parameters:
-  #             Directory: ""
-  #             CheckLinkGuidance: $true
+          - template: /eng/common/pipelines/templates/steps/verify-links.yml
+            parameters:
+              Directory: ""
+              CheckLinkGuidance: $true
 
-  #         - pwsh: |
-  #             New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name 'reports' -ItemType 'directory'
-  #           displayName: Create Directory for Aggregate Reports
+          - pwsh: |
+              New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name 'reports' -ItemType 'directory'
+            displayName: Create Directory for Aggregate Reports
 
-  #         - task: PowerShell@2
-  #           displayName: Generate Dependency Report
-  #           inputs:
-  #             pwsh: true
-  #             filePath: 'eng/scripts/dependencies/AnalyzeDeps.ps1'
-  #             arguments: >
-  #               -PackagesPath '$(Build.ArtifactStagingDirectory)/nupkgFiles'
-  #               -LockfilePath '$(Build.SourcesDirectory)/eng/Packages.Data.props'
-  #               -OutPath '$(Build.ArtifactStagingDirectory)/reports/dependencies.html'
-  #               -DumpPath '$(Build.ArtifactStagingDirectory)/reports'
+          - task: PowerShell@2
+            displayName: Generate Dependency Report
+            inputs:
+              pwsh: true
+              filePath: 'eng/scripts/dependencies/AnalyzeDeps.ps1'
+              arguments: >
+                -PackagesPath '$(Build.ArtifactStagingDirectory)/nupkgFiles'
+                -LockfilePath '$(Build.SourcesDirectory)/eng/Packages.Data.props'
+                -OutPath '$(Build.ArtifactStagingDirectory)/reports/dependencies.html'
+                -DumpPath '$(Build.ArtifactStagingDirectory)/reports'
 
-  #         - task: PowerShell@2
-  #           displayName: 'Generate azure-sdk.deps.json'
-  #           inputs:
-  #             pwsh: true
-  #             filePath: 'eng/scripts/dependencies/generate-deps.ps1'
-  #             arguments: >
-  #               -PackagesPath '$(Build.ArtifactStagingDirectory)/nupkgFiles'
-  #               -DepsOutputFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
-  #               -ProjectRefPath '$(Build.ArtifactStagingDirectory)/reports'
+          - task: PowerShell@2
+            displayName: 'Generate azure-sdk.deps.json'
+            inputs:
+              pwsh: true
+              filePath: 'eng/scripts/dependencies/generate-deps.ps1'
+              arguments: >
+                -PackagesPath '$(Build.ArtifactStagingDirectory)/nupkgFiles'
+                -DepsOutputFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
+                -ProjectRefPath '$(Build.ArtifactStagingDirectory)/reports'
 
-  #         - task: PowerShell@2
-  #           displayName: 'Validate dependencies with pwsh servicing'
-  #           inputs:
-  #             pwsh: true
-  #             filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
-  #             arguments: >
-  #               -PSDepsFile 'https://aka.ms/ps-deps-servicing'
-  #               -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
+          - task: PowerShell@2
+            displayName: 'Validate dependencies with pwsh servicing'
+            inputs:
+              pwsh: true
+              filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
+              arguments: >
+                -PSDepsFile 'https://aka.ms/ps-deps-servicing'
+                -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
 
-  #         - task: PowerShell@2
-  #           displayName: 'Validate dependencies with pwsh stable'
-  #           inputs:
-  #             pwsh: true
-  #             filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
-  #             arguments: >
-  #               -PSDepsFile 'https://aka.ms/ps-deps-stable'
-  #               -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
+          - task: PowerShell@2
+            displayName: 'Validate dependencies with pwsh stable'
+            inputs:
+              pwsh: true
+              filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
+              arguments: >
+                -PSDepsFile 'https://aka.ms/ps-deps-stable'
+                -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
 
-  #         - task: PowerShell@2
-  #           displayName: 'Validate dependencies with pwsh preview'
-  #           inputs:
-  #             pwsh: true
-  #             filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
-  #             arguments: >
-  #               -PSDepsFile 'https://aka.ms/ps-deps-preview'
-  #               -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
+          - task: PowerShell@2
+            displayName: 'Validate dependencies with pwsh preview'
+            inputs:
+              pwsh: true
+              filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
+              arguments: >
+                -PSDepsFile 'https://aka.ms/ps-deps-preview'
+                -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
 
-  #         - task: PublishPipelineArtifact@1
-  #           displayName: 'Publish Report Artifacts'
-  #           inputs:
-  #             artifactName: reports
-  #             path: '$(Build.ArtifactStagingDirectory)/reports'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Report Artifacts'
+            inputs:
+              artifactName: reports
+              path: '$(Build.ArtifactStagingDirectory)/reports'
 
-  #         - task: AzureFileCopy@6
-  #           displayName: 'Upload Dependency Report'
-  #           inputs:
-  #             sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
-  #             azureSubscription: 'Azure SDK Artifacts'
-  #             destination: AzureBlob
-  #             storage: azuresdkartifacts
-  #             containerName: 'azure-sdk-for-net'
-  #             blobPrefix: dependencies
-  #             AdditionalArgumentsForBlobCopy: '--exclude-pattern=*data.js*'
+          - task: AzureFileCopy@6
+            displayName: 'Upload Dependency Report'
+            inputs:
+              sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
+              azureSubscription: 'Azure SDK Artifacts'
+              destination: AzureBlob
+              storage: azuresdkartifacts
+              containerName: 'azure-sdk-for-net'
+              blobPrefix: dependencies
+              AdditionalArgumentsForBlobCopy: '--exclude-pattern=*data.js*'
 
-  #         - task: AzureFileCopy@6
-  #           displayName: 'Upload Dependency Graph'
-  #           inputs:
-  #             sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
-  #             azureSubscription: 'Azure SDK Artifacts'
-  #             destination: AzureBlob
-  #             storage: azuresdkartifacts
-  #             containerName: 'azure-sdk-for-net'
-  #             blobPrefix: dependencies/dependencyGraph
-  #             AdditionalArgumentsForBlobCopy: '--include-pattern=*data.js*'
+          - task: AzureFileCopy@6
+            displayName: 'Upload Dependency Graph'
+            inputs:
+              sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
+              azureSubscription: 'Azure SDK Artifacts'
+              destination: AzureBlob
+              storage: azuresdkartifacts
+              containerName: 'azure-sdk-for-net'
+              blobPrefix: dependencies/dependencyGraph
+              AdditionalArgumentsForBlobCopy: '--include-pattern=*data.js*'
 
-  #         - task: PowerShell@2
-  #           displayName: "Verify Repository Resource Refs"
-  #           inputs:
-  #             pwsh: true
-  #             workingDirectory: $(Build.SourcesDirectory)
-  #             filePath: eng/common/scripts/Verify-Resource-Ref.ps1
+          - task: PowerShell@2
+            displayName: "Verify Repository Resource Refs"
+            inputs:
+              pwsh: true
+              workingDirectory: $(Build.SourcesDirectory)
+              filePath: eng/common/scripts/Verify-Resource-Ref.ps1
 
   - stage: ComplianceTools
     displayName: Compliance Tools
     dependsOn: []
 
     jobs:
-      # - job: ComplianceTools
-      #   timeoutInMinutes: 120
-      #   steps:
-      #     - template: /eng/common/pipelines/templates/steps/policheck.yml
-      #       parameters:
-      #         ExclusionDataBaseFileName: "DotNetPoliCheckExclusion"
-      #         PublishAnalysisLogs: false
+      - job: ComplianceTools
+        timeoutInMinutes: 120
+        steps:
+          - template: /eng/common/pipelines/templates/steps/policheck.yml
+            parameters:
+              ExclusionDataBaseFileName: "DotNetPoliCheckExclusion"
+              PublishAnalysisLogs: false
 
-      #     - template: /eng/common/pipelines/templates/steps/credscan.yml
-      #       parameters:
-      #         BaselineFilePath: $(Build.sourcesdirectory)/eng/dotnet.gdnbaselines
+          - template: /eng/common/pipelines/templates/steps/credscan.yml
+            parameters:
+              BaselineFilePath: $(Build.sourcesdirectory)/eng/dotnet.gdnbaselines
 
       - job: APIScan
         timeoutInMinutes: 180
@@ -183,10 +183,11 @@ stages:
                 Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
 
           - pwsh: |
+                # Need to re-login with the az login so that it presists and can be used in the APISca task
                 az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_OIDC_TOKEN)
                 az --version
                 az account show
-            displayName: Check CLI Login
+            displayName: Persist CLI Login for ApiScan usage
 
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
             displayName: 'Run APIScan'
@@ -200,6 +201,13 @@ stages:
               verbosityLevel: standard
             env:
               AzureServicesAuthConnectionString: RunAs=Developer;DeveloperTool=AzureCli
+
+          - pwsh: |
+                az account show
+                az Logout
+                az account clear
+            displayName: Logout of Azure CLI
+            condition: succeededOrFailed()
 
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
             displayName: 'Post Analysis (ApiScan)'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -186,7 +186,7 @@ stages:
                 # Need to re-login with the az login so that it presists and can be used in the APISca task
                 az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_OIDC_TOKEN)
                 az --version
-                az account show
+                az account show -o json
             displayName: Persist CLI Login for ApiScan usage
 
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -17,142 +17,142 @@ variables:
   - template: templates/variables/globals.yml
 
 stages:
-  - stage: AggregateReports
-    displayName: Aggregate Reports
+  # - stage: AggregateReports
+  #   displayName: Aggregate Reports
 
-    jobs:
-      - job: GenerateReports
-        timeoutInMinutes: 120
-        steps:
-          - template: /eng/pipelines/templates/steps/install-dotnet.yml
+  #   jobs:
+  #     - job: GenerateReports
+  #       timeoutInMinutes: 120
+  #       steps:
+  #         - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
-          - task: PowerShell@2
-            displayName: Download Latest Dev Packages
-            inputs:
-              pwsh: true
-              filePath: 'eng/scripts/DownloadDevPackages.ps1'
-              arguments: >
-                -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
-                -NupkgFilesDestination 'nupkgFiles'
+  #         - task: PowerShell@2
+  #           displayName: Download Latest Dev Packages
+  #           inputs:
+  #             pwsh: true
+  #             filePath: 'eng/scripts/DownloadDevPackages.ps1'
+  #             arguments: >
+  #               -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
+  #               -NupkgFilesDestination 'nupkgFiles'
 
-          - pwsh: |
-              ."eng/common/spelling/Invoke-Cspell.ps1" `
-                -CSpellConfigPath "./.vscode/cspell.json" `
-                -ScanGlobs "sdk/*/*/api/*.cs"
-            displayName: Check spelling of public API surface
-            # Spelling errors in public api surface are not blockers yet but will
-            # become blockers when this is rolled out to all services. For now, turn
-            # the pipeline yellow if spelling errors are detected but do not block.
-            continueOnError: true
+  #         - pwsh: |
+  #             ."eng/common/spelling/Invoke-Cspell.ps1" `
+  #               -CSpellConfigPath "./.vscode/cspell.json" `
+  #               -ScanGlobs "sdk/*/*/api/*.cs"
+  #           displayName: Check spelling of public API surface
+  #           # Spelling errors in public api surface are not blockers yet but will
+  #           # become blockers when this is rolled out to all services. For now, turn
+  #           # the pipeline yellow if spelling errors are detected but do not block.
+  #           continueOnError: true
 
-          - template: /eng/common/pipelines/templates/steps/verify-links.yml
-            parameters:
-              Directory: ""
-              CheckLinkGuidance: $true
+  #         - template: /eng/common/pipelines/templates/steps/verify-links.yml
+  #           parameters:
+  #             Directory: ""
+  #             CheckLinkGuidance: $true
 
-          - pwsh: |
-              New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name 'reports' -ItemType 'directory'
-            displayName: Create Directory for Aggregate Reports
+  #         - pwsh: |
+  #             New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name 'reports' -ItemType 'directory'
+  #           displayName: Create Directory for Aggregate Reports
 
-          - task: PowerShell@2
-            displayName: Generate Dependency Report
-            inputs:
-              pwsh: true
-              filePath: 'eng/scripts/dependencies/AnalyzeDeps.ps1'
-              arguments: >
-                -PackagesPath '$(Build.ArtifactStagingDirectory)/nupkgFiles'
-                -LockfilePath '$(Build.SourcesDirectory)/eng/Packages.Data.props'
-                -OutPath '$(Build.ArtifactStagingDirectory)/reports/dependencies.html'
-                -DumpPath '$(Build.ArtifactStagingDirectory)/reports'
+  #         - task: PowerShell@2
+  #           displayName: Generate Dependency Report
+  #           inputs:
+  #             pwsh: true
+  #             filePath: 'eng/scripts/dependencies/AnalyzeDeps.ps1'
+  #             arguments: >
+  #               -PackagesPath '$(Build.ArtifactStagingDirectory)/nupkgFiles'
+  #               -LockfilePath '$(Build.SourcesDirectory)/eng/Packages.Data.props'
+  #               -OutPath '$(Build.ArtifactStagingDirectory)/reports/dependencies.html'
+  #               -DumpPath '$(Build.ArtifactStagingDirectory)/reports'
 
-          - task: PowerShell@2
-            displayName: 'Generate azure-sdk.deps.json'
-            inputs:
-              pwsh: true
-              filePath: 'eng/scripts/dependencies/generate-deps.ps1'
-              arguments: >
-                -PackagesPath '$(Build.ArtifactStagingDirectory)/nupkgFiles'
-                -DepsOutputFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
-                -ProjectRefPath '$(Build.ArtifactStagingDirectory)/reports'
+  #         - task: PowerShell@2
+  #           displayName: 'Generate azure-sdk.deps.json'
+  #           inputs:
+  #             pwsh: true
+  #             filePath: 'eng/scripts/dependencies/generate-deps.ps1'
+  #             arguments: >
+  #               -PackagesPath '$(Build.ArtifactStagingDirectory)/nupkgFiles'
+  #               -DepsOutputFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
+  #               -ProjectRefPath '$(Build.ArtifactStagingDirectory)/reports'
 
-          - task: PowerShell@2
-            displayName: 'Validate dependencies with pwsh servicing'
-            inputs:
-              pwsh: true
-              filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
-              arguments: >
-                -PSDepsFile 'https://aka.ms/ps-deps-servicing'
-                -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
+  #         - task: PowerShell@2
+  #           displayName: 'Validate dependencies with pwsh servicing'
+  #           inputs:
+  #             pwsh: true
+  #             filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
+  #             arguments: >
+  #               -PSDepsFile 'https://aka.ms/ps-deps-servicing'
+  #               -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
 
-          - task: PowerShell@2
-            displayName: 'Validate dependencies with pwsh stable'
-            inputs:
-              pwsh: true
-              filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
-              arguments: >
-                -PSDepsFile 'https://aka.ms/ps-deps-stable'
-                -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
+  #         - task: PowerShell@2
+  #           displayName: 'Validate dependencies with pwsh stable'
+  #           inputs:
+  #             pwsh: true
+  #             filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
+  #             arguments: >
+  #               -PSDepsFile 'https://aka.ms/ps-deps-stable'
+  #               -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
 
-          - task: PowerShell@2
-            displayName: 'Validate dependencies with pwsh preview'
-            inputs:
-              pwsh: true
-              filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
-              arguments: >
-                -PSDepsFile 'https://aka.ms/ps-deps-preview'
-                -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
+  #         - task: PowerShell@2
+  #           displayName: 'Validate dependencies with pwsh preview'
+  #           inputs:
+  #             pwsh: true
+  #             filePath: 'eng/scripts/dependencies/compare-deps-files.ps1'
+  #             arguments: >
+  #               -PSDepsFile 'https://aka.ms/ps-deps-preview'
+  #               -AzSdkDepsFile '$(Build.ArtifactStagingDirectory)/reports/azure-sdk.deps.json'
 
-          - task: PublishPipelineArtifact@1
-            displayName: 'Publish Report Artifacts'
-            inputs:
-              artifactName: reports
-              path: '$(Build.ArtifactStagingDirectory)/reports'
+  #         - task: PublishPipelineArtifact@1
+  #           displayName: 'Publish Report Artifacts'
+  #           inputs:
+  #             artifactName: reports
+  #             path: '$(Build.ArtifactStagingDirectory)/reports'
 
-          - task: AzureFileCopy@6
-            displayName: 'Upload Dependency Report'
-            inputs:
-              sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
-              azureSubscription: 'Azure SDK Artifacts'
-              destination: AzureBlob
-              storage: azuresdkartifacts
-              containerName: 'azure-sdk-for-net'
-              blobPrefix: dependencies
-              AdditionalArgumentsForBlobCopy: '--exclude-pattern=*data.js*'
+  #         - task: AzureFileCopy@6
+  #           displayName: 'Upload Dependency Report'
+  #           inputs:
+  #             sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
+  #             azureSubscription: 'Azure SDK Artifacts'
+  #             destination: AzureBlob
+  #             storage: azuresdkartifacts
+  #             containerName: 'azure-sdk-for-net'
+  #             blobPrefix: dependencies
+  #             AdditionalArgumentsForBlobCopy: '--exclude-pattern=*data.js*'
 
-          - task: AzureFileCopy@6
-            displayName: 'Upload Dependency Graph'
-            inputs:
-              sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
-              azureSubscription: 'Azure SDK Artifacts'
-              destination: AzureBlob
-              storage: azuresdkartifacts
-              containerName: 'azure-sdk-for-net'
-              blobPrefix: dependencies/dependencyGraph
-              AdditionalArgumentsForBlobCopy: '--include-pattern=*data.js*'
+  #         - task: AzureFileCopy@6
+  #           displayName: 'Upload Dependency Graph'
+  #           inputs:
+  #             sourcePath: '$(Build.ArtifactStagingDirectory)/reports/*'
+  #             azureSubscription: 'Azure SDK Artifacts'
+  #             destination: AzureBlob
+  #             storage: azuresdkartifacts
+  #             containerName: 'azure-sdk-for-net'
+  #             blobPrefix: dependencies/dependencyGraph
+  #             AdditionalArgumentsForBlobCopy: '--include-pattern=*data.js*'
 
-          - task: PowerShell@2
-            displayName: "Verify Repository Resource Refs"
-            inputs:
-              pwsh: true
-              workingDirectory: $(Build.SourcesDirectory)
-              filePath: eng/common/scripts/Verify-Resource-Ref.ps1
+  #         - task: PowerShell@2
+  #           displayName: "Verify Repository Resource Refs"
+  #           inputs:
+  #             pwsh: true
+  #             workingDirectory: $(Build.SourcesDirectory)
+  #             filePath: eng/common/scripts/Verify-Resource-Ref.ps1
 
   - stage: ComplianceTools
     displayName: Compliance Tools
     dependsOn: []
 
     jobs:
-      - job: ComplianceTools
-        timeoutInMinutes: 120
-        steps:
-          - template: /eng/common/pipelines/templates/steps/policheck.yml
-            parameters:
-              ExclusionDataBaseFileName: "DotNetPoliCheckExclusion"
-              PublishAnalysisLogs: false
+      # - job: ComplianceTools
+      #   timeoutInMinutes: 120
+      #   steps:
+      #     - template: /eng/common/pipelines/templates/steps/policheck.yml
+      #       parameters:
+      #         ExclusionDataBaseFileName: "DotNetPoliCheckExclusion"
+      #         PublishAnalysisLogs: false
 
-          - template: /eng/common/pipelines/templates/steps/credscan.yml
-            parameters:
-              BaselineFilePath: $(Build.sourcesdirectory)/eng/dotnet.gdnbaselines
+      #     - template: /eng/common/pipelines/templates/steps/credscan.yml
+      #       parameters:
+      #         BaselineFilePath: $(Build.sourcesdirectory)/eng/dotnet.gdnbaselines
 
       - job: APIScan
         timeoutInMinutes: 180
@@ -180,7 +180,7 @@ stages:
               verbosityLevel: standard
             env:
               # azure-sdk-apiscan (81109e5f-0620-423c-a37a-c22fbf8973a7)
-              AzureServicesAuthConnectionString: runAs=App;AppId=81109e5f-0620-423c-a37a-c22fbf8973a7;TenantId=72f988bf-86f1-41af-91ab-2d7cd011db47;AppKey=$(azure-sdk-apiscan-client-secret)
+              AzureServicesAuthConnectionString: runAs=App;AppId=81109e5f-0620-423c-a37a-c22fbf8973a7
 
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
             displayName: 'Post Analysis (ApiScan)'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -179,6 +179,11 @@ stages:
                 az --version
                 az account show
 
+          - pwsh: | 
+                az --version
+                az account show
+            displayName: Check CLI Login
+
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
             displayName: 'Run APIScan'
             inputs:

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -177,7 +177,7 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 az --version
-                az account show
+                az account show -o json
                 Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
                 Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
                 Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
@@ -203,7 +203,7 @@ stages:
               AzureServicesAuthConnectionString: RunAs=Developer;DeveloperTool=AzureCli
 
           - pwsh: |
-                az account show
+                az account show -o json
                 az logout
                 az account clear
             displayName: Logout of Azure CLI

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -185,7 +185,6 @@ stages:
           - pwsh: |
                 # Need to re-login with the az login so that it presists and can be used in the APISca task
                 az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_OIDC_TOKEN)
-                az --version
                 az account show -o json
             displayName: Persist CLI Login for ApiScan usage
 

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -159,14 +159,14 @@ stages:
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
-      #    - task: PowerShell@2
-      #      displayName: Download Latest Dev Packages
-      #      inputs:
-      #        pwsh: true
-      #        filePath: 'eng/scripts/DownloadDevPackages.ps1'
-      #        arguments: >
-      #          -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
-      #          -NupkgFilesDestination 'nupkgFiles'
+          - task: PowerShell@2
+            displayName: Download Latest Dev Packages
+            inputs:
+              pwsh: true
+              filePath: 'eng/scripts/DownloadDevPackages.ps1'
+              arguments: >
+                -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
+                -NupkgFilesDestination 'nupkgFiles'
 
           - task: AzureCLI@2
             displayName: Azure CLI Login

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -168,6 +168,16 @@ stages:
                 -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
                 -NupkgFilesDestination 'nupkgFiles'
 
+          - task: AzureCLI@2
+            displayName: Azure CLI Login
+            inputs:
+              azureSubscription: azure-sdk-apiscan
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                az --version
+                az account show
+
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
             displayName: 'Run APIScan'
             inputs:
@@ -179,8 +189,7 @@ stages:
               preserveLogsFolder: true
               verbosityLevel: standard
             env:
-              # azure-sdk-apiscan (81109e5f-0620-423c-a37a-c22fbf8973a7)
-              AzureServicesAuthConnectionString: runAs=App;AppId=81109e5f-0620-423c-a37a-c22fbf8973a7
+              AzureServicesAuthConnectionString: RunAs=Developer;DeveloperTool=AzureCli
 
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
             displayName: 'Post Analysis (ApiScan)'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -159,14 +159,14 @@ stages:
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
-          - task: PowerShell@2
-            displayName: Download Latest Dev Packages
-            inputs:
-              pwsh: true
-              filePath: 'eng/scripts/DownloadDevPackages.ps1'
-              arguments: >
-                -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
-                -NupkgFilesDestination 'nupkgFiles'
+      #    - task: PowerShell@2
+      #      displayName: Download Latest Dev Packages
+      #      inputs:
+      #        pwsh: true
+      #        filePath: 'eng/scripts/DownloadDevPackages.ps1'
+      #        arguments: >
+      #          -WorkingDirectory '$(Build.ArtifactStagingDirectory)'
+      #          -NupkgFilesDestination 'nupkgFiles'
 
           - task: AzureCLI@2
             displayName: Azure CLI Login
@@ -174,6 +174,7 @@ stages:
               azureSubscription: azure-sdk-apiscan
               scriptType: pscore
               scriptLocation: inlineScript
+              useGlobalConfig: true
               inlineScript: |
                 az --version
                 az account show

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -174,12 +174,16 @@ stages:
               azureSubscription: azure-sdk-apiscan
               scriptType: pscore
               scriptLocation: inlineScript
-              useGlobalConfig: true
+              addSpnToEnvironment: true
               inlineScript: |
                 az --version
                 az account show
+                Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
+                Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
+                Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
 
-          - pwsh: | 
+          - pwsh: |
+                az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_OIDC_TOKEN)
                 az --version
                 az account show
             displayName: Check CLI Login

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -204,7 +204,7 @@ stages:
 
           - pwsh: |
                 az account show
-                az Logout
+                az logout
                 az account clear
             displayName: Logout of Azure CLI
             condition: succeededOrFailed()


### PR DESCRIPTION
Switch ApiScan to use Azure CLI auth. While I'm not particularly happy with this approach, the APIScan tool/task doesn't support WIF directly currently so we are moving to use the Azure CLI login instead. 