### PR TITLE
Fix #44593 - Incorrect Type property for PineconeChatDataSource

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/OnYourData/PineconeChatDataSource.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/OnYourData/PineconeChatDataSource.cs
@@ -99,7 +99,7 @@ public partial class PineconeChatDataSource : AzureChatDataSource
 
     public PineconeChatDataSource()
     {
-        Type = "azure_search";
+        Type = "pinecone";
         InternalParameters = new();
         _serializedAdditionalRawData = new ChangeTrackingDictionary<string, BinaryData>();
     }


### PR DESCRIPTION
Fixes #44593, caused by the public constructor for `PineconeChatDataSource` setting an incorrect `Type` value of `azure_search`, it should be `pinecone` (like in this other generated class where it is correct: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Generated/PineconeChatDataSource.cs#L20)