### PR TITLE
Support for configuration properties in Postgre provisioning API

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.netstandard2.0.cs
@@ -17,6 +17,10 @@ namespace Azure.Provisioning.PostgreSql
         protected override string GetAzureName(Azure.Provisioning.IConstruct scope, string resourceName) { throw null; }
         public Azure.Provisioning.PostgreSql.PostgreSqlConnectionString GetConnectionString(Azure.Provisioning.Parameter administratorLogin, Azure.Provisioning.Parameter administratorPassword) { throw null; }
     }
+    public partial class PostgreSqlFlexibleServerConfiguration : Azure.Provisioning.Resource<Azure.ResourceManager.PostgreSql.FlexibleServers.PostgreSqlFlexibleServerConfigurationData>
+    {
+        public PostgreSqlFlexibleServerConfiguration(Azure.Provisioning.IConstruct scope, string propertyName, string propertyValue, string propertySource = "user-override", Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer? parent = null, string name = "config", string version = "2023-03-01-preview") : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.PostgreSql.FlexibleServers.PostgreSqlFlexibleServerConfigurationData>), default(bool)) { }
+    }
     public partial class PostgreSqlFlexibleServerDatabase : Azure.Provisioning.Resource<Azure.ResourceManager.PostgreSql.FlexibleServers.PostgreSqlFlexibleServerDatabaseData>
     {
         public PostgreSqlFlexibleServerDatabase(Azure.Provisioning.IConstruct scope, Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer? parent = null, string name = "db", string version = "2023-03-01-preview") : base (default(Azure.Provisioning.IConstruct), default(Azure.Provisioning.Resource), default(string), default(Azure.Core.ResourceType), default(string), default(System.Func<string, Azure.ResourceManager.PostgreSql.FlexibleServers.PostgreSqlFlexibleServerDatabaseData>), default(bool)) { }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/assets.json
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/provisioning/Azure.Provisioning.PostgreSql",
-  "Tag": "net/provisioning/Azure.Provisioning.PostgreSql_1e6911d93b"
+  "Tag": "net/provisioning/Azure.Provisioning.PostgreSql_21a0a604b5"
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/PostgreSqlFlexibleServerConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/PostgreSqlFlexibleServerConfiguration.cs
@@ -21,21 +21,21 @@ namespace Azure.Provisioning.PostgreSql
         /// Creates a new instance of the <see cref="PostgreSqlFlexibleServerConfiguration"/> class.
         /// </summary>
         /// <param name="scope">The scope.</param>
-        /// <param name="value">The value.</param>
-        /// <param name="source">The source.</param>
-        /// <param name="configPropertyName">The config property name.</param>
+        /// <param name="propertyName">The config property name.</param>
+        /// <param name="propertyValue">The value.</param>
+        /// <param name="propertySource">The source.</param>
         /// <param name="parent">The parent.</param>
         /// <param name="name">The name.</param>
         /// <param name="version">The version.</param>
         public PostgreSqlFlexibleServerConfiguration(
             IConstruct scope,
-            string value,
-            string source = "user-override",
-            string configPropertyName = "azure.extensions",
+            string propertyName,
+            string propertyValue,
+            string propertySource = "user-override",
             PostgreSqlFlexibleServer? parent = null,
             string name = "config",
             string version = PostgreSqlFlexibleServer.DefaultVersion)
-            : this(scope, parent, name, ResourceTypeName, version, (_) => ArmPostgreSqlFlexibleServersModelFactory.PostgreSqlFlexibleServerConfigurationData(name: configPropertyName, value: value, source: source))
+            : this(scope, parent, name, ResourceTypeName, version, (_) => ArmPostgreSqlFlexibleServersModelFactory.PostgreSqlFlexibleServerConfigurationData(name: propertyName, value: propertyValue, source: propertySource))
         {
         }
 

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/PostgreSqlFlexibleServerConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/PostgreSqlFlexibleServerConfiguration.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.ResourceManager.PostgreSql.FlexibleServers;
+using Azure.ResourceManager.PostgreSql.FlexibleServers.Models;
+
+namespace Azure.Provisioning.PostgreSql
+{
+    /// <summary>
+    /// Represents a PostgreSql flexible server configuration.
+    /// </summary>
+    public class PostgreSqlFlexibleServerConfiguration : Resource<PostgreSqlFlexibleServerConfigurationData>
+    {
+        private const string ResourceTypeName = "Microsoft.DBforPostgreSQL/flexibleServers/configurations";
+        private static PostgreSqlFlexibleServerConfigurationData Empty(string name)
+            => ArmPostgreSqlFlexibleServersModelFactory.PostgreSqlFlexibleServerConfigurationData();
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="PostgreSqlFlexibleServerConfiguration"/> class.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="source">The source.</param>
+        /// <param name="configPropertyName">The config property name.</param>
+        /// <param name="parent">The parent.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="version">The version.</param>
+        public PostgreSqlFlexibleServerConfiguration(
+            IConstruct scope,
+            string value,
+            string source = "user-override",
+            string configPropertyName = "azure.extensions",
+            PostgreSqlFlexibleServer? parent = null,
+            string name = "config",
+            string version = PostgreSqlFlexibleServer.DefaultVersion)
+            : this(scope, parent, name, ResourceTypeName, version, (_) => ArmPostgreSqlFlexibleServersModelFactory.PostgreSqlFlexibleServerConfigurationData(name: configPropertyName, value: value, source: source))
+        {
+        }
+
+        private PostgreSqlFlexibleServerConfiguration(
+            IConstruct scope,
+            Resource? parent,
+            string resourceName,
+            ResourceType resourceType,
+            string version,
+            Func<string, PostgreSqlFlexibleServerConfigurationData> createProperties,
+            bool isExisting = false)
+            : base(scope, parent, resourceName, resourceType, version, createProperties, isExisting)
+        {
+        }
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/Infrastructure/PostgreSqlResourceWithConfig/main.bicep
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/Infrastructure/PostgreSqlResourceWithConfig/main.bicep
@@ -1,0 +1,35 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+@description('Administrator login')
+param adminLogin string
+
+@secure()
+@description('Administrator password')
+param adminPassword string
+
+
+resource postgreSqlFlexibleServer_StT5lUao4 'Microsoft.DBforPostgreSQL/flexibleServers@2023-03-01-preview' = {
+  name: toLower(take('postgres${uniqueString(resourceGroup().id)}', 24))
+  location: location
+  sku: {
+    name: 'Standard_D4s_v3'
+    tier: 'GeneralPurpose'
+  }
+  properties: {
+    administratorLogin: adminLogin
+    administratorLoginPassword: adminPassword
+    version: ''
+  }
+}
+
+resource postgreSqlFlexibleServerConfiguration_fuQyXsjrO 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2023-03-01-preview' = {
+  parent: postgreSqlFlexibleServer_StT5lUao4
+  name: 'azure.extensions'
+  properties: {
+    value: 'VECTOR'
+    source: 'user-override'
+  }
+}

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/PostgreSqlTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/PostgreSqlTests.cs
@@ -79,5 +79,23 @@ namespace Azure.Provisioning.PostgreSql.Tests
 
             await ValidateBicepAsync();
         }
+
+        [RecordedTest]
+        public async Task PostgreSqlResourceWithConfig()
+        {
+            TestInfrastructure infrastructure = new TestInfrastructure(configuration: new Configuration { UseInteractiveMode = true });
+            var adminLogin = new Parameter("adminLogin", description: "Administrator login");
+            var adminPassword = new Parameter("adminPassword", description: "Administrator password", isSecure: true);
+            var server = new PostgreSqlFlexibleServer(
+                infrastructure,
+                administratorLogin: adminLogin,
+                administratorPassword: adminPassword);
+
+            _ = new PostgreSqlFlexibleServerConfiguration(infrastructure, "VECTOR", parent: server);
+
+            infrastructure.Build(GetOutputPath());
+
+            await ValidateBicepAsync();
+        }
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/PostgreSqlTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/PostgreSqlTests.cs
@@ -91,7 +91,11 @@ namespace Azure.Provisioning.PostgreSql.Tests
                 administratorLogin: adminLogin,
                 administratorPassword: adminPassword);
 
-            _ = new PostgreSqlFlexibleServerConfiguration(infrastructure, "VECTOR", parent: server);
+            _ = new PostgreSqlFlexibleServerConfiguration(
+                infrastructure,
+                "azure.extensions",
+                "VECTOR",
+                parent: server);
 
             infrastructure.Build(GetOutputPath());
 

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/PostgreSqlTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/PostgreSqlTests.cs
@@ -99,7 +99,13 @@ namespace Azure.Provisioning.PostgreSql.Tests
 
             infrastructure.Build(GetOutputPath());
 
-            await ValidateBicepAsync();
+            await ValidateBicepAsync(BinaryData.FromObjectAsJson(
+                    new
+                    {
+                        adminLogin = new { value = "password" },
+                        adminPassword = new { value = "password" },
+                    }),
+                    interactiveMode: true);
         }
     }
 }


### PR DESCRIPTION
Adding the ability to provide configuration to a PostgreSQL Flexible Server in provisioning SDK. This makes it possible to deploy things like the VECTOR extension

Added a test for the new API

Fixing #43175

This would unblock https://github.com/dotnet/aspire/pull/4335