### PR TITLE
[AppConfiguration] add support for filtering by tags

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -109,7 +109,7 @@ namespace Azure.Data.AppConfiguration
         public ConfigurationSettingsFilter(string key) { }
         public string Key { get { throw null; } set { } }
         public string Label { get { throw null; } set { } }
-        public System.Collections.Generic.IList<string> Tags { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> Tags { get { throw null; } }
     }
     public partial class ConfigurationSnapshot
     {
@@ -204,7 +204,7 @@ namespace Azure.Data.AppConfiguration
         public Azure.Data.AppConfiguration.SettingFields Fields { get { throw null; } set { } }
         public string KeyFilter { get { throw null; } set { } }
         public string LabelFilter { get { throw null; } set { } }
-        public System.Collections.Generic.IList<string> Tags { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> TagsFilter { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -71,11 +71,12 @@ namespace Azure.Data.AppConfiguration
     }
     public partial class ConfigurationClientOptions : Azure.Core.ClientOptions
     {
-        public ConfigurationClientOptions(Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion version = Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion.V2023_10_01) { }
+        public ConfigurationClientOptions(Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion version = Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion.V2023_11_01) { }
         public enum ServiceVersion
         {
             V1_0 = 0,
             V2023_10_01 = 1,
+            V2023_11_01 = 2,
         }
     }
     public static partial class ConfigurationModelFactory
@@ -108,6 +109,7 @@ namespace Azure.Data.AppConfiguration
         public ConfigurationSettingsFilter(string key) { }
         public string Key { get { throw null; } set { } }
         public string Label { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> Tags { get { throw null; } set { } }
     }
     public partial class ConfigurationSnapshot
     {
@@ -202,6 +204,7 @@ namespace Azure.Data.AppConfiguration
         public Azure.Data.AppConfiguration.SettingFields Fields { get { throw null; } set { } }
         public string KeyFilter { get { throw null; } set { } }
         public string LabelFilter { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> Tags { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/appconfiguration/Azure.Data.AppConfiguration",
-  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_cd95303075"
+  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_d2bf969163"
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/README.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/README.md
@@ -22,3 +22,4 @@ description: Samples for the Azure.Data.AppConfiguration client library
  - [Create, Retrieve and Delete a Feature Flag](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample9_FeatureFlags.md)
  - [Create, Retrieve and Delete a Secret Reference](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample10_SecretReference.md)
   - [Create, Retrieve and Update status of a Configuration Settings Snapshot](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample11_SettingsSnapshot.md)
+ - [Get Configuration Settings By Tags](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
@@ -12,7 +12,7 @@ For the sample below, you can set `connectionString` in an environment variable,
 var client = new ConfigurationClient(connectionString);
 ```
 
-## Create configuration setting
+## Create configuration setting with tags
 
 First, create an instance of `ConfigurationSetting` with a key, value, label, and tags.
 
@@ -23,9 +23,7 @@ First, create an instance of `ConfigurationSetting` with a key, value, label, an
  };
 ```
 
-There are two ways to create a Configuration Setting
-- `AddConfigurationSettingAsync` creates a setting only if the setting does not already exist in the store.
-- `SetConfigurationSettingAsync` creates a setting if it doesn't exist or overrides an existing setting with the same key and label.
+Then add the Configuration Setting.
 
 ```C# Snippet:AzConfigSample12_AddConfigurationSettingAsync
 await client.AddConfigurationSettingAsync(betaEndpoint);
@@ -36,19 +34,12 @@ await client.AddConfigurationSettingAsync(betaEndpoint);
 To gather all the information available for settings grouped by a specific tag, call `GetConfigurationSettingsAsync` with a setting selector that filters for settings with the "someKey=someValue" tag.  This will retrieve all the Configuration Settings in the store that satisfy that condition. See App Configuration [REST API](https://docs.microsoft.com/azure/azure-app-configuration/rest-api-key-value#filtering) for more information about filtering.
 
 ```C# Snippet:AzConfigSample12_GetConfigurationSettingsAsync
-var selector = new SettingSelector { TagsFilter = new string[] { "someKey=someValue" } };
+var selector = new SettingSelector();
+selector.TagsFilter.Add("someKey=someValue");
 
-Console.WriteLine("Settings for beta filtered by tag:");
+Debug.WriteLine("Settings for beta filtered by tag:");
 await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
 {
     Console.WriteLine(setting);
 }
-```
-
-## Delete configuration setting
-
-To delete a configuration setting that is no longer needed you can call `DeleteConfigurationSettingAsync`.
-
-```C# Snippet:AzConfigSample12_DeleteConfigurationSettingAsync
-await client.DeleteConfigurationSettingAsync(betaEndpoint.Key, betaEndpoint.Label);
 ```

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
@@ -37,7 +37,7 @@ To gather all the information available for settings grouped by a specific tag, 
 var selector = new SettingSelector();
 selector.TagsFilter.Add("someKey=someValue");
 
-Debug.WriteLine("Settings for beta filtered by tag:");
+Console.WriteLine("Settings for beta filtered by tag:");
 await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
 {
     Console.WriteLine(setting);

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
@@ -38,7 +38,7 @@ To gather all the information available for settings grouped by a specific tag, 
 ```C# Snippet:AzConfigSample12_GetConfigurationSettingsAsync
 var selector = new SettingSelector { TagsFilter = new string[] { "someKey=someValue" } };
 
-Debug.WriteLine("Settings for beta filtered by tag:");
+Console.WriteLine("Settings for beta filtered by tag:");
 await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
 {
     Console.WriteLine(setting);

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
@@ -17,10 +17,10 @@ var client = new ConfigurationClient(connectionString);
 First, create an instance of `ConfigurationSetting` with a key, value, label, and tags.
 
 ```C# Snippet:AzConfigSample12_CreateConfigurationSettingAsync
- var betaEndpoint = new ConfigurationSetting("endpoint", "https://beta.endpoint.com", "beta")
- {
-     Tags = { { "someKey", "someValue" } }
- };
+var betaEndpoint = new ConfigurationSetting("endpoint", "https://beta.endpoint.com", "beta")
+{
+    Tags = { { "someKey", "someValue" } }
+};
 ```
 
 Then add the Configuration Setting.

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
@@ -1,10 +1,10 @@
-# Asynchronously List Settings With Tags
+# Get Settings With Tags
 
-This sample demonstrates how to send requests to the Azure App Configuration service asynchronously. It also shows how to create configuration settings with tags, and provides an example scenario where tags are used to retrieve the settings.  To get started, you'll need a connection string to Azure App Configuration. See the [README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/README.md) for links and instructions.
+This sample demonstrates how to fetch configuration settings from the Azure App Configuration service using tags. To get started, you'll need a connection string to Azure App Configuration. See the [README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/README.md) for links and instructions.
 
  ## Create a ConfigurationClient
 
-To interact with Azure App Configuration, you need to instantiate a `ConfigurationClient`. You can use either an endpoint URL and a [`TokenCredential`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#credentials) or a connection string.
+To interact with Azure App Configuration, you need to instantiate a `ConfigurationClient`. You can use either an endpoint URL and a [`TokenCredential`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#credentials), or a connection string.
 
 For the sample below, you can set `connectionString` in an environment variable, a configuration setting, or any way that works for your application. The connection string is available from the App Configuration Access Keys view in the Azure Portal.
 
@@ -12,61 +12,43 @@ For the sample below, you can set `connectionString` in an environment variable,
 var client = new ConfigurationClient(connectionString);
 ```
 
-## Asynchronously create configuration settings
+## Create configuration setting
 
-First, you need to create several instances of `ConfigurationSetting` with different keys, values, labels, and tags.
+First, create an instance of `ConfigurationSetting` with a key, value, label, and tags.
 
 ```C# Snippet:AzConfigSample12_CreateConfigurationSettingAsync
-var betaEndpoint = new ConfigurationSetting("endpoint", "https://beta.endpoint.com", "beta")
-{
-    Tags = { { "someKey", "someValue" } }
-};
-var betaInstances = new ConfigurationSetting("instances", "1", "beta")
-{
-    Tags = { { "someKey", "someValue" } }
-};
-var productionEndpoint = new ConfigurationSetting("endpoint", "https://production.endpoint.com", "production")
-{
-    Tags = { { "someKey", "otherValue" } }
-};
-var productionInstances = new ConfigurationSetting("instances", "1", "production")
-{
-    Tags = { { "someKey", "otherValue" } }
-};
+ var betaEndpoint = new ConfigurationSetting("endpoint", "https://beta.endpoint.com", "beta")
+ {
+     Tags = { { "someKey", "someValue" } }
+ };
 ```
 
-There are two ways to create a Configuration Setting asynchronously:
+There are two ways to create a Configuration Setting
 - `AddConfigurationSettingAsync` creates a setting only if the setting does not already exist in the store.
 - `SetConfigurationSettingAsync` creates a setting if it doesn't exist or overrides an existing setting with the same key and label.
 
 ```C# Snippet:AzConfigSample12_AddConfigurationSettingAsync
 await client.AddConfigurationSettingAsync(betaEndpoint);
-await client.AddConfigurationSettingAsync(betaInstances);
-await client.AddConfigurationSettingAsync(productionEndpoint);
-await client.AddConfigurationSettingAsync(productionInstances);
 ```
 
 ## Search by tags filter
 
-To gather all the information available for settings grouped by a specific tag, call `GetConfigurationSettingsAsync` with a setting selector that filters for settings with the "someKey=otherValue" tag.  This will retrieve all the Configuration Settings in the store that satisfy that condition. See App Configuration [REST API](https://docs.microsoft.com/azure/azure-app-configuration/rest-api-key-value#filtering) for more information about filtering.
+To gather all the information available for settings grouped by a specific tag, call `GetConfigurationSettingsAsync` with a setting selector that filters for settings with the "someKey=someValue" tag.  This will retrieve all the Configuration Settings in the store that satisfy that condition. See App Configuration [REST API](https://docs.microsoft.com/azure/azure-app-configuration/rest-api-key-value#filtering) for more information about filtering.
 
 ```C# Snippet:AzConfigSample12_GetConfigurationSettingsAsync
-var selector = new SettingSelector { TagsFilter = new string[] { "someKey=otherValue" } };
+var selector = new SettingSelector { TagsFilter = new string[] { "someKey=someValue" } };
 
-Debug.WriteLine("Settings for production filtered by tag:");
+Debug.WriteLine("Settings for beta filtered by tag:");
 await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
 {
     Console.WriteLine(setting);
 }
 ```
 
-## Asynchronously delete configuration settings
+## Delete configuration setting
 
-To delete configuration settings that are no longer needed you can call `DeleteConfigurationSettingAsync`.
+To delete a configuration setting that is no longer needed you can call `DeleteConfigurationSettingAsync`.
 
 ```C# Snippet:AzConfigSample12_DeleteConfigurationSettingAsync
 await client.DeleteConfigurationSettingAsync(betaEndpoint.Key, betaEndpoint.Label);
-await client.DeleteConfigurationSettingAsync(betaInstances.Key, betaInstances.Label);
-await client.DeleteConfigurationSettingAsync(productionEndpoint.Key, productionEndpoint.Label);
-await client.DeleteConfigurationSettingAsync(productionInstances.Key, productionInstances.Label);
 ```

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample12_GetSettingsUsingTags.md
@@ -1,0 +1,72 @@
+# Asynchronously List Settings With Tags
+
+This sample demonstrates how to send requests to the Azure App Configuration service asynchronously. It also shows how to create configuration settings with tags, and provides an example scenario where tags are used to retrieve the settings.  To get started, you'll need a connection string to Azure App Configuration. See the [README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/README.md) for links and instructions.
+
+ ## Create a ConfigurationClient
+
+To interact with Azure App Configuration, you need to instantiate a `ConfigurationClient`. You can use either an endpoint URL and a [`TokenCredential`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#credentials) or a connection string.
+
+For the sample below, you can set `connectionString` in an environment variable, a configuration setting, or any way that works for your application. The connection string is available from the App Configuration Access Keys view in the Azure Portal.
+
+```C# Snippet:AzConfigSample12_CreateConfigurationClient
+var client = new ConfigurationClient(connectionString);
+```
+
+## Asynchronously create configuration settings
+
+First, you need to create several instances of `ConfigurationSetting` with different keys, values, labels, and tags.
+
+```C# Snippet:AzConfigSample12_CreateConfigurationSettingAsync
+var betaEndpoint = new ConfigurationSetting("endpoint", "https://beta.endpoint.com", "beta")
+{
+    Tags = { { "someKey", "someValue" } }
+};
+var betaInstances = new ConfigurationSetting("instances", "1", "beta")
+{
+    Tags = { { "someKey", "someValue" } }
+};
+var productionEndpoint = new ConfigurationSetting("endpoint", "https://production.endpoint.com", "production")
+{
+    Tags = { { "someKey", "otherValue" } }
+};
+var productionInstances = new ConfigurationSetting("instances", "1", "production")
+{
+    Tags = { { "someKey", "otherValue" } }
+};
+```
+
+There are two ways to create a Configuration Setting asynchronously:
+- `AddConfigurationSettingAsync` creates a setting only if the setting does not already exist in the store.
+- `SetConfigurationSettingAsync` creates a setting if it doesn't exist or overrides an existing setting with the same key and label.
+
+```C# Snippet:AzConfigSample12_AddConfigurationSettingAsync
+await client.AddConfigurationSettingAsync(betaEndpoint);
+await client.AddConfigurationSettingAsync(betaInstances);
+await client.AddConfigurationSettingAsync(productionEndpoint);
+await client.AddConfigurationSettingAsync(productionInstances);
+```
+
+## Search by tags filter
+
+To gather all the information available for settings grouped by a specific tag, call `GetConfigurationSettingsAsync` with a setting selector that filters for settings with the "someKey=otherValue" tag.  This will retrieve all the Configuration Settings in the store that satisfy that condition. See App Configuration [REST API](https://docs.microsoft.com/azure/azure-app-configuration/rest-api-key-value#filtering) for more information about filtering.
+
+```C# Snippet:AzConfigSample12_GetConfigurationSettingsAsync
+var selector = new SettingSelector { TagsFilter = new string[] { "someKey=otherValue" } };
+
+Debug.WriteLine("Settings for production filtered by tag:");
+await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
+{
+    Console.WriteLine(setting);
+}
+```
+
+## Asynchronously delete configuration settings
+
+To delete configuration settings that are no longer needed you can call `DeleteConfigurationSettingAsync`.
+
+```C# Snippet:AzConfigSample12_DeleteConfigurationSettingAsync
+await client.DeleteConfigurationSettingAsync(betaEndpoint.Key, betaEndpoint.Label);
+await client.DeleteConfigurationSettingAsync(betaInstances.Key, betaInstances.Label);
+await client.DeleteConfigurationSettingAsync(productionEndpoint.Key, productionEndpoint.Label);
+await client.DeleteConfigurationSettingAsync(productionInstances.Key, productionInstances.Label);
+```

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -669,6 +669,7 @@ namespace Azure.Data.AppConfiguration
             var key = selector.KeyFilter;
             var label = selector.LabelFilter;
             var dateTime = selector.AcceptDateTime?.UtcDateTime.ToString(AcceptDateTimeFormat, CultureInfo.InvariantCulture);
+            var tags = selector.TagsFilter;
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
             IEnumerable<string> fieldsString = selector.Fields.Split();
@@ -677,12 +678,12 @@ namespace Azure.Data.AppConfiguration
 
             HttpMessage FirstPageRequest(MatchConditions conditions, int? pageSizeHint)
             {
-                return CreateGetConfigurationSettingsRequest(key, label, null, dateTime, fieldsString, null, conditions, context);
+                return CreateGetConfigurationSettingsRequest(key, label, null, dateTime, fieldsString, null, tags, conditions, context);
             };
 
             HttpMessage NextPageRequest(MatchConditions conditions, int? pageSizeHint, string nextLink)
             {
-                return CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, null, conditions, context);
+                return CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, null, tags, conditions, context);
             }
 
             return new ConditionalPageableImplementation(FirstPageRequest, NextPageRequest, ParseGetConfigurationSettingsResponse, _pipeline, ClientDiagnostics, "ConfigurationClient.GetConfigurationSettings", context);
@@ -700,8 +701,8 @@ namespace Azure.Data.AppConfiguration
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
 
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, null, snapshotName, null, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, null, snapshotName, null, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, null, snapshotName, null, null, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, null, snapshotName, null, null, context);
             return PageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, ConfigurationServiceSerializer.ReadSetting, ClientDiagnostics, _pipeline, "ConfigurationClient.GetConfigurationSettingsForSnapshot", "items", "@nextLink", context);
         }
 
@@ -716,8 +717,8 @@ namespace Azure.Data.AppConfiguration
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
 
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, null, snapshotName, null, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, null, snapshotName, null, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, null, snapshotName, null, null, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, null, snapshotName, null, null, context);
             return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, ConfigurationServiceSerializer.ReadSetting, ClientDiagnostics, _pipeline, "ConfigurationClient.GetConfigurationSettingsForSnapshot", "items", "@nextLink", context);
         }
 
@@ -735,8 +736,8 @@ namespace Azure.Data.AppConfiguration
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
             IEnumerable<string> fieldsString = fields.Split();
 
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, fieldsString, snapshotName, null, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, fieldsString, snapshotName, null, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, fieldsString, snapshotName, null, null, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, fieldsString, snapshotName, null, null, context);
             return PageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, ConfigurationServiceSerializer.ReadSetting, ClientDiagnostics, _pipeline, "ConfigurationClient.GetConfigurationSettingsForSnapshot", "items", "@nextLink", context);
         }
 
@@ -753,8 +754,8 @@ namespace Azure.Data.AppConfiguration
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
             IEnumerable<string> fieldsString = fields.Split();
 
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, fieldsString, snapshotName, null, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, fieldsString, snapshotName, null, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, fieldsString, snapshotName, null, null, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, fieldsString, snapshotName, null, null, context);
             return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, ConfigurationServiceSerializer.ReadSetting, ClientDiagnostics, _pipeline, "ConfigurationClient.GetConfigurationSettingsForSnapshot", "items", "@nextLink", context);
         }
 
@@ -1251,11 +1252,12 @@ namespace Azure.Data.AppConfiguration
             var key = selector.KeyFilter;
             var label = selector.LabelFilter;
             var dateTime = selector.AcceptDateTime?.UtcDateTime.ToString(AcceptDateTimeFormat, CultureInfo.InvariantCulture);
+            var tags = selector.TagsFilter;
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
             IEnumerable<string> fieldsString = selector.Fields.Split();
 
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, null, dateTime, fieldsString, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, null, dateTime, fieldsString, tags, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, tags, context);
             return PageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, ConfigurationServiceSerializer.ReadSetting, ClientDiagnostics, _pipeline, "ConfigurationClient.GetRevisions", "items", "@nextLink", context);
         }
 
@@ -1270,11 +1272,12 @@ namespace Azure.Data.AppConfiguration
             var key = selector.KeyFilter;
             var label = selector.LabelFilter;
             var dateTime = selector.AcceptDateTime?.UtcDateTime.ToString(AcceptDateTimeFormat, CultureInfo.InvariantCulture);
+            var tags = selector.TagsFilter;
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
             IEnumerable<string> fieldsString = selector.Fields.Split();
 
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, null, dateTime, fieldsString, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, null, dateTime, fieldsString, tags, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, tags, context);
             return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, ConfigurationServiceSerializer.ReadSetting, ClientDiagnostics, _pipeline, "ConfigurationClient.GetRevisions", "items", "@nextLink", context);
         }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientOptions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientOptions.cs
@@ -12,7 +12,7 @@ namespace Azure.Data.AppConfiguration
     /// </summary>
     public partial class ConfigurationClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2023_10_01;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2023_11_01;
 
         /// <summary>
         /// The versions of the App Configuration service supported by this client library.
@@ -28,7 +28,12 @@ namespace Azure.Data.AppConfiguration
             /// <summary>
             /// Version 2023-10-01.
             /// </summary>
-            V2023_10_01 = 1
+            V2023_10_01 = 1,
+
+            /// <summary>
+            /// Version 2023-11-01.
+            /// </summary>
+            V2023_11_01 = 2
         }
 
         internal string Version { get; }
@@ -47,6 +52,7 @@ namespace Azure.Data.AppConfiguration
             {
                 ServiceVersion.V1_0 => "1.0",
                 ServiceVersion.V2023_10_01 => "2023-10-01",
+                ServiceVersion.V2023_11_01 => "2023-11-01",
 
                 _ => throw new NotSupportedException()
             };

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/ConfigurationClient.cs
@@ -107,23 +107,24 @@ namespace Azure.Data.AppConfiguration
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="key"> A filter used to match keys. </param>
-        /// <param name="label"> A filter used to match labels. </param>
+        /// <param name="key"> A filter used to match keys. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
+        /// <param name="label"> A filter used to match labels. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="snapshot"> A filter used get key-values for a snapshot. Not valid when used with 'key' and 'label' filters. </param>
+        /// <param name="tags"> A filter used to query by tags. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
         /// <param name="matchConditions"> The content to send as the request conditions of the request. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
-        internal virtual async Task<Response> CheckKeyValuesAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, string snapshot = null, MatchConditions matchConditions = null, RequestContext context = null)
+        internal virtual async Task<Response> CheckKeyValuesAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, string snapshot = null, IEnumerable<string> tags = null, MatchConditions matchConditions = null, RequestContext context = null)
         {
             using var scope = ClientDiagnostics.CreateScope("ConfigurationClient.CheckKeyValues");
             scope.Start();
             try
             {
-                using HttpMessage message = CreateCheckKeyValuesRequest(key, label, after, acceptDatetime, select, snapshot, matchConditions, context);
+                using HttpMessage message = CreateCheckKeyValuesRequest(key, label, after, acceptDatetime, select, snapshot, tags, matchConditions, context);
                 return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
             }
             catch (Exception e)
@@ -143,23 +144,24 @@ namespace Azure.Data.AppConfiguration
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="key"> A filter used to match keys. </param>
-        /// <param name="label"> A filter used to match labels. </param>
+        /// <param name="key"> A filter used to match keys. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
+        /// <param name="label"> A filter used to match labels. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="snapshot"> A filter used get key-values for a snapshot. Not valid when used with 'key' and 'label' filters. </param>
+        /// <param name="tags"> A filter used to query by tags. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
         /// <param name="matchConditions"> The content to send as the request conditions of the request. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
-        internal virtual Response CheckKeyValues(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, string snapshot = null, MatchConditions matchConditions = null, RequestContext context = null)
+        internal virtual Response CheckKeyValues(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, string snapshot = null, IEnumerable<string> tags = null, MatchConditions matchConditions = null, RequestContext context = null)
         {
             using var scope = ClientDiagnostics.CreateScope("ConfigurationClient.CheckKeyValues");
             scope.Start();
             try
             {
-                using HttpMessage message = CreateCheckKeyValuesRequest(key, label, after, acceptDatetime, select, snapshot, matchConditions, context);
+                using HttpMessage message = CreateCheckKeyValuesRequest(key, label, after, acceptDatetime, select, snapshot, tags, matchConditions, context);
                 return _pipeline.ProcessMessage(message, context);
             }
             catch (Exception e)
@@ -967,21 +969,22 @@ namespace Azure.Data.AppConfiguration
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="key"> A filter used to match keys. </param>
-        /// <param name="label"> A filter used to match labels. </param>
+        /// <param name="key"> A filter used to match keys. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
+        /// <param name="label"> A filter used to match labels. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
+        /// <param name="tags"> A filter used to query by tags. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
-        internal virtual async Task<Response> CheckRevisionsAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, RequestContext context = null)
+        internal virtual async Task<Response> CheckRevisionsAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, IEnumerable<string> tags = null, RequestContext context = null)
         {
             using var scope = ClientDiagnostics.CreateScope("ConfigurationClient.CheckRevisions");
             scope.Start();
             try
             {
-                using HttpMessage message = CreateCheckRevisionsRequest(key, label, after, acceptDatetime, select, context);
+                using HttpMessage message = CreateCheckRevisionsRequest(key, label, after, acceptDatetime, select, tags, context);
                 return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
             }
             catch (Exception e)
@@ -1001,21 +1004,22 @@ namespace Azure.Data.AppConfiguration
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="key"> A filter used to match keys. </param>
-        /// <param name="label"> A filter used to match labels. </param>
+        /// <param name="key"> A filter used to match keys. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
+        /// <param name="label"> A filter used to match labels. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
+        /// <param name="tags"> A filter used to query by tags. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
-        internal virtual Response CheckRevisions(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, RequestContext context = null)
+        internal virtual Response CheckRevisions(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, IEnumerable<string> tags = null, RequestContext context = null)
         {
             using var scope = ClientDiagnostics.CreateScope("ConfigurationClient.CheckRevisions");
             scope.Start();
             try
             {
-                using HttpMessage message = CreateCheckRevisionsRequest(key, label, after, acceptDatetime, select, context);
+                using HttpMessage message = CreateCheckRevisionsRequest(key, label, after, acceptDatetime, select, tags, context);
                 return _pipeline.ProcessMessage(message, context);
             }
             catch (Exception e)
@@ -1147,20 +1151,21 @@ namespace Azure.Data.AppConfiguration
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="key"> A filter used to match keys. </param>
-        /// <param name="label"> A filter used to match labels. </param>
+        /// <param name="key"> A filter used to match keys. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
+        /// <param name="label"> A filter used to match labels. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="snapshot"> A filter used get key-values for a snapshot. The value should be the name of the snapshot. Not valid when used with 'key' and 'label' filters. </param>
+        /// <param name="tags"> A filter used to query by tags. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
         /// <param name="matchConditions"> The content to send as the request conditions of the request. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The <see cref="AsyncPageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
-        internal virtual AsyncPageable<BinaryData> GetConfigurationSettingsAsync(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, MatchConditions matchConditions, RequestContext context)
+        internal virtual AsyncPageable<BinaryData> GetConfigurationSettingsAsync(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, IEnumerable<string> tags, MatchConditions matchConditions, RequestContext context)
         {
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(key, label, after, acceptDatetime, select, snapshot, matchConditions, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, after, acceptDatetime, select, snapshot, matchConditions, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(key, label, after, acceptDatetime, select, snapshot, tags, matchConditions, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, after, acceptDatetime, select, snapshot, tags, matchConditions, context);
             return GeneratorPageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "ConfigurationClient.GetConfigurationSettings", "items", "@nextLink", context);
         }
 
@@ -1174,20 +1179,21 @@ namespace Azure.Data.AppConfiguration
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="key"> A filter used to match keys. </param>
-        /// <param name="label"> A filter used to match labels. </param>
+        /// <param name="key"> A filter used to match keys. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
+        /// <param name="label"> A filter used to match labels. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="snapshot"> A filter used get key-values for a snapshot. The value should be the name of the snapshot. Not valid when used with 'key' and 'label' filters. </param>
+        /// <param name="tags"> A filter used to query by tags. Syntax reference: https://aka.ms/azconfig/docs/keyvaluefiltering. </param>
         /// <param name="matchConditions"> The content to send as the request conditions of the request. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The <see cref="Pageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
-        internal virtual Pageable<BinaryData> GetConfigurationSettings(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, MatchConditions matchConditions, RequestContext context)
+        internal virtual Pageable<BinaryData> GetConfigurationSettings(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, IEnumerable<string> tags, MatchConditions matchConditions, RequestContext context)
         {
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(key, label, after, acceptDatetime, select, snapshot, matchConditions, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, after, acceptDatetime, select, snapshot, matchConditions, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(key, label, after, acceptDatetime, select, snapshot, tags, matchConditions, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, after, acceptDatetime, select, snapshot, tags, matchConditions, context);
             return GeneratorPageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "ConfigurationClient.GetConfigurationSettings", "items", "@nextLink", context);
         }
 
@@ -1297,18 +1303,19 @@ namespace Azure.Data.AppConfiguration
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="key"> A filter used to match keys. </param>
-        /// <param name="label"> A filter used to match labels. </param>
+        /// <param name="key"> A filter used to match keys. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
+        /// <param name="label"> A filter used to match labels. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
+        /// <param name="tags"> A filter used to query by tags. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The <see cref="AsyncPageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
-        internal virtual AsyncPageable<BinaryData> GetRevisionsAsync(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, RequestContext context)
+        internal virtual AsyncPageable<BinaryData> GetRevisionsAsync(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, IEnumerable<string> tags, RequestContext context)
         {
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, after, acceptDatetime, select, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, after, acceptDatetime, select, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, after, acceptDatetime, select, tags, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, after, acceptDatetime, select, tags, context);
             return GeneratorPageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "ConfigurationClient.GetRevisions", "items", "@nextLink", context);
         }
 
@@ -1322,18 +1329,19 @@ namespace Azure.Data.AppConfiguration
         /// </item>
         /// </list>
         /// </summary>
-        /// <param name="key"> A filter used to match keys. </param>
-        /// <param name="label"> A filter used to match labels. </param>
+        /// <param name="key"> A filter used to match keys. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
+        /// <param name="label"> A filter used to match labels. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
+        /// <param name="tags"> A filter used to query by tags. Syntax reference: https://aka.ms/azconfig/docs/restapirevisions. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The <see cref="Pageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
-        internal virtual Pageable<BinaryData> GetRevisions(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, RequestContext context)
+        internal virtual Pageable<BinaryData> GetRevisions(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, IEnumerable<string> tags, RequestContext context)
         {
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, after, acceptDatetime, select, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, after, acceptDatetime, select, context);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, after, acceptDatetime, select, tags, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, after, acceptDatetime, select, tags, context);
             return GeneratorPageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "ConfigurationClient.GetRevisions", "items", "@nextLink", context);
         }
 
@@ -1472,7 +1480,7 @@ namespace Azure.Data.AppConfiguration
             return message;
         }
 
-        internal HttpMessage CreateGetConfigurationSettingsRequest(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, MatchConditions matchConditions, RequestContext context)
+        internal HttpMessage CreateGetConfigurationSettingsRequest(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, IEnumerable<string> tags, MatchConditions matchConditions, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;
@@ -1501,6 +1509,13 @@ namespace Azure.Data.AppConfiguration
             {
                 uri.AppendQuery("snapshot", snapshot, true);
             }
+            if (tags != null && !(tags is ChangeTrackingList<string> changeTrackingList0 && changeTrackingList0.IsUndefined))
+            {
+                foreach (var param in tags)
+                {
+                    uri.AppendQuery("tags", param, true);
+                }
+            }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/vnd.microsoft.appconfig.kvset+json, application/problem+json");
             if (_syncToken != null)
@@ -1518,7 +1533,7 @@ namespace Azure.Data.AppConfiguration
             return message;
         }
 
-        internal HttpMessage CreateCheckKeyValuesRequest(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, MatchConditions matchConditions, RequestContext context)
+        internal HttpMessage CreateCheckKeyValuesRequest(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, IEnumerable<string> tags, MatchConditions matchConditions, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;
@@ -1546,6 +1561,13 @@ namespace Azure.Data.AppConfiguration
             if (snapshot != null)
             {
                 uri.AppendQuery("snapshot", snapshot, true);
+            }
+            if (tags != null && !(tags is ChangeTrackingList<string> changeTrackingList0 && changeTrackingList0.IsUndefined))
+            {
+                foreach (var param in tags)
+                {
+                    uri.AppendQuery("tags", param, true);
+                }
             }
             request.Uri = uri;
             if (_syncToken != null)
@@ -1959,7 +1981,7 @@ namespace Azure.Data.AppConfiguration
             return message;
         }
 
-        internal HttpMessage CreateGetRevisionsRequest(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, RequestContext context)
+        internal HttpMessage CreateGetRevisionsRequest(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, IEnumerable<string> tags, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;
@@ -1984,6 +2006,13 @@ namespace Azure.Data.AppConfiguration
             {
                 uri.AppendQueryDelimited("$Select", select, ",", true);
             }
+            if (tags != null && !(tags is ChangeTrackingList<string> changeTrackingList0 && changeTrackingList0.IsUndefined))
+            {
+                foreach (var param in tags)
+                {
+                    uri.AppendQuery("tags", param, true);
+                }
+            }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/vnd.microsoft.appconfig.kvset+json, application/problem+json");
             if (_syncToken != null)
@@ -1997,7 +2026,7 @@ namespace Azure.Data.AppConfiguration
             return message;
         }
 
-        internal HttpMessage CreateCheckRevisionsRequest(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, RequestContext context)
+        internal HttpMessage CreateCheckRevisionsRequest(string key, string label, string after, string acceptDatetime, IEnumerable<string> select, IEnumerable<string> tags, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;
@@ -2021,6 +2050,13 @@ namespace Azure.Data.AppConfiguration
             if (select != null && !(select is ChangeTrackingList<string> changeTrackingList && changeTrackingList.IsUndefined))
             {
                 uri.AppendQueryDelimited("$Select", select, ",", true);
+            }
+            if (tags != null && !(tags is ChangeTrackingList<string> changeTrackingList0 && changeTrackingList0.IsUndefined))
+            {
+                foreach (var param in tags)
+                {
+                    uri.AppendQuery("tags", param, true);
+                }
             }
             request.Uri = uri;
             if (_syncToken != null)
@@ -2070,7 +2106,7 @@ namespace Azure.Data.AppConfiguration
             return message;
         }
 
-        internal HttpMessage CreateGetConfigurationSettingsNextPageRequest(string nextLink, string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, MatchConditions matchConditions, RequestContext context)
+        internal HttpMessage CreateGetConfigurationSettingsNextPageRequest(string nextLink, string key, string label, string after, string acceptDatetime, IEnumerable<string> select, string snapshot, IEnumerable<string> tags, MatchConditions matchConditions, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;
@@ -2133,7 +2169,7 @@ namespace Azure.Data.AppConfiguration
             return message;
         }
 
-        internal HttpMessage CreateGetRevisionsNextPageRequest(string nextLink, string key, string label, string after, string acceptDatetime, IEnumerable<string> select, RequestContext context)
+        internal HttpMessage CreateGetRevisionsNextPageRequest(string nextLink, string key, string label, string after, string acceptDatetime, IEnumerable<string> select, IEnumerable<string> tags, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsFilter.Serialization.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsFilter.Serialization.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
@@ -18,6 +19,16 @@ namespace Azure.Data.AppConfiguration
                 writer.WritePropertyName("label");
                 writer.WriteStringValue(Label);
             }
+            if (Optional.IsCollectionDefined(Tags))
+            {
+                writer.WritePropertyName("tags");
+                writer.WriteStartArray();
+                foreach (var item in Tags)
+                {
+                    writer.WriteStringValue(item);
+                }
+                writer.WriteEndArray();
+            }
             writer.WriteEndObject();
         }
 
@@ -25,6 +36,7 @@ namespace Azure.Data.AppConfiguration
         {
             string key = default;
             string label = default;
+            List<string> tags = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("key"))
@@ -37,8 +49,17 @@ namespace Azure.Data.AppConfiguration
                     label = property.Value.GetString();
                     continue;
                 }
+                if (property.NameEquals("tags"))
+                {
+                    tags = new List<string>();
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        tags.Add(item.GetString());
+                    }
+                    continue;
+                }
             }
-            return new ConfigurationSettingsFilter(key, label);
+            return new ConfigurationSettingsFilter(key, label, tags);
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsFilter.Serialization.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsFilter.Serialization.cs
@@ -49,12 +49,12 @@ namespace Azure.Data.AppConfiguration
                     label = property.Value.GetString();
                     continue;
                 }
-                if (property.NameEquals("tags"))
+                if (property.NameEquals("tags"u8))
                 {
                     tags = new List<string>();
-                    foreach (var item in property.Value.EnumerateArray())
+                    foreach (JsonElement tag in property.Value.EnumerateArray())
                     {
-                        tags.Add(item.GetString());
+                        tags.Add(tag.GetString());
                     }
                     continue;
                 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsFilter.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsFilter.cs
@@ -17,7 +17,7 @@ namespace Azure.Data.AppConfiguration
             Argument.AssertNotNull(key, nameof(key));
 
             Key = key;
-            Tags = new ChangeTrackingList<string>();
+            Tags = new List<string>();
         }
 
         /// <summary> Initializes a new instance of KeyValueFilter. </summary>
@@ -40,6 +40,6 @@ namespace Azure.Data.AppConfiguration
         /// <summary> Filters key-values by their tags field.
         /// Each tag in the list should be expressed as a string in the format `tag=value`.
         /// </summary>
-        public IList<string> Tags { get; set; }
+        public IList<string> Tags { get; }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsFilter.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsFilter.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Core;
+using System.Collections.Generic;
 
 namespace Azure.Data.AppConfiguration
 {
@@ -17,20 +17,29 @@ namespace Azure.Data.AppConfiguration
             Argument.AssertNotNull(key, nameof(key));
 
             Key = key;
+            Tags = new ChangeTrackingList<string>();
         }
 
         /// <summary> Initializes a new instance of KeyValueFilter. </summary>
         /// <param name="key"> Filters key-values by their key field. </param>
         /// <param name="label"> Filters key-values by their label field. </param>
-        internal ConfigurationSettingsFilter(string key, string label)
+        /// <param name="tags"> Filters key-values by their tags field.
+        /// Each tag in the list should be expressed as a string in the format `tag=value`.
+        /// </param>
+        internal ConfigurationSettingsFilter(string key, string label, IList<string> tags)
         {
             Key = key;
             Label = label;
+            Tags = tags;
         }
 
         /// <summary> Filters key-values by their key field. </summary>
         public string Key { get; set; }
         /// <summary> Filters key-values by their label field. </summary>
         public string Label { get; set; }
+        /// <summary> Filters key-values by their tags field.
+        /// Each tag in the list should be expressed as a string in the format `tag=value`.
+        /// </summary>
+        public IList<string> Tags { get; set; }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingSelector.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingSelector.cs
@@ -40,7 +40,7 @@ namespace Azure.Data.AppConfiguration
         /// Each tag in the list should be expressed as a string in the format `tag=value`.
         /// </summary>
         /// <remarks>See the documentation for this client library for details on the format of filter expressions.</remarks>
-        public IList<string> TagsFilter { get; set; }
+        public IList<string> TagsFilter { get; }
 
         /// <summary>
         /// The fields of the <see cref="ConfigurationSetting"/> to retrieve for each setting in the retrieved group.
@@ -59,7 +59,7 @@ namespace Azure.Data.AppConfiguration
         /// </summary>
         public SettingSelector()
         {
-            TagsFilter = new ChangeTrackingList<string>();
+            TagsFilter = new List<string>();
         }
 
         #region nobody wants to see these

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingSelector.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingSelector.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Threading;
 
 namespace Azure.Data.AppConfiguration
 {
@@ -37,6 +36,13 @@ namespace Azure.Data.AppConfiguration
         public string LabelFilter { get; set; }
 
         /// <summary>
+        /// Tag filter that will be used to select a set of <see cref="ConfigurationSetting"/> entities.
+        /// Each tag in the list should be expressed as a string in the format `tag=value`.
+        /// </summary>
+        /// <remarks>See the documentation for this client library for details on the format of filter expressions.</remarks>
+        public IList<string> TagsFilter { get; set; }
+
+        /// <summary>
         /// The fields of the <see cref="ConfigurationSetting"/> to retrieve for each setting in the retrieved group.
         /// </summary>
         public SettingFields Fields { get; set; } = SettingFields.All;
@@ -51,7 +57,10 @@ namespace Azure.Data.AppConfiguration
         /// <summary>
         /// Creates a default <see cref="SettingSelector"/> that will retrieve all <see cref="ConfigurationSetting"/> entities in the configuration store.
         /// </summary>
-        public SettingSelector() { }
+        public SettingSelector()
+        {
+            TagsFilter = new ChangeTrackingList<string>();
+        }
 
         #region nobody wants to see these
         /// <summary>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/autorest.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 > see https://aka.ms/autorest
 ``` yaml
 input-file:
-- https://github.com/Azure/azure-rest-api-specs/blob/c77bbf822be2deaac1b690270c6cd03a52df0e37/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/2023-10-01/appconfiguration.json
+- https://github.com/Azure/azure-rest-api-specs/blob/c1af3ab8e803da2f40fc90217a6d023bc13b677f/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/2023-11-01/appconfiguration.json
 namespace: Azure.Data.AppConfiguration
 title: ConfigurationClient
 ```

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -579,7 +579,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         // Validates that the expected revisions are retrieved correctly when specifying a list of tags.
-        [LiveOnly]
+        [Ignore("Requires service V2023_11_01")]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task GetRevisionsByTags()
         {
@@ -1597,7 +1597,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
         }
 
-        [LiveOnly]
+        [Ignore("Requires service V2023_11_01")]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task GetBatchSettingByTags()
         {
@@ -1644,7 +1644,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
         }
 
-        [LiveOnly]
+        [Ignore("Requires service V2023_11_01")]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task GetBatchSettingByTagsNoMatchingSettings()
         {
@@ -2160,6 +2160,7 @@ namespace Azure.Data.AppConfiguration.Tests
             try
             {
                 await service.AddConfigurationSettingAsync(testSetting);
+
                 var settingsFilter = new List<ConfigurationSettingsFilter>(new ConfigurationSettingsFilter[] { new ConfigurationSettingsFilter(testSetting.Key) });
                 var settingsSnapshot = new ConfigurationSnapshot(settingsFilter);
 
@@ -2208,7 +2209,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
         // Validates that the snapshot is successfully created for the settings that match the key and tags filter. In
         // addition, the settings' filters are validated in the created snapshot.
-        [LiveOnly]
+        [Ignore("Requires service V2023_11_01")]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task CreateSnapshotWithTagsUsingWaitForCompletion()
         {
@@ -2327,7 +2328,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         // Validates that the snapshots are created for the settings that match the key and tags filter.
-        [LiveOnly]
+        [Ignore("Requires service V2023_11_01")]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task CreateSnapshotUsingTags()
         {
@@ -2396,7 +2397,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         // Validates that a snapshot is created for no settings when the tags filter does not match any setting.
-        [LiveOnly]
+        [Ignore("Requires service V2023_11_01")]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task CreateSnapshotUsingTagsNoMatchingSetting()
         {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -578,6 +578,68 @@ namespace Azure.Data.AppConfiguration.Tests
             }
         }
 
+        // Validates that the expected revisions are retrieved correctly when specifying a list of tags.
+        [LiveOnly]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
+        public async Task GetRevisionsByTags()
+        {
+            ConfigurationClient service = GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
+
+            //Prepare environment
+            ConfigurationSetting setting = testSetting;
+
+            setting.Key = GenerateKeyId("key-");
+            ConfigurationSetting testSettingUpdate = setting.Clone();
+            testSettingUpdate.Label = "test_label_update";
+            testSettingUpdate.Tags = new Dictionary<string, string>
+            {
+                { "foo", "bar" },
+                { "foo2", "bar2" },
+                { "foo3", "bar3" },
+                { "foo4", "bar4" },
+                { "foo5", "bar5" }
+            };
+            int expectedRevisions = 1;
+
+            try
+            {
+                await service.SetConfigurationSettingAsync(setting);
+                await service.SetConfigurationSettingAsync(testSettingUpdate);
+
+                var parsedTags = testSettingUpdate.Tags.Select(t => $"{t.Key}={t.Value}").ToArray();
+
+                // Test
+                var selector = new SettingSelector
+                {
+                    KeyFilter = setting.Key,
+                    AcceptDateTime = DateTimeOffset.MaxValue,
+                    TagsFilter = parsedTags
+                };
+
+                int resultsReturned = 0;
+                await foreach (ConfigurationSetting value in service.GetRevisionsAsync(selector, CancellationToken.None))
+                {
+                    if (value.Label.Contains("update"))
+                    {
+                        Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(value, testSettingUpdate));
+                    }
+                    else
+                    {
+                        Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(value, setting));
+                    }
+                    resultsReturned++;
+                }
+
+                Assert.AreEqual(expectedRevisions, resultsReturned);
+            }
+            finally
+            {
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSettingUpdate.Key, testSettingUpdate.Label));
+            }
+        }
+
         [RecordedTest]
         public async Task GetRevisionsByKeyAndLabel()
         {
@@ -1532,6 +1594,80 @@ namespace Azure.Data.AppConfiguration.Tests
             }
         }
 
+        [LiveOnly]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
+        public async Task GetBatchSettingByTags()
+        {
+            ConfigurationClient service = GetClient();
+            var expectedTags = new Dictionary<string, string>
+            {
+                { "my_tag", "my_tag_value" }
+            };
+
+            ConfigurationSetting abcSetting = new ConfigurationSetting("abcd", "foobar")
+            {
+                Tags = expectedTags
+            };
+            ConfigurationSetting xyzSetting = new ConfigurationSetting("wxyz", "barfoo")
+            {
+                Tags = expectedTags
+            };
+
+            try
+            {
+                await service.SetConfigurationSettingAsync(abcSetting);
+                await service.SetConfigurationSettingAsync(xyzSetting);
+
+                var tags = expectedTags.Select(t => $"{t.Key}={t.Value}").ToArray();
+                var selector = new SettingSelector { TagsFilter = tags };
+
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+
+                Assert.AreEqual(2, settings.Length);
+                Assert.IsTrue(settings.Any(s => s.Key == "abcd"));
+                Assert.IsTrue(settings.Any(s => s.Key == "wxyz"));
+                Assert.IsTrue(settings.Any(s => s.Tags.Any() == true));
+                Assert.IsTrue(settings.Any(s => s.Tags.SequenceEqual(expectedTags)));
+            }
+            finally
+            {
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(abcSetting.Key));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(xyzSetting.Key));
+            }
+        }
+
+        [LiveOnly]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
+        public async Task GetBatchSettingByTagsNoMatchingSettings()
+        {
+            ConfigurationClient service = GetClient();
+            var tags = new Dictionary<string, string>
+            {
+                { "my_tag", "my_tag_value" }
+            };
+
+            ConfigurationSetting abcSetting = new ConfigurationSetting("abcd", "foobar");
+            ConfigurationSetting xyzSetting = new ConfigurationSetting("wxyz", "barfoo");
+
+            try
+            {
+                await service.SetConfigurationSettingAsync(abcSetting);
+                await service.SetConfigurationSettingAsync(xyzSetting);
+
+                var parsedTags = tags.Select(t => $"{t.Key}={t.Value}").ToArray();
+                var selector = new SettingSelector { TagsFilter = parsedTags };
+
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+
+                Assert.AreEqual(0, settings.Length);
+            }
+            finally
+            {
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(abcSetting.Key));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(xyzSetting.Key));
+            }
+        }
+
         [RecordedTest]
         public async Task GetBatchSettingsWithCommaInSelectorKey()
         {
@@ -2012,7 +2148,6 @@ namespace Azure.Data.AppConfiguration.Tests
             try
             {
                 await service.AddConfigurationSettingAsync(testSetting);
-
                 var settingsFilter = new List<ConfigurationSettingsFilter>(new ConfigurationSettingsFilter[] { new ConfigurationSettingsFilter(testSetting.Key) });
                 var settingsSnapshot = new ConfigurationSnapshot(settingsFilter);
 
@@ -2042,6 +2177,38 @@ namespace Azure.Data.AppConfiguration.Tests
                 await service.AddConfigurationSettingAsync(testSetting);
 
                 var settingsFilter = new List<ConfigurationSettingsFilter>(new ConfigurationSettingsFilter[] { new ConfigurationSettingsFilter(testSetting.Key) });
+                var settingsSnapshot = new ConfigurationSnapshot(settingsFilter);
+
+                var snapshotName = GenerateSnapshotName();
+                var operation = await service.CreateSnapshotAsync(WaitUntil.Started, snapshotName, settingsSnapshot);
+                await operation.WaitForCompletionAsync().ConfigureAwait(false);
+                ValidateCompletedOperation(operation);
+                var createdSnapshot = operation.Value;
+
+                var retrievedSnapshot = await service.GetSnapshotAsync(snapshotName);
+                ValidateCreatedSnapshot(createdSnapshot, retrievedSnapshot, snapshotName);
+            }
+            finally
+            {
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
+            }
+        }
+
+        // Validates that the snapshot is successfully created for the settings that match the key and tags filter. In
+        // addition, the settings' filters are validated in the created snapshot.
+        [LiveOnly]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
+        public async Task CreateSnapshotWithTagsUsingWaitForCompletion()
+        {
+            var service = GetClient();
+            var testSetting = CreateSetting();
+
+            try
+            {
+                await service.AddConfigurationSettingAsync(testSetting);
+
+                var parsedTags = testSetting.Tags.Select(t => $"{t.Key}={t.Value}").ToArray();
+                var settingsFilter = new List<ConfigurationSettingsFilter>(new ConfigurationSettingsFilter[] { new ConfigurationSettingsFilter(testSetting.Key) { Tags = parsedTags } });
                 var settingsSnapshot = new ConfigurationSnapshot(settingsFilter);
 
                 var snapshotName = GenerateSnapshotName();
@@ -2127,6 +2294,130 @@ namespace Azure.Data.AppConfiguration.Tests
 
                 Assert.AreEqual(key1, settings[0].Key);
                 Assert.AreEqual(key2, settings[1].Key);
+            }
+            finally
+            {
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(firstSetting.Key, firstSetting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(secondSetting.Key, secondSetting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(thirdSetting.Key, thirdSetting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(fourthSetting.Key, fourthSetting.Label));
+            }
+        }
+
+        // Validates that the snapshots are created for the settings that match the key and tags filter.
+        [LiveOnly]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
+        public async Task CreateSnapshotUsingTags()
+        {
+            var service = GetClient();
+            var key1 = GenerateKeyId("KeyBar-1");
+            var key2 = GenerateKeyId("KeyBar-2");
+            var key3 = GenerateKeyId("KeyBar-3");
+            var key4 = GenerateKeyId("Key1");
+            var expectedTags = new Dictionary<string, string>
+            {
+                { "foo", "bartemp1" }
+            };
+            var firstSetting = new ConfigurationSetting(key1, "value1")
+            {
+                Tags = expectedTags
+            };
+            var secondSetting = new ConfigurationSetting(key2, "value2")
+            {
+                Tags = expectedTags
+            };
+            var thirdSetting = new ConfigurationSetting(key3, "value3")
+            {
+                Tags = expectedTags
+            };
+            var fourthSetting = new ConfigurationSetting(key4, "value4");
+
+            try
+            {
+                await service.AddConfigurationSettingAsync(firstSetting);
+                await service.AddConfigurationSettingAsync(secondSetting);
+                await service.AddConfigurationSettingAsync(thirdSetting);
+                await service.AddConfigurationSettingAsync(fourthSetting);
+
+                var parsedTags = expectedTags.Select(t => $"{t.Key}={t.Value}").ToArray();
+                var settingsFilter = new List<ConfigurationSettingsFilter>(new ConfigurationSettingsFilter[]
+                {
+                    new ConfigurationSettingsFilter("KeyBar-*")
+                    {
+                        Tags = parsedTags
+                    }
+                });
+                var snapshotName = GenerateSnapshotName();
+                var operation = await service.CreateSnapshotAsync(WaitUntil.Completed, snapshotName, new ConfigurationSnapshot(settingsFilter));
+                ValidateCompletedOperation(operation);
+
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsForSnapshotAsync(snapshotName, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                Assert.AreEqual(3, settings.Count());
+
+                Assert.AreEqual(key1, settings[0].Key);
+                Assert.AreEqual(key2, settings[1].Key);
+                Assert.AreEqual(key3, settings[2].Key);
+                Assert.AreEqual(expectedTags, settings[0].Tags);
+                Assert.AreEqual(expectedTags, settings[1].Tags);
+                Assert.AreEqual(expectedTags, settings[2].Tags);
+            }
+            finally
+            {
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(firstSetting.Key, firstSetting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(secondSetting.Key, secondSetting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(thirdSetting.Key, thirdSetting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(fourthSetting.Key, fourthSetting.Label));
+            }
+        }
+
+        // Validates that a snapshot is created for no settings when the tags filter does not match any setting.
+        [LiveOnly]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
+        public async Task CreateSnapshotUsingTagsNoMatchingSetting()
+        {
+            var service = GetClient();
+            var key1 = GenerateKeyId("KeyBar-1");
+            var key2 = GenerateKeyId("KeyBar-2");
+            var key3 = GenerateKeyId("KeyBar-3");
+            var key4 = GenerateKeyId("KeyBar-4");
+            var expectedTags = new Dictionary<string, string>
+            {
+                { "foo", "bar" }
+            };
+            var firstSetting = new ConfigurationSetting(key1, "value1")
+            {
+                Tags = expectedTags
+            };
+            var secondSetting = new ConfigurationSetting(key2, "value2")
+            {
+                Tags = expectedTags
+            };
+            var thirdSetting = new ConfigurationSetting(key3, "value3")
+            {
+                Tags = expectedTags
+            };
+            var fourthSetting = new ConfigurationSetting(key4, "value4");
+
+            try
+            {
+                await service.AddConfigurationSettingAsync(firstSetting);
+                await service.AddConfigurationSettingAsync(secondSetting);
+                await service.AddConfigurationSettingAsync(thirdSetting);
+                await service.AddConfigurationSettingAsync(fourthSetting);
+
+                var settingsFilter = new List<ConfigurationSettingsFilter>(new ConfigurationSettingsFilter[]
+                {
+                    new ConfigurationSettingsFilter("KeyBar-*")
+                    {
+                        Tags = new string[] { "uknown=tag" }
+                    }
+                });
+                var snapshotName = GenerateSnapshotName();
+                var operation = await service.CreateSnapshotAsync(WaitUntil.Completed, snapshotName, new ConfigurationSnapshot(settingsFilter));
+                ValidateCompletedOperation(operation);
+
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsForSnapshotAsync(snapshotName, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                Assert.AreEqual(0, settings.Count());
             }
             finally
             {
@@ -2345,6 +2636,18 @@ namespace Azure.Data.AppConfiguration.Tests
 
             Assert.NotNull(retrievedSnapshot);
             Assert.AreEqual(createdSnapshot.Name, retrievedSnapshot.Name);
+
+            // validate retrieved filters
+            if (createdSnapshot.Filters != null)
+            {
+                Assert.NotNull(retrievedSnapshot.Filters);
+                Assert.AreEqual(createdSnapshot.Filters.Count, retrievedSnapshot.Filters.Count);
+                for (int i = 0; i < createdSnapshot.Filters.Count; i++)
+                {
+                    Assert.AreEqual(createdSnapshot.Filters[i].Key, retrievedSnapshot.Filters[i].Key);
+                    Assert.AreEqual(createdSnapshot.Filters[i].Tags, retrievedSnapshot.Filters[i].Tags);
+                }
+            }
         }
 
         private static void ValidateCompletedOperation(CreateSnapshotOperation operation)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
@@ -535,10 +535,11 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationClient service = CreateTestService(mockTransport);
 
             var parsedTags = mockTags.Select(t => $"{t.Key}={t.Value}").ToList();
-            var query = new SettingSelector()
+            var query = new SettingSelector();
+            foreach (var tag in mockTags)
             {
-                TagsFilter = parsedTags
-            };
+                query.TagsFilter.Add($"{tag.Key}={tag.Value}");
+            }
             int keyIndex = 0;
 
             await foreach (ConfigurationSetting value in service.GetConfigurationSettingsAsync(query, CancellationToken.None))

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
@@ -507,6 +507,62 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [Test]
+        public async Task GetBatchUsingTags()
+        {
+            var response1 = new MockResponse(200);
+            var mockTags = new Dictionary<string, string>
+            {
+                { "tag1", "value1" },
+                { "tag2", "value2" }
+            };
+            var response1Settings = new[]
+            {
+                CreateSetting(0, mockTags),
+                CreateSetting(1, mockTags)
+            };
+            response1.SetContent(SerializationHelpers.Serialize((Settings: response1Settings, NextLink: $"/kv?after=5&api-version={s_version}"), SerializeBatch));
+
+            var response2 = new MockResponse(200);
+            var response2Settings = new[]
+            {
+                CreateSetting(2, mockTags),
+                CreateSetting(3, mockTags),
+                CreateSetting(4, mockTags),
+            };
+            response2.SetContent(SerializationHelpers.Serialize((Settings: response2Settings, NextLink: (string)null), SerializeBatch));
+
+            var mockTransport = new MockTransport(response1, response2);
+            ConfigurationClient service = CreateTestService(mockTransport);
+
+            var parsedTags = mockTags.Select(t => $"{t.Key}={t.Value}").ToList();
+            var query = new SettingSelector()
+            {
+                TagsFilter = parsedTags
+            };
+            int keyIndex = 0;
+
+            await foreach (ConfigurationSetting value in service.GetConfigurationSettingsAsync(query, CancellationToken.None))
+            {
+                Assert.AreEqual("key" + keyIndex, value.Key);
+                Assert.AreEqual(mockTags, value.Tags);
+                keyIndex++;
+            }
+
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+
+            MockRequest request1 = mockTransport.Requests[0];
+            var expectedTagsQuery = string.Join("&tags=", parsedTags.Select(Uri.EscapeDataString));
+            Assert.AreEqual(RequestMethod.Get, request1.Method);
+            Assert.AreEqual($"https://contoso.appconfig.io/kv?api-version={s_version}&tags={expectedTagsQuery}", request1.Uri.ToString());
+            AssertRequestCommon(request1);
+
+            MockRequest request2 = mockTransport.Requests[1];
+            Assert.AreEqual(RequestMethod.Get, request2.Method);
+            Assert.AreEqual($"https://contoso.appconfig.io/kv?after=5&api-version={s_version}", request2.Uri.ToString());
+            AssertRequestCommon(request1);
+        }
+
+        [Test]
         public async Task ConfiguringTheClient()
         {
             var response = new MockResponse(200);
@@ -944,8 +1000,13 @@ namespace Azure.Data.AppConfiguration.Tests
             StringAssert.Contains($"azsdk-net-Data.AppConfiguration/{version.Major}.{version.Minor}.{version.Build}", value);
         }
 
-        private static ConfigurationSetting CreateSetting(int i)
+        private static ConfigurationSetting CreateSetting(int i, IDictionary<string, string> tags = null)
         {
+            if (tags != null)
+            {
+                return new ConfigurationSetting($"key{i}", "val") { Label = "label", ETag = new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"), ContentType = "text", Tags = tags };
+            }
+
             return new ConfigurationSetting($"key{i}", "val") { Label = "label", ETag = new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"), ContentType = "text" };
         }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingsFilterTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingsFilterTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Azure.Data.AppConfiguration.Tests
+{
+    public class ConfigurationSettingsFilterTests
+    {
+        [TestCaseSource(nameof(DeserializeKeyValueFilterTestCases))]
+        public void DeserializeKeyValueFilter(string json, bool hasTags)
+        {
+            var element = JsonDocument.Parse(json).RootElement;
+
+            // Act
+            var filter = ConfigurationSettingsFilter.DeserializeKeyValueFilter(element);
+
+            // Assert
+            Assert.AreEqual("testKey", filter.Key);
+            Assert.AreEqual("testLabel", filter.Label);
+            if (hasTags)
+            {
+                Assert.IsNotNull(filter.Tags);
+                Assert.AreEqual(new List<string> { "tag1=value1", "tag2=value2" }, filter.Tags);
+            }
+            else
+            {
+                Assert.IsNull(filter.Tags);
+            }
+        }
+
+        public static IEnumerable<TestCaseData> DeserializeKeyValueFilterTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(@"{
+                ""key"": ""testKey"",
+                ""label"": ""testLabel"",
+                ""tags"": [""tag1=value1"", ""tag2=value2""]
+                }", true);
+                yield return new TestCaseData(@"{
+                ""key"": ""testKey"",
+                ""label"": ""testLabel""
+                }", false);
+            }
+        }
+    }
+}

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingsSnapshotTest.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingsSnapshotTest.cs
@@ -32,7 +32,7 @@ namespace Azure.Data.AppConfiguration.Tests
         [Test]
         public void SetRetentionPeriodUsingSetter()
         {
-            List<ConfigurationSettingsFilter> filters = new() { new ConfigurationSettingsFilter("key", "val") };
+            List<ConfigurationSettingsFilter> filters = new() { new ConfigurationSettingsFilter("key", "val", Array.Empty<string>()) };
 
             var settingSnapshot = new ConfigurationSnapshot(filters);
             settingSnapshot.RetentionPeriod = TimeSpan.FromSeconds(10675199);

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
@@ -31,7 +31,8 @@ namespace Azure.Data.AppConfiguration.Samples
             #endregion
 
             #region Snippet:AzConfigSample12_GetConfigurationSettingsAsync
-            var selector = new SettingSelector { TagsFilter = new string[] { "someKey=someValue" } };
+            var selector = new SettingSelector();
+            selector.TagsFilter.Add("someKey=someValue");
 
             Debug.WriteLine("Settings for beta filtered by tag:");
             await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
@@ -34,7 +34,7 @@ namespace Azure.Data.AppConfiguration.Samples
             var selector = new SettingSelector();
             selector.TagsFilter.Add("someKey=someValue");
 
-            Debug.WriteLine("Settings for beta filtered by tag:");
+            Console.WriteLine("Settings for beta filtered by tag:");
             await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
             {
                 Console.WriteLine(setting);

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
@@ -41,11 +41,6 @@ namespace Azure.Data.AppConfiguration.Samples
             }
 
             #endregion
-
-            // Delete the Configuration Settings from the Configuration Store.
-            #region Snippet:AzConfigSample12_DeleteConfigurationSettingAsync
-            await client.DeleteConfigurationSettingAsync(betaEndpoint.Key, betaEndpoint.Label);
-            #endregion
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
@@ -39,6 +39,7 @@ namespace Azure.Data.AppConfiguration.Samples
             {
                 Console.WriteLine(setting);
             }
+
             #endregion
 
             // Delete the Configuration Settings from the Configuration Store.

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
@@ -24,31 +24,16 @@ namespace Azure.Data.AppConfiguration.Samples
             {
                 Tags = { { "someKey", "someValue" } }
             };
-            var betaInstances = new ConfigurationSetting("instances", "1", "beta")
-            {
-                Tags = { { "someKey", "someValue" } }
-            };
-            var productionEndpoint = new ConfigurationSetting("endpoint", "https://production.endpoint.com", "production")
-            {
-                Tags = { { "someKey", "otherValue" } }
-            };
-            var productionInstances = new ConfigurationSetting("instances", "1", "production")
-            {
-                Tags = { { "someKey", "otherValue" } }
-            };
             #endregion
 
             #region Snippet:AzConfigSample12_AddConfigurationSettingAsync
             await client.AddConfigurationSettingAsync(betaEndpoint);
-            await client.AddConfigurationSettingAsync(betaInstances);
-            await client.AddConfigurationSettingAsync(productionEndpoint);
-            await client.AddConfigurationSettingAsync(productionInstances);
             #endregion
 
             #region Snippet:AzConfigSample12_GetConfigurationSettingsAsync
-            var selector = new SettingSelector { TagsFilter = new string[] { "someKey=otherValue" } };
+            var selector = new SettingSelector { TagsFilter = new string[] { "someKey=someValue" } };
 
-            Debug.WriteLine("Settings for production filtered by tag:");
+            Debug.WriteLine("Settings for beta filtered by tag:");
             await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
             {
                 Console.WriteLine(setting);
@@ -58,9 +43,6 @@ namespace Azure.Data.AppConfiguration.Samples
             // Delete the Configuration Settings from the Configuration Store.
             #region Snippet:AzConfigSample12_DeleteConfigurationSettingAsync
             await client.DeleteConfigurationSettingAsync(betaEndpoint.Key, betaEndpoint.Label);
-            await client.DeleteConfigurationSettingAsync(betaInstances.Key, betaInstances.Label);
-            await client.DeleteConfigurationSettingAsync(productionEndpoint.Key, productionEndpoint.Label);
-            await client.DeleteConfigurationSettingAsync(productionInstances.Key, productionInstances.Label);
             #endregion
         }
     }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Data.AppConfiguration.Samples
+{
+    public partial class ConfigurationSamples
+    {
+        [Test]
+        public async Task GetSettingsUsingTags()
+        {
+            var connectionString = TestEnvironment.ConnectionString;
+
+            #region Snippet:AzConfigSample12_CreateConfigurationClient
+            var client = new ConfigurationClient(connectionString);
+            #endregion
+
+            #region Snippet:AzConfigSample12_CreateConfigurationSettingAsync
+            var betaEndpoint = new ConfigurationSetting("endpoint", "https://beta.endpoint.com", "beta")
+            {
+                Tags = { { "someKey", "someValue" } }
+            };
+            var betaInstances = new ConfigurationSetting("instances", "1", "beta")
+            {
+                Tags = { { "someKey", "someValue" } }
+            };
+            var productionEndpoint = new ConfigurationSetting("endpoint", "https://production.endpoint.com", "production")
+            {
+                Tags = { { "someKey", "otherValue" } }
+            };
+            var productionInstances = new ConfigurationSetting("instances", "1", "production")
+            {
+                Tags = { { "someKey", "otherValue" } }
+            };
+            #endregion
+
+            #region Snippet:AzConfigSample12_AddConfigurationSettingAsync
+            await client.AddConfigurationSettingAsync(betaEndpoint);
+            await client.AddConfigurationSettingAsync(betaInstances);
+            await client.AddConfigurationSettingAsync(productionEndpoint);
+            await client.AddConfigurationSettingAsync(productionInstances);
+            #endregion
+
+            #region Snippet:AzConfigSample12_GetConfigurationSettingsAsync
+            var selector = new SettingSelector { TagsFilter = new string[] { "someKey=otherValue" } };
+
+            Debug.WriteLine("Settings for production filtered by tag:");
+            await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
+            {
+                Console.WriteLine(setting);
+            }
+            #endregion
+
+            // Delete the Configuration Settings from the Configuration Store.
+            #region Snippet:AzConfigSample12_DeleteConfigurationSettingAsync
+            await client.DeleteConfigurationSettingAsync(betaEndpoint.Key, betaEndpoint.Label);
+            await client.DeleteConfigurationSettingAsync(betaInstances.Key, betaInstances.Label);
+            await client.DeleteConfigurationSettingAsync(productionEndpoint.Key, productionEndpoint.Label);
+            await client.DeleteConfigurationSettingAsync(productionInstances.Key, productionInstances.Label);
+            #endregion
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support to filter configuration settings by Tags to the `GetConfigurationSettings` operation. It also adds client support for a new service version `V2023_11_01` and regenerates the client using the [2023-11-01](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/2023-11-01/appconfiguration.json) API version of the spec.

Closes #43381.