### PR TITLE
Set AZURESUBSCRIPTION_CLIENT_ID and AZURESUBSCRIPTION_TENANT_ID

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -173,6 +173,10 @@ jobs:
             pwsh: true
             ScriptType: InlineScript
             Inline: >-
+              $account = (Get-AzContext).Account;
+              $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
+              $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
+
               dotnet test eng/service.proj
               --framework $(TestTargetFramework)
               --filter "TestCategory!=Manually & ($(AdditionalTestFilters))"


### PR DESCRIPTION
Needed to ensure the variables are set when running in a Windows context