### PR TITLE
Link to mocking guidance in XML docs for credential types

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AuthorizationCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AuthorizationCodeCredential.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity
         internal TenantIdResolverBase TenantIdResolver { get; }
 
         /// <summary>
-        /// Protected constructor for mocking.
+        /// Protected constructor for <see href="https://aka.ms/azsdk/net/mocking">mocking</see>.
         /// </summary>
         protected AuthorizationCodeCredential()
         {

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs
@@ -25,7 +25,7 @@ namespace Azure.Identity
         private const string OIDC_API_VERSION = "7.1";
 
         /// <summary>
-        /// Protected constructor for mocking.
+        /// Protected constructor for <see href="https://aka.ms/azsdk/net/mocking">mocking</see>.
         /// </summary>
         protected AzurePipelinesCredential()
         { }

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientAssertionCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientAssertionCredential.cs
@@ -25,7 +25,7 @@ namespace Azure.Identity
         internal TenantIdResolverBase TenantIdResolver { get; }
 
         /// <summary>
-        /// Protected constructor for mocking.
+        /// Protected constructor for <see href="https://aka.ms/azsdk/net/mocking">mocking</see>.
         /// </summary>
         protected ClientAssertionCredential()
         { }

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
@@ -41,7 +41,7 @@ namespace Azure.Identity
         internal TenantIdResolverBase TenantIdResolver { get; }
 
         /// <summary>
-        /// Protected constructor for mocking.
+        /// Protected constructor for <see href="https://aka.ms/azsdk/net/mocking">mocking</see>.
         /// </summary>
         protected ClientCertificateCredential()
         { }

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientSecretCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientSecretCredential.cs
@@ -40,7 +40,7 @@ namespace Azure.Identity
         internal TenantIdResolverBase TenantIdResolver { get; }
 
         /// <summary>
-        /// Protected constructor for mocking.
+        /// Protected constructor for <see href="https://aka.ms/azsdk/net/mocking">mocking</see>.
         /// </summary>
         protected ClientSecretCredential()
         {

--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -27,7 +27,7 @@ namespace Azure.Identity
             "See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/managedidentitycredential/troubleshoot";
 
         /// <summary>
-        /// Protected constructor for mocking.
+        /// Protected constructor for <see href="https://aka.ms/azsdk/net/mocking">mocking</see>.
         /// </summary>
         protected ManagedIdentityCredential()
         { }

--- a/sdk/identity/Azure.Identity/src/Credentials/OnBehalfOfCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/OnBehalfOfCredential.cs
@@ -26,7 +26,7 @@ namespace Azure.Identity
         internal TenantIdResolverBase TenantIdResolver { get; }
 
         /// <summary>
-        /// Protected constructor for mocking.
+        /// Protected constructor for <see href="https://aka.ms/azsdk/net/mocking">mocking</see>.
         /// </summary>
         protected OnBehalfOfCredential()
         { }


### PR DESCRIPTION
Related to the discussion in https://github.com/Azure/azure-sdk-for-net/issues/20911. This change makes the official mocking guidance easier to locate.
