### PR TITLE
update require url format  on eng\templates\Azure.ResourceManager.Template\src\autorest.md

### DIFF
--- a/eng/templates/Azure.ResourceManager.Template/src/autorest.md
+++ b/eng/templates/Azure.ResourceManager.Template/src/autorest.md
@@ -7,7 +7,7 @@ azure-arm: true
 csharp: true
 library-name: ProviderShortName
 namespace: Azure.ResourceManager.ProviderShortName
-require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/ProviderNameLowercase/resource-manager/readme.md
+require: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/ProviderNameLowercase/resource-manager/readme.md
 output-folder: $(this-folder)/Generated
 clear-output-folder: true
 sample-gen:


### PR DESCRIPTION
the template url does not fit the actual url format, since we want to create a project and replace the commit id in a automation script process. so we changed to the actual url format ："https://github.com/Azure/azure-rest-api-specs/blob/main/specification/ProviderNameLowercase/resource-manager/readme.md" , what the automation process does is to replace the main to the commit id  user typed.