### PR TITLE
[Messaging] Relax emulator endpoint restrictions

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -151,7 +151,7 @@
     <PackageReference Update="Azure.ResourceManager.Storage" Version="1.2.1" />
 
     <!-- Other approved packages -->
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.6" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.7" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.2.0" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.60.3" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.60.3" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -243,18 +243,6 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The Event Hubs emulator is only available locally.  The endpoint must reference to the local host..
-        /// </summary>
-        internal static string InvalidEmulatorEndpoint
-        {
-            get
-            {
-                return ResourceManager.GetString("InvalidEmulatorEndpoint", resourceCulture);
-            }
-        }
-
-
-        /// <summary>
         ///   Looks up a localized string similar to The string has an invalid encoding format..
         /// </summary>
         internal static string InvalidEncoding

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -342,9 +342,6 @@
   <data name="TroubleshootingGuideLink" xml:space="preserve">
     <value>For troubleshooting information, see https://aka.ms/azsdk/net/eventhubs/exceptions/troubleshoot</value>
   </data>
-  <data name="InvalidEmulatorEndpoint" xml:space="preserve">
-    <value>The Event Hubs emulator is only available locally.  The endpoint must reference to the local host.</value>
-  </data>
   <data name="BufferedProducerStartupTimeout" xml:space="preserve">
     <value>The buffered producer took too long to start.</value>
   </data>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Release History
 
-## 5.12.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.11.3 (2024-05-15)
 
 ### Bugs Fixed
 
+- Fixed an error that caused connection strings using host names without a scheme to fail parsing and be considered invalid.
+
 ### Other Changes
 
-- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.6, which includes a bug fix for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258](https://github.com/azure/azure-amqp/issues/258))_
+- Removed the restriction that endpoints used with the development emulator had to resolve to a `localhost` variant.
+
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.7, which contains several bug fixes, including for an internal `NullReferenceException` that would sometimes impact creating new links. _(see: [#258](https://github.com/azure/azure-amqp/issues/258))_
 
 ## 5.11.2 (2024-04-10)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.12.0-beta.1</Version>
+    <Version>5.11.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.11.2</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsConnectionStringProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsConnectionStringProperties.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Azure.Core;
 
@@ -244,13 +245,6 @@ namespace Azure.Messaging.EventHubs
             {
                 throw new ArgumentException(Resources.MissingConnectionInformation, connectionStringArgumentName);
             }
-
-            // Ensure that the namespace reflects the local host when the development emulator is being used.
-
-            if ((UseDevelopmentEmulator) && (!Endpoint.IsLoopback))
-            {
-                throw new ArgumentException(Resources.InvalidEmulatorEndpoint, connectionStringArgumentName);
-            }
         }
 
         /// <summary>
@@ -334,6 +328,17 @@ namespace Azure.Messaging.EventHubs
                         {
                             endpointUri = null;
                         }
+                        else if (string.IsNullOrEmpty(endpointUri.Host) && (CountChar(':', value.AsSpan()) == 1))
+                        {
+                            // If the host was empty after parsing and the value has a single port/scheme separator,
+                            // then the parsing likely failed to recognize the host due to the lack of a scheme.  Add
+                            // an artificial scheme and try to parse again.
+
+                            if (!Uri.TryCreate(string.Concat(EventHubsEndpointScheme, value), UriKind.Absolute, out endpointUri))
+                            {
+                                endpointUri = null;
+                            }
+                        }
 
                         var endpointBuilder = endpointUri switch
                         {
@@ -399,6 +404,31 @@ namespace Azure.Messaging.EventHubs
             }
 
             return parsedValues;
+        }
+
+        /// <summary>
+        ///   Counts the number of times a character occurs in a given span.
+        /// </summary>
+        ///
+        /// <param name="span">The span to evaluate.</param>
+        /// <param name="value">The character to count.</param>
+        ///
+        /// <returns>The number of times the <paramref name="value"/> occurs in <paramref name="span"/>.</returns>
+        ///
+        private static int CountChar(char value,
+                                     ReadOnlySpan<char> span)
+        {
+            var count = 0;
+
+            foreach (var character in span)
+            {
+                if (character == value)
+                {
+                    ++count;
+                }
+            }
+
+            return count;
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Bugs Fixed
 
+- Fixed an error that caused connection strings using host names without a scheme to fail parsing and be considered invalid.
+
 ### Other Changes
+
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.7, which contains a fix for decoding messages with a null format code as the body.
 
 ## 7.18.0-beta.1 (2024-05-08)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Primitives/ServiceBusConnectionStringPropertiesTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Primitives/ServiceBusConnectionStringPropertiesTests.cs
@@ -363,7 +363,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase("test.endpoint.com:443")]
+        [TestCase("test-endpoint|com:443")]
         [TestCase("notvalid=[broke]")]
         public void ParseDoesNotAllowAnInvalidEndpointFormat(string endpointValue)
         {
@@ -394,6 +394,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         ///   method.
         /// </summary>
         ///
+        [Test]
         public void ParseDetectsDevelopmentEmulatorUse()
         {
             var connectionString = "Endpoint=localhost:1234;SharedAccessKeyName=[name];SharedAccessKey=[value];UseDevelopmentEmulator=true";
@@ -408,6 +409,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         ///   method.
         /// </summary>
         ///
+        [Test]
         public void ParseRespectsDevelopmentEmulatorValue()
         {
             var connectionString = "Endpoint=localhost:1234;SharedAccessKeyName=[name];SharedAccessKey=[value];UseDevelopmentEmulator=false";
@@ -415,6 +417,57 @@ namespace Azure.Messaging.ServiceBus.Tests
 
             Assert.That(parsed.Endpoint.IsLoopback, Is.True, "The endpoint should be a local address.");
             Assert.That(parsed.UseDevelopmentEmulator, Is.False, "The development emulator flag should have been unset.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ServiceBusConnectionStringProperties.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("localhost")]
+        [TestCase("localhost:9084")]
+        [TestCase("127.0.0.1")]
+        [TestCase("local.docker.com")]
+        [TestCase("local.docker.com:8080")]
+        [TestCase("www.fake.com")]
+        [TestCase("www.fake.com:443")]
+        public void ParseRespectsTheEndpointForDevelopmentEmulatorValue(string host)
+        {
+            var connectionString = $"Endpoint={ host };SharedAccessKeyName=[name];SharedAccessKey=[value];UseDevelopmentEmulator=true";
+            var endpoint = new Uri(string.Concat(GetServiceBusEndpointScheme(), host));
+            var parsed = ServiceBusConnectionStringProperties.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint.Host, Is.EqualTo(endpoint.Host), "The endpoint hosts should match.");
+            Assert.That(parsed.Endpoint.Port, Is.EqualTo(endpoint.Port), "The endpoint ports should match.");
+            Assert.That(parsed.UseDevelopmentEmulator, Is.True, "The development emulator flag should have been set.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ServiceBusConnectionStringProperties.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("sb://localhost")]
+        [TestCase("http://localhost:9084")]
+        [TestCase("sb://local.docker.com")]
+        [TestCase("amqps://local.docker.com:8080")]
+        [TestCase("sb://www.fake.com")]
+        [TestCase("amqp://www.fake.com:443")]
+        public void ParseRespectsTheUrlFormatEndpointForDevelopmentEmulatorValue(string host)
+        {
+            var endpoint = new UriBuilder(host)
+            {
+                Scheme = GetServiceBusEndpointScheme()
+            };
+
+            var connectionString = $"Endpoint={ host };SharedAccessKeyName=[name];SharedAccessKey=[value];UseDevelopmentEmulator=true";
+            var parsed = ServiceBusConnectionStringProperties.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint.Host, Is.EqualTo(endpoint.Host), "The endpoint hosts should match.");
+            Assert.That(parsed.Endpoint.Port, Is.EqualTo(endpoint.Port), "The endpoint ports should match.");
+            Assert.That(parsed.UseDevelopmentEmulator, Is.True, "The development emulator flag should have been set.");
         }
 
         /// <summary>
@@ -581,32 +634,6 @@ namespace Azure.Messaging.ServiceBus.Tests
             var properties = ServiceBusConnectionStringProperties.Parse(fakeConnection);
 
             Assert.That(() => properties.ToConnectionString(), Throws.Nothing, "Validation should accept the shared access signature authorization.");
-        }
-
-        /// <summary>
-        ///    Verifies functionality of the <see cref="ServiceBusConnectionStringProperties.Validate" />
-        ///    method.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase("localhost", true)]
-        [TestCase("127.0.0.1", true)]
-        [TestCase("www.microsoft.com", false)]
-        [TestCase("fake.servicebus.windows.net", false)]
-        [TestCase("weirdname:8080", false)]
-        public void ValidateRequiresLocalEndpointForDevelopmentEmulator(string endpoint,
-                                                                        bool isValid)
-        {
-            var fakeConnection = $"Endpoint=sb://{ endpoint };SharedAccessSignature=[not_real];UseDevelopmentEmulator=true";
-
-            if (isValid)
-            {
-                Assert.That(() =>  ServiceBusConnectionStringProperties.Parse(fakeConnection), Throws.Nothing, "Validation should allow a local endpoint.");
-            }
-            else
-            {
-                Assert.That(() =>  ServiceBusConnectionStringProperties.Parse(fakeConnection), Throws.ArgumentException.And.Message.Contains("local"), "Parse should enforce that the endpoint is a local address.");
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the restriction that the endpoint used in connection strings must resolve to a variant of `localhost` when using the development emulator.  A fix to parsing was also made to be resilient to an endpoint with no scheme that specifies a custom port. Previously, this would parse incorrectly and be rejected.  The scenario is now detected and parsed.

Also included is a package bump for the AMQP transport library and release prep for the Event Hubs core package.
