### PR TITLE
Remove some redundant list creation

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/Page.cs
+++ b/sdk/core/Azure.Core/src/Shared/Page.cs
@@ -10,6 +10,9 @@ namespace Azure.Core
 {
     internal static class Page
     {
+        public static Page<T> FromValues<T>(IReadOnlyList<T> values, string? continuationToken, Response response) =>
+            Page<T>.FromValues(values, continuationToken, response);
+
         public static Page<T> FromValues<T>(IEnumerable<T> values, string continuationToken, Response response) =>
             Page<T>.FromValues(values.ToList(), continuationToken, response);
     }

--- a/sdk/core/Azure.Core/src/Shared/Page.cs
+++ b/sdk/core/Azure.Core/src/Shared/Page.cs
@@ -10,9 +10,6 @@ namespace Azure.Core
 {
     internal static class Page
     {
-        public static Page<T> FromValues<T>(IReadOnlyList<T> values, string? continuationToken, Response response) =>
-            Page<T>.FromValues(values, continuationToken, response);
-
         public static Page<T> FromValues<T>(IEnumerable<T> values, string continuationToken, Response response) =>
             Page<T>.FromValues(values.ToList(), continuationToken, response);
     }

--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed an issue where custom models decorated with the `DataMemberAttribute` that didn't explicitly set a name caused the query filter to be malformed.
 
 ### Other Changes
+- Reduce List allocations when uploading batches to table storage
 
 ## 12.8.3 (2024-02-06)
 

--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -1150,7 +1150,7 @@ namespace Azure.Data.Tables
                                 cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
 
-                        return Page.FromValues(
+                        return Page<T>.FromValues(
                             response.Value.Value.ToTableEntityList<T>(),
                             CreateContinuationTokenFromHeaders(response.Headers),
                             response.GetRawResponse());
@@ -1177,7 +1177,7 @@ namespace Azure.Data.Tables
                                 cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
 
-                        return Page.FromValues(
+                        return Page<T>.FromValues(
                             response.Value.Value.ToTableEntityList<T>(),
                             CreateContinuationTokenFromHeaders(response.Headers),
                             response.GetRawResponse());
@@ -1232,7 +1232,7 @@ namespace Azure.Data.Tables
                             queryOptions: queryOptions,
                             cancellationToken: cancellationToken);
 
-                        return Page.FromValues(
+                        return Page<T>.FromValues(
                             response.Value.Value.ToTableEntityList<T>(),
                             CreateContinuationTokenFromHeaders(response.Headers),
                             response.GetRawResponse());
@@ -1260,7 +1260,7 @@ namespace Azure.Data.Tables
                             nextRowKey: NextRowKey,
                             cancellationToken: cancellationToken);
 
-                        return Page.FromValues(
+                        return Page<T>.FromValues(
                             response.Value.Value.ToTableEntityList<T>(),
                             CreateContinuationTokenFromHeaders(response.Headers),
                             response.GetRawResponse());

--- a/sdk/tables/Azure.Data.Tables/src/TableRestClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableRestClient.cs
@@ -80,7 +80,7 @@ namespace Azure.Data.Tables
                         var failedSubResponse = responses.FirstOrDefault(r => r.Status >= 400);
                         if (failedSubResponse == null)
                         {
-                            return Response.FromValue(responses.ToList() as IReadOnlyList<Response>, message.Response);
+                            return Response.FromValue((IReadOnlyList<Response>)responses, message.Response);
                         }
 
                         RequestFailedException rfex = new(failedSubResponse);
@@ -116,7 +116,7 @@ namespace Azure.Data.Tables
                         var failedSubResponse = responses.FirstOrDefault(r => r.Status >= 400);
                         if (failedSubResponse == null)
                         {
-                            return Response.FromValue(responses.ToList() as IReadOnlyList<Response>, message.Response);
+                            return Response.FromValue((IReadOnlyList<Response>)responses, message.Response);
                         }
 
                         RequestFailedException rfex = new(failedSubResponse);

--- a/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
@@ -411,7 +411,7 @@ namespace Azure.Data.Tables
                                 new QueryOptions() { Filter = filter, Select = null, Top = pageSizeHint, Format = _format },
                                 cancellationToken)
                             .ConfigureAwait(false);
-                        return Page.FromValues(response.Value.Value, response.Headers.XMsContinuationNextTableName, response.GetRawResponse());
+                        return Page<TableItem>.FromValues(response.Value.Value, response.Headers.XMsContinuationNextTableName, response.GetRawResponse());
                     }
                     catch (Exception ex)
                     {
@@ -431,7 +431,7 @@ namespace Azure.Data.Tables
                                 new QueryOptions() { Filter = filter, Select = null, Top = pageSizeHint, Format = _format },
                                 cancellationToken)
                             .ConfigureAwait(false);
-                        return Page.FromValues(response.Value.Value, response.Headers.XMsContinuationNextTableName, response.GetRawResponse());
+                        return Page<TableItem>.FromValues(response.Value.Value, response.Headers.XMsContinuationNextTableName, response.GetRawResponse());
                     }
                     catch (Exception ex)
                     {
@@ -468,7 +468,7 @@ namespace Azure.Data.Tables
                             null,
                             new QueryOptions() { Filter = filter, Select = null, Top = pageSizeHint, Format = _format },
                             cancellationToken);
-                        return Page.FromValues(response.Value.Value, response.Headers.XMsContinuationNextTableName, response.GetRawResponse());
+                        return Page<TableItem>.FromValues(response.Value.Value, response.Headers.XMsContinuationNextTableName, response.GetRawResponse());
                     }
                     catch (Exception ex)
                     {
@@ -487,7 +487,7 @@ namespace Azure.Data.Tables
                             nextLink,
                             new QueryOptions() { Filter = filter, Select = null, Top = pageSizeHint, Format = _format },
                             cancellationToken);
-                        return Page.FromValues(response.Value.Value, response.Headers.XMsContinuationNextTableName, response.GetRawResponse());
+                        return Page<TableItem>.FromValues(response.Value.Value, response.Headers.XMsContinuationNextTableName, response.GetRawResponse());
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Relatively trivial Pull Request to reduce the number of lists being created where we're already dealing with a list. I have looked at all of the call sites to try and make sure that a new list being passed on was not a necessity (such as changes being made to the list that did not want to be made back on the original).

There are no breaking changes, and no changes to any API surfaces (internal or external).

Apologies if I've missed anything, this is my first PR to this repo. 

As an aside, I have two more similar sized changes to suggest but I'll wait for feedback on this one first so that I'm not wasting anyone's time having to repeat things to me.

# sdk/core/Azure.Core/src/Shared/Page.cs

I believe that this class only exists because the compiler tried to remove the `<T>` argument from the callsites for it which caused a namespace clash at some point. It's possible that this class can be removed entirely.

# sdk/tables/Azure.Data.Tables/src/TableClient.cs

The main reason that a List was being created here was to check to see if there were no items to be processed. This pattern achieves that without having to generate a new List or enumerate the IEnumerable more than once.

# sdk/tables/Azure.Data.Tables/src/TableRestClient.cs

This change returns the original array rather than copying the array to a new List, as [single dimension Arrays already implement](https://learn.microsoft.com/en-us/dotnet/api/system.array?view=net-8.0&redirectedfrom=MSDN#:~:text=Single%2Ddimensional%20arrays%20implement%20the) `IReadOnlyList<T>`
