### PR TITLE
[Azure Functions] [Queue extension] Fix queue length

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
         {
             try
             {
-                QueueProperties queueProperties = await _queue.GetPropertiesAsync().ConfigureAwait(false);
-                return queueProperties.ApproximateMessagesCount;
+                QueueTriggerMetrics queueProperties = await GetMetricsAsync().ConfigureAwait(false);
+                return queueProperties.QueueLength;
             }
             catch (RequestFailedException ex)
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
         {
             try
             {
-                QueueTriggerMetrics queueProperties = await GetMetricsAsync().ConfigureAwait(false);
-                return queueProperties.QueueLength;
+                QueueTriggerMetrics queueMetrics = await GetMetricsAsync().ConfigureAwait(false);
+                return queueMetrics.QueueLength;
             }
             catch (RequestFailedException ex)
             {


### PR DESCRIPTION
we need to rely on `PeekMessagesAsync` when calculating message queue length as ApproximateMessageCount often returns a stale value, especially when the queue is empty.