### PR TITLE
[Service Bus] Additional batch delete tests

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -753,7 +753,7 @@ namespace Azure.Messaging.ServiceBus
         {
             // Remove after service bug fixed.  Currently, the service responds
             // with a completely indecipherable message when the count is too high.
-            // https://github.com/Azure/azure-sdk-for-net/issues/43801            //
+            // https://github.com/Azure/azure-sdk-for-net/issues/43801
             Argument.AssertInRange(messageCount, 1, MaxDeleteMessageCount, nameof(messageCount));
 
             Argument.AssertAtLeast(messageCount, 1, nameof(messageCount));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -753,8 +753,7 @@ namespace Azure.Messaging.ServiceBus
         {
             // Remove after service bug fixed.  Currently, the service responds
             // with a completely indecipherable message when the count is too high.
-            // https://github.com/Azure/azure-sdk-for-net/issues/43801
-            //
+            // https://github.com/Azure/azure-sdk-for-net/issues/43801            //
             Argument.AssertInRange(messageCount, 1, MaxDeleteMessageCount, nameof(messageCount));
 
             Argument.AssertAtLeast(messageCount, 1, nameof(messageCount));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -1347,8 +1347,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var numMessagesDeleted = await receiver.PurgeMessagesAsync();
 
-                //Assert.AreEqual(messageCount, numMessagesDeleted);
-                Assert.AreEqual(messageCount, numMessagesDeleted, $"Unexpected message count.  Namespace: [{client.FullyQualifiedNamespace}]  Queue: [{scope.QueueName}]  Time: [{ DateTimeOffset.UtcNow}]");
+                Assert.AreEqual(messageCount, numMessagesDeleted);
 
                 // All messages should have been deleted.
                 var peekedMessage = receiver.PeekMessageAsync();
@@ -1382,8 +1381,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var numMessagesDeleted = await receiver.PurgeMessagesAsync(targetDate);
 
-                //Assert.AreEqual(messageCount, numMessagesDeleted);
-                Assert.AreEqual(messageCount, numMessagesDeleted, $"Unexpected message count.  Namespace: [{client.FullyQualifiedNamespace}]  Queue: [{scope.QueueName}]  Time: [{ DateTimeOffset.UtcNow}]");
+                Assert.AreEqual(messageCount, numMessagesDeleted);
 
                 // All messages should have been deleted, except for our designated survivor.
                 var peekedMessage = receiver.PeekMessageAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -1316,8 +1316,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await SendMessagesAsync(client, scope.QueueName, messageCount);
 
                 // Delay a moment to ensure that the messages are available to
-                // read/delete.
-                await Task.Delay(TimeSpan.FromSeconds(2));
+                // read/delete and lower the chance of being throttled.
+                await Task.Delay(TimeSpan.FromSeconds(5));
 
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var numMessagesDeleted = await receiver.PurgeMessagesAsync();
@@ -1341,13 +1341,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await SendMessagesAsync(client, scope.QueueName, messageCount);
 
                 // Delay a moment to ensure that the messages are available to
-                // read/delete.
-                await Task.Delay(TimeSpan.FromSeconds(2));
+                // read/delete and lower the chance of being throttled.
+                await Task.Delay(TimeSpan.FromSeconds(10));
 
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var numMessagesDeleted = await receiver.PurgeMessagesAsync();
 
-                Assert.AreEqual(messageCount, numMessagesDeleted);
+                //Assert.AreEqual(messageCount, numMessagesDeleted);
+                Assert.AreEqual(messageCount, numMessagesDeleted, $"Unexpected message count.  Namespace: [{client.FullyQualifiedNamespace}]  Queue: [{scope.QueueName}]  Time: [{ DateTimeOffset.UtcNow}]");
 
                 // All messages should have been deleted.
                 var peekedMessage = receiver.PeekMessageAsync();
@@ -1366,8 +1367,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await SendMessagesAsync(client, scope.QueueName, messageCount);
 
                 // Delay a moment to ensure that the messages are available to
-                // read/delete.
-                await Task.Delay(TimeSpan.FromSeconds(2));
+                // read/delete and lower the chance of being throttled.
+                await Task.Delay(TimeSpan.FromSeconds(10));
 
                 // Mark the time for deleting.
                 var targetDate = DateTime.UtcNow;
@@ -1381,7 +1382,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var numMessagesDeleted = await receiver.PurgeMessagesAsync(targetDate);
 
-                Assert.AreEqual(messageCount, numMessagesDeleted);
+                //Assert.AreEqual(messageCount, numMessagesDeleted);
+                Assert.AreEqual(messageCount, numMessagesDeleted, $"Unexpected message count.  Namespace: [{client.FullyQualifiedNamespace}]  Queue: [{scope.QueueName}]  Time: [{ DateTimeOffset.UtcNow}]");
 
                 // All messages should have been deleted, except for our designated survivor.
                 var peekedMessage = receiver.PeekMessageAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -5,11 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus.Amqp;
-using Microsoft.Azure.Amqp.Framing;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Receiver
@@ -1283,13 +1281,63 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         }
 
         [Test]
-        public async Task PurgeMessages()
+        public async Task PurgeMessagesWithOneCall()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
 
-                var messageCount = ServiceBusReceiver.MaxDeleteMessageCount * 3;
+                var messageCount = ServiceBusReceiver.MaxDeleteMessageCount;
+                await SendMessagesAsync(client, scope.QueueName, messageCount);
+
+                // Delay a moment to ensure that the messages are available to
+                // read/delete.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+                var numMessagesDeleted = await receiver.PurgeMessagesAsync();
+
+                Assert.AreEqual(messageCount, numMessagesDeleted);
+
+                // All messages should have been deleted.
+                var peekedMessage = receiver.PeekMessageAsync();
+                Assert.IsNull(peekedMessage.Result);
+            }
+        }
+
+        [Test]
+        public async Task PurgeMessagesWithTwoCalls()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                var messageCount = ServiceBusReceiver.MaxDeleteMessageCount + 10;
+                await SendMessagesAsync(client, scope.QueueName, messageCount);
+
+                // Delay a moment to ensure that the messages are available to
+                // read/delete.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+                var numMessagesDeleted = await receiver.PurgeMessagesAsync();
+
+                Assert.AreEqual(messageCount, numMessagesDeleted);
+
+                // All messages should have been deleted.
+                var peekedMessage = receiver.PeekMessageAsync();
+                Assert.IsNull(peekedMessage.Result);
+            }
+        }
+
+        [Test]
+        public async Task PurgeMessagesWithMultipleCalls()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                var messageCount = (ServiceBusReceiver.MaxDeleteMessageCount * 4) + 5;
                 await SendMessagesAsync(client, scope.QueueName, messageCount);
 
                 // Delay a moment to ensure that the messages are available to
@@ -1314,7 +1362,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
 
-                var messageCount = ServiceBusReceiver.MaxDeleteMessageCount * 3;
+                var messageCount = (ServiceBusReceiver.MaxDeleteMessageCount * 3) + 2;
                 await SendMessagesAsync(client, scope.QueueName, messageCount);
 
                 // Delay a moment to ensure that the messages are available to


### PR DESCRIPTION
# Summary

The focus of these changes is to add some additional test scenarios for the batch delete operation, covering scenarios with different numbers of calls needed to complete purging.