### PR TITLE
Fix EINVAL when running autorest for resourcehealth

### DIFF
--- a/sdk/resourcehealth/Azure.ResourceManager.ResourceHealth/src/autorest.md
+++ b/sdk/resourcehealth/Azure.ResourceManager.ResourceHealth/src/autorest.md
@@ -3,6 +3,7 @@
 Run `dotnet build /t:GenerateCode` to generate code.
 
 ``` yaml
+v3: true
 azure-arm: true
 csharp: true
 library-name: ResourceHealth


### PR DESCRIPTION
Azure.ResourceManager.ResourceHealth's autorest config sets `azure-validator: true`.

Without `v3:true`, this adds extension `classic-openapi-validator` which has an npm script of `"start": "dotnet authrest ...`.  

classic-openapi-validator's `dotnet` dependency is an npm package that defines the bin command `dotnet`.

On windows, this becomes `dotnet.cmd` and causes the `einval` because Autorest isn't spawning the process with `{ shell: true }`

Autorest needs to be updated to use `{shell:true}` on windows or use the `cross-spawn` package instead of `child_process`