### PR TITLE
revert(devcenter): roll back some changes in tsp 0.56 upgrade

### DIFF
--- a/sdk/devcenter/Azure.Developer.DevCenter/api/Azure.Developer.DevCenter.netstandard2.0.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/api/Azure.Developer.DevCenter.netstandard2.0.cs
@@ -141,12 +141,10 @@ namespace Azure.Developer.DevCenter
     }
     public partial class DevCenterClientOptions : Azure.Core.ClientOptions
     {
-        public DevCenterClientOptions(Azure.Developer.DevCenter.DevCenterClientOptions.ServiceVersion version = Azure.Developer.DevCenter.DevCenterClientOptions.ServiceVersion.V2024_05_01_Preview) { }
+        public DevCenterClientOptions(Azure.Developer.DevCenter.DevCenterClientOptions.ServiceVersion version = Azure.Developer.DevCenter.DevCenterClientOptions.ServiceVersion.V2023_04_01) { }
         public enum ServiceVersion
         {
             V2023_04_01 = 1,
-            V2024_02_01 = 2,
-            V2024_05_01_Preview = 3,
         }
     }
 }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DeploymentEnvironmentsClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DeploymentEnvironmentsClient.cs
@@ -101,7 +101,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets an environment.
+        /// [Protocol Method] Gets an environment
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -145,7 +145,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets an environment.
+        /// [Protocol Method] Gets an environment
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -223,7 +223,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets the specified catalog within the project.
+        /// [Protocol Method] Gets the specified catalog within the project
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -265,7 +265,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets the specified catalog within the project.
+        /// [Protocol Method] Gets the specified catalog within the project
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -919,7 +919,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary> Lists all environment types configured for a project. </summary>
-        /// <param name="projectName"> Name of the project. </param>
+        /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
@@ -935,7 +935,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary> Lists all environment types configured for a project. </summary>
-        /// <param name="projectName"> Name of the project. </param>
+        /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
@@ -965,7 +965,7 @@ namespace Azure.Developer.DevCenter
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="projectName"> Name of the project. </param>
+        /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
@@ -996,7 +996,7 @@ namespace Azure.Developer.DevCenter
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="projectName"> Name of the project. </param>
+        /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevBoxesClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevBoxesClient.cs
@@ -97,7 +97,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets a pool.
+        /// [Protocol Method] Gets a pool
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -139,7 +139,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets a pool.
+        /// [Protocol Method] Gets a pool
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -345,7 +345,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets a Dev Box.
+        /// [Protocol Method] Gets a Dev Box
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -389,7 +389,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets a Dev Box.
+        /// [Protocol Method] Gets a Dev Box
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -471,7 +471,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets RDP Connection info.
+        /// [Protocol Method] Gets RDP Connection info
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -515,7 +515,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Gets RDP Connection info.
+        /// [Protocol Method] Gets RDP Connection info
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -947,7 +947,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Lists available pools.
+        /// [Protocol Method] Lists available pools
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -978,7 +978,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Lists available pools.
+        /// [Protocol Method] Lists available pools
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -1008,9 +1008,9 @@ namespace Azure.Developer.DevCenter
             return GeneratorPageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "DevBoxesClient.GetPools", "value", "nextLink", context);
         }
 
-        /// <summary> Lists all schedules within a pool that are configured by your project administrator. </summary>
-        /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
-        /// <param name="poolName"> The name of a pool of Dev Boxes. </param>
+        /// <summary> Lists available schedules for a pool. </summary>
+        /// <param name="projectName"> Name of the project. </param>
+        /// <param name="poolName"> Pool name. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> or <paramref name="poolName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> or <paramref name="poolName"/> is an empty string, and was expected to be non-empty. </exception>
@@ -1026,9 +1026,9 @@ namespace Azure.Developer.DevCenter
             return GeneratorPageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => DevBoxSchedule.DeserializeDevBoxSchedule(e), ClientDiagnostics, _pipeline, "DevBoxesClient.GetSchedules", "value", "nextLink", context);
         }
 
-        /// <summary> Lists all schedules within a pool that are configured by your project administrator. </summary>
-        /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
-        /// <param name="poolName"> The name of a pool of Dev Boxes. </param>
+        /// <summary> Lists available schedules for a pool. </summary>
+        /// <param name="projectName"> Name of the project. </param>
+        /// <param name="poolName"> Pool name. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> or <paramref name="poolName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> or <paramref name="poolName"/> is an empty string, and was expected to be non-empty. </exception>
@@ -1045,7 +1045,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Lists all schedules within a pool that are configured by your project administrator.
+        /// [Protocol Method] Lists available schedules for a pool.
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -1059,8 +1059,8 @@ namespace Azure.Developer.DevCenter
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
-        /// <param name="poolName"> The name of a pool of Dev Boxes. </param>
+        /// <param name="projectName"> Name of the project. </param>
+        /// <param name="poolName"> Pool name. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> or <paramref name="poolName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> or <paramref name="poolName"/> is an empty string, and was expected to be non-empty. </exception>
@@ -1078,7 +1078,7 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary>
-        /// [Protocol Method] Lists all schedules within a pool that are configured by your project administrator.
+        /// [Protocol Method] Lists available schedules for a pool.
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -1092,8 +1092,8 @@ namespace Azure.Developer.DevCenter
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
-        /// <param name="poolName"> The name of a pool of Dev Boxes. </param>
+        /// <param name="projectName"> Name of the project. </param>
+        /// <param name="poolName"> Pool name. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> or <paramref name="poolName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> or <paramref name="poolName"/> is an empty string, and was expected to be non-empty. </exception>
@@ -1772,7 +1772,7 @@ namespace Azure.Developer.DevCenter
 
         // The convenience method is omitted here because it has exactly the same parameter list as the corresponding protocol method
         /// <summary>
-        /// [Protocol Method] Starts a Dev Box.
+        /// [Protocol Method] Starts a Dev Box
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -1813,7 +1813,7 @@ namespace Azure.Developer.DevCenter
 
         // The convenience method is omitted here because it has exactly the same parameter list as the corresponding protocol method
         /// <summary>
-        /// [Protocol Method] Starts a Dev Box.
+        /// [Protocol Method] Starts a Dev Box
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -1854,7 +1854,7 @@ namespace Azure.Developer.DevCenter
 
         // The convenience method is omitted here because it has exactly the same parameter list as the corresponding protocol method
         /// <summary>
-        /// [Protocol Method] Stops a Dev Box.
+        /// [Protocol Method] Stops a Dev Box
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -1896,7 +1896,7 @@ namespace Azure.Developer.DevCenter
 
         // The convenience method is omitted here because it has exactly the same parameter list as the corresponding protocol method
         /// <summary>
-        /// [Protocol Method] Stops a Dev Box.
+        /// [Protocol Method] Stops a Dev Box
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -1938,7 +1938,7 @@ namespace Azure.Developer.DevCenter
 
         // The convenience method is omitted here because it has exactly the same parameter list as the corresponding protocol method
         /// <summary>
-        /// [Protocol Method] Restarts a Dev Box.
+        /// [Protocol Method] Restarts a Dev Box
         /// <list type="bullet">
         /// <item>
         /// <description>
@@ -1979,7 +1979,7 @@ namespace Azure.Developer.DevCenter
 
         // The convenience method is omitted here because it has exactly the same parameter list as the corresponding protocol method
         /// <summary>
-        /// [Protocol Method] Restarts a Dev Box.
+        /// [Protocol Method] Restarts a Dev Box
         /// <list type="bullet">
         /// <item>
         /// <description>

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterClientOptions.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterClientOptions.cs
@@ -13,17 +13,13 @@ namespace Azure.Developer.DevCenter
     /// <summary> Client options for Azure.Developer.DevCenter library clients. </summary>
     public partial class DevCenterClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2024_05_01_Preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2023_04_01;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2023-04-01". </summary>
             V2023_04_01 = 1,
-            /// <summary> Service version "2024-02-01". </summary>
-            V2024_02_01 = 2,
-            /// <summary> Service version "2024-05-01-preview". </summary>
-            V2024_05_01_Preview = 3,
         }
 
         internal string Version { get; }
@@ -34,8 +30,6 @@ namespace Azure.Developer.DevCenter
             Version = version switch
             {
                 ServiceVersion.V2023_04_01 => "2023-04-01",
-                ServiceVersion.V2024_02_01 => "2024-02-01",
-                ServiceVersion.V2024_05_01_Preview => "2024-05-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterModelFactory.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterModelFactory.cs
@@ -303,7 +303,7 @@ namespace Azure.Developer.DevCenter.Models
         /// <param name="defaultValue"> Default value of the parameter. </param>
         /// <param name="parameterType">
         /// A string of one of the basic JSON types (number, integer, array, object,
-        /// boolean, string).
+        /// boolean, string)
         /// </param>
         /// <param name="readOnly">
         /// Whether or not this parameter is read-only.  If true, default should have a

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterEnvironmentType.Serialization.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterEnvironmentType.Serialization.cs
@@ -26,11 +26,8 @@ namespace Azure.Developer.DevCenter.Models
             }
 
             writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name);
             writer.WritePropertyName("deploymentTargetId"u8);
             writer.WriteStringValue(DeploymentTargetId);
             writer.WritePropertyName("status"u8);

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterEnvironmentType.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/DevCenterEnvironmentType.cs
@@ -47,17 +47,20 @@ namespace Azure.Developer.DevCenter.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="DevCenterEnvironmentType"/>. </summary>
+        /// <param name="name"> Name of the environment type. </param>
         /// <param name="deploymentTargetId">
         /// Id of a subscription or management group that the environment type will be
         /// mapped to. The environment's resources will be deployed into this subscription
         /// or management group.
         /// </param>
         /// <param name="status"> Indicates whether this environment type is enabled for use in this project. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="deploymentTargetId"/> is null. </exception>
-        internal DevCenterEnvironmentType(ResourceIdentifier deploymentTargetId, EnvironmentTypeStatus status)
+        /// <exception cref="ArgumentNullException"> <paramref name="name"/> or <paramref name="deploymentTargetId"/> is null. </exception>
+        internal DevCenterEnvironmentType(string name, ResourceIdentifier deploymentTargetId, EnvironmentTypeStatus status)
         {
+            Argument.AssertNotNull(name, nameof(name));
             Argument.AssertNotNull(deploymentTargetId, nameof(deploymentTargetId));
 
+            Name = name;
             DeploymentTargetId = deploymentTargetId;
             Status = status;
         }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/EnvironmentDefinitionParameter.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Models/EnvironmentDefinitionParameter.cs
@@ -49,7 +49,7 @@ namespace Azure.Developer.DevCenter.Models
         /// <param name="id"> Unique ID of the parameter. </param>
         /// <param name="parameterType">
         /// A string of one of the basic JSON types (number, integer, array, object,
-        /// boolean, string).
+        /// boolean, string)
         /// </param>
         /// <param name="required"> Whether or not this parameter is required. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="id"/> is null. </exception>
@@ -70,7 +70,7 @@ namespace Azure.Developer.DevCenter.Models
         /// <param name="defaultValue"> Default value of the parameter. </param>
         /// <param name="parameterType">
         /// A string of one of the basic JSON types (number, integer, array, object,
-        /// boolean, string).
+        /// boolean, string)
         /// </param>
         /// <param name="readOnly">
         /// Whether or not this parameter is read-only.  If true, default should have a
@@ -107,7 +107,7 @@ namespace Azure.Developer.DevCenter.Models
         public string DefaultValue { get; }
         /// <summary>
         /// A string of one of the basic JSON types (number, integer, array, object,
-        /// boolean, string).
+        /// boolean, string)
         /// </summary>
         public EnvironmentDefinitionParameterType ParameterType { get; }
         /// <summary>

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DeploymentEnvironmentsClientTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DeploymentEnvironmentsClientTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Developer.DevCenter.Tests
             InstrumentClient(new DeploymentEnvironmentsClient(
                 TestEnvironment.Endpoint,
                 TestEnvironment.Credential,
-                InstrumentClientOptions(new DevCenterClientOptions(DevCenterClientOptions.ServiceVersion.V2023_04_01))));
+                InstrumentClientOptions(new DevCenterClientOptions())));
 
         public DeploymentEnvironmentsClientTests(bool isAsync) : base(isAsync)
         {

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DevBoxesClientTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DevBoxesClientTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Developer.DevCenter.Tests
             InstrumentClient(new DevBoxesClient(
                 TestEnvironment.Endpoint,
                 TestEnvironment.Credential,
-                InstrumentClientOptions(new DevCenterClientOptions(DevCenterClientOptions.ServiceVersion.V2023_04_01))));
+                InstrumentClientOptions(new DevCenterClientOptions())));
 
         public DevBoxesClientTests(bool isAsync) : base(isAsync)
         {

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DevCenterClientTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DevCenterClientTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Developer.DevCenter.Tests
             InstrumentClient(new DevCenterClient(
                 TestEnvironment.Endpoint,
                 TestEnvironment.Credential,
-                InstrumentClientOptions(new DevCenterClientOptions(DevCenterClientOptions.ServiceVersion.V2023_04_01))));
+                InstrumentClientOptions(new DevCenterClientOptions())));
 
         public DevCenterClientTests(bool isAsync) : base(isAsync)
         {

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/Generated/Samples/Samples_DeploymentEnvironmentsClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/Generated/Samples/Samples_DeploymentEnvironmentsClient.cs
@@ -1053,7 +1053,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public void Example_EnvironmentType_GetEnvironmentTypes_ShortVersion()
+        public void Example_EnvironmentClientOperations_GetEnvironmentTypes_ShortVersion()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1070,7 +1070,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public async Task Example_EnvironmentType_GetEnvironmentTypes_ShortVersion_Async()
+        public async Task Example_EnvironmentClientOperations_GetEnvironmentTypes_ShortVersion_Async()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1087,7 +1087,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public void Example_EnvironmentType_GetEnvironmentTypes_ShortVersion_Convenience()
+        public void Example_EnvironmentClientOperations_GetEnvironmentTypes_ShortVersion_Convenience()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1100,7 +1100,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public async Task Example_EnvironmentType_GetEnvironmentTypes_ShortVersion_Convenience_Async()
+        public async Task Example_EnvironmentClientOperations_GetEnvironmentTypes_ShortVersion_Convenience_Async()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1113,7 +1113,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public void Example_EnvironmentType_GetEnvironmentTypes_AllParameters()
+        public void Example_EnvironmentClientOperations_GetEnvironmentTypes_AllParameters()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1130,7 +1130,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public async Task Example_EnvironmentType_GetEnvironmentTypes_AllParameters_Async()
+        public async Task Example_EnvironmentClientOperations_GetEnvironmentTypes_AllParameters_Async()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1147,7 +1147,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public void Example_EnvironmentType_GetEnvironmentTypes_AllParameters_Convenience()
+        public void Example_EnvironmentClientOperations_GetEnvironmentTypes_AllParameters_Convenience()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1160,7 +1160,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public async Task Example_EnvironmentType_GetEnvironmentTypes_AllParameters_Convenience_Async()
+        public async Task Example_EnvironmentClientOperations_GetEnvironmentTypes_AllParameters_Convenience_Async()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/Generated/Samples/Samples_DevBoxesClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/Generated/Samples/Samples_DevBoxesClient.cs
@@ -949,7 +949,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public void Example_DevBoxesClientOperations_GetSchedules_ShortVersion()
+        public void Example_Schedule_GetSchedules_ShortVersion()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -968,7 +968,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public async Task Example_DevBoxesClientOperations_GetSchedules_ShortVersion_Async()
+        public async Task Example_Schedule_GetSchedules_ShortVersion_Async()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -987,7 +987,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public void Example_DevBoxesClientOperations_GetSchedules_ShortVersion_Convenience()
+        public void Example_Schedule_GetSchedules_ShortVersion_Convenience()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1000,7 +1000,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public async Task Example_DevBoxesClientOperations_GetSchedules_ShortVersion_Convenience_Async()
+        public async Task Example_Schedule_GetSchedules_ShortVersion_Convenience_Async()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1013,7 +1013,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public void Example_DevBoxesClientOperations_GetSchedules_AllParameters()
+        public void Example_Schedule_GetSchedules_AllParameters()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1032,7 +1032,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public async Task Example_DevBoxesClientOperations_GetSchedules_AllParameters_Async()
+        public async Task Example_Schedule_GetSchedules_AllParameters_Async()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1051,7 +1051,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public void Example_DevBoxesClientOperations_GetSchedules_AllParameters_Convenience()
+        public void Example_Schedule_GetSchedules_AllParameters_Convenience()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();
@@ -1064,7 +1064,7 @@ namespace Azure.Developer.DevCenter.Samples
 
         [Test]
         [Ignore("Only validating compilation of examples")]
-        public async Task Example_DevBoxesClientOperations_GetSchedules_AllParameters_Convenience_Async()
+        public async Task Example_Schedule_GetSchedules_AllParameters_Convenience_Async()
         {
             Uri endpoint = new Uri("<https://my-service.azure.com>");
             TokenCredential credential = new DefaultAzureCredential();

--- a/sdk/devcenter/Azure.Developer.DevCenter/tsp-location.yaml
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/devcenter/DevCenter
-commit: ce6f7ab21a4b93ab5857febfedfba89c127837cf
+commit: 63dc797c014849ef0c5da7eb91197975efb6a474
 repo: Azure/azure-rest-api-specs
 cleanup: false


### PR DESCRIPTION
- use a fix branch in `azure-rest-api-specs` which include the minimal change to fix tsp 0.56 upgrade
- regen the codes
- roll back test case changes

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
