### PR TITLE
build(regen): exclude all track1 SDKs

### DIFF
--- a/eng/service.proj
+++ b/eng/service.proj
@@ -32,6 +32,12 @@
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
   <Import Project="$(RepoRoot)$(ProjectListOverrideFile)" Condition="'$(ProjectListOverrideFile)' != '' " />
 
+  <!-- Remove all track1 SDKs from Regen -->
+  <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' ">
+    <Track1ProjectsToRemove Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" />
+    <ProjectReference Remove="@(Track1ProjectsToRemove)" />
+  </ItemGroup>
+
   <!-- Remove all projects except the ones included by the SDKType filter -->
   <ItemGroup Condition="'$(SDKType)' != 'all'">
     <ProjectsToRemove Include="@(ProjectReference)" Exclude="@(ProjectsToIncludeBySDKType)" />


### PR DESCRIPTION
Some track1 SDKs have depending libraries with vulnerabilities, which will break our regen pipeline. Since they are deprecated, exlude them from regen pipeline.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
