### PR TITLE
Scope Build to SDKType for all steps

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -57,6 +57,7 @@ jobs:
       Codeql.Enabled: true
       Codeql.BuildIdentifier: ${{ parameters.ServiceDirectory }}
       Codeql.SkipTaskAutoInjection: false
+      SDKType: ${{ parameters.SDKType }}
 
     steps:
       - checkout: self


### PR DESCRIPTION
Should fix issues like https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3886006&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=e2744c02-d5ab-5ec4-b597-2a76a072b500