### PR TITLE
Added OpenAIClient constructors that accept an end point uri and API Key

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -1393,6 +1393,8 @@ namespace Azure.AI.OpenAI
         public OpenAIClient(System.Uri endpoint, Azure.AzureKeyCredential keyCredential, Azure.AI.OpenAI.OpenAIClientOptions options) { }
         public OpenAIClient(System.Uri endpoint, Azure.Core.TokenCredential tokenCredential) { }
         public OpenAIClient(System.Uri endpoint, Azure.Core.TokenCredential tokenCredential, Azure.AI.OpenAI.OpenAIClientOptions options) { }
+        public OpenAIClient(System.Uri endpoint, string openAIApiKey) { }
+        public OpenAIClient(System.Uri endpoint, string openAIApiKey, Azure.AI.OpenAI.OpenAIClientOptions options) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public virtual Azure.Response<System.BinaryData> GenerateSpeechFromText(Azure.AI.OpenAI.SpeechGenerationOptions speechGenerationOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GenerateSpeechFromTextAsync(Azure.AI.OpenAI.SpeechGenerationOptions speechGenerationOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/OpenAIClient.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/OpenAIClient.cs
@@ -130,6 +130,31 @@ public partial class OpenAIClient
         _isConfiguredForAzureOpenAI = false;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the OpenAIClient class with an end point and API key for used with non-Azure OpenAI-compatible endpoints.
+    /// </summary>
+    /// <param name="endpoint">The URI of the OpenAI endpoint.</param>
+    /// <param name="openAIApiKey">The API key for OpenAI.</param>
+    /// <param name="options">The options for configuring the client.</param>
+    /// <remarks>
+    ///     <see cref="OpenAIClient"/> objects initialized with this constructor can only be used with the
+    ///     non-Azure OpenAI inference endpoint. To use <see cref="OpenAIClient"/> with an Azure OpenAI resource,
+    ///     use a constructor that accepts a resource URI and Azure authentication credential, instead.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"> <paramref name="openAIApiKey"/> is null. </exception>
+    public OpenAIClient(Uri endpoint, string openAIApiKey, OpenAIClientOptions options)
+        : this(endpoint, CreateDelegatedToken(openAIApiKey), options)
+    {
+        _isConfiguredForAzureOpenAI = false;
+    }
+
+    /// <inheritdoc cref="OpenAIClient(Uri, string, OpenAIClientOptions)"/>
+    public OpenAIClient(Uri endpoint, string openAIApiKey)
+        : this(endpoint, CreateDelegatedToken(openAIApiKey), new OpenAIClientOptions())
+    {
+        _isConfiguredForAzureOpenAI = false;
+    }
+
     /// <summary> Return textual completions as configured for a given prompt. </summary>
     /// <param name="completionsOptions">
     ///     The options for this completions request.


### PR DESCRIPTION
This change allows for using a specified non-Azure endpoint when constructing an OpenAIClient.  This was previously not possible.

The use-case is for alternative OpenAI uris, for example test or alternate API end points, and to allow use of other OpenAI-compatible endpoints (for example: Groq).

The existing set of constructors for the OpenAiClient do not contemplate, nor allow, specifying a uri end point while also using a non-Azure service.  And because certain internal states (like _isConfiguredForAzureOpenAI) are managed by the constructors there exists no workaround either.

These changes are minor, merely wrapping other constructors and setting this one internal state appropriately.

No tests were created because none of the OpenAiClient constructors have explicit tests, and the framework developed for testing these services does not contemplate this scenario in a way that could be easily injected. Only the idea of an Azure and a hard-coded (in the SDK) end point for Non-Azure clients is supported.  This presumption runs deep in the base test mechanisms, and I wasn't able to find even a hacky way to get it in there that felt reasonable.

All existing tests pass with this change. and these two new constructors work fine tested externally (for what that is worth).
