### PR TITLE
add isSynthetic to StandardMetrics

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricConstants.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
     internal static class StandardMetricConstants
@@ -27,5 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal const string CloudRoleNameKey = "cloud/roleName";
         internal const string CloudRoleInstanceKey = "cloud/roleInstance";
         internal const string MetricIdKey = "_MS.MetricId";
+
+        internal static  ReadOnlySpan<string> SyntheticUserAgentValues => new string[] { "AlwaysOn", "AppInsights", "search", "spider", "crawl", "Bot", "Monitor", "Gomez", "Pingdom" };
     }
 }


### PR DESCRIPTION
This PR adds isSynthetic to StandardMetrics, as per the spec.




### Notes
This is almost identical to the implementation in Application Insights SDK.
https://github.com/microsoft/ApplicationInsights-dotnet/blob/99118c924d3880f3853c0b1c9ebe67289073dbfa/WEB/Src/Web/Web/SyntheticUserAgentTelemetryInitializer.cs#L69-L82