### PR TITLE
[Misc] Fix outdated package errors

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
@@ -13,8 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--using the preview version of Azure.Identity to have access to KnownAuthorityHosts static class.-->
-    <PackageReference Include="Azure.Identity" Version="1.10.3" />
+    <PackageReference Include="Azure.Identity" Version="1.11.13" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.13" />
+    <PackageReference Include="Azure.Identity" Version="1.11.3" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
 

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/Directory.Build.props
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/Directory.Build.props
@@ -6,6 +6,11 @@
     <ImportRepoCommonSettings>true</ImportRepoCommonSettings>
     <SupportsNetStandard20>true</SupportsNetStandard20>
     <IsShippingLibrary>false</IsShippingLibrary>
+    <ImportDefaultReferences>false</ImportDefaultReferences>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
+
+  <ItemGroup>
+    <PackageReference Remove="*" />
+  </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/Directory.Build.props
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/Directory.Build.props
@@ -9,5 +9,4 @@
     <ImportDefaultReferences>false</ImportDefaultReferences>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-
 </Project>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/Directory.Build.props
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/Directory.Build.props
@@ -10,7 +10,4 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
-  <ItemGroup>
-    <PackageReference Remove="*" />
-  </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/src/EventGridSourceGenerator.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/src/EventGridSourceGenerator.cs
@@ -68,13 +68,13 @@ namespace Azure.Messaging.EventGrid
                     sourceBuilder.AppendLine();
                 }
                 SystemEventNode sysEvent = _visitor.SystemEvents[i];
-                
+
                 // Add the ref docs for each constant
                 sourceBuilder.AppendLine($"{Indent}{Indent}/// <summary>");
                 sourceBuilder.AppendLine($"{Indent}{Indent}/// The value of the Event Type stored in <see cref=\"EventGridEvent.EventType\"/> and <see cref=\"CloudEvent.Type\"/> ");
                 sourceBuilder.AppendLine($"{Indent}{Indent}/// for the <see cref=\"{sysEvent.EventName}\"/> system event.");
                 sourceBuilder.AppendLine($"{Indent}{Indent}/// </summary>");
-                
+
                 // Add the constant
                 sourceBuilder.AppendLine($"{Indent}{Indent}public const string {sysEvent.EventConstantName} = {sysEvent.EventType};");
             }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix outdated package errors that began after the upgrade to the .NET 8 SDK.

## References and resources

- [Vulnerable libraries in some track2 data plane SDKs (#44343)](https://github.com/Azure/azure-sdk-for-net/issues/44343)

