### PR TITLE
Add workload-identity capabilities to live test

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -142,6 +142,7 @@ jobs:
                 ArmTemplateParameters: $(ArmTemplateParameters)
                 UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
                 ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+                SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}
         - ${{ if not(parameters.TestResourceDirectories) }}:
           - template: /eng/common/TestResources/deploy-test-resources.yml
             parameters:
@@ -153,6 +154,7 @@ jobs:
               ArmTemplateParameters: $(ArmTemplateParameters)
               UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
               ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+              SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}
 
       - pwsh: |
           if ($env:SupportsRecording -and $env:Record) {
@@ -229,6 +231,8 @@ jobs:
                 SubscriptionConfiguration: $(SubscriptionConfiguration)
                 UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
                 ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+                SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}
+
         - ${{ if not(parameters.TestResourceDirectories) }}:
           - template: /eng/common/TestResources/remove-test-resources.yml
             parameters:
@@ -236,6 +240,7 @@ jobs:
               SubscriptionConfiguration: $(SubscriptionConfiguration)
               UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
               ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+              SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}
 
       - task: PublishTestResults@2
         condition: always()

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -93,10 +93,6 @@ jobs:
       container: $[ variables['Container'] ]
 
     steps:
-      - pwsh: |
-          Write-Host '${{ convertToJson(parameters.CloudConfig) }}'
-        displayName: parameters.CloudConfig
-
       - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -54,6 +54,8 @@ parameters:
     default: false
   - name: OSName
     type: string
+  - name: UseFederatedAuth
+    type: boolean
 
 jobs:
   - job:
@@ -91,6 +93,10 @@ jobs:
       container: $[ variables['Container'] ]
 
     steps:
+      - pwsh: |
+          Write-Host '${{ convertToJson(parameters.CloudConfig) }}'
+        displayName: parameters.CloudConfig
+
       - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
@@ -134,6 +140,8 @@ jobs:
                 TestResourcesDirectory: '$(TestResourcesDirectory)'
                 SubscriptionConfiguration: $(SubscriptionConfiguration)
                 ArmTemplateParameters: $(ArmTemplateParameters)
+                UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+                ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
         - ${{ if not(parameters.TestResourceDirectories) }}:
           - template: /eng/common/TestResources/deploy-test-resources.yml
             parameters:
@@ -143,6 +151,9 @@ jobs:
               TestResourcesDirectory: '$(TestResourcesDirectory)'
               SubscriptionConfiguration: $(SubscriptionConfiguration)
               ArmTemplateParameters: $(ArmTemplateParameters)
+              UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+              ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+
       - pwsh: |
           if ($env:SupportsRecording -and $env:Record) {
             Write-Host "Enabling Record mode"
@@ -152,30 +163,62 @@ jobs:
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
         parameters:
           Container: ${{ parameters.UsePlatformContainer }}
-      - script: >
-          dotnet test eng/service.proj
-          --framework $(TestTargetFramework)
-          --filter "TestCategory!=Manually & ($(AdditionalTestFilters))"
-          --logger "trx"
-          --logger:"console;verbosity=normal"
-          --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TimeoutInMinutes}}minutes
-          /p:SDKType=${{ parameters.SDKType }}
-          /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
-          /p:Project=${{ parameters.Project }}
-          /p:IncludeSrc=false
-          /p:IncludeSamples=false
-          /p:IncludePerf=false
-          /p:IncludeStress=false
-          /p:BuildInParallel=${{ parameters.BuildInParallel }}
-          /p:CollectCoverage=$(CollectCoverage) /p:CodeCoverageDirectory=$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}
-          /p:EnableSourceLink=false
-          $(AdditionalTestArguments)
 
-        displayName: "Build & Test (all tests for $(TestTargetFramework))"
-        env:
-          AZURE_TEST_MODE: $(TestMode)
-          ${{ each var in parameters.EnvVars }}:
-            ${{ var.key }}: ${{ var.value }}
+      - ${{ if eq('true', parameters.UseFederatedAuth) }}:
+        - task: AzurePowerShell@5
+          displayName: "Build & Test (all tests for $(TestTargetFramework)) - Federated Auth"
+          inputs:
+            azureSubscription: ${{ parameters.CloudConfig.ServiceConnection }}
+            azurePowerShellVersion: LatestVersion
+            pwsh: true
+            ScriptType: InlineScript
+            Inline: >-
+              dotnet test eng/service.proj
+              --framework $(TestTargetFramework)
+              --filter "TestCategory!=Manually & ($(AdditionalTestFilters))"
+              --logger "trx"
+              --logger:"console;verbosity=normal"
+              --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TimeoutInMinutes}}minutes
+              /p:SDKType=${{ parameters.SDKType }}
+              /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
+              /p:Project=${{ parameters.Project }}
+              /p:IncludeSrc=false
+              /p:IncludeSamples=false
+              /p:IncludePerf=false
+              /p:IncludeStress=false
+              /p:BuildInParallel=${{ parameters.BuildInParallel }}
+              /p:CollectCoverage=$(CollectCoverage) /p:CodeCoverageDirectory=$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}
+              /p:EnableSourceLink=false
+              $(AdditionalTestArguments)
+          env:
+            AZURE_TEST_MODE: $(TestMode)
+            ${{ each var in parameters.EnvVars }}:
+              ${{ var.key }}: ${{ var.value }}
+
+      - ${{ else }}:
+        - script: >-
+            dotnet test eng/service.proj
+            --framework $(TestTargetFramework)
+            --filter "TestCategory!=Manually & ($(AdditionalTestFilters))"
+            --logger "trx"
+            --logger:"console;verbosity=normal"
+            --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TimeoutInMinutes}}minutes
+            /p:SDKType=${{ parameters.SDKType }}
+            /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
+            /p:Project=${{ parameters.Project }}
+            /p:IncludeSrc=false
+            /p:IncludeSamples=false
+            /p:IncludePerf=false
+            /p:IncludeStress=false
+            /p:BuildInParallel=${{ parameters.BuildInParallel }}
+            /p:CollectCoverage=$(CollectCoverage) /p:CodeCoverageDirectory=$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}
+            /p:EnableSourceLink=false
+            $(AdditionalTestArguments)
+          displayName: "Build & Test (all tests for $(TestTargetFramework)) - Client Secret Auth"
+          env:
+            AZURE_TEST_MODE: $(TestMode)
+            ${{ each var in parameters.EnvVars }}:
+              ${{ var.key }}: ${{ var.value }}
 
       - ${{ if parameters.DeployTestResources }}:
         - ${{ if parameters.TestResourceDirectories }}:
@@ -184,11 +227,15 @@ jobs:
               parameters:
                 ServiceDirectory: '${{ directory }}'
                 SubscriptionConfiguration: $(SubscriptionConfiguration)
+                UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+                ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
         - ${{ if not(parameters.TestResourceDirectories) }}:
           - template: /eng/common/TestResources/remove-test-resources.yml
             parameters:
               ServiceDirectory: '${{ parameters.ServiceDirectory }}'
               SubscriptionConfiguration: $(SubscriptionConfiguration)
+              UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+              ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
 
       - task: PublishTestResults@2
         condition: always()

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -56,6 +56,7 @@ parameters:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePath: eng/common/TestResources/sub-config/AzurePublicMsft.json
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
         ServiceConnection: azure-sdk-tests
@@ -171,6 +172,8 @@ extends:
                     CloudConfig:
                       SubscriptionConfiguration: ${{ cloud.value.SubscriptionConfiguration }}
                       ServiceConnection: ${{ cloud.value.ServiceConnection }}
+                      SubscriptionConfigurationFilePath: ${{ cloud.value.SubscriptionConfigurationFilePath }}
                       SubscriptionConfigurations: ${{ cloud.value.SubscriptionConfigurations }}
                       Location: ${{ coalesce(parameters.Location, cloud.value.Location) }}
                       Cloud: ${{ cloud.key }}
+

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -62,13 +62,13 @@ parameters:
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'eastus2euap'
-        ServiceConnection: TODO
+        ServiceConnection: azure-sdk-tests
       UsGov:
         SubscriptionConfiguration: $(sub-config-gov-test-resources)
-        ServiceConnection: TODO
+        ServiceConnection: usgov_azure-sdk-tests
       China:
         SubscriptionConfiguration: $(sub-config-cn-test-resources)
-        ServiceConnection: TODO
+        ServiceConnection: china_azure-sdk-tests
   - name: MatrixConfigs
     type: object
     default:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -55,15 +55,20 @@ parameters:
     default:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        ServiceConnection: azure-sdk-tests
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+        ServiceConnection: azure-sdk-tests
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'eastus2euap'
+        ServiceConnection: TODO
       UsGov:
         SubscriptionConfiguration: $(sub-config-gov-test-resources)
+        ServiceConnection: TODO
       China:
         SubscriptionConfiguration: $(sub-config-cn-test-resources)
+        ServiceConnection: TODO
   - name: MatrixConfigs
     type: object
     default:
@@ -105,6 +110,9 @@ parameters:
   - name: oneESTemplateTag
     type: string
     default: true
+  - name: UseFederatedAuth
+    type: boolean
+    default: true
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -145,6 +153,7 @@ extends:
                       Project: ${{ parameters.Project }}
                       TestSetupSteps: ${{ parameters.TestSetupSteps }}
                       DeployTestResources: ${{ parameters.DeployTestResources }}
+                      UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
                     MatrixConfigs:
                       # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).
                       - ${{ each config in parameters.MatrixConfigs }}:
@@ -161,7 +170,7 @@ extends:
                       - ${{ parameters.MatrixReplace }}
                     CloudConfig:
                       SubscriptionConfiguration: ${{ cloud.value.SubscriptionConfiguration }}
+                      ServiceConnection: ${{ cloud.value.ServiceConnection }}
                       SubscriptionConfigurations: ${{ cloud.value.SubscriptionConfigurations }}
                       Location: ${{ coalesce(parameters.Location, cloud.value.Location) }}
                       Cloud: ${{ cloud.key }}
-

--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -3,6 +3,7 @@ trigger: none
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
+    UseFederatedAuth: true
     ServiceDirectory: keyvault
     SDKType: client
     MaxParallel: 5
@@ -11,12 +12,14 @@ extends:
     CloudConfig:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        ServiceConnection: azure-sdk-tests
         ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'
+        ServiceConnection: azure-sdk-tests
         # Managed HSM test resources are expensive and provisioning has not been reliable.
         # Given test coverage of non-canary regions we probably don't need to test in canary.
         MatrixFilters:
@@ -26,6 +29,7 @@ extends:
          - 'ArmTemplateParameters=(.*)enableAttestation.*?\$true(.*)/$1enableAttestation \= $false$2'
       UsGov:
         SubscriptionConfiguration: $(sub-config-gov-test-resources)
+        ServiceConnection: usgov_azure-sdk-tests
         MatrixFilters:
          - ArmTemplateParameters=^(?!.*enableHsm.*true)
     MatrixConfigs:

--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -3,7 +3,6 @@ trigger: none
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
-    UseFederatedAuth: true
     ServiceDirectory: keyvault
     SDKType: client
     MaxParallel: 5


### PR DESCRIPTION
Includes updated configurations for sovereign cloud testing. Sovereign cloud testing pipelines pass (includes testing in public cloud): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3792708&view=results


Test run with federated auth: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3828865&view=results

Test run without federated auth: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3828829&view=results