### PR TITLE
[Messaging] Allow relative URI property values

### DIFF
--- a/sdk/core/Azure.Core.Amqp/src/Shared/AmqpAnnotatedMessageConverter.cs
+++ b/sdk/core/Azure.Core.Amqp/src/Shared/AmqpAnnotatedMessageConverter.cs
@@ -511,7 +511,11 @@ namespace Azure.Core.Amqp.Shared
                     break;
 
                 case AmqpType.Uri:
-                    amqpPropertyValue = new DescribedType((AmqpSymbol)AmqpMessageConstants.Uri, ((Uri)propertyValue).AbsoluteUri);
+                    amqpPropertyValue = new DescribedType((AmqpSymbol)AmqpMessageConstants.Uri, propertyValue switch
+                    {
+                        Uri uriValue when uriValue.IsAbsoluteUri => uriValue.AbsoluteUri,
+                        _ => propertyValue.ToString()
+                    });
                     break;
 
                 case AmqpType.DateTimeOffset:
@@ -819,7 +823,7 @@ namespace Azure.Core.Amqp.Shared
         {
             if (symbol.Equals(AmqpMessageConstants.Uri))
             {
-                return new Uri((string)value);
+                return new Uri((string)value, UriKind.RelativeOrAbsolute);
             }
 
             if (symbol.Equals(AmqpMessageConstants.TimeSpan))

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Bugs Fixed
 
+- Fixed an error that prevented relative URIs from being used with [application properties](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties) in the `EventData.Properties` collection. 
+
 ### Other Changes
+
+- The processor will now refresh the maximum message size each time a new AMQP link is opened; this is necessary for large message support, where the maximum message size for entities can be reconfigured and adjusted on the fly.  Because the client had cached the value, it would not be aware of the change and would enforce the wrong size for batch creation. 
 
 ## 5.12.0-beta.1 (2024-05-17)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### Bugs Fixed
 
+- Fixed an error that prevented relative URIs from being used with [application properties](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties) in the `EventData.Properties` collection. 
+
 ### Other Changes
 
-- The client will now refresh the maximum message size each time a new AMQP link is opened; this is necessary for large message support, where the maximum message size for entities can be reconfigureed adjusted on the fly.  Because the client had cached the value, it would not be aware of the change and would enforce the wrong size for batch creation. 
+- The client will now refresh the maximum message size each time a new AMQP link is opened; this is necessary for large message support, where the maximum message size for entities can be reconfigured and adjusted on the fly.  Because the client had cached the value, it would not be aware of the change and would enforce the wrong size for batch creation. 
 
 - The `PluggableCheckpointStoreEventProcessor` will now emit a diagnostic span when a checkpoint is created/updated.  While this span is not defined by the Open Telemetry specification, this change aligns diagnostic spans with those emitted by `EventProcessorClient`.
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fixed an error that caused connection strings using host names without a scheme to fail parsing and be considered invalid.
 
+- Fixed an error that prevented relative URIs from being used with [application properties](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties) in the `ServiceBusMessage.ApplicationProperties` and `ServiceBusReceivedMessage.ApplicationProperties` collections. 
+
 ### Other Changes
 
 - The client will now refresh the maximum message size each time a new AMQP link is opened; this is necessary for large message support, where the maximum message size for entities can be reconfigureed adjusted on the fly.  Because the client had cached the value, it would not be aware of the change and would enforce the wrong size for batch creation. 


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a but in the AMQP converter that assumed all URI described types represented an absolute URI. If a relative URI was provided, conversion would fail.