### PR TITLE
Utilize formatted message from AzureEventSourceListener in LogEvent

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/AzureSdkCompat/AzureEventSourceLogForwarder.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/AzureSdkCompat/AzureEventSourceLogForwarder.cs
@@ -59,13 +59,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
             }
         }
 
-        private static string FormatMessage(EventSourceEvent eventSourceEvent, Exception _) => eventSourceEvent.Format();
-
         public Task StartAsync(CancellationToken cancellationToken)
         {
             if (_loggerFactory != null)
             {
-                _listener ??= new AzureEventSourceListener((e, s) => LogEvent(e, s), EventLevel.Verbose);
+                _listener ??= new AzureEventSourceListener(LogEvent, EventLevel.Verbose);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
closes #44028 

@lmolkova - If this fix makes sense, there are other files where we should make this fix.