### PR TITLE
Typos fixed and removed extra blank lines from Azure.Services.AppAuthentication Module

### DIFF
--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AccessToken.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AccessToken.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
             try
             {
-                // Access token as 3 parts. We are interested in the second part, which has claims. 
+                // Access token has 3 parts. We are interested in the second part, which has claims. 
                 string[] splitStrings = accessToken.Split('.');
 
                 var token = JsonHelper.Deserialize<AccessToken>(DecodeBytes(splitStrings[1]));

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <summary>
         /// Creates an instance of the AzureServiceTokenProvider class.
         /// If no connection string is specified, Managed Service Identity, Visual Studio, Azure CLI, and Integrated Windows Authentication are tried to get a token.
-        /// Even If no connection string is specified in code, one can be specified in the AzureServicesAuthConnectionString environment variable. 
+        /// Even if no connection string is specified in code, one can be specified in the AzureServicesAuthConnectionString environment variable. 
         /// </summary>
         /// <param name="connectionString">Connection string to specify which option to use to get the token.</param>
         /// <param name="azureAdInstance">Specify a value for clouds other than the Public Cloud.</param>
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
             _azureAdInstance = azureAdInstance;
 
-            // Check the environment variable to see if a connection string is specified. 
+            // Check the environment variables to see if a connection string is specified. 
             if (connectionString == default)
             {
                 connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServicesAuthConnectionString");

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/SqlAppAuthenticationProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/SqlAppAuthenticationProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         public Principal PrincipalUsed { get; private set; }
 
         /// <summary>
-        /// If the userId parameter is a valid GUID, return an token provider connection string to use a user-assigned managed identity
+        /// If the userId parameter is a valid GUID, return a token provider connection string to use a user-assigned managed identity
         /// </summary>
         /// <param name="userId"></param>
         /// <returns></returns>

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/AzureCliAccessTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/AzureCliAccessTokenProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         private const string GetTokenCommand = "az account get-access-token -o json";
         private const string ResourceArgumentName = "--resource";
 
-        // This is the path that a develop can set to tell this class what the install path for Azure CLI is. 
+        // This is the path that a developer can set to tell this class what the install path for Azure CLI is. 
         private const string AzureCliPath = "AzureCLIPath";
 
         // The default install paths are used to find Azure CLI. This is for security, so that any path in the calling program's Path environment is not used to execute Azure CLI.
@@ -54,7 +54,6 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
         private ProcessStartInfo GetProcessStartInfo(string resource)
         {
-
             ProcessStartInfo startInfo;
             string processPath;
             string currentPath = EnvironmentHelper.GetEnvironmentVariable("PATH");

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientCertificateAccessTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientCertificateAccessTokenProvider.cs
@@ -235,6 +235,5 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
             throw new AzureServiceTokenProviderException(ConnectionString, resource, authority, message);
         }
-
     }
 }

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         // Azure App Services MSI endpoint constants
         private const string AppServicesApiVersion = "2019-08-01";
 
-        // Each environment require different header
+        // Each environment requires a different header
         internal const string AppServicesHeader = "X-IDENTITY-HEADER";
         internal const string AzureVMImdsHeader = "Metadata";
         internal const string ServiceFabricHeader = "secret";

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/VisualStudioAccessTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/VisualStudioAccessTokenProvider.cs
@@ -149,7 +149,6 @@ namespace Microsoft.Azure.Services.AppAuthentication
                         }
 
                         return AppAuthenticationResult.Create(tokenResponse);
-
                     }
                     catch (Exception exp)
                     {
@@ -170,7 +169,6 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
                 // Throw exception if none of the token providers worked
                 throw new Exception(message);
-                
             }
             catch (Exception exp)
             {

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenResponse.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenResponse.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
     internal class TokenResponse
     {
         private const string TokenResponseFormatExceptionMessage = "Token response is not in the expected format.";
-
-
+        
         // VS token service and MSI endpoint return access_token
         [DataMember(Name = "access_token", IsRequired = false)]
         public string AccessToken { get; private set; }
@@ -61,6 +60,5 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 throw new FormatException($"{TokenResponseFormatExceptionMessage} Exception Message: {exp.Message}");
             }
         }
-
     }
 }


### PR DESCRIPTION
Fixed typos and spelling mistakes in comments in various files inside Azure.Services.AppAuthentication Module and also removed unneccessary empty lines.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
