### PR TITLE
[Draft] Testing AOT CI for Exporter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp/Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp/Azure.Monitor.OpenTelemetry.Exporter.AotCompatibilityTestApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsTestSupportProject>true</IsTestSupportProject>
   </PropertyGroup>
 
@@ -13,10 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
     <ProjectReference Include="..\..\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <TrimmerRootAssembly Include="Azure.Monitor.OpenTelemetry.Exporter" />
+      <TrimmerRootAssembly Include="Azure.Monitor.OpenTelemetry.Exporter" />
   </ItemGroup>
 
   <!--Temp fix for "error : No files matching ;NU5105;CA1812;"-->

--- a/sdk/monitor/ci.yml
+++ b/sdk/monitor/ci.yml
@@ -47,3 +47,7 @@ extends:
       safeName: AzureMonitorQuery
     - name: Azure.Monitor.Ingestion
       safeName: AzureMonitorIngestion
+    CheckAOTCompat: true
+    AOTTestInputs:
+    - ArtifactName: Azure.Monitor.OpenTelemetry.Exporter
+      ExpectedWarningsFilepath: None


### PR DESCRIPTION
Onboard Exporter to the AOT CI to prevent future regressions. No AOT warnings should be expected, this won't work until this PR goes in which will remove the warnings currently being reported: https://github.com/Azure/azure-sdk-for-net/pull/44208