### PR TITLE
Fix for demo in readme file: ChatCompletionOptions are not passed correctly

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/README.md
+++ b/sdk/openai/Azure.AI.OpenAI/README.md
@@ -358,7 +358,8 @@ options.AddDataSource(new AzureSearchChatDataSource()
 ChatCompletion completion = chatClient.CompleteChat(
     [
         new UserChatMessage("What are the best-selling Contoso products this month?"),
-    ]);
+    ],
+    options);
 
 AzureChatMessageContext onYourDataContext = completion.GetAzureMessageContext();
 


### PR DESCRIPTION
The section *Use your own data with Azure OpenAI* has some demo code that is not correct:

ChatCompletionOptions is not passed to the call to `CompleteChat`

This makes the code fail. This PR corrects the demo code by passing the options to the CompleteChat method:

```csharp
ChatCompletion completion = chatClient.CompleteChat(
    [
        new UserChatMessage("What are the best-selling Contoso products this month?"),
    ],
    options);
```