### PR TITLE
[AzureMonitorDistro] prep distro release 1.2.0-beta4

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -119,8 +119,7 @@
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.3.0" />
     <PackageReference Update="Azure.MixedReality.Authentication" version= "1.2.0" />
-    <PackageReference Update="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0-beta.1" />
-    <PackageReference Update="Azure.Monitor.OpenTelemetry.LiveMetrics" Version="1.0.0-beta.3" />
+    <PackageReference Update="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0-beta.2" />
     <PackageReference Update="Azure.Monitor.Query" Version="1.1.0" />
     <PackageReference Update="Azure.Identity" Version="1.11.1" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -14,16 +14,8 @@
 
 ### Other Changes
 
-* Update OpenTelemetry dependencies.
-  ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
-  - OpenTelemetry 1.8.1
-  - OpenTelemetry.Extensions.Hosting 1.8.1
-  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
-  - OpenTelemetry.Instrumentation.Http 1.8.1
-  - This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028)
-
 * Update Azure.Monitor.OpenTelemetry.Exporter to 1.3.0-beta.2
-  ([TODO]())
+  ([#44159](https://github.com/Azure/azure-sdk-for-net/pull/44159))
 
 ## 1.1.1 (2024-04-26)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -1,14 +1,41 @@
 # Release History
 
-## 1.2.0-beta.4 (Unreleased)
+## 1.2.0-beta.4 (2024-05-20)
 
 ### Features Added
 
-### Breaking Changes
+* Added CustomProperties to LiveMetrics Documents
+  ([#43600](https://github.com/Azure/azure-sdk-for-net/pull/43600))
 
 ### Bugs Fixed
 
+* Fixed a bug in LiveMetrics Document filtering
+  ([#43546](https://github.com/Azure/azure-sdk-for-net/pull/43546))
+
 ### Other Changes
+
+* Update OpenTelemetry dependencies.
+  ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
+  - OpenTelemetry 1.8.1
+  - OpenTelemetry.Extensions.Hosting 1.8.1
+  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
+  - OpenTelemetry.Instrumentation.Http 1.8.1
+  - This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028)
+
+* Update Azure.Monitor.OpenTelemetry.Exporter to 1.3.0-beta.2
+  ([TODO]())
+
+## 1.1.1 (2024-04-26)
+
+### Other Changes
+
+* Update OpenTelemetry dependencies.
+  ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
+  - OpenTelemetry 1.8.1
+  - OpenTelemetry.Extensions.Hosting 1.8.1
+  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
+  - OpenTelemetry.Instrumentation.Http 1.8.1
+  - This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028)
 
 ## 1.2.0-beta.3 (2024-04-19)
 
@@ -100,18 +127,6 @@
 * Updated the vendored code in the `OpenTelemetry.ResourceDetectors.Azure`
   resource detector to include the Azure Container Apps resource detector.
   ([#41803](https://github.com/Azure/azure-sdk-for-net/pull/41803))
-
-## 1.1.1 (2024-04-26)
-
-### Other Changes
-
-* Update OpenTelemetry dependencies.
-  ([#43432](https://github.com/Azure/azure-sdk-for-net/pull/43432))
-  - OpenTelemetry 1.8.1
-  - OpenTelemetry.Extensions.Hosting 1.8.1
-  - OpenTelemetry.Instrumentation.AspNetCore 1.8.1
-  - OpenTelemetry.Instrumentation.Http 1.8.1
-  - This update is a response to [CVE-2024-32028](https://nvd.nist.gov/vuln/detail/CVE-2024-32028)
 
 ## 1.1.0 (2024-01-25)
 


### PR DESCRIPTION
### Changes
- Updated with the latest beta version of Exporter released last week.
- The versioning script complained that we had no Changelog entries for this release. I summarized all the work.
- The versioning script sorted the releases in our Changelog. We did a hotfix (1.1.1) a few weeks ago. When I merged that change into main, I sorted by version. The script sorted by date.
- The deprecated `Azure.Monitor.OpenTelemetry.LiveMetrics` package was still in the Package.Data.props. Removed.