### PR TITLE
Azure OpenAI: 2.0.0-beta.2 release

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Release History
 
-## 2.0.0-beta.2 (Unreleased)
+## 2.0.0-beta.2 (2024-06-14)
 
 ### Features Added
 
+- Per changes to the [OpenAI .NET client library](https://github.com/openai/openai-dotnet), most convenience methods now provide the direct ability to provide optional `CancellationTokens`, removing the need to use protocol methods
+
 ### Breaking Changes
+
+- In support of `CancellationToken`s in methods, an overriden method signature for streaming chat completions was changed and a new minimum version dependency of 2.0.0-beta.5 is established for the OpenAI dependency. These styles of breaks will be extraordinarily rare.
 
 ### Bugs Fixed
 
-### Other Changes
+- See breaking changes: when streaming chat completions, an error of "Unrecognized request argument supplied: stream_options" is introduced when using Azure.AI.OpenAI 2.0.0-beta.1 with OpenAI 2.0.0-beta.5+. This is fixed with the new version.
 
 ## 2.0.0-beta.1 (2024-06-07)
 

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="OpenAI" VersionOverride="2.0.0-beta.5" />
+    <PackageReference Include="OpenAI" VersionOverride="2.0.0-*" />
   </ItemGroup>
 
 </Project>

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="OpenAI" VersionOverride="2.0.0-*" />
+    <PackageReference Include="OpenAI" VersionOverride="2.0.0-beta.5" />
   </ItemGroup>
 
 </Project>

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatClient.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatClient.cs
@@ -38,18 +38,18 @@ internal partial class AzureChatClient : ChatClient
     { }
 
     /// <inheritdoc/>
-    public override AsyncResultCollection<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null)
+    public override AsyncResultCollection<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
         options ??= new();
         options.StreamOptions = null;
-        return base.CompleteChatStreamingAsync(messages, options);
+        return base.CompleteChatStreamingAsync(messages, options, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public override ResultCollection<StreamingChatCompletionUpdate> CompleteChatStreaming(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null)
+    public override ResultCollection<StreamingChatCompletionUpdate> CompleteChatStreaming(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
         options ??= new();
         options.StreamOptions = null;
-        return base.CompleteChatStreaming(messages, options);
+        return base.CompleteChatStreaming(messages, options, cancellationToken);
     }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/AssistantTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/AssistantTests.cs
@@ -407,46 +407,6 @@ public class AssistantTests(bool isAsync) : AoaiTestBase<AssistantClient>(isAsyn
         });
     }
 
-#nullable enable
-    [RecordedTest]
-    public async Task BasicStreamingRunStepFunctionalityWorks()
-    {
-        AssistantClient client = GetTestClient();
-        Assistant assistant = await client.CreateAssistantAsync(
-            TestConfig.GetDeploymentNameFor<AssistantClient>(),
-            new AssistantCreationOptions()
-            {
-                Tools = { new CodeInterpreterToolDefinition() },
-                Instructions = "Call the code interpreter tool when asked to visualize mathematical concepts.",
-            });
-        Validate(assistant);
-
-        AssistantThread thread = await client.CreateThreadAsync(new ThreadCreationOptions()
-        {
-            InitialMessages = { new(["Please graph the equation y = 3x + 4"]), },
-        });
-        Validate(thread);
-
-        AsyncResultCollection<StreamingUpdate> streamingUpdates = client.CreateRunStreamingAsync(thread, assistant);
-
-        RunStepDetailsUpdate? latestDetailsUpdate = null;
-
-        await foreach (StreamingUpdate streamingUpdate in streamingUpdates)
-        {
-            latestDetailsUpdate = streamingUpdate as RunStepDetailsUpdate ?? latestDetailsUpdate;
-
-            if (streamingUpdate is RunStepUpdate runStepUpdate && latestDetailsUpdate != null)
-            {
-                foreach (RunStepUpdateCodeInterpreterOutput output in latestDetailsUpdate.CodeInterpreterOutputs)
-                {
-                    Console.WriteLine($"Code logs: {output.Logs}");
-                    Console.WriteLine($"Code file: {output.ImageFileId}");
-                }
-            }
-        }
-    }
-#nullable disable
-
     [RecordedTest]
     public async Task FunctionToolsWork()
     {

--- a/sdk/openai/Azure.AI.OpenAI/tests/VectorStoreTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/VectorStoreTests.cs
@@ -43,7 +43,7 @@ public class VectorStoreTests : AoaiTestBase<VectorStoreClient>
 
         IReadOnlyList<OpenAIFileInfo> testFiles = await GetNewTestFilesAsync(5);
 
-        vectorStore = await client.CreateVectorStoreAsync(new()
+        vectorStore = await client.CreateVectorStoreAsync(new VectorStoreCreationOptions()
         {
             FileIds = { testFiles[0].Id },
             Name = "test vector store",
@@ -84,7 +84,7 @@ public class VectorStoreTests : AoaiTestBase<VectorStoreClient>
         deleted = await client.DeleteVectorStoreAsync(vectorStore.Id);
         Assert.That(deleted, Is.True);
 
-        vectorStore = await client.CreateVectorStoreAsync(new()
+        vectorStore = await client.CreateVectorStoreAsync(new VectorStoreCreationOptions()
         {
             FileIds = testFiles.Select(file => file.Id).ToList()
         });


### PR DESCRIPTION
Please note: due to a breaking change in the `2.0.0-beta.5` `OpenAI` dependency library, this update is mandatory when upgrading the `OpenAI` library past `2.0.0-beta.4`.