### PR TITLE
Fix typo in EdmBoolean constant value

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableConstants.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableConstants.cs
@@ -55,7 +55,7 @@ namespace Azure.Data.Tables
         {
             internal const string OdataTypeString = "@odata.type";
             internal const string EdmBinary = "Edm.Binary";
-            internal const string EdmBoolean = "Emd.Boolean";
+            internal const string EdmBoolean = "Edm.Boolean";
             internal const string EdmDateTime = "Edm.DateTime";
             internal const string EdmDouble = "Edm.Double";
             internal const string EdmGuid = "Edm.Guid";

--- a/sdk/tables/Azure.Data.Tables/src/TableConstants.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableConstants.cs
@@ -24,21 +24,6 @@ namespace Azure.Data.Tables
             public const string SharedKey = "SharedKeyLite";
             public const string Authorization = "Authorization";
             public const string IfMatch = "If-Match";
-            public const string Accept = "Accept";
-            public const string Content = "Content-Type";
-        }
-
-        internal static class MimeType
-        {
-            internal const string ApplicationJson = "application/json";
-            internal const string ApplicationXml = "application/xml";
-        }
-
-        internal static class QueryParameterNames
-        {
-            public const string NextTableName = "NextTableName";
-            public const string NextPartitionKey = "NextPartitionKey";
-            public const string NextRowKey = "NextRowKey";
         }
 
         internal static class PropertyNames
@@ -55,21 +40,15 @@ namespace Azure.Data.Tables
         {
             internal const string OdataTypeString = "@odata.type";
             internal const string EdmBinary = "Edm.Binary";
-            internal const string EdmBoolean = "Edm.Boolean";
             internal const string EdmDateTime = "Edm.DateTime";
             internal const string EdmDouble = "Edm.Double";
             internal const string EdmGuid = "Edm.Guid";
-            internal const string EdmInt32 = "Edm.Int32";
             internal const string EdmInt64 = "Edm.Int64";
-            internal const string EdmString = "Edm.String";
             internal const string MinimalMetadata = "application/json;odata=minimalmetadata";
         }
 
         internal static class ExceptionMessages
         {
-            internal const string MissingPartitionKey = "The entity must contain a PartitionKey value";
-            internal const string MissingRowKey = "The entity must contain a RowKey value";
-            internal const string BatchCanOnlyBeSubmittedOnce = "A batch can only be submitted once.";
             internal const string BatchIsEmpty = "The batch contains no entity operations.";
         }
 
@@ -104,7 +83,6 @@ namespace Azure.Data.Tables
                 public const char List = 'l';
                 public const char Add = 'a';
                 public const char Update = 'u';
-                public const char Create = 'c';
             }
 
             internal static class Parameters
@@ -118,7 +96,6 @@ namespace Azure.Data.Tables
                 public const string TableNameUpper = "TN";
                 public const string VersionUpper = "SV";
                 public const string Services = "ss";
-                public const string ServicesUpper = "SS";
                 public const string ResourceTypes = "srt";
                 public const string ResourceTypesUpper = "SRT";
                 public const string Protocol = "spr";
@@ -161,7 +138,6 @@ namespace Azure.Data.Tables
             internal const string DevelopmentProxyUriSetting = "DevelopmentStorageProxyUri";
             internal const string DefaultEndpointsProtocolSetting = "DefaultEndpointsProtocol";
             internal const string AccountNameSetting = "AccountName";
-            internal const string AccountKeyNameSetting = "AccountKeyName";
             internal const string AccountKeySetting = "AccountKey";
             internal const string TableEndpointSetting = "TableEndpoint";
             internal const string TableSecondaryEndpointSetting = "TableSecondaryEndpoint";


### PR DESCRIPTION
Fixes #29255.

The value for `EdmBolean` was `"Edm.Boolean"` instead of `"Emd.Boolean"`.