### PR TITLE
[AzureMonitor] upgrade OTel to 1.9.0

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -168,10 +168,10 @@
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Monitor.OpenTelemetry'))">
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.9.0-rc.1" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.9.0-rc.1" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+    <PackageReference Update="OpenTelemetry" Version="1.9.0" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Update="OpenTelemetry.PersistentStorage.FileSystem" Version="1.0.0" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1,6.0)" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="[2.1.1,6.0)" />
@@ -333,9 +333,9 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Update="OpenTelemetry" Version="1.9.0-rc.1" />
-    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.9.0-rc.1" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
+    <PackageReference Update="OpenTelemetry" Version="1.9.0" />
+    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -21,7 +21,7 @@
   ([#44511](https://github.com/Azure/azure-sdk-for-net/pull/44511))
 
 * Update OpenTelemetry dependencies.
-  ([#44522](https://github.com/Azure/azure-sdk-for-net/pull/44522))
+  ([#44650](https://github.com/Azure/azure-sdk-for-net/pull/44650))
   - OpenTelemetry 1.9.0
   - OpenTelemetry.Extensions.Hosting 1.9.0
   - OpenTelemetry.Instrumentation.AspNetCore 1.9.0

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -22,8 +22,10 @@
 
 * Update OpenTelemetry dependencies.
   ([#44522](https://github.com/Azure/azure-sdk-for-net/pull/44522))
-  - OpenTelemetry 1.9.0-rc.1
-  - OpenTelemetry.Extensions.Hosting 1.9.0-rc.1
+  - OpenTelemetry 1.9.0
+  - OpenTelemetry.Extensions.Hosting 1.9.0
+  - OpenTelemetry.Instrumentation.AspNetCore 1.9.0
+  - OpenTelemetry.Instrumentation.Http 1.9.0
 
 ## 1.2.0 (2024-06-11)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -16,7 +16,7 @@
   ([#44511](https://github.com/Azure/azure-sdk-for-net/pull/44511))
 
 * Update OpenTelemetry dependencies
-  ([]())
+  ([#44650](https://github.com/Azure/azure-sdk-for-net/pull/44650))
   - OpenTelemetry 1.9.0
 
 ## 1.3.0 (2024-06-07)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release History
 
-## 1.4.0-beta.1 (2024-06-11)
+## 1.4.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
 
 ### Other Changes
 
@@ -10,8 +16,8 @@
   ([#44511](https://github.com/Azure/azure-sdk-for-net/pull/44511))
 
 * Update OpenTelemetry dependencies
-  ([#44522](https://github.com/Azure/azure-sdk-for-net/pull/44522))
-  - OpenTelemetry 1.9.0-rc.1
+  ([]())
+  - OpenTelemetry 1.9.0
 
 ## 1.3.0 (2024-06-07)
 


### PR DESCRIPTION
This PR updates all OTel package references to 1.9.0.

I'll update the Distro's vendored libraries in a second PR.