### PR TITLE
[Messaging] Bump Microsoft.Azure.Amqp version

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -150,7 +150,7 @@
     <PackageReference Update="Azure.ResourceManager.Storage" Version="1.2.1" />
 
     <!-- Other approved packages -->
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.5" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.6" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.2.0" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.60.3" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.60.3" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258]( Azure/azure-amqp#258))_
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258](https://github.com/azure/azure-amqp/issues/258))_
 
 ## 5.11.2 (2024-04-10)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258]( Azure/azure-amqp#258))_
+
 ## 5.11.2 (2024-04-10)
 
 ### Bugs Fixed

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258]( Azure/azure-amqp#258))_
+
 ## 5.11.2 (2024-04-10)
 
 ### Features Added

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258]( Azure/azure-amqp#258))_
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258](https://github.com/azure/azure-amqp/issues/258))_
 
 ## 5.11.2 (2024-04-10)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Other Changes
 
-- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258]( Azure/azure-amqp#258))_
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258](https://github.com/azure/azure-amqp/issues/258))_
 
 ## 7.17.5 (2024-04-09)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Fixed issue where the `SupportOrdering` property was not being respected when set on `CreateTopicOptions`.
 
+### Other Changes
+
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258]( Azure/azure-amqp#258))_
+
 ## 7.17.5 (2024-04-09)
 
 ### Bugs Fixed

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -672,18 +672,18 @@ namespace Azure.Messaging.ServiceBus
         /// Attempts to purge all messages from an entity.  Locked messages are not eligible for removal and
         /// will remain in the entity.
         /// </summary>
-        /// <param name="beforeEnqueueTime">An optional <see cref="DateTimeOffset"/>, in UTC, representing the cutoff time for deletion. Only messages that were enqueued before this time will be purgeCount.  If not specified, <see cref="DateTimeOffset.UtcNow"/> will be assumed.</param>
+        /// <param name="beforeEnqueueTime">An optional <see cref="DateTimeOffset"/>, in UTC, representing the cutoff time for deletion. Only messages that were enqueued before this time will be deleted.  If not specified, <see cref="DateTimeOffset.UtcNow"/> will be assumed.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <remarks>
-        /// If the lock for a message is held by a receiver, it will be respected and the message will not be purgeCount.
+        /// If the lock for a message is held by a receiver, it will be respected and the message will not be deleted.
         ///
         /// This method may invoke multiple service requests to delete all messages.  As a result, it may exceed the configured <see cref="ServiceBusRetryOptions.TryTimeout"/>.
         /// If you need control over the amount of time the operation takes, it is recommended that you pass a <paramref name="cancellationToken"/> with the desired timeout set for cancellation.
         ///
         /// Because multiple service requests may be made, the possibility of partial success exists.  In this scenario, the method will stop attempting to delete additional messages
-        /// and throw the exception that was encountered.  It is recommended to evaluate this exception and determine which messages may not have been purgeCount.
+        /// and throw the exception that was encountered.  It is recommended to evaluate this exception and determine which messages may not have been deleted.
         /// </remarks>
-        /// <returns>The number of messages that were purgeCount.</returns>
+        /// <returns>The number of messages that were deleted.</returns>
         public virtual async Task<int> PurgeMessagesAsync(
             DateTimeOffset? beforeEnqueueTime = null,
             CancellationToken cancellationToken = default)
@@ -735,13 +735,13 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Deletes up to <paramref name="messageCount"/> messages from the entity. The actual number
-        /// of purgeCount messages may be less if there are fewer eligible messages in the entity.
+        /// of deleted messages may be less if there are fewer eligible messages in the entity.
         /// </summary>
         /// <param name="messageCount">The desired number of messages to delete.  This value is limited by the service and governed <see href="https://learn.microsoft.com/azure/service-bus-messaging/service-bus-quotas">Service Bus quotas</see>.  The service may delete fewer messages than this limit.</param>
-        /// <param name="beforeEnqueueTime">An optional <see cref="DateTimeOffset"/>, in UTC, representing the cutoff time for deletion. Only messages that were enqueued before this time will be purgeCount.  If not specified, <see cref="DateTimeOffset.UtcNow"/> will be assumed.</param>
+        /// <param name="beforeEnqueueTime">An optional <see cref="DateTimeOffset"/>, in UTC, representing the cutoff time for deletion. Only messages that were enqueued before this time will be deleted.  If not specified, <see cref="DateTimeOffset.UtcNow"/> will be assumed.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <returns>The number of messages that were purgeCount.</returns>
-        /// <remarks>If the lock for a message is held by a receiver, it will be respected and the message will not be purgeCount.</remarks>
+        /// <returns>The number of messages that were deleted.</returns>
+        /// <remarks>If the lock for a message is held by a receiver, it will be respected and the message will not be deleted.</remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Occurs when the <paramref name="messageCount"/> is less than 1 or exceeds the maximum allowed, as determined by the Service Bus service.
         /// For more information on service limits, see <see href="https://learn.microsoft.com/azure/service-bus-messaging/service-bus-quotas#messaging-quotas"/>.


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the version of Microsoft.Azure.Amqp to v2.6.6 to include a fix for an internal `NullReferenceException` within the transport.  Also included are some corrections for a bad copy/paste in the `ServiceBusReceiver` doc comments.