### PR TITLE
Remove some suppression of AZC0006 and AZC0007

### DIFF
--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/Azure.Verticals.AgriFood.Farming.csproj
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/Azure.Verticals.AgriFood.Farming.csproj
@@ -5,7 +5,7 @@
     <Version>1.0.0-beta.2</Version>
     <PackageTags>Azure FarmBeats</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);AZC0012;AZC0007;AZC0006</NoWarn>
+    <NoWarn>$(NoWarn);AZC0012</NoWarn>
     <DefineConstants>$(DefineConstants);EXPERIMENTAL</DefineConstants>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/GlobalSuppressions.cs
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/GlobalSuppressions.cs
@@ -1,4 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/GlobalSuppressions.cs
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/GlobalSuppressions.cs
@@ -2,6 +2,3 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0007: A client type should have a public constructor with equivalent parameters that doesn't take a Azure.Core.ClientOptions-derived type as the last argument", Justification = "")]
-[assembly: SuppressMessage("Usage", "AZC0006: A client type should have a public constructor with equivalent parameters that takes a Azure.Core.ClientOptions-derived type as the last argument", Justification = "")]

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/GlobalSuppressions.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/GlobalSuppressions.cs
@@ -3,7 +3,5 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Usage", "AZC0007:DO provide a minimal constructor that takes only the parameters required to connect to the service.", Justification = "False positives on minimal constructors", Scope = "namespaceanddescendants", Target = "~N:Azure.Developer.DevCenter")]
-[assembly: SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "False positives on options constructors", Scope = "namespaceanddescendants", Target = "~N:Azure.Developer.DevCenter")]
 [assembly: SuppressMessage("Usage", "AZC0031: Model name 'EnvironmentDefinition' ends with 'Definition'. Suggest to rename it to an appropriate name.", Justification = "Environment Definition is a Deployment Environment concept", Scope = "namespaceanddescendants", Target = "~N:Azure.Developer.DevCenter")]
 [assembly: SuppressMessage("Usage", "AZC0030: Model name 'EnvironmentDefinitionParameter' ends with 'Parameter'. Suggest to rename it to 'EnvironmentDefinitionContent' or 'EnvironmentDefinitionPatch' or any other appropriate name.", Justification = "Environment Definition Parameter is a Deployment Environment concept", Scope = "namespaceanddescendants", Target = "~N:Azure.Developer.DevCenter")]

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Properties/AssemblyInfo.cs
@@ -9,5 +9,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: SuppressMessage("Usage", "AZC0004:DO provide both asynchronous and synchronous variants for all service methods.", Justification = "As an AMQP-based offering, Event Hubs has been exempted from providing a synchronous surface.")]
 [assembly: SuppressMessage("Usage", "AZC0008:ClientOptions should have a nested enum called ServiceVersion", Justification = "The Event Hubs interface does not support the concept of versions.")]
-[assembly: SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "Analysis is flagging incorrectly. The Event Hubs constructor patterns adhere to guidance and have obtained board approval.")]
 [assembly: SuppressMessage("Usage", "AZC0015:Unexpected client method return type.", Justification = "As an AMQP-based offering, Event Hubs has been exempted from HTTP-based return types.")]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Properties/AssemblyInfo.cs
@@ -9,5 +9,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: SuppressMessage("Usage", "AZC0004:DO provide both asynchronous and synchronous variants for all service methods.", Justification = "As an AMQP-based offering, Event Hubs has been exempted from providing a synchronous surface.")]
 [assembly: SuppressMessage("Usage", "AZC0008:ClientOptions should have a nested enum called ServiceVersion", Justification = "The Event Hubs interface does not support the concept of versions.")]
-[assembly: SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "Analysis is flagging incorrectly. The Event Hubs constructor patterns adhere to guidance and have obtained board approval.")]
 [assembly: SuppressMessage("Usage", "AZC0015:Unexpected client method return type.", Justification = "As an AMQP-based offering, Event Hubs has been exempted from HTTP-based return types.")]

--- a/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
+++ b/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
@@ -14,7 +14,7 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <!-- These are still firing but not valid -->
-    <NoWarn>$(NoWarn);AZC0007;AZC0004</NoWarn>
+    <NoWarn>$(NoWarn);AZC0004</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexClient.cs
@@ -121,7 +121,6 @@ namespace Azure.Search.Documents.Indexes
         /// <param name="options">Client configuration options for connecting to Azure Cognitive Search.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="tokenCredential"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "Avoid ambiguous method definition")]
         public SearchIndexClient(
             Uri endpoint,
             TokenCredential tokenCredential,

--- a/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexerClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexerClient.cs
@@ -119,7 +119,6 @@ namespace Azure.Search.Documents.Indexes
         /// <param name="options">Client configuration options for connecting to Azure Cognitive Search.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="tokenCredential"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "Avoid ambiguous method definition")]
         public SearchIndexerClient(
             Uri endpoint,
             TokenCredential tokenCredential,

--- a/sdk/search/Azure.Search.Documents/src/SearchClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchClient.cs
@@ -240,7 +240,6 @@ namespace Azure.Search.Documents
         /// Thrown when the <paramref name="endpoint"/> is not using HTTPS or
         /// the <paramref name="indexName"/> is empty.
         /// </exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "Avoid ambiguous method definition")]
         public SearchClient(
             Uri endpoint,
             string indexName,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/Directory.Build.props
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/Directory.Build.props
@@ -9,8 +9,8 @@
     These analyzers are blocked by https://github.com/Azure/azure-sdk-tools/issues/127
      -->
     <NoWarn>
-      AZC0007;
       $(NoWarn);
+      AZC0007;
     </NoWarn>
   </PropertyGroup>
   

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/Directory.Build.props
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/Directory.Build.props
@@ -9,6 +9,7 @@
     These analyzers are blocked by https://github.com/Azure/azure-sdk-tools/issues/127
      -->
     <NoWarn>
+      AZC0007;
       $(NoWarn);
     </NoWarn>
   </PropertyGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/Directory.Build.props
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/Directory.Build.props
@@ -10,8 +10,6 @@
      -->
     <NoWarn>
       $(NoWarn);
-      AZC0006;
-      AZC0007;
     </NoWarn>
   </PropertyGroup>
   

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Properties/AssemblyInfo.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Properties/AssemblyInfo.cs
@@ -9,6 +9,5 @@ using System.Runtime.CompilerServices;
 
 [assembly: SuppressMessage("Usage", "AZC0004:DO provide both asynchronous and synchronous variants for all service methods.", Justification = "As an AMQP-based offering, Service Bus has been exempted from providing a synchronous surface.")]
 [assembly: SuppressMessage("Usage", "AZC0008:ClientOptions should have a nested enum called ServiceVersion", Justification = "The Service Bus interface does not support the concept of versions.")]
-[assembly: SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "Analysis is flagging incorrectly. The Service Bus constructor patterns adhere to guidance and have obtained board approval.")]
 [assembly: SuppressMessage("Usage", "AZC0015:Unexpected client method return type.", Justification = "As an AMQP-based offering, Service Bus has been exempted from HTTP-based return types.")]
 [assembly: Azure.Core.AzureResourceProviderNamespace("Microsoft.ServiceBus")]


### PR DESCRIPTION
There are some suppressions in the repo but the targeting code is not violating the rules. We could remove these suppressions. 
There was a [PR](https://github.com/Azure/azure-sdk-for-net/pull/38657) before and for some reason it was put off. But these two are actually doing the same thing.

We might need to [change the analyzer](https://github.com/Azure/azure-sdk-tools/pull/8478) to loosen the rules according to the agreement [here](https://github.com/Azure/autorest.csharp/issues/3706#issuecomment-1752374728). So I want to make sure the language repo is clean.

