### PR TITLE
[Messaging] Update message size on link creation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- The client will now refresh the maximum message size each time a new AMQP link is opened; this is necessary for large message support, where the maximum message size for entities can be reconfigureed adjusted on the fly.  Because the client had cached the value, it would not be aware of the change and would enforce the wrong size for batch creation. 
+
 ## 5.12.0-beta.1 (2024-05-17)
 
 ### Features Added

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- The client will now refresh the maximum message size each time a new AMQP link is opened; this is necessary for large message support, where the maximum message size for entities can be reconfigureed adjusted on the fly.  Because the client had cached the value, it would not be aware of the change and would enforce the wrong size for batch creation. 
+
 - Updated the `Microsoft.Azure.Amqp` dependency to 2.6.7, which contains a fix for decoding messages with a null format code as the body.
 
 ## 7.18.0-beta.1 (2024-05-08)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -602,19 +602,20 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     timeout: timeout,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                if (!MaxMessageSize.HasValue)
-                {
-                    // This delay is necessary to prevent the link from causing issues for subsequent
-                    // operations after creating a batch.  Without it, operations using the link consistently
-                    // timeout.  The length of the delay does not appear significant, just the act of introducing
-                    // an asynchronous delay.
-                    //
-                    // For consistency the value used by the legacy Service Bus client has been brought forward and
-                    // used here.
+                // Update the known maximum message size each time a link is opened, as the
+                // configuration can be changed on-the-fly and may not match the previously cached value.
+                //
+                // This delay is necessary to prevent the link from causing issues for subsequent
+                // operations after creating a batch.  Without it, operations using the link consistently
+                // timeout.  The length of the delay does not appear significant, just the act of introducing
+                // an asynchronous delay.
+                //
+                // For consistency the value used by the legacy Service Bus client has been brought forward and
+                // used here.
 
-                    await Task.Delay(15, cancellationToken).ConfigureAwait(false);
-                    MaxMessageSize = (long)link.Settings.MaxMessageSize;
-                }
+                await Task.Delay(15, cancellationToken).ConfigureAwait(false);
+                MaxMessageSize = (long)link.Settings.MaxMessageSize;
+
                 ServiceBusEventSource.Log.CreateSendLinkComplete(Identifier);
                 link.Closed += OnSenderLinkClosed;
                 return link;


### PR DESCRIPTION
# Summary

The focus of these changes is to enable the client to refresh the maximum message size each time a new AMQP link is opened; this is necessary for large message support, where the maximum message size for entities can be reconfigred adjusted on the fly.  Because the client had cached the value, it would not be aware of the change and would enforce the wrong size for batch creation. 

## References and related

- [[Feature Req] ServiceBusMessageSender should refresh maximum message size when service settings change (#43983)](https://github.com/Azure/azure-sdk-for-net/issues/43983)
