### PR TITLE
Reduce memory allocation in EventSourceEventFormatting

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/EventSourceEventFormatting.cs
+++ b/sdk/core/Azure.Core/src/Shared/EventSourceEventFormatting.cs
@@ -80,8 +80,8 @@ internal static class EventSourceEventFormatting
                 for (int i = 0; i < bytes.Length; i++)
                 {
                     byte b = bytes[i];
-                    buffer[i * 2] = ToHex(b >> 4);
-                    buffer[i * 2 + 1] = ToHex(b & 0xF);
+                    buffer[i * 2] = ToHex(b >> 4); // Shift upper nibble into lower 4 bits and convert to hex
+                    buffer[i * 2 + 1] = ToHex(b & 0xF); // Mask off lower nibble and convert to hex
                 }
 
                 return buffer.ToString();

--- a/sdk/core/Azure.Core/src/Shared/EventSourceEventFormatting.cs
+++ b/sdk/core/Azure.Core/src/Shared/EventSourceEventFormatting.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core.Diagnostics;
 using System;
+using System.Buffers;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Linq;
@@ -10,70 +10,116 @@ using System.Text;
 
 #nullable enable
 
-namespace Azure.Core.Shared
+namespace Azure.Core.Shared;
+
+internal static class EventSourceEventFormatting
 {
-    internal static class EventSourceEventFormatting
+    [ThreadStatic]
+    private static StringBuilder? s_cachedStringBuilder;
+    private const int CachedStringBuilderCapacity = 512;
+
+    public static string Format(EventWrittenEventArgs eventData)
     {
-        public static string Format(EventWrittenEventArgs eventData)
+        var payloadArray = eventData.Payload?.ToArray() ?? Array.Empty<object?>();
+
+        ProcessPayloadArray(payloadArray);
+
+        if (eventData.Message != null)
         {
-            var payloadArray = eventData.Payload?.ToArray() ?? Array.Empty<object?>();
-
-            ProcessPayloadArray(payloadArray);
-
-            if (eventData.Message != null)
+            try
             {
-                try
-                {
-                    return string.Format(CultureInfo.InvariantCulture, eventData.Message, payloadArray);
-                }
-                catch (FormatException)
-                {
-                }
+                return string.Format(CultureInfo.InvariantCulture, eventData.Message, payloadArray);
             }
+            catch (FormatException)
+            {
+            }
+        }
 
-            var stringBuilder = new StringBuilder();
-            stringBuilder.Append(eventData.EventName);
+        StringBuilder stringBuilder = RentStringBuilder();
+        stringBuilder.Append(eventData.EventName);
 
-            if (!string.IsNullOrWhiteSpace(eventData.Message))
+        if (!string.IsNullOrWhiteSpace(eventData.Message))
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.Append(nameof(eventData.Message)).Append(" = ").Append(eventData.Message);
+        }
+
+        if (eventData.PayloadNames != null)
+        {
+            for (int i = 0; i < eventData.PayloadNames.Count; i++)
             {
                 stringBuilder.AppendLine();
-                stringBuilder.Append(nameof(eventData.Message)).Append(" = ").Append(eventData.Message);
+                stringBuilder.Append(eventData.PayloadNames[i]).Append(" = ").Append(payloadArray[i]);
+            }
+        }
+
+        return ToStringAndReturnStringBuilder(stringBuilder);
+    }
+
+    private static void ProcessPayloadArray(object?[] payloadArray)
+    {
+        for (int i = 0; i < payloadArray.Length; i++)
+        {
+            payloadArray[i] = FormatValue(payloadArray[i]);
+        }
+    }
+
+    private static object? FormatValue(object? o)
+    {
+        if (o is byte[] bytes)
+        {
+#if NET6_0_OR_GREATER
+            return Convert.ToHexString(bytes);
+#else
+            int length = 2 * bytes.Length; // Two hex characters per byte
+            if (length < 256)
+            {
+                static char ToHex(int value) => (char)(value < 10 ? value + '0' : value - 10 + 'A');
+
+                Span<char> buffer = stackalloc char[length];
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    byte b = bytes[i];
+                    buffer[i * 2] = ToHex(b >> 4);
+                    buffer[i * 2 + 1] = ToHex(b & 0xF);
+                }
+
+                return buffer.ToString();
             }
 
-            if (eventData.PayloadNames != null)
+            var stringBuilder = new StringBuilder(length);
+            foreach (byte b in bytes)
             {
-                for (int i = 0; i < eventData.PayloadNames.Count; i++)
-                {
-                    stringBuilder.AppendLine();
-                    stringBuilder.Append(eventData.PayloadNames[i]).Append(" = ").Append(payloadArray[i]);
-                }
+                stringBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0:X2}", b);
             }
 
             return stringBuilder.ToString();
+#endif
         }
 
-        private static void ProcessPayloadArray(object?[] payloadArray)
+        return o;
+    }
+
+    private static StringBuilder RentStringBuilder()
+    {
+        StringBuilder? builder = s_cachedStringBuilder;
+        if (builder is null)
         {
-            for (int i = 0; i < payloadArray.Length; i++)
-            {
-                payloadArray[i] = FormatValue(payloadArray[i]);
-            }
+            return new StringBuilder(CachedStringBuilderCapacity);
         }
 
-        private static object? FormatValue(object? o)
+        s_cachedStringBuilder = null;
+        return builder;
+    }
+
+    private static string ToStringAndReturnStringBuilder(StringBuilder builder)
+    {
+        string result = builder.ToString();
+        if (builder.Capacity <= CachedStringBuilderCapacity)
         {
-            if (o is byte[] bytes)
-            {
-                var stringBuilder = new StringBuilder();
-                foreach (byte b in bytes)
-                {
-                    stringBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0:X2}", b);
-                }
-
-                return stringBuilder.ToString();
-            }
-
-            return o;
+            s_cachedStringBuilder = builder.Clear();
         }
+
+        return result;
     }
 }

--- a/sdk/core/Azure.Core/tests/AzureEventSourceListenerTests.cs
+++ b/sdk/core/Azure.Core/tests/AzureEventSourceListenerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Security.Cryptography;
 using Azure.Core.Diagnostics;
 using Moq;
 using NUnit.Framework;
@@ -81,6 +82,17 @@ namespace Azure.Core.Tests
         {
             (EventWrittenEventArgs e, string message) = ExpectSingleEvent(() => TestSource.Log.LogWithByteArray(new byte[] { 0, 1, 233 }));
             Assert.AreEqual("Logging 0001E9", message);
+        }
+
+        [Test]
+        public void FormatsLargeByteArrays()
+        {
+            byte[] largeArray = new byte[64];
+            using RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(largeArray);
+
+            (EventWrittenEventArgs e, string message) = ExpectSingleEvent(() => TestSource.Log.LogWithByteArray(largeArray));
+            Assert.AreEqual($"Logging {string.Join("", largeArray.Select(b => b.ToString("X2")))}", message);
         }
 
         [Test]


### PR DESCRIPTION
This is a performance improvement for EventSourceEventFormatting to reduce the memory allocated in common cases.

There are two optimization techniques:
1. Use a cached StringBuilder
2. Use Convert.ToHexString, where available (.NET 6 and above). Where not available, if the string is small enough, use Span<char> with stackalloc

Benchmarks are already present for EventSourceListener:

#### Baseline

|                                      Method |              Runtime |      Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|-------------------------------------------- |--------------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
|                        'Old implementation' |             .NET 6.0 |  6.762 us | 0.6321 us | 0.7280 us |  1.00 |    0.00 |      - |   6.38 KB |        1.00 |
| 'New implementation, includes reformatting' |             .NET 6.0 |  7.323 us | 0.6139 us | 0.7070 us |  1.10 |    0.18 |      - |   6.83 KB |        1.07 |
|       'New implementation, no reformatting' |             .NET 6.0 |  5.096 us | 0.5186 us | 0.5972 us |  0.76 |    0.07 |      - |   5.07 KB |        0.80 |
|                                             |                      |           |           |           |       |         |        |           |             |
|                        'Old implementation' | .NET Framework 4.6.2 | 13.782 us | 1.6758 us | 1.9298 us |  1.00 |    0.00 | 2.7938 |  17.39 KB |        1.00 |
| 'New implementation, includes reformatting' | .NET Framework 4.6.2 | 23.269 us | 2.4829 us | 2.8593 us |  1.70 |    0.17 | 2.9446 |  18.36 KB |        1.06 |
|       'New implementation, no reformatting' | .NET Framework 4.6.2 | 18.491 us | 2.1708 us | 2.4999 us |  1.34 |    0.06 | 2.5934 |  16.13 KB |        0.93 |

#### Candidate

|                                      Method |              Runtime |      Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|-------------------------------------------- |--------------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
|                        'Old implementation' |             .NET 6.0 |  2.902 us | 0.0858 us | 0.0988 us |  1.00 |    0.00 |      - |      3 KB |        1.00 |
| 'New implementation, includes reformatting' |             .NET 6.0 |  3.453 us | 0.0427 us | 0.0400 us |  1.19 |    0.05 |      - |   3.45 KB |        1.15 |
|       'New implementation, no reformatting' |             .NET 6.0 |  1.292 us | 0.0299 us | 0.0344 us |  0.45 |    0.02 |      - |    1.7 KB |        0.57 |
|                                             |                      |           |           |           |       |         |        |           |             |
|                        'Old implementation' | .NET Framework 4.6.2 |  4.646 us | 0.3443 us | 0.3965 us |  1.00 |    0.00 | 0.5874 |   3.67 KB |        1.00 |
| 'New implementation, includes reformatting' | .NET Framework 4.6.2 | 12.413 us | 0.7478 us | 0.8612 us |  2.69 |    0.31 | 0.7331 |   4.63 KB |        1.26 |
|       'New implementation, no reformatting' | .NET Framework 4.6.2 |  8.836 us | 0.5962 us | 0.6865 us |  1.92 |    0.26 | 0.3878 |    2.4 KB |        0.65 |

Memory reductions across the board and also at least 2x speed ups.