### PR TITLE
Dispose of streams that are created to wrap BinaryData

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -1042,13 +1042,18 @@ namespace Azure.Storage.Blobs
         public virtual Response<BlobContentInfo> Upload(
             BinaryData content,
             BlobUploadOptions options,
-            CancellationToken cancellationToken = default) =>
-            StagedUploadInternal(
-                content.ToStream(),
-                options,
-                async: false,
-                cancellationToken: cancellationToken)
-                .EnsureCompleted();
+            CancellationToken cancellationToken = default)
+        {
+            using (var stream = content.ToStream())
+            {
+                return StagedUploadInternal(
+                    stream,
+                    options,
+                    async: false,
+                    cancellationToken: cancellationToken)
+                    .EnsureCompleted();
+            }
+        }
 
         /// <summary>
         /// The <see cref="Upload(Stream, BlobHttpHeaders, Metadata, BlobRequestConditions, IProgress{long}, AccessTier?, StorageTransferOptions, CancellationToken)"/>
@@ -1360,13 +1365,18 @@ namespace Azure.Storage.Blobs
         public virtual async Task<Response<BlobContentInfo>> UploadAsync(
             BinaryData content,
             BlobUploadOptions options,
-            CancellationToken cancellationToken = default) =>
-            await StagedUploadInternal(
-                content.ToStream(),
-                options,
-                async: true,
-                cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+            CancellationToken cancellationToken = default)
+        {
+            using (var stream = content.ToStream())
+            {
+                return await StagedUploadInternal(
+                    stream,
+                    options,
+                    async: true,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
         /// The <see cref="UploadAsync(Stream, BlobHttpHeaders, Metadata, BlobRequestConditions, IProgress{long}, AccessTier?, StorageTransferOptions, CancellationToken)"/>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -3238,14 +3238,18 @@ namespace Azure.Storage.Blobs.Specialized
                             LeaseId = args.Conditions.LeaseId
                         };
                     }
-                    await client.StageBlockInternal(
-                            Shared.StorageExtensions.GenerateBlockId(offset),
-                            content.ToStream(),
-                            validationOptions,
-                            conditions,
-                            progressHandler,
-                            async,
-                            cancellationToken).ConfigureAwait(false);
+
+                    using (var stream = content.ToStream())
+                    {
+                        await client.StageBlockInternal(
+                                Shared.StorageExtensions.GenerateBlockId(offset),
+                                stream,
+                                validationOptions,
+                                conditions,
+                                progressHandler,
+                                async,
+                                cancellationToken).ConfigureAwait(false);
+                    }
                 },
                 CommitPartitionedUpload = async (partitions, args, async, cancellationToken)
                     => await client.CommitBlockListInternal(


### PR DESCRIPTION
Certain overloads for blob storage create streams to wrap the bytes that are sent in. These Streams are not disposed ~which means (unless I've misunderstood something) they'll hang around for longer than required and cause additional pressure for GC~.

There are no breaking changes, and no changes to any API surfaces (internal or external).

EDIT: Just realised I was getting `IDisposable` and `Finalizers` confused, so my comment above about extra GC pressure is incorrect. It's not necessary for these Streams to be disposed of (as MemoryStream doesn't deal with any unmanaged resources) so it's just down to whether it's considered good practice I believe.