### PR TITLE
Fix AOT warnings in Azure.Core

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -47,8 +47,8 @@
     <PackageReference Update="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.Cng" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.Primitives" Version="4.3.0" />
-    <PackageReference Update="System.Text.Encodings.Web" Version="4.5.1" />
-    <PackageReference Update="System.Text.Json" Version="4.7.2" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Update="System.Text.Json" Version="6.0.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
 
     <PackageReference Update="WindowsAzure.Storage" Version="9.3.3" />
@@ -99,10 +99,10 @@
     <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     <PackageReference Update="System.Threading.Channels" Version="4.7.1" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Update="System.Text.Json" Version="4.7.2" />
-    <PackageReference Update="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Update="System.Text.Json" Version="6.0.0" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+    <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Update="Microsoft.CSharp" Version="4.7.0" />
 
     <!-- Azure SDK packages -->

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -47,8 +47,8 @@
     <PackageReference Update="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.Cng" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.Primitives" Version="4.3.0" />
-    <PackageReference Update="System.Text.Encodings.Web" Version="6.0.0" />
-    <PackageReference Update="System.Text.Json" Version="6.0.0" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Update="System.Text.Json" Version="4.7.2" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
 
     <PackageReference Update="WindowsAzure.Storage" Version="9.3.3" />
@@ -99,7 +99,7 @@
     <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     <PackageReference Update="System.Threading.Channels" Version="4.7.1" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Update="System.Text.Json" Version="6.0.0" />
+    <PackageReference Update="System.Text.Json" Version="6.0.9" />
     <PackageReference Update="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />

--- a/sdk/attestation/Azure.ResourceManager.Attestation/src/Azure.ResourceManager.Attestation.csproj
+++ b/sdk/attestation/Azure.ResourceManager.Attestation/src/Azure.ResourceManager.Attestation.csproj
@@ -8,4 +8,8 @@
   <ItemGroup>
     <Folder Include="Custom\Models\" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+  </ItemGroup>
 </Project>

--- a/sdk/attestation/Azure.Security.Attestation/src/AttestationToken.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/AttestationToken.cs
@@ -658,7 +658,7 @@ namespace Azure.Security.Attestation
             };
             var serializationOptions = new JsonSerializerOptions
             {
-                IgnoreNullValues = true,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
             };
             byte[] jwtHeader = JsonSerializer.SerializeToUtf8Bytes<JsonWebTokenHeader>(header, serializationOptions);
             string encodedHeader = Base64Url.Encode(jwtHeader);

--- a/sdk/attestation/Azure.Security.Attestation/src/Azure.Security.Attestation.csproj
+++ b/sdk/attestation/Azure.Security.Attestation/src/Azure.Security.Attestation.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="System.Text.Json" />
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
+++ b/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.CSharp" />
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
+++ b/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryKeyVaultSecret.Serialization.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryKeyVaultSecret.Serialization.cs
@@ -35,7 +35,7 @@ namespace Azure.Core.Expressions.DataFactory
             }
             DataFactoryLinkedServiceReference? store = default;
             DataFactoryElement<string>? secretName = default;
-            Optional<DataFactoryElement<string>> secretVersion = default;
+            DataFactoryElement<string>? secretVersion = default;
             string? type = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -64,7 +64,7 @@ namespace Azure.Core.Expressions.DataFactory
                     continue;
                 }
             }
-            return new DataFactoryKeyVaultSecret(type, store, secretName, secretVersion.Value);
+            return new DataFactoryKeyVaultSecret(type, store, secretName, secretVersion);
         }
 
         internal partial class DataFactoryKeyVaultSecretConverter : JsonConverter<DataFactoryKeyVaultSecret?>

--- a/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryLinkedServiceReference.Serialization.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryLinkedServiceReference.Serialization.cs
@@ -54,7 +54,7 @@ namespace Azure.Core.Expressions.DataFactory
             {
                 if (property.NameEquals("type"u8))
                 {
-                    kind = new DataFactoryLinkedServiceReferenceKind(property.Value.GetString());
+                    kind = new DataFactoryLinkedServiceReferenceKind(property.Value.GetString()!);
                     continue;
                 }
                 if (property.NameEquals("referenceName"u8))

--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="System.Text.Json" />
     <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net47'" />
 
     <!--Temporary solution to pin the version of generator here to workaround the issue in our pipelines that gets conflicts in git push -->

--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
     <PackageReference Include="System.Text.Json" />
     <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net47'" />
 

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -214,7 +214,7 @@ namespace Azure.Core
             {
                 lastKnownLocation = null;
             }
-            return GetRehydrationToken(requestMethod, startRequestUri, nextRequestUri, headerSource.ToString(), lastKnownLocation, finalStateVia.ToString(), NotSet);
+            return GetRehydrationToken(requestMethod, startRequestUri, nextRequestUri, headerSource.ToString(), lastKnownLocation, finalStateVia.ToString());
         }
 
         public static RehydrationToken GetRehydrationToken(
@@ -224,17 +224,17 @@ namespace Azure.Core
             string headerSource,
             string? lastKnownLocation,
             string finalStateVia,
-            string operationId)
+            string? operationId = null)
         {
             // TODO: Once we remove NextLinkOperationImplementation from internal shared and make it internal to Azure.Core only, we can access the internal members from RehydrationToken directly
             var json = $$"""
-            {"version":"{{RehydrationTokenVersion}}","id":"{{operationId}}","requestMethod":"{{requestMethod}}","initialUri":"{{startRequestUri.AbsoluteUri}}","nextRequestUri":"{{nextRequestUri}}","headerSource":"{{headerSource}}","finalStateVia":"{{finalStateVia}}","lastKnownLocation":{{ConstructStringValue(lastKnownLocation)}}}
+            {"version":"{{RehydrationTokenVersion}}","id":"{{ConstructStringValue(operationId)}}","requestMethod":"{{requestMethod}}","initialUri":"{{startRequestUri.AbsoluteUri}}","nextRequestUri":"{{nextRequestUri}}","headerSource":"{{headerSource}}","finalStateVia":"{{finalStateVia}}","lastKnownLocation":{{ConstructStringValue(lastKnownLocation)}}}
             """;
             var data = new BinaryData(json);
             return ModelReaderWriter.Read<RehydrationToken>(data);
         }
 
-        private static string? ConstructStringValue(string? value) => value is null ? "null" : $"\"{value}\"";
+        private static string? ConstructStringValue(string? value) => value is null ? "null" : $$"""{{value}}""";
 
         public async ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken)
         {

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -100,7 +100,7 @@ namespace Azure.Core
 
             // TODO: Once we remove NextLinkOperationImplementation from internal shared and make it internal to Azure.Core only, we can access the internal members from RehydrationToken directly
             var data = ModelReaderWriter.Write(rehydrationToken!, ModelReaderWriterOptions.Json);
-            // We are sure that data is a valid JsonObject as we are serializing RehydrationToken
+            // We are sure that JsonNode.Parse(data) is a valid JsonObject as we are serializing RehydrationToken
             var lroDetails = (JsonObject)JsonNode.Parse(data)!;
 
             var initialUri = GetContentFromRehydrationToken(lroDetails, "initialUri");
@@ -226,8 +226,9 @@ namespace Azure.Core
             string finalStateVia,
             string operationId)
         {
+            // TODO: Once we remove NextLinkOperationImplementation from internal shared and make it internal to Azure.Core only, we can access the internal members from RehydrationToken directly
             var json = $"{{\"version\":\"{RehydrationTokenVersion}\",\"id\":\"{operationId}\",\"requestMethod\":\"{requestMethod}\",\"initialUri\":\"{startRequestUri.AbsoluteUri}\",\"nextRequestUri\":\"{nextRequestUri}\",\"headerSource\":\"{headerSource}\",\"finalStateVia\":\"{finalStateVia}\",\"lastKnownLocation\":{ConstructStringValue(lastKnownLocation)}}}";
-            var data = BinaryData.FromString(json);
+            var data = new BinaryData(json);
             return ModelReaderWriter.Read<RehydrationToken>(data);
         }
 

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -227,7 +227,9 @@ namespace Azure.Core
             string operationId)
         {
             // TODO: Once we remove NextLinkOperationImplementation from internal shared and make it internal to Azure.Core only, we can access the internal members from RehydrationToken directly
-            var json = $"{{\"version\":\"{RehydrationTokenVersion}\",\"id\":\"{operationId}\",\"requestMethod\":\"{requestMethod}\",\"initialUri\":\"{startRequestUri.AbsoluteUri}\",\"nextRequestUri\":\"{nextRequestUri}\",\"headerSource\":\"{headerSource}\",\"finalStateVia\":\"{finalStateVia}\",\"lastKnownLocation\":{ConstructStringValue(lastKnownLocation)}}}";
+            var json = $$"""
+            {"version":"{{RehydrationTokenVersion}}","id":"{{operationId}}","requestMethod":"{{requestMethod}}","initialUri":"{{startRequestUri.AbsoluteUri}}","nextRequestUri":"{{nextRequestUri}}","headerSource":"{{headerSource}}","finalStateVia":"{{finalStateVia}}","lastKnownLocation":{{ConstructStringValue(lastKnownLocation)}}}
+            """;
             var data = new BinaryData(json);
             return ModelReaderWriter.Read<RehydrationToken>(data);
         }

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -99,7 +99,7 @@ namespace Azure.Core
             AssertNotNull(pipeline, nameof(pipeline));
 
             // TODO: Once we remove NextLinkOperationImplementation from internal shared and make it internal to Azure.Core only, we can access the internal members from RehydrationToken directly
-            var data = ModelReaderWriter.Write(rehydrationToken!, ModelReaderWriterOptions.Json);
+            var data = ModelReaderWriter.Write(rehydrationToken!, ModelReaderWriterOptions.Json).ToString();
             // We are sure that data is a valid JsonObject as we are serializing RehydrationToken
             var lroDetails = (JsonObject)JsonNode.Parse(data)!;
 

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -228,13 +228,13 @@ namespace Azure.Core
         {
             // TODO: Once we remove NextLinkOperationImplementation from internal shared and make it internal to Azure.Core only, we can access the internal members from RehydrationToken directly
             var json = $$"""
-            {"version":"{{RehydrationTokenVersion}}","id":"{{ConstructStringValue(operationId)}}","requestMethod":"{{requestMethod}}","initialUri":"{{startRequestUri.AbsoluteUri}}","nextRequestUri":"{{nextRequestUri}}","headerSource":"{{headerSource}}","finalStateVia":"{{finalStateVia}}","lastKnownLocation":{{ConstructStringValue(lastKnownLocation)}}}
+            {"version":"{{RehydrationTokenVersion}}","id":{{ConstructStringValue(operationId)}},"requestMethod":"{{requestMethod}}","initialUri":"{{startRequestUri.AbsoluteUri}}","nextRequestUri":"{{nextRequestUri}}","headerSource":"{{headerSource}}","finalStateVia":"{{finalStateVia}}","lastKnownLocation":{{ConstructStringValue(lastKnownLocation)}}}
             """;
             var data = new BinaryData(json);
             return ModelReaderWriter.Read<RehydrationToken>(data);
         }
 
-        private static string? ConstructStringValue(string? value) => value is null ? "null" : $$"""{{value}}""";
+        private static string? ConstructStringValue(string? value) => value is null ? "null" : $"\"{value}\"";
 
         public async ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken)
         {

--- a/sdk/core/Azure.Core/tests/NextLinkOperationImplementationTests.cs
+++ b/sdk/core/Azure.Core/tests/NextLinkOperationImplementationTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Core.Tests
             var headerSource = "None";
             string lastKnownLocation = null;
             var finalStateVia = OperationFinalStateVia.OperationLocation.ToString();
-            var token = NextLinkOperationImplementation.GetRehydrationToken(requetMethod, startRequestUri, nextRequestUri, headerSource, lastKnownLocation, finalStateVia, NextLinkOperationImplementation.NotSet);
+            var token = NextLinkOperationImplementation.GetRehydrationToken(requetMethod, startRequestUri, nextRequestUri, headerSource, lastKnownLocation, finalStateVia);
             Assert.AreEqual(requetMethod, token.RequestMethod);
             Assert.AreEqual(startRequestUri, token.InitialUri);
             Assert.AreEqual(nextRequestUri, token.NextRequestUri);

--- a/sdk/core/Azure.Core/tests/NextLinkOperationImplementationTests.cs
+++ b/sdk/core/Azure.Core/tests/NextLinkOperationImplementationTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Core.Tests
             var headerSource = "None";
             string lastKnownLocation = null;
             var finalStateVia = OperationFinalStateVia.OperationLocation.ToString();
-            var token = NextLinkOperationImplementation.GetRehydrationToken(requetMethod, startRequestUri, nextRequestUri, headerSource, lastKnownLocation, finalStateVia);
+            var token = NextLinkOperationImplementation.GetRehydrationToken(requetMethod, startRequestUri, nextRequestUri, headerSource, lastKnownLocation, finalStateVia, NextLinkOperationImplementation.NotSet);
             Assert.AreEqual(requetMethod, token.RequestMethod);
             Assert.AreEqual(startRequestUri, token.InitialUri);
             Assert.AreEqual(nextRequestUri, token.NextRequestUri);

--- a/sdk/core/Azure.Core/tests/OperationTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationTests.cs
@@ -216,7 +216,7 @@ namespace Azure.Core.Tests
         public async Task GetRehydrationTokenAsync()
         {
             var pipeline = CreateMockHttpPipeline(HttpStatusCode.OK, out _);
-            var rehydrationToken = new RehydrationToken(NextLinkOperationImplementation.NotSet, null, "None", "test", "https://test/", RequestMethod.Delete, null, OperationFinalStateVia.AzureAsyncOperation.ToString());
+            var rehydrationToken = new RehydrationToken(NextLinkOperationImplementation.NotSet, null, "None", "test", "https://test/", RequestMethod.Delete, "https://test/", OperationFinalStateVia.AzureAsyncOperation.ToString());
             var operation = await Operation.RehydrateAsync(pipeline, rehydrationToken);
             var token = operation.GetRehydrationToken();
             Assert.AreEqual(ModelReaderWriter.Write(rehydrationToken).ToString(), ModelReaderWriter.Write(token).ToString());

--- a/sdk/eventgrid/Azure.Messaging.EventGrid.Namespaces/src/Azure.Messaging.EventGrid.Namespaces.csproj
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid.Namespaces/src/Azure.Messaging.EventGrid.Namespaces.csproj
@@ -19,6 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Text.Json" />
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 
 </Project>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Memory.Data" />
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/eventgrid/Azure.ResourceManager.EventGrid/src/Azure.ResourceManager.EventGrid.csproj
+++ b/sdk/eventgrid/Azure.ResourceManager.EventGrid/src/Azure.ResourceManager.EventGrid.csproj
@@ -7,4 +7,8 @@
     <Description>Microsoft Azure Resource Manager client SDK for Azure resource provider Microsoft.EventGrid.</Description>
     <PackageTags>azure;management;arm;resource manager;eventgrid</PackageTags>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+  </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -19,9 +19,7 @@
     <PackageReference Include="Azure.Messaging.EventGrid" />
     <PackageReference Include="CloudNative.CloudEvents" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" />
-<!-- This is required to prevent version conflict stemming from The CloudNative.CloudEvents.SystemTestJson depending on -->
-<!-- version 5.0.0.-->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 		<PackageReference Include="Azure.Core"/>
   </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -20,5 +20,7 @@
     <PackageReference Include="CloudNative.CloudEvents" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" />
 		<PackageReference Include="Azure.Core"/>
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>CloudNative CloudEvents support for Azure.Messaging.EventGrid library</AssemblyTitle>
     <Description>This library allows the CloudEvent model from CloudNative.CloudEvents to be published using the Azure Event Grid client library.</Description>
@@ -19,7 +19,6 @@
     <PackageReference Include="Azure.Messaging.EventGrid" />
     <PackageReference Include="CloudNative.CloudEvents" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 		<PackageReference Include="Azure.Core"/>
   </ItemGroup>
 </Project>

--- a/sdk/personalizer/Azure.AI.Personalizer/src/Azure.AI.Personalizer.csproj
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/Azure.AI.Personalizer.csproj
@@ -22,6 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="RL.Net" VersionOverride="0.2.0" />
   </ItemGroup>
 

--- a/sdk/personalizer/Azure.AI.Personalizer/src/Models/RlNetProcessor.cs
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/Models/RlNetProcessor.cs
@@ -95,7 +95,7 @@ namespace Azure.AI.Personalizer
                 {
                      new JsonBinaryDataConverter(),
                 },
-                IgnoreNullValues = true
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
             };
             var contextJson = JsonSerializer.Serialize(decisionContext, jsonSerializerOptions);
             ActionFlags flags = options.DeferActivation == true ? ActionFlags.Deferred : ActionFlags.Default;

--- a/sdk/personalizer/Azure.AI.Personalizer/src/Models/RlObjectConverter.cs
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/Models/RlObjectConverter.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.Personalizer
                 {
                      new JsonBinaryDataConverter(),
                 },
-                IgnoreNullValues = true
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
             };
             return JsonSerializer.Serialize(decisionContext, jsonSerializerOptions);
         }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Azure.Messaging.WebPubSub.Client.csproj
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Azure.Messaging.WebPubSub.Client.csproj
@@ -12,6 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    <!-- TODO: Remove this pacakge reference when new version of Azure.Core is released -->
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/44127

- Change the usage of BinaryData from
https://github.com/dotnet/runtime/blob/3b95ae9494c6d1580b2ccbf06db7b04af1a265b1/src/libraries/System.Memory.Data/src/System/BinaryData.cs#L88-L92
   to 
https://github.com/dotnet/runtime/blob/3b95ae9494c6d1580b2ccbf06db7b04af1a265b1/src/libraries/System.Memory.Data/src/System/BinaryData.cs#L140
- Change from
https://github.com/dotnet/runtime/blob/3b95ae9494c6d1580b2ccbf06db7b04af1a265b1/src/libraries/System.Memory.Data/src/System/BinaryData.cs#L424-L427
   to 
https://github.com/dotnet/runtime/blob/3b95ae9494c6d1580b2ccbf06db7b04af1a265b1/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs#L96-L99
- To be able to use `JsonNode`, upgrade `System.Text.Json` to `6.0.0` and its dependencies to `6.0.0`

The AOT warnings now running from https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp/test-aot-compat.ps1 are
```
ILC : Trim analysis warning IL2026: [Azure.Core]Azure.Core.Serialization.DynamicData: Using member 'Azure.Core.Serialization.DynamicData.DynamicDataJsonConverter.DynamicDataJsonConverter()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Using DynamicData or DynamicDataConverter is not compatible with trimming due to reflection-based serialization. [C:\src\azure-sdk-for-net\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp.csproj::TargetFramework=net7.0]
ILC : Trim analysis warning IL2026: [Azure.Core]Azure.Core.Json.MutableJsonDocument: Using member 'Azure.Core.Json.MutableJsonDocument.MutableJsonDocumentConverter.MutableJsonDocumentConverter()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Using MutableJsonDocument or MutableJsonDocumentConverter is not compatible with trimming due to reflection-based serialization. [C:\src\azure-sdk-for-net\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp.csproj::TargetFramework=net7.0]
ILC : AOT analysis warning IL3050: Microsoft.Extensions.DependencyInjection.ServiceLookup.IEnumerableCallSite.ServiceType.get: Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime. [C:\src\azure-sdk-for-net\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp.csproj::TargetFramework=net7.0]
/_/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs(2239): AOT analysis warning IL3050: System.Linq.Expressions.Expression.GetResultTypeOfShift(Type,Type): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime. [C:\src\azure-sdk-for-net\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp.csproj::TargetFramework=net7.0]
/_/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs(28): AOT analysis warning IL3050: System.Dynamic.Utils.TypeUtils.GetNullableType(Type): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime. [C:\src\azure-sdk-for-net\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp\Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp.csproj::TargetFramework=net7.0]
Actual warning count is: 5
```

Other options are:
- Use `JsonElement`, which we need to traverse it every time we look up a value, not efficient as `JsonObject`.
- Remove `NextLinkOperationImplementation.cs` from shared core, so that we can use internal members of `RehdyrationToken` in it directly
- Make internal members in `RehydrationToken` public as in https://github.com/Azure/azure-sdk-for-net/pull/43549