### PR TITLE
Fix AzurePipelinesCredential in release pipelines

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs
@@ -93,10 +93,11 @@ namespace Azure.Identity
             string planId = options.PlanId ?? throw new CredentialUnavailableException("AzurePipelinesCredential is not available: environment variable SYSTEM_PLANID is not set.");
             string jobId = options.JobId ?? throw new CredentialUnavailableException("AzurePipelinesCredential is not available: environment variable SYSTEM_JOBID is not set.");
             string systemToken = options.SystemAccessToken ?? throw new CredentialUnavailableException("AzurePipelinesCredential is not available: environment variable SYSTEM_ACCESSTOKEN is not set.");
+            string hubName = options.HubName ?? throw new CredentialUnavailableException("AzurePipelineCredential is not available: environment variable SYSTEM_HOSTTYPE is not set.");
 
             var message = Pipeline.HttpPipeline.CreateMessage();
 
-            var requestUri = new Uri($"{CollectionUri}{projectId}/_apis/distributedtask/hubs/build/plans/{planId}/jobs/{jobId}/oidctoken?api-version={OIDC_API_VERSION}&serviceConnectionId={serviceConnectionId}");
+            var requestUri = new Uri($"{CollectionUri}{projectId}/_apis/distributedtask/hubs/{hubName}/plans/{planId}/jobs/{jobId}/oidctoken?api-version={OIDC_API_VERSION}&serviceConnectionId={serviceConnectionId}");
             message.Request.Uri.Reset(requestUri);
             message.Request.Headers.SetValue(HttpHeader.Names.Authorization, $"Bearer {systemToken}");
             message.Request.Headers.SetValue(HttpHeader.Names.ContentType, "application/json");

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredentialOptions.cs
@@ -40,6 +40,11 @@ namespace Azure.Identity
         /// </summary>
         internal string TeamProjectId { get; set; } = Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECTID");
 
+        /// <summary>
+        /// The hub under which this pipeline is running - typically "build" or "release".
+        /// </summary>
+        internal string HubName { get; set; } = Environment.GetEnvironmentVariable("SYSTEM_HOSTTYPE");
+
         /// <inheritdoc/>
         public IList<string> AdditionallyAllowedTenants { get; internal set; } = new List<string>();
 

--- a/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialTests.cs
@@ -83,6 +83,7 @@ namespace Azure.Identity.Tests
                 Assert.AreEqual("mockPlanId", options.PlanId);
                 Assert.AreEqual("mockSystemAccessToken", options.SystemAccessToken);
                 Assert.AreEqual("mockTeamProjectId", options.TeamProjectId);
+                Assert.AreEqual("mockHubName", options.HubName);
             }
         }
 


### PR DESCRIPTION
This is initially a bug that I made in my team's implementation of this credential, which was used as the basis for this credential. If you hard-code the hub as "build", the credential fails when used in a release pipeline. This is just down-streaming the fix made on my team's end.
