### PR TITLE
[AzureMonitorDistro] Add LoggerProviderBuilder extensions and use WithTracing in distro.

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.4.0-beta.1 (2024-06-11)
 
+### Features Added
+
+* Added `LoggerProviderBuilder.AddAzureMonitorLogExporter` registration extensions.
+  ([#44617](https://github.com/Azure/azure-sdk-for-net/pull/44617))
+
 ### Other Changes
 
 * Changed `AzureMonitorLogExporter` to be public.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-* Added `LoggerProviderBuilder.AddAzureMonitorLogExporter` registration extensions.
+* Added `LoggerProviderBuilder.AddAzureMonitorLogExporter` registration extension.
   ([#44617](https://github.com/Azure/azure-sdk-for-net/pull/44617))
 
 ### Other Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net6.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net6.0.cs
@@ -2,6 +2,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 {
     public static partial class AzureMonitorExporterExtensions
     {
+        public static OpenTelemetry.Logs.LoggerProviderBuilder AddAzureMonitorLogExporter(this OpenTelemetry.Logs.LoggerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null, Azure.Core.TokenCredential credential = null, string name = null) { throw null; }
         public static OpenTelemetry.Logs.OpenTelemetryLoggerOptions AddAzureMonitorLogExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions loggerOptions, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null, Azure.Core.TokenCredential credential = null) { throw null; }
         public static OpenTelemetry.Metrics.MeterProviderBuilder AddAzureMonitorMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null, Azure.Core.TokenCredential credential = null, string name = null) { throw null; }
         public static OpenTelemetry.Trace.TracerProviderBuilder AddAzureMonitorTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null, Azure.Core.TokenCredential credential = null, string name = null) { throw null; }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -2,6 +2,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 {
     public static partial class AzureMonitorExporterExtensions
     {
+        public static OpenTelemetry.Logs.LoggerProviderBuilder AddAzureMonitorLogExporter(this OpenTelemetry.Logs.LoggerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null, Azure.Core.TokenCredential credential = null, string name = null) { throw null; }
         public static OpenTelemetry.Logs.OpenTelemetryLoggerOptions AddAzureMonitorLogExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions loggerOptions, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null, Azure.Core.TokenCredential credential = null) { throw null; }
         public static OpenTelemetry.Metrics.MeterProviderBuilder AddAzureMonitorMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null, Azure.Core.TokenCredential credential = null, string name = null) { throw null; }
         public static OpenTelemetry.Trace.TracerProviderBuilder AddAzureMonitorTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null, Azure.Core.TokenCredential credential = null, string name = null) { throw null; }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterExtensions.cs
@@ -185,13 +185,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// Adds Azure Monitor Log Exporter to the LoggerProvider.
         /// </summary>
         /// <param name="builder"><see cref="LoggerProviderBuilder"/> builder to use.</param>
-        /// <param name="name">Optional name which is used when retrieving options.</param>
         /// <param name="configure">Optional callback action for configuring <see cref="AzureMonitorExporterOptions"/>.</param>
         /// <param name="credential">
         /// An Azure <see cref="TokenCredential" /> capable of providing an OAuth token.
         /// Note: if a credential is provided to both <see cref="AzureMonitorExporterOptions"/> and this parameter,
         /// the Options will take precedence.
         /// </param>
+        /// <param name="name">Optional name which is used when retrieving options.</param>
         /// <returns>The instance of <see cref="LoggerProviderBuilder"/> to chain the calls.</returns>
         public static LoggerProviderBuilder AddAzureMonitorLogExporter(
             this LoggerProviderBuilder builder,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterExtensions.cs
@@ -239,7 +239,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     exporterOptions.Credential ??= credential;
                 }
 
-                // TODO: Do we need provide an option to alter BatchExportActivityProcessorOptions?
+                // TODO: Do we need provide an option to alter BatchExportLogRecordProcessorOptions?
                 return new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(exporterOptions));
             });
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterExtensions.cs
@@ -59,6 +59,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 throw new InvalidOperationException("The provided TracerProviderBuilder does not implement IDeferredTracerProviderBuilder.");
             }
 
+            // TODO: Do we need provide an option to alter BatchExportActivityProcessorOptions?
             return deferredBuilder.Configure((sp, builder) =>
             {
                 var exporterOptions = sp.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().Get(finalOptionsName);
@@ -211,7 +212,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return builder.AddProcessor(sp =>
             {
                 AzureMonitorExporterOptions exporterOptions;
-                BatchExportLogRecordProcessorOptions batchExportLogRecordProcessorOptions;
 
                 if (name == null)
                 {
@@ -221,7 +221,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     // name, delegates for all signals will mix together. See:
                     // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4043
                     exporterOptions = sp.GetRequiredService<IOptionsFactory<AzureMonitorExporterOptions>>().Create(finalOptionsName);
-                    batchExportLogRecordProcessorOptions = sp.GetRequiredService<IOptionsFactory<BatchExportLogRecordProcessorOptions>>().Create(finalOptionsName);
 
                     // Configuration delegate is executed inline on the fresh instance.
                     configure?.Invoke(exporterOptions);
@@ -231,7 +230,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     // When using named options we can properly utilize Options
                     // API to create or reuse an instance.
                     exporterOptions = sp.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().Get(finalOptionsName);
-                    batchExportLogRecordProcessorOptions = sp.GetRequiredService<IOptionsMonitor<BatchExportLogRecordProcessorOptions>>().Get(finalOptionsName);
                 }
 
                 if (credential != null)
@@ -241,6 +239,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     exporterOptions.Credential ??= credential;
                 }
 
+                // TODO: Do we need provide an option to alter BatchExportActivityProcessorOptions?
                 return new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(exporterOptions));
             });
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterExtensionsTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Logs;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public  class AzureMonitorExporterExtensionsTests
+    {
+        [Fact]
+        public void AddAzureMonitorLogExporterWithNamedOptions()
+        {
+            var testIkey = "test_ikey";
+            var testEndpoint = "https://www.bing.com/";
+
+            string connectionString = $"InstrumentationKey={testIkey};IngestionEndpoint={testEndpoint}";
+
+            int defaultConfigureExporterOptionsInvocations = 0;
+            int namedConfigureExporterOptionsInvocations = 0;
+
+            var sp = new ServiceCollection();
+            sp.AddOpenTelemetry().WithLogging(builder => builder
+                .ConfigureServices(services =>
+                {
+                    services.Configure<AzureMonitorExporterOptions>(o =>
+                    {
+                        o.ConnectionString = connectionString;
+                        defaultConfigureExporterOptionsInvocations++;
+                    });
+                    services.Configure<AzureMonitorExporterOptions>("Exporter2", o =>
+                    {
+                        o.ConnectionString = connectionString;
+                        namedConfigureExporterOptionsInvocations++;
+                    });
+                    services.Configure<AzureMonitorExporterOptions>("Exporter3", o =>
+                    {
+                        o.ConnectionString = connectionString;
+                        namedConfigureExporterOptionsInvocations++;
+                    });
+                })
+                .AddAzureMonitorLogExporter()
+                .AddAzureMonitorLogExporter(configure: o => { }, name: "Exporter2")
+                .AddAzureMonitorLogExporter(configure: o => { }, name: "Exporter3"));
+
+            var s = sp.BuildServiceProvider();
+
+            _ = s.GetRequiredService<LoggerProvider>();
+            Assert.Equal(1, defaultConfigureExporterOptionsInvocations);
+            Assert.Equal(2, namedConfigureExporterOptionsInvocations);
+        }
+    }
+}


### PR DESCRIPTION
- Add `LoggerProviderBuilder` extensions to Azure Monitor Exporter.
- Modified the internal logic in distro to migrate from `builder.Services.AddLogging` to `builder.WithLogging`