### PR TITLE
[AzureMonitorDistro] Add field validation to Integration Tests (part1)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/DistroWebAppLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/DistroWebAppLiveTests.cs
@@ -170,45 +170,26 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
 
         private async Task QueryAndVerifyDependency(string description, string query, ExpectedAppDependency expectedAppDependency)
         {
-            LogsTable logsTable = await QueryTelemetryAsync(description, query);
+            LogsTable? logsTable = await _logsQueryClient!.QueryTelemetryAsync(description, query);
             ValidateExpectedTelemetry(description, logsTable, expectedAppDependency);
         }
 
         private async Task QueryAndVerifyRequest(string description, string query, ExpectedAppRequest expectedAppRequest)
         {
-            LogsTable logsTable = await QueryTelemetryAsync(description, query);
+            LogsTable? logsTable = await _logsQueryClient!.QueryTelemetryAsync(description, query);
             ValidateExpectedTelemetry(description, logsTable, expectedAppRequest);
         }
 
         private async Task QueryAndVerifyMetric(string description, string query, ExpectedAppMetric expectedAppMetric)
         {
-            LogsTable logsTable = await QueryTelemetryAsync(description, query);
+            LogsTable? logsTable = await _logsQueryClient!.QueryTelemetryAsync(description, query);
             ValidateExpectedTelemetry(description, logsTable, expectedAppMetric);
         }
 
         private async Task QueryAndVerifyTrace(string description, string query, ExpectedAppTrace expectedAppTrace)
         {
-            LogsTable logsTable = await QueryTelemetryAsync(description, query);
+            LogsTable? logsTable = await _logsQueryClient!.QueryTelemetryAsync(description, query);
             ValidateExpectedTelemetry(description, logsTable, expectedAppTrace);
-        }
-
-        private async Task<LogsTable> QueryTelemetryAsync(string description, string query)
-        {
-            Debug.WriteLine($"UnitTest: Query Telemetry ({description})");
-            TestContext.Out.WriteLine($"Query Telemetry ({description})");
-
-            LogsTable? resultTable = await _logsQueryClient!.CheckForRecordAsync(query);
-
-            var rowCount = resultTable?.Rows.Count;
-            if (rowCount == null || rowCount == 0)
-            {
-                Assert.Fail($"No telemetry records were found: {description}");
-                return null!;
-            }
-            else
-            {
-                return resultTable!;
-            }
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/LogsQueryClientExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/LogsQueryClientExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
@@ -11,38 +12,32 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
     internal static class LogsQueryClientExtensions
     {
         private static string s_workspaceId = string.Empty;
+        private static TimeSpan s_queryDelay = TimeSpan.FromSeconds(30);
 
         public static void SetQueryWorkSpaceId(this LogsQueryClient client, string workspaceId) => s_workspaceId = workspaceId;
 
         public static async Task<LogsTable?> CheckForRecordAsync(this LogsQueryClient client, string query)
         {
-            LogsTable? table = null;
-            int count = 0;
-
             // Try every 30 secs for total of 5 minutes.
             int maxTries = 10;
-            while (count == 0 && maxTries > 0)
+            for (int attempt = 1; attempt <= maxTries; attempt++)
             {
                 Response<LogsQueryResult> response = await client.QueryWorkspaceAsync(
                     s_workspaceId,
                     query,
                     new QueryTimeRange(TimeSpan.FromMinutes(30)));
 
-                table = response.Value.Table;
-
-                count = table.Rows.Count;
-
-                if (count > 0)
+                if (response.Value.Table.Rows.Count > 0)
                 {
-                    break;
+                    return response.Value.Table;
                 }
 
-                maxTries--;
+                Debug.WriteLine($"UnitTest: query attempt {attempt}/{maxTries} returned no records...");
 
-                await Task.Delay(TimeSpan.FromSeconds(30));
+                await Task.Delay(s_queryDelay);
             }
 
-            return table;
+            return null;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/LogsQueryClientExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/LogsQueryClientExtensions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
+using NUnit.Framework;
 
 namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
 {
@@ -16,8 +17,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
 
         public static void SetQueryWorkSpaceId(this LogsQueryClient client, string workspaceId) => s_workspaceId = workspaceId;
 
-        public static async Task<LogsTable?> CheckForRecordAsync(this LogsQueryClient client, string query)
+        public static async Task<LogsTable?> QueryTelemetryAsync(this LogsQueryClient client, string description, string query)
         {
+            Debug.WriteLine($"UnitTest: Query Telemetry ({description})");
+            TestContext.Out.WriteLine($"Query Telemetry ({description})");
+
             // Try every 30 secs for total of 5 minutes.
             int maxTries = 10;
             for (int attempt = 1; attempt <= maxTries; attempt++)
@@ -32,8 +36,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
                     return response.Value.Table;
                 }
 
-                Debug.WriteLine($"UnitTest: query attempt {attempt}/{maxTries} returned no records...");
-
+                Debug.WriteLine($"UnitTest: Query attempt {attempt}/{maxTries} returned no records. Waiting {s_queryDelay.TotalSeconds} seconds...");
+                TestContext.Out.WriteLine($"Query attempt {attempt}/{maxTries} returned no records. Waiting {s_queryDelay.TotalSeconds} seconds...");
                 await Task.Delay(s_queryDelay);
             }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/SessionRecords/DistroWebAppLiveTests/VerifyDistro.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/SessionRecords/DistroWebAppLiveTests/VerifyDistro.json
@@ -1,33 +1,34 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://api.loganalytics.io/v1/workspaces/33283218-aeb0-4388-b0c0-77a9bf80a8d2/query",
+      "RequestUri": "https://api.loganalytics.io/v1/workspaces/d49041ed-21aa-42c5-a6f3-6d60bb93d63c/query",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "179",
         "Content-Type": "application/json",
-        "traceparent": "00-96c190206c9672f1717ab6c6ef2aecd7-2e8e334b521fb0e0-00",
-        "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "28a87c500b38f9446fbd8fd6b0e14494",
+        "traceparent": "00-c3e7a25d0a6f219049ed08d7f6e270f1-1f8a9ad2a328a4cd-00",
+        "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
+        "x-ms-client-request-id": "Sanitized",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "query": "AppDependencies | where Data == \u0027http://localhost:9998/\u0027 | where AppRoleName == \u0027DistroWebAppLiveTests\u0027 | top 1 by TimeGenerated",
+        "query": "AppDependencies | where Data == 'http://localhost:9998/' | where AppRoleName == 'DistroWebAppLiveTests' | top 1 by TimeGenerated",
         "timespan": "PT30M"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "38",
         "Connection": "keep-alive",
-        "Content-Length": "2436",
+        "Content-Length": "2423",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 24 May 2023 20:39:02 GMT",
+        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-65c7bccb55-g79dl",
+        "Via": "1.1 draft-oms-84fccbf47-c9v62",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -202,22 +203,22 @@
             ],
             "rows": [
               [
-                "33283218-aeb0-4388-b0c0-77a9bf80a8d2",
-                "2023-05-24T20:21:02.429781Z",
-                "f9452d1aabcf2dd7",
+                "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
+                "2024-06-06T23:26:08.1123769Z",
+                "b434b58b936550d7",
                 "localhost:9998",
                 "HTTP",
                 "GET /",
                 "http://localhost:9998/",
                 true,
                 "200",
-                11.628,
-                "\u003C250ms",
-                "{\u0022http.flavor\u0022:\u00221.1\u0022,\u0022_MS.ProcessedByMetricExtractors\u0022:\u0022(Name: X,Ver:\u00271.1\u0027)\u0022}",
+                72.1313,
+                "<250ms",
+                "{\"_MS.ProcessedByMetricExtractors\":\"(Name: X,Ver:'1.1')\"}",
                 null,
                 "",
-                "bc260bdd4f27f54a7d4d1270a26d6d09",
-                "bc260bdd4f27f54a7d4d1270a26d6d09",
+                "9ecb410d3e5ab365cddb5f16e3e14bc2",
+                "9ecb410d3e5ab365cddb5f16e3e14bc2",
                 "",
                 "",
                 "",
@@ -225,24 +226,909 @@
                 "",
                 "",
                 "DistroWebAppLiveTests",
-                "Mac-1684957586475.local",
+                "af7c72ee-94a1-42f8-8306-395ce9147b22",
                 "PC",
                 "Other",
-                "Other",
+                "Windows 10",
                 "0.0.0.0",
-                "San Jose",
-                "California",
+                "Quincy",
+                "Washington",
                 "United States",
                 "Other",
-                "6cbe8a21-11ea-42f8-b456-19144d0c3dde",
-                "375a4ad1-58c9-4f8f-bf21-7f483a813bd5",
-                "dotnet7.0.1:otel1.4.0:ext1.0.0-alpha.20230524.3",
+                "8df423be-a013-477c-88b9-8186722e3d49",
+                "7b1ad079-51c6-4824-91c1-9decb485ba64",
+                "dotnet7.0.20:otel1.8.1:ext1.3.0-beta.2-d",
                 1,
                 "",
                 "",
                 "Azure",
                 "AppDependencies",
-                "/subscriptions/65b2f83e-7bf1-4be3-bafc-3a4163265a52/resourcegroups/rg-mothrmonitor/providers/microsoft.insights/components/tca5ef17935bdced8"
+                "/subscriptions/65b2f83e-7bf1-4be3-bafc-3a4163265a52/resourcegroups/rg-tileemonitor/providers/microsoft.insights/components/t48da106dbe0b9268"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://api.loganalytics.io/v1/workspaces/d49041ed-21aa-42c5-a6f3-6d60bb93d63c/query",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "174",
+        "Content-Type": "application/json",
+        "traceparent": "00-d4bef785fb62c4cd4c2bcedb153baed1-e0bdd341f8fd29c5-00",
+        "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
+        "x-ms-client-request-id": "Sanitized",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "query": "AppRequests | where Url == 'http://localhost:9998/' | where AppRoleName == 'DistroWebAppLiveTests' | top 1 by TimeGenerated",
+        "timespan": "PT30M"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "37",
+        "Connection": "keep-alive",
+        "Content-Length": "2392",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-84fccbf47-kplpm",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "tables": [
+          {
+            "name": "PrimaryResult",
+            "columns": [
+              {
+                "name": "TenantId",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Id",
+                "type": "string"
+              },
+              {
+                "name": "Source",
+                "type": "string"
+              },
+              {
+                "name": "Name",
+                "type": "string"
+              },
+              {
+                "name": "Url",
+                "type": "string"
+              },
+              {
+                "name": "Success",
+                "type": "bool"
+              },
+              {
+                "name": "ResultCode",
+                "type": "string"
+              },
+              {
+                "name": "DurationMs",
+                "type": "real"
+              },
+              {
+                "name": "PerformanceBucket",
+                "type": "string"
+              },
+              {
+                "name": "Properties",
+                "type": "dynamic"
+              },
+              {
+                "name": "Measurements",
+                "type": "dynamic"
+              },
+              {
+                "name": "OperationName",
+                "type": "string"
+              },
+              {
+                "name": "OperationId",
+                "type": "string"
+              },
+              {
+                "name": "OperationLinks",
+                "type": "dynamic"
+              },
+              {
+                "name": "ParentId",
+                "type": "string"
+              },
+              {
+                "name": "SyntheticSource",
+                "type": "string"
+              },
+              {
+                "name": "SessionId",
+                "type": "string"
+              },
+              {
+                "name": "UserId",
+                "type": "string"
+              },
+              {
+                "name": "UserAuthenticatedId",
+                "type": "string"
+              },
+              {
+                "name": "UserAccountId",
+                "type": "string"
+              },
+              {
+                "name": "AppVersion",
+                "type": "string"
+              },
+              {
+                "name": "AppRoleName",
+                "type": "string"
+              },
+              {
+                "name": "AppRoleInstance",
+                "type": "string"
+              },
+              {
+                "name": "ClientType",
+                "type": "string"
+              },
+              {
+                "name": "ClientModel",
+                "type": "string"
+              },
+              {
+                "name": "ClientOS",
+                "type": "string"
+              },
+              {
+                "name": "ClientIP",
+                "type": "string"
+              },
+              {
+                "name": "ClientCity",
+                "type": "string"
+              },
+              {
+                "name": "ClientStateOrProvince",
+                "type": "string"
+              },
+              {
+                "name": "ClientCountryOrRegion",
+                "type": "string"
+              },
+              {
+                "name": "ClientBrowser",
+                "type": "string"
+              },
+              {
+                "name": "ResourceGUID",
+                "type": "string"
+              },
+              {
+                "name": "IKey",
+                "type": "string"
+              },
+              {
+                "name": "SDKVersion",
+                "type": "string"
+              },
+              {
+                "name": "ItemCount",
+                "type": "int"
+              },
+              {
+                "name": "ReferencedItemId",
+                "type": "string"
+              },
+              {
+                "name": "ReferencedType",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              },
+              {
+                "name": "_ResourceId",
+                "type": "string"
+              }
+            ],
+            "rows": [
+              [
+                "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
+                "2024-06-06T23:26:08.1499588Z",
+                "dc6e1dfc2402c31f",
+                "",
+                "GET /",
+                "http://localhost:9998/",
+                true,
+                "200",
+                33.9489,
+                "<250ms",
+                "{\"_MS.ProcessedByMetricExtractors\":\"(Name: X,Ver:'1.1')\"}",
+                null,
+                "GET /",
+                "9ecb410d3e5ab365cddb5f16e3e14bc2",
+                null,
+                "b434b58b936550d7",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "DistroWebAppLiveTests",
+                "af7c72ee-94a1-42f8-8306-395ce9147b22",
+                "PC",
+                "Other",
+                "Windows 10",
+                "0.0.0.0",
+                "Quincy",
+                "Washington",
+                "United States",
+                "Other",
+                "8df423be-a013-477c-88b9-8186722e3d49",
+                "7b1ad079-51c6-4824-91c1-9decb485ba64",
+                "dotnet7.0.20:otel1.8.1:ext1.3.0-beta.2-d",
+                1,
+                "",
+                "",
+                "Azure",
+                "AppRequests",
+                "/subscriptions/65b2f83e-7bf1-4be3-bafc-3a4163265a52/resourcegroups/rg-tileemonitor/providers/microsoft.insights/components/t48da106dbe0b9268"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://api.loganalytics.io/v1/workspaces/d49041ed-21aa-42c5-a6f3-6d60bb93d63c/query",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "253",
+        "Content-Type": "application/json",
+        "traceparent": "00-b0274ddbe31c5276320cdf112e2c113c-4a1b30a8e53f7d8a-00",
+        "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
+        "x-ms-client-request-id": "Sanitized",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "query": "AppMetrics | where Name == 'http.client.request.duration' | where AppRoleName == 'DistroWebAppLiveTests' | where Properties.['server.address'] == 'localhost' | top 1 by TimeGenerated",
+        "timespan": "PT30M"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "36",
+        "Connection": "keep-alive",
+        "Content-Length": "2099",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-84fccbf47-dp62z",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "tables": [
+          {
+            "name": "PrimaryResult",
+            "columns": [
+              {
+                "name": "TenantId",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Name",
+                "type": "string"
+              },
+              {
+                "name": "ItemCount",
+                "type": "int"
+              },
+              {
+                "name": "Sum",
+                "type": "real"
+              },
+              {
+                "name": "Min",
+                "type": "real"
+              },
+              {
+                "name": "Max",
+                "type": "real"
+              },
+              {
+                "name": "Properties",
+                "type": "dynamic"
+              },
+              {
+                "name": "OperationName",
+                "type": "string"
+              },
+              {
+                "name": "OperationId",
+                "type": "string"
+              },
+              {
+                "name": "ParentId",
+                "type": "string"
+              },
+              {
+                "name": "SyntheticSource",
+                "type": "string"
+              },
+              {
+                "name": "SessionId",
+                "type": "string"
+              },
+              {
+                "name": "UserId",
+                "type": "string"
+              },
+              {
+                "name": "UserAuthenticatedId",
+                "type": "string"
+              },
+              {
+                "name": "UserAccountId",
+                "type": "string"
+              },
+              {
+                "name": "AppVersion",
+                "type": "string"
+              },
+              {
+                "name": "AppRoleName",
+                "type": "string"
+              },
+              {
+                "name": "AppRoleInstance",
+                "type": "string"
+              },
+              {
+                "name": "ClientType",
+                "type": "string"
+              },
+              {
+                "name": "ClientModel",
+                "type": "string"
+              },
+              {
+                "name": "ClientOS",
+                "type": "string"
+              },
+              {
+                "name": "ClientIP",
+                "type": "string"
+              },
+              {
+                "name": "ClientCity",
+                "type": "string"
+              },
+              {
+                "name": "ClientStateOrProvince",
+                "type": "string"
+              },
+              {
+                "name": "ClientCountryOrRegion",
+                "type": "string"
+              },
+              {
+                "name": "ClientBrowser",
+                "type": "string"
+              },
+              {
+                "name": "ResourceGUID",
+                "type": "string"
+              },
+              {
+                "name": "IKey",
+                "type": "string"
+              },
+              {
+                "name": "SDKVersion",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              },
+              {
+                "name": "_ResourceId",
+                "type": "string"
+              }
+            ],
+            "rows": [
+              [
+                "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
+                "2024-06-06T23:26:08.3550237Z",
+                "http.client.request.duration",
+                1,
+                0.0721313,
+                0.0721313,
+                0.0721313,
+                "{\"http.request.method\":\"GET\",\"server.address\":\"localhost\",\"url.scheme\":\"http\",\"http.response.status_code\":\"200\",\"network.protocol.version\":\"1.1\",\"server.port\":\"9998\"}",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "DistroWebAppLiveTests",
+                "af7c72ee-94a1-42f8-8306-395ce9147b22",
+                "PC",
+                "Other",
+                "Windows 10",
+                "0.0.0.0",
+                "Quincy",
+                "Washington",
+                "United States",
+                "Other",
+                "8df423be-a013-477c-88b9-8186722e3d49",
+                "7b1ad079-51c6-4824-91c1-9decb485ba64",
+                "dotnet7.0.20:otel1.8.1:ext1.3.0-beta.2-d",
+                "Azure",
+                "AppMetrics",
+                "/subscriptions/65b2f83e-7bf1-4be3-bafc-3a4163265a52/resourcegroups/rg-tileemonitor/providers/microsoft.insights/components/t48da106dbe0b9268"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://api.loganalytics.io/v1/workspaces/d49041ed-21aa-42c5-a6f3-6d60bb93d63c/query",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "180",
+        "Content-Type": "application/json",
+        "traceparent": "00-2f4de0df6742bbeeb4b415277e45ae11-20265699c2e11e87-00",
+        "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
+        "x-ms-client-request-id": "Sanitized",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "query": "AppMetrics | where Name == 'http.server.request.duration' | where AppRoleName == 'DistroWebAppLiveTests' | top 1 by TimeGenerated",
+        "timespan": "PT30M"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "36",
+        "Connection": "keep-alive",
+        "Content-Length": "2062",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-84fccbf47-kjlrh",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "tables": [
+          {
+            "name": "PrimaryResult",
+            "columns": [
+              {
+                "name": "TenantId",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Name",
+                "type": "string"
+              },
+              {
+                "name": "ItemCount",
+                "type": "int"
+              },
+              {
+                "name": "Sum",
+                "type": "real"
+              },
+              {
+                "name": "Min",
+                "type": "real"
+              },
+              {
+                "name": "Max",
+                "type": "real"
+              },
+              {
+                "name": "Properties",
+                "type": "dynamic"
+              },
+              {
+                "name": "OperationName",
+                "type": "string"
+              },
+              {
+                "name": "OperationId",
+                "type": "string"
+              },
+              {
+                "name": "ParentId",
+                "type": "string"
+              },
+              {
+                "name": "SyntheticSource",
+                "type": "string"
+              },
+              {
+                "name": "SessionId",
+                "type": "string"
+              },
+              {
+                "name": "UserId",
+                "type": "string"
+              },
+              {
+                "name": "UserAuthenticatedId",
+                "type": "string"
+              },
+              {
+                "name": "UserAccountId",
+                "type": "string"
+              },
+              {
+                "name": "AppVersion",
+                "type": "string"
+              },
+              {
+                "name": "AppRoleName",
+                "type": "string"
+              },
+              {
+                "name": "AppRoleInstance",
+                "type": "string"
+              },
+              {
+                "name": "ClientType",
+                "type": "string"
+              },
+              {
+                "name": "ClientModel",
+                "type": "string"
+              },
+              {
+                "name": "ClientOS",
+                "type": "string"
+              },
+              {
+                "name": "ClientIP",
+                "type": "string"
+              },
+              {
+                "name": "ClientCity",
+                "type": "string"
+              },
+              {
+                "name": "ClientStateOrProvince",
+                "type": "string"
+              },
+              {
+                "name": "ClientCountryOrRegion",
+                "type": "string"
+              },
+              {
+                "name": "ClientBrowser",
+                "type": "string"
+              },
+              {
+                "name": "ResourceGUID",
+                "type": "string"
+              },
+              {
+                "name": "IKey",
+                "type": "string"
+              },
+              {
+                "name": "SDKVersion",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              },
+              {
+                "name": "_ResourceId",
+                "type": "string"
+              }
+            ],
+            "rows": [
+              [
+                "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
+                "2024-06-06T23:26:08.3549805Z",
+                "http.server.request.duration",
+                1,
+                0.0339489,
+                0.0339489,
+                0.0339489,
+                "{\"http.route\":\"/\",\"http.request.method\":\"GET\",\"url.scheme\":\"http\",\"http.response.status_code\":\"200\",\"network.protocol.version\":\"1.1\"}",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "DistroWebAppLiveTests",
+                "af7c72ee-94a1-42f8-8306-395ce9147b22",
+                "PC",
+                "Other",
+                "Windows 10",
+                "0.0.0.0",
+                "Quincy",
+                "Washington",
+                "United States",
+                "Other",
+                "8df423be-a013-477c-88b9-8186722e3d49",
+                "7b1ad079-51c6-4824-91c1-9decb485ba64",
+                "dotnet7.0.20:otel1.8.1:ext1.3.0-beta.2-d",
+                "Azure",
+                "AppMetrics",
+                "/subscriptions/65b2f83e-7bf1-4be3-bafc-3a4163265a52/resourcegroups/rg-tileemonitor/providers/microsoft.insights/components/t48da106dbe0b9268"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://api.loganalytics.io/v1/workspaces/d49041ed-21aa-42c5-a6f3-6d60bb93d63c/query",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "173",
+        "Content-Type": "application/json",
+        "traceparent": "00-de70c3847aa1995b4953540a99862725-1f2d670b73aa45fd-00",
+        "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
+        "x-ms-client-request-id": "Sanitized",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "query": "AppTraces | where Message == 'Message via ILogger' | where AppRoleName == 'DistroWebAppLiveTests' | top 1 by TimeGenerated",
+        "timespan": "PT30M"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "35",
+        "Connection": "keep-alive",
+        "Content-Length": "1989",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-84fccbf47-kjmsk",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "tables": [
+          {
+            "name": "PrimaryResult",
+            "columns": [
+              {
+                "name": "TenantId",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Message",
+                "type": "string"
+              },
+              {
+                "name": "SeverityLevel",
+                "type": "int"
+              },
+              {
+                "name": "Properties",
+                "type": "dynamic"
+              },
+              {
+                "name": "Measurements",
+                "type": "dynamic"
+              },
+              {
+                "name": "OperationName",
+                "type": "string"
+              },
+              {
+                "name": "OperationId",
+                "type": "string"
+              },
+              {
+                "name": "ParentId",
+                "type": "string"
+              },
+              {
+                "name": "SyntheticSource",
+                "type": "string"
+              },
+              {
+                "name": "SessionId",
+                "type": "string"
+              },
+              {
+                "name": "UserId",
+                "type": "string"
+              },
+              {
+                "name": "UserAuthenticatedId",
+                "type": "string"
+              },
+              {
+                "name": "UserAccountId",
+                "type": "string"
+              },
+              {
+                "name": "AppVersion",
+                "type": "string"
+              },
+              {
+                "name": "AppRoleName",
+                "type": "string"
+              },
+              {
+                "name": "AppRoleInstance",
+                "type": "string"
+              },
+              {
+                "name": "ClientType",
+                "type": "string"
+              },
+              {
+                "name": "ClientModel",
+                "type": "string"
+              },
+              {
+                "name": "ClientOS",
+                "type": "string"
+              },
+              {
+                "name": "ClientIP",
+                "type": "string"
+              },
+              {
+                "name": "ClientCity",
+                "type": "string"
+              },
+              {
+                "name": "ClientStateOrProvince",
+                "type": "string"
+              },
+              {
+                "name": "ClientCountryOrRegion",
+                "type": "string"
+              },
+              {
+                "name": "ClientBrowser",
+                "type": "string"
+              },
+              {
+                "name": "ResourceGUID",
+                "type": "string"
+              },
+              {
+                "name": "IKey",
+                "type": "string"
+              },
+              {
+                "name": "SDKVersion",
+                "type": "string"
+              },
+              {
+                "name": "ItemCount",
+                "type": "int"
+              },
+              {
+                "name": "ReferencedItemId",
+                "type": "string"
+              },
+              {
+                "name": "ReferencedType",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              },
+              {
+                "name": "_ResourceId",
+                "type": "string"
+              }
+            ],
+            "rows": [
+              [
+                "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
+                "2024-06-06T23:26:08.1803116Z",
+                "Message via ILogger",
+                1,
+                null,
+                null,
+                "",
+                "9ecb410d3e5ab365cddb5f16e3e14bc2",
+                "dc6e1dfc2402c31f",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "DistroWebAppLiveTests",
+                "tilee-devbox",
+                "PC",
+                "Other",
+                "Windows 10",
+                "0.0.0.0",
+                "Quincy",
+                "Washington",
+                "United States",
+                "Other",
+                "8df423be-a013-477c-88b9-8186722e3d49",
+                "7b1ad079-51c6-4824-91c1-9decb485ba64",
+                "dotnet7.0.20:otel1.8.1:ext1.3.0-beta.2-d",
+                1,
+                "",
+                "",
+                "Azure",
+                "AppTraces",
+                "/subscriptions/65b2f83e-7bf1-4be3-bafc-3a4163265a52/resourcegroups/rg-tileemonitor/providers/microsoft.insights/components/t48da106dbe0b9268"
               ]
             ]
           }
@@ -251,10 +1137,9 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
-    "CONNECTION_STRING": "InstrumentationKey=375a4ad1-58c9-4f8f-bf21-7f483a813bd5;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus.livediagnostics.monitor.azure.com/",
+    "CONNECTION_STRING": "InstrumentationKey=7b1ad079-51c6-4824-91c1-9decb485ba64;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus.livediagnostics.monitor.azure.com/;ApplicationId=8df423be-a013-477c-88b9-8186722e3d49",
     "LOGS_ENDPOINT": "https://api.loganalytics.io",
-    "RandomSeed": "277228534",
-    "WORKSPACE_ID": "33283218-aeb0-4388-b0c0-77a9bf80a8d2"
+    "RandomSeed": "119435784",
+    "WORKSPACE_ID": "d49041ed-21aa-42c5-a6f3-6d60bb93d63c"
   }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/SessionRecords/DistroWebAppLiveTests/VerifyDistro.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/SessionRecords/DistroWebAppLiveTests/VerifyDistro.json
@@ -8,7 +8,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "179",
         "Content-Type": "application/json",
-        "traceparent": "00-c3e7a25d0a6f219049ed08d7f6e270f1-1f8a9ad2a328a4cd-00",
+        "traceparent": "00-c4516adafd33bcee5da05c3bcb37dd40-938a217833252e6f-00",
         "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
         "x-ms-client-request-id": "Sanitized",
         "x-ms-return-client-request-id": "true"
@@ -21,14 +21,13 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "38",
         "Connection": "keep-alive",
         "Content-Length": "2423",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Date": "Fri, 07 Jun 2024 21:44:57 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-84fccbf47-c9v62",
+        "Via": "1.1 draft-oms-84fccbf47-9zf5l",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -204,21 +203,21 @@
             "rows": [
               [
                 "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
-                "2024-06-06T23:26:08.1123769Z",
-                "b434b58b936550d7",
+                "2024-06-07T21:44:23.1556457Z",
+                "2f64853161967288",
                 "localhost:9998",
                 "HTTP",
                 "GET /",
                 "http://localhost:9998/",
                 true,
                 "200",
-                72.1313,
+                81.8636,
                 "<250ms",
                 "{\"_MS.ProcessedByMetricExtractors\":\"(Name: X,Ver:'1.1')\"}",
                 null,
                 "",
-                "9ecb410d3e5ab365cddb5f16e3e14bc2",
-                "9ecb410d3e5ab365cddb5f16e3e14bc2",
+                "2f5dc72a16261a3a9e74e74ca0f3b4bf",
+                "2f5dc72a16261a3a9e74e74ca0f3b4bf",
                 "",
                 "",
                 "",
@@ -258,7 +257,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "174",
         "Content-Type": "application/json",
-        "traceparent": "00-d4bef785fb62c4cd4c2bcedb153baed1-e0bdd341f8fd29c5-00",
+        "traceparent": "00-d90e7a2bf246528d5c75c004752cfefc-25dd917267728ea9-00",
         "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
         "x-ms-client-request-id": "Sanitized",
         "x-ms-return-client-request-id": "true"
@@ -271,14 +270,13 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "37",
         "Connection": "keep-alive",
         "Content-Length": "2392",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Date": "Fri, 07 Jun 2024 21:44:58 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-84fccbf47-kplpm",
+        "Via": "1.1 draft-oms-84fccbf47-vv6qb",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -454,21 +452,21 @@
             "rows": [
               [
                 "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
-                "2024-06-06T23:26:08.1499588Z",
-                "dc6e1dfc2402c31f",
+                "2024-06-07T21:44:23.2035048Z",
+                "52f6536389172c57",
                 "",
                 "GET /",
                 "http://localhost:9998/",
                 true,
                 "200",
-                33.9489,
+                33.8512,
                 "<250ms",
                 "{\"_MS.ProcessedByMetricExtractors\":\"(Name: X,Ver:'1.1')\"}",
                 null,
                 "GET /",
-                "9ecb410d3e5ab365cddb5f16e3e14bc2",
+                "2f5dc72a16261a3a9e74e74ca0f3b4bf",
                 null,
-                "b434b58b936550d7",
+                "2f64853161967288",
                 "",
                 "",
                 "",
@@ -508,7 +506,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "253",
         "Content-Type": "application/json",
-        "traceparent": "00-b0274ddbe31c5276320cdf112e2c113c-4a1b30a8e53f7d8a-00",
+        "traceparent": "00-cf77b2398e6b1a6ebf333d08dae5624f-5b6a30caa64b9b65-00",
         "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
         "x-ms-client-request-id": "Sanitized",
         "x-ms-return-client-request-id": "true"
@@ -521,14 +519,13 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "36",
         "Connection": "keep-alive",
-        "Content-Length": "2099",
+        "Content-Length": "2097",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Date": "Fri, 07 Jun 2024 21:44:58 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-84fccbf47-dp62z",
+        "Via": "1.1 draft-oms-84fccbf47-9ff58",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -672,13 +669,13 @@
             "rows": [
               [
                 "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
-                "2024-06-06T23:26:08.3550237Z",
+                "2024-06-07T21:44:23.41758Z",
                 "http.client.request.duration",
                 1,
-                0.0721313,
-                0.0721313,
-                0.0721313,
-                "{\"http.request.method\":\"GET\",\"server.address\":\"localhost\",\"url.scheme\":\"http\",\"http.response.status_code\":\"200\",\"network.protocol.version\":\"1.1\",\"server.port\":\"9998\"}",
+                0.0818636,
+                0.0818636,
+                0.0818636,
+                "{\"http.request.method\":\"GET\",\"http.response.status_code\":\"200\",\"network.protocol.version\":\"1.1\",\"server.address\":\"localhost\",\"server.port\":\"9998\",\"url.scheme\":\"http\"}",
                 "",
                 "",
                 "",
@@ -718,7 +715,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "180",
         "Content-Type": "application/json",
-        "traceparent": "00-2f4de0df6742bbeeb4b415277e45ae11-20265699c2e11e87-00",
+        "traceparent": "00-154cc7d705defc8173d6ade388684c0e-58f18a6b885d49f9-00",
         "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
         "x-ms-client-request-id": "Sanitized",
         "x-ms-return-client-request-id": "true"
@@ -731,14 +728,13 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "36",
         "Connection": "keep-alive",
         "Content-Length": "2062",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Date": "Fri, 07 Jun 2024 21:45:00 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-84fccbf47-kjlrh",
+        "Via": "1.1 draft-oms-84fccbf47-z4b84",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -882,13 +878,13 @@
             "rows": [
               [
                 "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
-                "2024-06-06T23:26:08.3549805Z",
+                "2024-06-07T21:44:23.4175451Z",
                 "http.server.request.duration",
                 1,
-                0.0339489,
-                0.0339489,
-                0.0339489,
-                "{\"http.route\":\"/\",\"http.request.method\":\"GET\",\"url.scheme\":\"http\",\"http.response.status_code\":\"200\",\"network.protocol.version\":\"1.1\"}",
+                0.0338512,
+                0.0338512,
+                0.0338512,
+                "{\"http.request.method\":\"GET\",\"http.response.status_code\":\"200\",\"http.route\":\"/\",\"network.protocol.version\":\"1.1\",\"url.scheme\":\"http\"}",
                 "",
                 "",
                 "",
@@ -928,7 +924,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "173",
         "Content-Type": "application/json",
-        "traceparent": "00-de70c3847aa1995b4953540a99862725-1f2d670b73aa45fd-00",
+        "traceparent": "00-9759964878634526a529cfa2071f06c9-0d03ec30c641be54-00",
         "User-Agent": "azsdk-net-Monitor.Query/1.1.0 (.NET 7.0.20; Microsoft Windows 10.0.22631)",
         "x-ms-client-request-id": "Sanitized",
         "x-ms-return-client-request-id": "true"
@@ -941,14 +937,13 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "35",
         "Connection": "keep-alive",
         "Content-Length": "1989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Jun 2024 23:52:35 GMT",
+        "Date": "Fri, 07 Jun 2024 21:45:01 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-84fccbf47-kjmsk",
+        "Via": "1.1 draft-oms-84fccbf47-q7zwk",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -1096,14 +1091,14 @@
             "rows": [
               [
                 "d49041ed-21aa-42c5-a6f3-6d60bb93d63c",
-                "2024-06-06T23:26:08.1803116Z",
+                "2024-06-07T21:44:23.2335203Z",
                 "Message via ILogger",
                 1,
                 null,
                 null,
                 "",
-                "9ecb410d3e5ab365cddb5f16e3e14bc2",
-                "dc6e1dfc2402c31f",
+                "2f5dc72a16261a3a9e74e74ca0f3b4bf",
+                "52f6536389172c57",
                 "",
                 "",
                 "",
@@ -1139,7 +1134,7 @@
   "Variables": {
     "CONNECTION_STRING": "InstrumentationKey=7b1ad079-51c6-4824-91c1-9decb485ba64;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus.livediagnostics.monitor.azure.com/;ApplicationId=8df423be-a013-477c-88b9-8186722e3d49",
     "LOGS_ENDPOINT": "https://api.loganalytics.io",
-    "RandomSeed": "119435784",
+    "RandomSeed": "1564761728",
     "WORKSPACE_ID": "d49041ed-21aa-42c5-a6f3-6d60bb93d63c"
   }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
@@ -13,20 +13,22 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
 {
     internal static class TelemetryValidationHelper
     {
-        public static void ValidateExpectedTelemetry(string description, LogsTable logsTable, object expectedTelemetry)
+        public static void ValidateExpectedTelemetry(string description, LogsTable? logsTable, object expectedTelemetry)
         {
             TestContext.Out.WriteLine($"{nameof(ValidateExpectedTelemetry)}: '{description}'");
 
-            Assert.AreEqual(1, logsTable.Rows.Count, $"Expected 1 row in the table for {description} but found {logsTable.Rows.Count} rows.");
+            Assert.IsNotNull(logsTable, $"({description}) Expected a non-null table.");
+            Assert.AreEqual(1, logsTable!.Rows.Count, $"({description}) Expected 1 row in the table but found {logsTable.Rows.Count} rows.");
 
             var row = logsTable.Rows[0];
             foreach (PropertyInfo property in expectedTelemetry.GetType().GetProperties())
             {
                 if (property.Name == "Properties")
                 {
-                    // TODO: NULL CHECKS
                     var jsonString = row[property.Name].ToString();
+                    Assert.IsNotNull(jsonString, $"({description}) Expected a non-null value for {property.Name}");
                     var expectedProperties = property.GetValue(expectedTelemetry, null) as List<KeyValuePair<string, string>>;
+                    Assert.IsNotNull(expectedProperties, $"({description}) Expected a non-null value for {property.Name}.");
 
                     ValidateProperties(
                         description: description,
@@ -48,10 +50,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
         private static void ValidateProperties(string description, string jsonString, List<KeyValuePair<string, string>> expectedProperties)
         {
 #if NET6_0_OR_GREATER
-            // TODO: NULL CHECKS
-            var jsonNode = JsonNode.Parse(jsonString!);
+            var jsonNode = JsonNode.Parse(jsonString);
+            Assert.IsNotNull(jsonNode, $"({description}) Expected a non-null JSON node.");
 
-            foreach (var expectedProperty in expectedProperties!)
+            foreach (var expectedProperty in expectedProperties)
             {
                 var actualValue = jsonNode![expectedProperty.Key]!.ToString();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
@@ -28,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
                     var jsonString = row[property.Name].ToString();
                     Assert.IsNotNull(jsonString, $"({description}) Expected a non-null value for {property.Name}");
                     var expectedProperties = property.GetValue(expectedTelemetry, null) as List<KeyValuePair<string, string>>;
-                    Assert.IsNotNull(expectedProperties, $"({description}) Expected a non-null value for {property.Name}.");
+                    Assert.IsNotNull(expectedProperties, $"({description}) Expected a non-null value for {nameof(expectedTelemetry)}.Properties");
 
                     ValidateProperties(
                         description: description,
@@ -42,9 +42,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
                     Assert.AreEqual(
                         expected: property.GetValue(expectedTelemetry, null),
                         actual: row[property.Name],
-                        message: $"({description}) Expected {property.Name} to be {property.GetValue(expectedTelemetry, null)} but found {logsTable.Rows[0][property.Name]}.");
+                        message: $"({description}) Expected {property.Name} to be '{property.GetValue(expectedTelemetry, null)}' but found '{logsTable.Rows[0][property.Name]}'.");
                 }
             }
+
+            TestContext.Out.WriteLine();
         }
 
         private static void ValidateProperties(string description, string jsonString, List<KeyValuePair<string, string>> expectedProperties)
@@ -55,14 +57,16 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
 
             foreach (var expectedProperty in expectedProperties)
             {
-                var actualValue = jsonNode![expectedProperty.Key]!.ToString();
+                var jsonValue = jsonNode![expectedProperty.Key];
+                Assert.IsNotNull(jsonValue, $"({description}) Expected a non-null JSON value for Properties.'{expectedProperty.Key}'.");
+                var actualValue = jsonValue!.ToString();
 
                 TestContext.Out.WriteLine($"Properties.'{expectedProperty.Key}' ExpectedValue: '{expectedProperty.Value}' ActualValue: '{actualValue}'");
 
                 Assert.AreEqual(
                     expected: expectedProperty.Value,
                     actual: actualValue,
-                    message: $"({description}) Expected {expectedProperty.Key} to be {expectedProperty.Value} but found {actualValue}.");
+                    message: $"({description}) Expected Properties.'{expectedProperty.Key}' to be '{expectedProperty.Value}' but found '{actualValue}'.");
             }
 #endif
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Reflection;
+#if NET6_0_OR_GREATER
+using System.Text.Json.Nodes;
+#endif
+using Azure.Monitor.Query.Models;
+using NUnit.Framework;
+
+namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
+{
+    internal static class TelemetryValidationHelper
+    {
+        public static void ValidateExpectedTelemetry(string description, LogsTable logsTable, object expectedTelemetry)
+        {
+            TestContext.Out.WriteLine($"{nameof(ValidateExpectedTelemetry)}: '{description}'");
+
+            Assert.AreEqual(1, logsTable.Rows.Count, $"Expected 1 row in the table for {description} but found {logsTable.Rows.Count} rows.");
+
+            var row = logsTable.Rows[0];
+            foreach (PropertyInfo property in expectedTelemetry.GetType().GetProperties())
+            {
+                if (property.Name == "Properties")
+                {
+                    // TODO: NULL CHECKS
+                    var jsonString = row[property.Name].ToString();
+                    var expectedProperties = property.GetValue(expectedTelemetry, null) as List<KeyValuePair<string, string>>;
+
+                    ValidateProperties(
+                        description: description,
+                        jsonString: jsonString!,
+                        expectedProperties: expectedProperties!);
+                }
+                else
+                {
+                    TestContext.Out.WriteLine($"Property: '{property.Name}' ExpectedValue: '{property.GetValue(expectedTelemetry, null)}' ActualValue: '{row[property.Name]}'");
+
+                    Assert.AreEqual(
+                        expected: property.GetValue(expectedTelemetry, null),
+                        actual: row[property.Name],
+                        message: $"({description}) Expected {property.Name} to be {property.GetValue(expectedTelemetry, null)} but found {logsTable.Rows[0][property.Name]}.");
+                }
+            }
+        }
+
+        private static void ValidateProperties(string description, string jsonString, List<KeyValuePair<string, string>> expectedProperties)
+        {
+#if NET6_0_OR_GREATER
+            // TODO: NULL CHECKS
+            var jsonNode = JsonNode.Parse(jsonString!);
+
+            foreach (var expectedProperty in expectedProperties!)
+            {
+                var actualValue = jsonNode![expectedProperty.Key]!.ToString();
+
+                TestContext.Out.WriteLine($"Properties.'{expectedProperty.Key}' ExpectedValue: '{expectedProperty.Value}' ActualValue: '{actualValue}'");
+
+                Assert.AreEqual(
+                    expected: expectedProperty.Value,
+                    actual: actualValue,
+                    message: $"({description}) Expected {expectedProperty.Key} to be {expectedProperty.Value} but found {actualValue}.");
+            }
+#endif
+        }
+
+        public struct ExpectedAppDependency
+        {
+            public string Data { get; set; }
+            public string AppRoleName { get; set; }
+        }
+
+        public struct ExpectedAppRequest
+        {
+            public string Url { get; set; }
+            public string AppRoleName { get; set; }
+        }
+
+        public struct ExpectedAppMetric
+        {
+            public string Name { get; set; }
+            public string AppRoleName { get; set; }
+            public List<KeyValuePair<string, string>> Properties { get; set; }
+        }
+
+        public struct ExpectedAppTrace
+        {
+            public string Message { get; set; }
+            public string AppRoleName { get; set; }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
@@ -75,12 +75,16 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
         {
             public string Data { get; set; }
             public string AppRoleName { get; set; }
+
+            // TODO: ADD REMAINING PROPERTIES IN FOLLOW UP PR.
         }
 
         public struct ExpectedAppRequest
         {
             public string Url { get; set; }
             public string AppRoleName { get; set; }
+
+            // TODO: ADD REMAINING PROPERTIES IN FOLLOW UP PR.
         }
 
         public struct ExpectedAppMetric
@@ -88,12 +92,16 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
             public string Name { get; set; }
             public string AppRoleName { get; set; }
             public List<KeyValuePair<string, string>> Properties { get; set; }
+
+            // TODO: ADD REMAINING PROPERTIES IN FOLLOW UP PR.
         }
 
         public struct ExpectedAppTrace
         {
             public string Message { get; set; }
             public string AppRoleName { get; set; }
+
+            // TODO: ADD REMAINING PROPERTIES IN FOLLOW UP PR.
         }
     }
 }


### PR DESCRIPTION
This PR is adding field validation in our Integration Tests.
This adds an ExpectedTelemetry struct with properties.
Each properties are iterated and compared to the telemetry returned from Log Analytics.

## Changes
- Adds additional logging to help troubleshoot tests. Both `Debug.WriteLine` for local debugging and `TestContext.Out.WriteLine` for test output.
- Adds very simple `structs` for expected telemetry: `ExpectedAppDependency`, `ExpectedAppRequest`, `ExpectedAppMetric`, `ExpectedAppTrace`.
  These names match the table names in Log Analytics and the struct Property names match the field names.
  I'll finished adding the remaining fields to these structs in a follow up PR.
