### PR TITLE
[CODEOWNERS] Remove "all API changes" rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -995,9 +995,6 @@
 # ServiceLabel: %Spring App Discovery %Mgmt
 # ServiceOwners:                                                   @sunkun99
 
-# Reviewers to double check any API changes
-/sdk/**/api/                                                       @KrzysztofCwalina @tg-msft
-
 # ######## Eng Sys ########
 /eng/                                                              @hallipr @weshaggard @benbp
 /eng/common/                                                       @Azure/azure-sdk-eng


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the rule that required the .NET architects to sign-off on all pull requests that resulted in a public API change.  

This rule predates the use of API View as the gate for API approvals and is redundant.  With the enforcement that a CODEOWNER for each area approve pull requests, this rule blocked them from closing out regardless of whether or not the associated API View had been approved.