### PR TITLE
[Service Bus] Batch delete test tweaks

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -1292,10 +1292,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = ServiceBusReceiver.MaxDeleteMessageCount * 3;
                 await SendMessagesAsync(client, scope.QueueName, messageCount);
 
+                // Delay a moment to ensure that the messages are available to
+                // read/delete.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var numMessagesDeleted = await receiver.PurgeMessagesAsync();
 
-                Assert.AreEqual(numMessagesDeleted, messageCount);
+                Assert.AreEqual(messageCount, numMessagesDeleted);
 
                 // All messages should have been deleted.
                 var peekedMessage = receiver.PeekMessageAsync();
@@ -1313,7 +1317,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = ServiceBusReceiver.MaxDeleteMessageCount * 3;
                 await SendMessagesAsync(client, scope.QueueName, messageCount);
 
-                var targetDate = DateTime.UtcNow.AddSeconds(1);
+                // Delay a moment to ensure that the messages are available to
+                // read/delete.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                // Mark the time for deleting.
+                var targetDate = DateTime.UtcNow;
 
                 // Wait a few seconds, then send a new message that should survive the purge.
                 await Task.Delay(TimeSpan.FromSeconds(15));
@@ -1324,7 +1333,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var numMessagesDeleted = await receiver.PurgeMessagesAsync(targetDate);
 
-                Assert.AreEqual(numMessagesDeleted, messageCount);
+                Assert.AreEqual(messageCount, numMessagesDeleted);
 
                 // All messages should have been deleted, except for our designated survivor.
                 var peekedMessage = receiver.PeekMessageAsync();


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the order of "expected" and "actual" for the purge scenarios and to add a short delay between publishing messages and purging to ensure there is adequate time for
the messages to be made available in the queue.