### PR TITLE
[AzureMonitorDistro] implement extra headers for LiveMetrics

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorAspNetCoreEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorAspNetCoreEventSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.Tracing;
+using System.Net;
 using System.Runtime.CompilerServices;
 using Azure.Monitor.OpenTelemetry.AspNetCore.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
@@ -157,20 +158,20 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         public void SetAADCredentialsToPipeline(string credentialTypeName, string scope) => WriteEvent(14, credentialTypeName, scope);
 
         [NonEvent]
-        public void PingFailed(Response response)
+        public void PingFailed(Response response, string configuredEndpoint, string actualEndpoint)
         {
             if (IsEnabled(EventLevel.Error))
             {
-                ServiceCallFailed(name: "Ping", response.Status, response.ReasonPhrase);
+                ServiceCallFailed(name: "Ping", response.Status, response.ReasonPhrase, configuredEndpoint, actualEndpoint);
             }
         }
 
         [NonEvent]
-        public void PostFailed(Response response)
+        public void PostFailed(Response response, string configuredEndpoint, string actualEndpoint)
         {
             if (IsEnabled(EventLevel.Error))
             {
-                ServiceCallFailed(name: "Post", response.Status, response.ReasonPhrase);
+                ServiceCallFailed(name: "Post", response.Status, response.ReasonPhrase, configuredEndpoint, actualEndpoint);
             }
         }
 
@@ -210,8 +211,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             }
         }
 
-        [Event(15, Message = "Service call failed. Name: {0}. Status Code: {1} Reason: {2}.", Level = EventLevel.Error)]
-        public void ServiceCallFailed(string name, int statusCode, string reasonPhrase) => WriteEvent(15, name, statusCode, reasonPhrase);
+        [Event(15, Message = "Service call failed. Name: {0}. Status Code: {1} Reason: {2} Configured Endpoint: {3} Actual Endpoint: {4}", Level = EventLevel.Error)]
+        public void ServiceCallFailed(string name, int statusCode, string reasonPhrase, string configuredEndpoint, string actualEndpoint) => WriteEvent(15, name, statusCode, reasonPhrase, configuredEndpoint, actualEndpoint);
 
         [Event(16, Message = "Service call failed with exception. Name: {0}. Exception: {1}", Level = EventLevel.Error)]
         public void ServiceCallFailedWithUnknownException(string name, string exceptionMessage) => WriteEvent(16, name, exceptionMessage);
@@ -263,5 +264,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
 
         [Event(23, Message = "Failed to create telemetry document due to an exception. DocumentType: {0}. Exception: {1}", Level = EventLevel.Error)]
         public void FailedToCreateTelemetryDocument(string documentTypeName, string exceptionMessage) => WriteEvent(23, documentTypeName, exceptionMessage);
+
+        [Event(24, Message = "Redirect received from LiveMetrics service: {0}", Level = EventLevel.Informational)]
+        public void LiveMetricsRedirectReceived(string redirectUri) => WriteEvent(24, redirectUri);
+
+        [Event(25, Message = "Polling Interval received from LiveMetrics service: {0}", Level = EventLevel.Informational)]
+        public void LiveMetricsPolingIntervalReceived(int pollingInterval) => WriteEvent(25, pollingInterval);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorAspNetCoreEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorAspNetCoreEventSource.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.Tracing;
-using System.Net;
 using System.Runtime.CompilerServices;
 using Azure.Monitor.OpenTelemetry.AspNetCore.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Customizations/LiveMetricsRestAPIsForClientSDKsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Customizations/LiveMetricsRestAPIsForClientSDKsRestClient.cs
@@ -59,7 +59,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                 case 200:
                     {
                         CollectionConfigurationInfo value = default;
-                        if (message.Response.Headers.ContentLength != 0)
+                        if (message.Response.Headers.ContentLength is not null && message.Response.Headers.ContentLength != 0)
                         {
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
                             value = CollectionConfigurationInfo.DeserializeCollectionConfigurationInfo(document.RootElement);
@@ -74,7 +74,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                 case 503:
                     {
                         ServiceError value = default;
-                        if (message.Response.Headers.ContentLength != 0)
+                        if (message.Response.Headers.ContentLength is not null && message.Response.Headers.ContentLength != 0)
                         {
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
                             value = ServiceError.DeserializeServiceError(document.RootElement);
@@ -118,7 +118,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                 case 200:
                     {
                         CollectionConfigurationInfo value = default;
-                        if (message.Response.Headers.ContentLength != 0)
+                        if (message.Response.Headers.ContentLength is not null && message.Response.Headers.ContentLength != 0)
                         {
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
                             value = CollectionConfigurationInfo.DeserializeCollectionConfigurationInfo(document.RootElement);
@@ -133,7 +133,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                 case 503:
                     {
                         ServiceError value = default;
-                        if (message.Response.Headers.ContentLength != 0)
+                        if (message.Response.Headers.ContentLength is not null && message.Response.Headers.ContentLength != 0)
                         {
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
                             value = ServiceError.DeserializeServiceError(document.RootElement);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Customizations/LiveMetricsRestAPIsForClientSDKsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Customizations/LiveMetricsRestAPIsForClientSDKsRestClient.cs
@@ -82,7 +82,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                         }
 
                         Debug.WriteLine($"{DateTime.Now}: Ping FAILED: {message.Response.Status} {message.Response.ReasonPhrase}.");
-                        AzureMonitorAspNetCoreEventSource.Log.PingFailed(message.Response);
+                        AzureMonitorAspNetCoreEventSource.Log.PingFailed(message.Response, _host, message.Request.Uri.Host);
                         return new QuickPulseResponse(success: false);
                     }
                 default:
@@ -141,7 +141,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                         }
 
                         Debug.WriteLine($"{DateTime.Now}: Post FAILED: {message.Response.Status} {message.Response.ReasonPhrase}.");
-                        AzureMonitorAspNetCoreEventSource.Log.PostFailed(message.Response);
+                        AzureMonitorAspNetCoreEventSource.Log.PostFailed(message.Response, _host, message.Request.Uri.Host);
                         return new QuickPulseResponse(success: false);
                     }
                 default:

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsRedirectPolicy.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsRedirectPolicy.cs
@@ -27,7 +27,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
         {
             // Check if we've already processed the redirection
             if (message.TryGetProperty("redirectionComplete", out object? objValue)
-                && objValue != null
                 && objValue is bool isComplete
                 && isComplete)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsRedirectPolicy.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsRedirectPolicy.cs
@@ -59,7 +59,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
             while (redirectCount <= MaxRedirect && IsRedirection(response, out string? redirectionValue))
             {
                 Debug.WriteLine($"OnPing: Received Redirection: {redirectionValue}");
-                AzureMonitorAspNetCoreEventSource.Log.ReceivedRedirection(redirectionValue);
+                AzureMonitorAspNetCoreEventSource.Log.LiveMetricsRedirectReceived(redirectionValue);
 
                 response.Dispose();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsRedirectPolicy.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsRedirectPolicy.cs
@@ -59,6 +59,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
             while (redirectCount <= MaxRedirect && IsRedirection(response, out string? redirectionValue))
             {
                 Debug.WriteLine($"OnPing: Received Redirection: {redirectionValue}");
+                AzureMonitorAspNetCoreEventSource.Log.ReceivedRedirection(redirectionValue);
 
                 response.Dispose();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsRedirectPolicy.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsRedirectPolicy.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
+{
+    internal sealed class LiveMetricsRedirectPolicy : HttpPipelinePolicy
+    {
+        // To prevent circular redirects, max redirect is set to 1.
+        internal const int MaxRedirect = 1;
+        private string? _redirectHostValue;
+
+        public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            ProcessAsync(message, pipeline, false).EnsureCompleted();
+        }
+
+        public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            return ProcessAsync(message, pipeline, true);
+        }
+
+        private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
+        {
+            // Check if we've already processed the redirection
+            if (message.TryGetProperty("redirectionComplete", out object? objValue)
+                && objValue != null
+                && objValue is bool isComplete
+                && isComplete)
+            {
+                return;
+            }
+
+            Request request = message.Request;
+
+            // If we have a cached redirect, apply it
+            if (_redirectHostValue is not null)
+            {
+                request.Uri.Host = _redirectHostValue;
+            }
+
+            // Process the request
+            if (async)
+            {
+                await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+            }
+            else
+            {
+                ProcessNext(message, pipeline);
+            }
+
+            // Check for redirection
+            uint redirectCount = 1;
+            Response response = message.Response;
+
+            while (redirectCount <= MaxRedirect && IsRedirection(response, out string? redirectionValue))
+            {
+                Debug.WriteLine($"OnPing: Received Redirection: {redirectionValue}");
+
+                response.Dispose();
+
+                // ORIGINAL VALUE (default endpoint):
+                // https://rt.services.visualstudio.com/QuickPulseService.svc/ping?api-version=2024-04-01-preview&ikey=00000000-0000-0000-0000-000000000000
+
+                // REDIRECT VALUE (regional endpoint):
+                // https://westus.livediagnostics.monitor.azure.com/QuickPulseService.svc
+
+                // FINAL VALUE:
+                // https://westus.livediagnostics.monitor.azure.com/QuickPulseService.svc/ping?api-version=2024-04-01-preview&ikey=00000000-0000-0000-0000-000000000000
+
+                // Extract the host value from the redirection URI
+                _redirectHostValue = new Uri(redirectionValue).Host;
+
+                // Apply redirect
+                request.Uri.Host = _redirectHostValue;
+
+                // Issue the redirected request.
+                if (async)
+                {
+                    await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+                }
+                else
+                {
+                    ProcessNext(message, pipeline);
+                }
+
+                response = message.Response;
+
+                redirectCount++;
+            }
+
+            message.SetProperty("redirectionComplete", true);
+            return;
+        }
+
+        private static bool IsRedirection(Response response, [NotNullWhen(true)] out string? redirectValue)
+        {
+            // example: https://westus.livediagnostics.monitor.azure.com/QuickPulseService.svc
+            return response.Headers.TryGetValue("x-ms-qps-service-endpoint-redirect-v2", out redirectValue);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.RestClient.cs
@@ -52,6 +52,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
                         RefreshConfigurationOnEtagChange(response);
                         SetPostState();
                     }
+
+                    SetPingIntervalFromService(response.PollingIntervalMilliseconds);
                 }
             }
             catch (System.Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.RestClient.cs
@@ -23,7 +23,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
         private DateTimeOffset _lastSuccessfulPing = DateTimeOffset.UtcNow;
         private DateTimeOffset _lastSuccessfulPost = DateTimeOffset.UtcNow;
 
-        private void OnPing()
+        internal void OnPing()
         {
             try
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.State.cs
@@ -65,6 +65,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
                     || _pingPeriodFromService.Value.TotalMilliseconds != milliseconds)
                 {
                     _pingPeriodFromService = TimeSpan.FromMilliseconds(Convert.ToDouble(milliseconds));
+                    AzureMonitorAspNetCoreEventSource.Log.LiveMetricsPolingIntervalReceived(milliseconds.Value);
                 }
             }
             else

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.State.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Runtime.CompilerServices;
 using Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics;
 using OpenTelemetry;
 
@@ -57,6 +58,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
             _shutdownEvent.Dispose();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetPingIntervalFromService(int? milliseconds)
         {
             if (milliseconds.HasValue)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.State.cs
@@ -28,6 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
         private bool _shouldCollect = false;
         private Action _callbackAction = () => { };
         private Func<bool> _evaluateBackoff = () => false;
+        private TimeSpan? _pingPeriodFromService;
 
         private readonly TimeSpan _pingPeriod = TimeSpan.FromSeconds(5);
         private readonly TimeSpan _postPeriod = TimeSpan.FromSeconds(1);
@@ -56,12 +57,28 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
             _shutdownEvent.Dispose();
         }
 
+        private void SetPingIntervalFromService(int? milliseconds)
+        {
+            if (milliseconds.HasValue)
+            {
+                if (!_pingPeriodFromService.HasValue
+                    || _pingPeriodFromService.Value.TotalMilliseconds != milliseconds)
+                {
+                    _pingPeriodFromService = TimeSpan.FromMilliseconds(Convert.ToDouble(milliseconds));
+                }
+            }
+            else
+            {
+                _pingPeriodFromService = null;
+            }
+        }
+
         private void SetPingState()
         {
             _state.Update(LiveMetricsState.Ping);
             _shouldCollect = false;
             _callbackAction = OnPing;
-            _period = _pingPeriod;
+            _period = _pingPeriodFromService ?? _pingPeriod;
             _evaluateBackoff = () => DateTimeOffset.UtcNow - _lastSuccessfulPing > _maximumPingInterval;
 
             // Must reset the timestamp here.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.State.cs
@@ -29,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
         private bool _shouldCollect = false;
         private Action _callbackAction = () => { };
         private Func<bool> _evaluateBackoff = () => false;
-        private TimeSpan? _pingPeriodFromService;
+        internal TimeSpan? _pingPeriodFromService;
 
         private readonly TimeSpan _pingPeriod = TimeSpan.FromSeconds(5);
         private readonly TimeSpan _postPeriod = TimeSpan.FromSeconds(1);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.cs
@@ -5,6 +5,7 @@ using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics;
 using Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering;
 using Azure.Monitor.OpenTelemetry.AspNetCore.Models;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 
@@ -65,6 +66,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
                 var httpPipelinePolicy = new HttpPipelinePolicy[]
                 {
                     new BearerTokenAuthenticationPolicy(options.Credential, scope),
+                    new LiveMetricsRedirectPolicy(),
                 };
 
                 isAadEnabled = true;
@@ -74,7 +76,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
             else
             {
                 isAadEnabled = false;
-                pipeline = HttpPipelineBuilder.Build(options);
+                var httpPipelinePolicy = new HttpPipelinePolicy[] { new LiveMetricsRedirectPolicy() };
+                pipeline = HttpPipelineBuilder.Build(options, httpPipelinePolicy);
             }
 
             return new LiveMetricsRestAPIsForClientSDKsRestClient(new ClientDiagnostics(options), pipeline, connectionVars: connectionVars);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/QuickPulseResponse.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/QuickPulseResponse.cs
@@ -24,6 +24,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics
                     Subscribed = Convert.ToBoolean(subscribedValue);
                 }
 
+                if (responseHeaders?.TryGetValue("x-ms-qps-service-polling-interval-hint", out string? pollingInterval) ?? false)
+                {
+                    PollingIntervalMilliseconds = Convert.ToInt32(pollingInterval);
+                }
+
                 CollectionConfigurationInfo = info;
             }
         }
@@ -31,6 +36,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics
         public bool Success { get; }
         public string? ConfigurationEtag { get; }
         public bool Subscribed { get; }
+        public int? PollingIntervalMilliseconds { get; }
         public CollectionConfigurationInfo? CollectionConfigurationInfo { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/LiveMetricsPolingIntervalTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/LiveMetricsPolingIntervalTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.TestFramework;
+using Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics
+{
+    public class LiveMetricsPolingIntervalTests
+    {
+        [Fact]
+        public void VerifyLiveMetricsReadsPolingIntervalHeader()
+        {
+            var mockTransport = new MockTransport(_ => new MockResponse(200).AddHeader("x-ms-qps-service-polling-interval-hint", "123"));
+
+            AzureMonitorOptions options = new AzureMonitorOptions
+            {
+                ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+                EnableLiveMetrics = false, // set to false to prevent the manager from starting.
+                Transport = mockTransport
+            };
+
+            var manager = new Manager(options, new DefaultPlatform());
+
+            Assert.Empty(mockTransport.Requests);
+            Assert.Null(manager._pingPeriodFromService);
+
+            manager.OnPing();
+
+            Assert.Single(mockTransport.Requests);
+            Assert.Equal(123, manager._pingPeriodFromService!.Value.TotalMilliseconds);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/LiveMetricsRedirectPolicyTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/LiveMetricsRedirectPolicyTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics
+{
+    public class LiveMetricsRedirectPolicyTests
+    {
+        [Fact]
+        public void VerifyLiveMetricsRedirectPolicyReadsHeader()
+        {
+            var mockTransport = new MockTransport(new MockResponse(200).AddHeader("x-ms-qps-service-endpoint-redirect-v2", "http://new.host/Service.svc"));
+
+            AzureMonitorOptions options = new AzureMonitorOptions
+            {
+                Transport = mockTransport
+            };
+
+            var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new LiveMetricsRedirectPolicy() });
+            var message = new HttpMessage(CreateMockRequest(new Uri("http://host1/Service.svc?key=value")), new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            Assert.Equal("http://new.host/Service.svc?key=value", mockTransport.Requests[1].Uri.ToString());
+            Assert.Equal(2, mockTransport.Requests.Count);
+
+            // Verify Redirect is cached.
+            message = new HttpMessage(CreateMockRequest(new Uri("http://host2/Service.svc?key=value")), new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            Assert.Equal(3, mockTransport.Requests.Count);
+            Assert.Equal("http://new.host/Service.svc?key=value", mockTransport.Requests[2].Uri.ToString());
+        }
+
+        private static MockRequest CreateMockRequest(Uri uri)
+        {
+            MockRequest mockRequest = new();
+            mockRequest.Uri.Reset(uri);
+            mockRequest.Method = RequestMethod.Get;
+            return mockRequest;
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- implement Redirection. 
  This will happen if Pings are sent to the global endpoint
- implement PollingInterval
  This will happen if service needs to throttle client
- extra logging. 