### PR TITLE
Remove usage of azure-sdk-docs-prod-sas

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -233,7 +233,6 @@ stages:
                           - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
                             parameters:
                               FolderForUpload: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}'
-                              BlobSASKey: '$(azure-sdk-docs-prod-sas)'
                               BlobName: '$(azure-sdk-docs-prod-blob-name)'
                               TargetLanguage: 'dotnet'
                               ArtifactLocation: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}'


### PR DESCRIPTION
The publish-blobs.yml uses AzurePowerShell now and no longer required the azure-sdk-docs-prod-sas. This is cleanup needs to be done in order to remove the SAS from the variable group and, ultimately, the keyvault.