### PR TITLE
Remove check for MemoryStream in TablesRequestFailedDetailsParser

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TablesRequestFailedDetailsParser.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TablesRequestFailedDetailsParser.cs
@@ -15,7 +15,7 @@ namespace Azure.Data.Tables
         {
             error = null;
             data = null;
-            if (response.ContentStream == null || !(response.ContentStream is MemoryStream))
+            if (response.ContentStream == null)
             {
                 return false;
             }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/41647

Now that `Response.ContentStream` in `Azure.Core` is an [internal custom stream](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/Response.cs#L32) type, we don't longer need to check if the `response.ContentStream` is of type `MemoryStream`.