### PR TITLE
[Event Hubs] Post-release updates

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -246,7 +246,7 @@
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Identity" Version="1.11.1" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.17.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.11.2" />
+    <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.11.3" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.2.0" />
     <PackageReference Update="Azure.ResourceManager.CognitiveServices" Version="1.3.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsConnectionStringProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsConnectionStringProperties.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Azure.Core;
 


### PR DESCRIPTION
# Summary

The focus of these changes is to bump central version of the processor package to the latest stable release.    Also riding along is removal of an unused namespace.