### PR TITLE
[AzureMonitor] remove features before stable release

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -157,7 +157,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                     .Configure<IOptionsMonitor<AzureMonitorOptions>>((loggingOptions, azureOptions) =>
                     {
                         var azureMonitorOptions = azureOptions.Get(Options.DefaultName);
+                        loggingOptions.AddAzureMonitorLogExporter(o => azureMonitorOptions.SetValueToExporterOptions(o));
 
+                        // TODO:WILL RE-ENABLE IN NEXT BETA
+                        /*
                         bool enableLogSampling = false;
                         try
                         {
@@ -169,17 +172,17 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                             AzureMonitorAspNetCoreEventSource.Log.GetEnvironmentVariableFailed(EnableLogSamplingEnvVar, ex);
                         }
 
-                        // TODO: WILL RE-ENABLE IN NEXT BETA
-                        //if (enableLogSampling)
-                        //{
-                        //    var azureMonitorExporterOptions = new AzureMonitorExporterOptions();
-                        //    azureMonitorOptions.SetValueToExporterOptions(azureMonitorExporterOptions);
-                        //    loggingOptions.AddProcessor(new LogFilteringProcessor(new AzureMonitorLogExporter(azureMonitorExporterOptions)));
-                        //}
-                        //else
-                        //{
-                        //    loggingOptions.AddAzureMonitorLogExporter(o => azureMonitorOptions.SetValueToExporterOptions(o));
-                        //}
+                        if (enableLogSampling)
+                        {
+                            var azureMonitorExporterOptions = new AzureMonitorExporterOptions();
+                            azureMonitorOptions.SetValueToExporterOptions(azureMonitorExporterOptions);
+                            loggingOptions.AddProcessor(new LogFilteringProcessor(new AzureMonitorLogExporter(azureMonitorExporterOptions)));
+                        }
+                        else
+                        {
+                            loggingOptions.AddAzureMonitorLogExporter(o => azureMonitorOptions.SetValueToExporterOptions(o));
+                        }
+                        */
 
                         if (azureMonitorOptions.EnableLiveMetrics)
                         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -169,16 +169,17 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                             AzureMonitorAspNetCoreEventSource.Log.GetEnvironmentVariableFailed(EnableLogSamplingEnvVar, ex);
                         }
 
-                        if (enableLogSampling)
-                        {
-                            var azureMonitorExporterOptions = new AzureMonitorExporterOptions();
-                            azureMonitorOptions.SetValueToExporterOptions(azureMonitorExporterOptions);
-                            loggingOptions.AddProcessor(new LogFilteringProcessor(new AzureMonitorLogExporter(azureMonitorExporterOptions)));
-                        }
-                        else
-                        {
-                            loggingOptions.AddAzureMonitorLogExporter(o => azureMonitorOptions.SetValueToExporterOptions(o));
-                        }
+                        // TODO: WILL RE-ENABLE IN NEXT BETA
+                        //if (enableLogSampling)
+                        //{
+                        //    var azureMonitorExporterOptions = new AzureMonitorExporterOptions();
+                        //    azureMonitorOptions.SetValueToExporterOptions(azureMonitorExporterOptions);
+                        //    loggingOptions.AddProcessor(new LogFilteringProcessor(new AzureMonitorLogExporter(azureMonitorExporterOptions)));
+                        //}
+                        //else
+                        //{
+                        //    loggingOptions.AddAzureMonitorLogExporter(o => azureMonitorOptions.SetValueToExporterOptions(o));
+                        //}
 
                         if (azureMonitorOptions.EnableLiveMetrics)
                         {
@@ -200,20 +201,21 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                         azureMonitorOptions.Get(Options.DefaultName).SetValueToExporterOptions(exporterOptions);
                     });
 
+            // TODO: WILL RE-ENABLE IN NEXT BETA
             // Register Azure SDK log forwarder in the case it was not registered by the user application.
-            builder.Services.AddHostedService(sp =>
-            {
-                var logForwarderType = Type.GetType("Microsoft.Extensions.Azure.AzureEventSourceLogForwarder, Microsoft.Extensions.Azure", false);
+            //builder.Services.AddHostedService(sp =>
+            //{
+            //    var logForwarderType = Type.GetType("Microsoft.Extensions.Azure.AzureEventSourceLogForwarder, Microsoft.Extensions.Azure", false);
 
-                if (logForwarderType != null && sp.GetService(logForwarderType) != null)
-                {
-                    AzureMonitorAspNetCoreEventSource.Log.LogForwarderIsAlreadyRegistered();
-                    return AzureEventSourceLogForwarder.Noop;
-                }
+            //    if (logForwarderType != null && sp.GetService(logForwarderType) != null)
+            //    {
+            //        AzureMonitorAspNetCoreEventSource.Log.LogForwarderIsAlreadyRegistered();
+            //        return AzureEventSourceLogForwarder.Noop;
+            //    }
 
-                var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-                return new AzureEventSourceLogForwarder(loggerFactory);
-            });
+            //    var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            //    return new AzureEventSourceLogForwarder(loggerFactory);
+            //});
 
             // Register Manager as a singleton
             builder.Services.AddSingleton<Manager>(sp =>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
@@ -22,11 +22,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 {
     public class AzureSdkLoggingTests
     {
-#if NET6_0
-        [ConditionallySkipOSTheory(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
-#else
-        [Theory]
-#endif
+        [Theory(Skip = "Temporary skip for stable release")]
+        //#if NET6_0
+        //        [ConditionallySkipOSTheory(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+        //#else
+        //        [Theory]
+        //#endif
         [InlineData(LogLevel.Information, "TestInfoEvent: hello")]
         [InlineData(LogLevel.Warning, "TestWarningEvent: hello")]
         [InlineData(LogLevel.Debug, null)]
@@ -54,11 +55,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             }
         }
 
-#if NET6_0
-        [ConditionallySkipOSTheory(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
-#else
-        [Theory]
-#endif
+        [Theory(Skip = "Temporary skip for stable release")]
+        //#if NET6_0
+        //        [ConditionallySkipOSTheory(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+        //#else
+        //        [Theory]
+        //#endif
         [InlineData(LogLevel.Information, "TestInfoEvent: hello")]
         [InlineData(LogLevel.Warning, "TestWarningEvent: hello")]
         [InlineData(LogLevel.Debug, null)]
@@ -95,11 +97,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             }
         }
 
-#if NET6_0
-        [ConditionallySkipOSFact(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
-#else
-        [Fact]
-#endif
+        [Fact(Skip = "Temporary skip for stable release")]
+        //#if NET6_0
+        //        [ConditionallySkipOSFact(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+        //#else
+        //        [Fact]
+        //#endif
         public async Task SelfDiagnosticsIsDisabled()
         {
             var enableLevel = LogLevel.Debug;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Includes all changes from 1.3.0-beta.1 and 1.3.0-beta.2
 * Changed `AzureMonitorLogExporter` to be internal.
+  This will be changed back to public in our next Beta while we experiment with options to enable log filtering.
   ([#44479](https://github.com/Azure/azure-sdk-for-net/pull/44479))
 
 ## 1.3.0-beta.2 (2024-05-08)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Other Changes
 
 * Includes all changes from 1.3.0-beta.1 and 1.3.0-beta.2
+* Changed `AzureMonitorLogExporter` to be internal.
+  ([#44479](https://github.com/Azure/azure-sdk-for-net/pull/44479))
 
 ## 1.3.0-beta.2 (2024-05-08)
 
@@ -23,8 +25,8 @@
 ### Other Changes
 
 * Update OpenTelemetry dependencies
-  ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
-  - OpenTelemetry 1.8.0
+  ([#43688](https://github.com/Azure/azure-sdk-for-net/pull/43688))
+  - OpenTelemetry 1.8.1
 
 ## 1.3.0-beta.1 (2024-02-08)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net6.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net6.0.cs
@@ -21,10 +21,4 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             v2_1 = 1,
         }
     }
-    public sealed partial class AzureMonitorLogExporter : OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord>
-    {
-        public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
-        protected override void Dispose(bool disposing) { }
-        public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
-    }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -21,10 +21,4 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             v2_1 = 1,
         }
     }
-    public sealed partial class AzureMonitorLogExporter : OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord>
-    {
-        public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
-        protected override void Dispose(bool disposing) { }
-        public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
-    }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -14,7 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     /// <summary>
     /// Azure Monitor Log Exporter.
     /// </summary>
-    public sealed class AzureMonitorLogExporter : BaseExporter<LogRecord>
+    internal sealed class AzureMonitorLogExporter : BaseExporter<LogRecord>
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;


### PR DESCRIPTION
Removing certain logging features before stable release.
These features will be added back for an immediate beta release.


## Changes
- change LogExporter to `internal`
- remove LogFiltering from Distro
- remove AzureLogForwarding from Distro