### PR TITLE
[Smoke Tests] Exclude non-standard WCF package

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
@@ -24,14 +24,14 @@
       The static set is included here to allow for local testing of the smoke tests project
       without the need to run CI scripts to rewrite package references.
     -->
-    <PackageReference Include="Azure.Identity" Version="1.10.3" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.2" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.2" />
-    <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.3.0-beta.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.10" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.36.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.16.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.3" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.11.3" />
+    <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.6.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.7" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.39.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.22.0" />
     <PackageReference Include="Azure.Template" Version="1.0.3-beta.1218030" />
 
     <!-- This is needed to resolve a build conflict and force the correct version -->

--- a/common/SmokeTests/SmokeTest/Update-Dependencies.ps1
+++ b/common/SmokeTests/SmokeTest/Update-Dependencies.ps1
@@ -13,7 +13,8 @@ param(
 # filter upstream to restrict to the appropriate packages for the running target.
 
 $packageExcludeSet = @(
-    "Microsoft.Azure.WebPubSub.AspNetCore"
+    "Microsoft.Azure.WebPubSub.AspNetCore",
+    "Microsoft.WCF.Azure.StorageQueues"
 )
 
 function Log-Warning($message) {


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the WCF extensions package that is not compatible with `netstandard2.0` from the smoke tests, and to bump static testing dependencies to the latest versions.