### PR TITLE
[AzureMonitor] reenable logging features

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release History
 
+## 1.3.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+* Enabled support for log collection from Azure SDKs via `Microsoft.Extensions.Logging`.
+  See [Logging with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/logging) for the details.
+
+* Added an experimental feature for logs emitted within an active tracing context to follow the Activity's sampling decision.
+  The feature can be enabled by setting `OTEL_DOTNET_AZURE_MONITOR_EXPERIMENTAL_ENABLE_LOG_SAMPLING` environment variable to `true`.
+
 ## 1.2.0 (2024-06-11)
 
 ### Other Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -12,9 +12,13 @@
 
 * Enabled support for log collection from Azure SDKs via `Microsoft.Extensions.Logging`.
   See [Logging with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/logging) for the details.
+  (This feature was originally introduced in 1.2.0-beta.2)
+  ([#44511](https://github.com/Azure/azure-sdk-for-net/pull/44511))
 
 * Added an experimental feature for logs emitted within an active tracing context to follow the Activity's sampling decision.
   The feature can be enabled by setting `OTEL_DOTNET_AZURE_MONITOR_EXPERIMENTAL_ENABLE_LOG_SAMPLING` environment variable to `true`.
+  (This feature was originally introduced in 1.2.0-beta.1)
+  ([#44511](https://github.com/Azure/azure-sdk-for-net/pull/44511))
 
 ## 1.2.0 (2024-06-11)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <Description>An OpenTelemetry .NET distro that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry ASP.NET Core Distro</AssemblyTitle>
-    <Version>1.2.0</Version>
+    <Version>1.3.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <!-- TODO: Remove this condition from ApiCompatVersion after we release our next stable. Need to disable this because added new target framwork. -->
-    <ApiCompatVersion Condition="'$(TargetFramework)' != 'net6.0'">1.1.0</ApiCompatVersion>
+    <ApiCompatVersion>1.2.0</ApiCompatVersion>
     <PackageTags>Azure Monitor OpenTelemetry Exporter Distro ApplicationInsights</PackageTags>
     <TargetFrameworks>net6.0;$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
@@ -24,10 +23,10 @@
     <!-- Depending on monthly deliverables, we may switch between PackageReference or ProjectReference. Keeping both here to make the switch easier. -->
 
     <!-- FOR PUBLIC RELEASES, MUST USE PackageReference. THIS REQUIRES A STAGGERED RELEASE IF SHIPPING A NEW EXPORTER. -->
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <!--<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />-->
 
     <!-- FOR LOCAL DEV, ProjectReference IS PREFERRED. -->
-    <!--<ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />-->
+    <ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
   </ItemGroup>
 
   <!-- Shared sources from Azure.Core -->

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -157,10 +157,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                     .Configure<IOptionsMonitor<AzureMonitorOptions>>((loggingOptions, azureOptions) =>
                     {
                         var azureMonitorOptions = azureOptions.Get(Options.DefaultName);
-                        loggingOptions.AddAzureMonitorLogExporter(o => azureMonitorOptions.SetValueToExporterOptions(o));
 
-                        // TODO:WILL RE-ENABLE IN NEXT BETA
-                        /*
                         bool enableLogSampling = false;
                         try
                         {
@@ -182,7 +179,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                         {
                             loggingOptions.AddAzureMonitorLogExporter(o => azureMonitorOptions.SetValueToExporterOptions(o));
                         }
-                        */
 
                         if (azureMonitorOptions.EnableLiveMetrics)
                         {
@@ -204,21 +200,20 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                         azureMonitorOptions.Get(Options.DefaultName).SetValueToExporterOptions(exporterOptions);
                     });
 
-            // TODO: WILL RE-ENABLE IN NEXT BETA
             // Register Azure SDK log forwarder in the case it was not registered by the user application.
-            //builder.Services.AddHostedService(sp =>
-            //{
-            //    var logForwarderType = Type.GetType("Microsoft.Extensions.Azure.AzureEventSourceLogForwarder, Microsoft.Extensions.Azure", false);
+            builder.Services.AddHostedService(sp =>
+            {
+                var logForwarderType = Type.GetType("Microsoft.Extensions.Azure.AzureEventSourceLogForwarder, Microsoft.Extensions.Azure", false);
 
-            //    if (logForwarderType != null && sp.GetService(logForwarderType) != null)
-            //    {
-            //        AzureMonitorAspNetCoreEventSource.Log.LogForwarderIsAlreadyRegistered();
-            //        return AzureEventSourceLogForwarder.Noop;
-            //    }
+                if (logForwarderType != null && sp.GetService(logForwarderType) != null)
+                {
+                    AzureMonitorAspNetCoreEventSource.Log.LogForwarderIsAlreadyRegistered();
+                    return AzureEventSourceLogForwarder.Noop;
+                }
 
-            //    var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-            //    return new AzureEventSourceLogForwarder(loggerFactory);
-            //});
+                var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+                return new AzureEventSourceLogForwarder(loggerFactory);
+            });
 
             // Register Manager as a singleton
             builder.Services.AddSingleton<Manager>(sp =>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
@@ -22,12 +22,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 {
     public class AzureSdkLoggingTests
     {
-        [Theory(Skip = "Temporary skip for stable release")]
-        //#if NET6_0
-        //        [ConditionallySkipOSTheory(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
-        //#else
-        //        [Theory]
-        //#endif
+#if NET6_0
+        [ConditionallySkipOSTheory(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+#else
+        [Theory]
+#endif
         [InlineData(LogLevel.Information, "TestInfoEvent: hello")]
         [InlineData(LogLevel.Warning, "TestWarningEvent: hello")]
         [InlineData(LogLevel.Debug, null)]
@@ -55,12 +54,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             }
         }
 
-        [Theory(Skip = "Temporary skip for stable release")]
-        //#if NET6_0
-        //        [ConditionallySkipOSTheory(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
-        //#else
-        //        [Theory]
-        //#endif
+#if NET6_0
+        [ConditionallySkipOSTheory(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+#else
+        [Theory]
+#endif
         [InlineData(LogLevel.Information, "TestInfoEvent: hello")]
         [InlineData(LogLevel.Warning, "TestWarningEvent: hello")]
         [InlineData(LogLevel.Debug, null)]
@@ -97,12 +95,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             }
         }
 
-        [Fact(Skip = "Temporary skip for stable release")]
-        //#if NET6_0
-        //        [ConditionallySkipOSFact(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
-        //#else
-        //        [Fact]
-        //#endif
+#if NET6_0
+        [ConditionallySkipOSFact(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+#else
+        [Fact]
+#endif
         public async Task SelfDiagnosticsIsDisabled()
         {
             var enableLevel = LogLevel.Debug;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -40,8 +40,8 @@
 ### Other Changes
 
 * Update OpenTelemetry dependencies
-  ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
-  - OpenTelemetry 1.8.0
+  ([#43688](https://github.com/Azure/azure-sdk-for-net/pull/43688))
+  - OpenTelemetry 1.8.1
 
 ## 1.3.0-beta.1 (2024-02-08)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-* Changed `AzureMonitorLogExporter` to be internal.
+* Changed `AzureMonitorLogExporter` to be public.
   This will allow users to write custom processors for filtering logs.
   (This feature was originally introduced in 1.3.0-beta.1)
   ([#44511](https://github.com/Azure/azure-sdk-for-net/pull/44511))

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Changed `AzureMonitorLogExporter` to be internal.
   This will allow users to write custom processors for filtering logs.
+  (This feature was originally introduced in 1.3.0-beta.1)
+  ([#44511](https://github.com/Azure/azure-sdk-for-net/pull/44511))
 
 ## 1.3.0 (2024-06-07)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+* Changed `AzureMonitorLogExporter` to be internal.
+  This will allow users to write custom processors for filtering logs.
+
 ## 1.3.0 (2024-06-07)
 
 ### Other Changes
@@ -35,8 +38,8 @@
 ### Other Changes
 
 * Update OpenTelemetry dependencies
-  ([#43688](https://github.com/Azure/azure-sdk-for-net/pull/43688))
-  - OpenTelemetry 1.8.1
+  ([#43197](https://github.com/Azure/azure-sdk-for-net/pull/43197))
+  - OpenTelemetry 1.8.0
 
 ## 1.3.0-beta.1 (2024-02-08)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net6.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net6.0.cs
@@ -21,4 +21,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             v2_1 = 1,
         }
     }
+    public sealed partial class AzureMonitorLogExporter : OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord>
+    {
+        public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
+        protected override void Dispose(bool disposing) { }
+        public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
+    }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -21,4 +21,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             v2_1 = 1,
         }
     }
+    public sealed partial class AzureMonitorLogExporter : OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord>
+    {
+        public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
+        protected override void Dispose(bool disposing) { }
+        public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
+    }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -14,7 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     /// <summary>
     /// Azure Monitor Log Exporter.
     /// </summary>
-    internal sealed class AzureMonitorLogExporter : BaseExporter<LogRecord>
+    public sealed class AzureMonitorLogExporter : BaseExporter<LogRecord>
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;


### PR DESCRIPTION
We disabled a few features still in development to unblock June's stable release.
This PR reenables those features (Reverting the changes in #44479).

## Changes
- change LogExporter to `public`
- add LogFiltering to Distro
- add AzureLogForwarding to Distro