### PR TITLE
[Storage] [DataMovement] Added support for Share File to/from Blob for Single Transfer

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Storage.Blobs.Models;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
@@ -637,6 +638,22 @@ namespace Azure.Storage.DataMovement.Blobs
                 properties: properties);
         }
 
+        private static string ConvertContentPropertyObjectToString(object contentPropertyValue)
+        {
+            if (contentPropertyValue is string)
+            {
+                return Convert.ToString(contentPropertyValue);
+            }
+            else if (contentPropertyValue is string[])
+            {
+                return string.Join(",", (string[])contentPropertyValue);
+            }
+            else
+            {
+                throw Errors.UnexpectedPropertyType(DataMovementConstants.ResourceProperties.ContentType, DataMovementConstants.StringTypeStr, DataMovementConstants.StringArrayTypeStr);
+            }
+        }
+
         private static BlobHttpHeaders GetHttpHeaders(
             BlobStorageResourceOptions options,
             Dictionary<string, object> properties)
@@ -644,27 +661,27 @@ namespace Azure.Storage.DataMovement.Blobs
             {
                 ContentType = (options?.ContentType?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.ContentType, out object contentType) == true
-                        ? (string) contentType
+                        ? (contentType is string) ? Convert.ToString(contentType) : throw Errors.UnexpectedPropertyType(DataMovementConstants.ResourceProperties.ContentType, DataMovementConstants.StringTypeStr)
                         : default
                     : options?.ContentType?.Value,
                 ContentEncoding = (options?.ContentEncoding?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.ContentEncoding, out object contentEncoding) == true
-                        ? (string) contentEncoding
+                        ? ConvertContentPropertyObjectToString(contentEncoding)
                         : default
                     : options?.ContentEncoding?.Value,
                 ContentLanguage = (options?.ContentLanguage?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.ContentLanguage, out object contentLanguage) == true
-                        ? (string) contentLanguage
+                        ? ConvertContentPropertyObjectToString(contentLanguage)
                         : default
                     : options?.ContentLanguage?.Value,
                 ContentDisposition = (options?.ContentDisposition?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.ContentDisposition, out object contentDisposition) == true
-                        ? (string) contentDisposition
+                        ? (contentDisposition is string) ? Convert.ToString(contentDisposition) : throw Errors.UnexpectedPropertyType(DataMovementConstants.ResourceProperties.ContentType, DataMovementConstants.StringTypeStr)
                         : default
                     : options?.ContentDisposition?.Value,
                 CacheControl = (options?.CacheControl?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.CacheControl, out object cacheControl) == true
-                        ? (string) cacheControl
+                        ? (cacheControl is string) ? Convert.ToString(cacheControl) : throw Errors.UnexpectedPropertyType(DataMovementConstants.ResourceProperties.ContentType, DataMovementConstants.StringTypeStr, cacheControl.GetType().ToString())
                         : default
                     : options?.CacheControl?.Value,
             };

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -638,11 +638,11 @@ namespace Azure.Storage.DataMovement.Blobs
                 properties: properties);
         }
 
-        private static string ConvertContentPropertyObjectToString(object contentPropertyValue)
+        private static string ConvertContentPropertyObjectToString(string contentPropertyName, object contentPropertyValue)
         {
             if (contentPropertyValue is string)
             {
-                return Convert.ToString(contentPropertyValue);
+                return contentPropertyValue as string;
             }
             else if (contentPropertyValue is string[])
             {
@@ -650,7 +650,7 @@ namespace Azure.Storage.DataMovement.Blobs
             }
             else
             {
-                throw Errors.UnexpectedPropertyType(DataMovementConstants.ResourceProperties.ContentType, DataMovementConstants.StringTypeStr, DataMovementConstants.StringArrayTypeStr);
+                throw Errors.UnexpectedPropertyType(contentPropertyName, DataMovementConstants.StringTypeStr, DataMovementConstants.StringArrayTypeStr);
             }
         }
 
@@ -661,27 +661,27 @@ namespace Azure.Storage.DataMovement.Blobs
             {
                 ContentType = (options?.ContentType?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.ContentType, out object contentType) == true
-                        ? (contentType is string) ? Convert.ToString(contentType) : throw Errors.UnexpectedPropertyType(DataMovementConstants.ResourceProperties.ContentType, DataMovementConstants.StringTypeStr)
+                        ? (string) contentType
                         : default
                     : options?.ContentType?.Value,
                 ContentEncoding = (options?.ContentEncoding?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.ContentEncoding, out object contentEncoding) == true
-                        ? ConvertContentPropertyObjectToString(contentEncoding)
+                        ? ConvertContentPropertyObjectToString(DataMovementConstants.ResourceProperties.ContentEncoding, contentEncoding)
                         : default
                     : options?.ContentEncoding?.Value,
                 ContentLanguage = (options?.ContentLanguage?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.ContentLanguage, out object contentLanguage) == true
-                        ? ConvertContentPropertyObjectToString(contentLanguage)
+                        ? ConvertContentPropertyObjectToString(DataMovementConstants.ResourceProperties.ContentLanguage, contentLanguage)
                         : default
                     : options?.ContentLanguage?.Value,
                 ContentDisposition = (options?.ContentDisposition?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.ContentDisposition, out object contentDisposition) == true
-                        ? (contentDisposition is string) ? Convert.ToString(contentDisposition) : throw Errors.UnexpectedPropertyType(DataMovementConstants.ResourceProperties.ContentType, DataMovementConstants.StringTypeStr)
+                        ? (string) contentDisposition
                         : default
                     : options?.ContentDisposition?.Value,
                 CacheControl = (options?.CacheControl?.Preserve ?? true)
                     ? properties?.TryGetValue(DataMovementConstants.ResourceProperties.CacheControl, out object cacheControl) == true
-                        ? (cacheControl is string) ? Convert.ToString(cacheControl) : throw Errors.UnexpectedPropertyType(DataMovementConstants.ResourceProperties.ContentType, DataMovementConstants.StringTypeStr, cacheControl.GetType().ToString())
+                        ? (string) cacheControl
                         : default
                     : options?.CacheControl?.Value,
             };

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobStartTransferCopyTests.cs
@@ -129,7 +129,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
             => GetAppendBlobClientAsync(
                 container,
                 objectLength,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobToBlockBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobToBlockBlobTests.cs
@@ -72,7 +72,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             AppendBlobClient blobClient = container.GetAppendBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobToPageBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobToPageBlobTests.cs
@@ -73,7 +73,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             AppendBlobClient blobClient = container.GetAppendBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobStartTransferCopyTests.cs
@@ -70,7 +70,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             BlockBlobClient blobClient = container.GetBlockBlobClient(objectName);
@@ -116,7 +117,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
             => GetBlockBlobClientAsync(
                 container,
                 objectLength,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobToAppendBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobToAppendBlobTests.cs
@@ -73,7 +73,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             BlockBlobClient blobClient = container.GetBlockBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobToPageBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobToPageBlobTests.cs
@@ -73,7 +73,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             BlockBlobClient blobClient = container.GetBlockBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobStartTransferCopyTests.cs
@@ -131,7 +131,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
             => GetPageBlobClientAsync(
                 container,
                 objectLength,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobToAppendBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobToAppendBlobTests.cs
@@ -73,7 +73,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             PageBlobClient blobClient = container.GetPageBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobToBlockBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobToBlockBlobTests.cs
@@ -73,7 +73,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             PageBlobClient blobClient = container.GetPageBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/AppendBlobToShareFileTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/AppendBlobToShareFileTests.cs
@@ -100,7 +100,8 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             AppendBlobClient blobClient = container.GetAppendBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/AppendBlobToShareFileTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/AppendBlobToShareFileTests.cs
@@ -18,6 +18,10 @@ using Azure.Storage.Shared;
 using Azure.Storage.DataMovement.Files.Shares;
 using DMBlob::Azure.Storage.DataMovement.Blobs;
 using NUnit.Framework;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Files.Shares.Models;
+using Azure.Storage.Test;
+using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 {
@@ -37,6 +41,14 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         private const string _fileResourcePrefix = "test-file-";
         private const string _expectedOverwriteExceptionMessage = "Cannot overwrite file.";
         protected readonly object _serviceVersion;
+        private const string _defaultContentType = "text/plain";
+        private const string _defaultContentLanguage = "en-US";
+        private const string _defaultContentDisposition = "inline";
+        private const string _defaultCacheControl = "no-cache";
+        private readonly Metadata _defaultMetadata = DataProvider.BuildMetadata();
+        private readonly DateTimeOffset _defaultFileCreatedOn = new DateTimeOffset(2024, 4, 1, 9, 5, 55, default);
+        private readonly DateTimeOffset _defaultFileLastWrittenOn = new DateTimeOffset(2024, 4, 1, 12, 16, 6, default);
+        private readonly DateTimeOffset _defaultFileChangedOn = new DateTimeOffset(2024, 4, 1, 13, 30, 3, default);
 
         public AppendBlobToShareFileTests(
             bool async,
@@ -206,46 +218,59 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             return InstrumentClientOptions(options);
         }
 
-        protected override Task VerifyPropertiesCopyAsync(
+        protected override async Task VerifyPropertiesCopyAsync(
             DataTransfer transfer,
             TransferPropertiesTestType transferPropertiesTestType,
             TestEventsRaised testEventsRaised,
             AppendBlobClient sourceClient,
             ShareFileClient destinationClient)
         {
-            throw new NotImplementedException();
-        }
+            // Verify completion
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(DataTransferState.Completed, transfer.TransferStatus.State);
+            // Verify Copy - using original source File and Copying the destination
+            await testEventsRaised.AssertSingleCompletedCheck();
+            using Stream sourceStream = await sourceClient.OpenReadAsync();
+            using Stream destinationStream = await destinationClient.OpenReadAsync();
+            Assert.AreEqual(sourceStream, destinationStream);
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_DefaultProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+            if (transferPropertiesTestType == TransferPropertiesTestType.NoPreserve)
+            {
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_PreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                Assert.IsEmpty(destinationProperties.Metadata);
+                Assert.IsNull(destinationProperties.ContentDisposition);
+                Assert.IsNull(destinationProperties.ContentLanguage);
+                Assert.IsNull(destinationProperties.CacheControl);
+            }
+            else if (transferPropertiesTestType == TransferPropertiesTestType.NewProperties)
+            {
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NoPreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                Assert.That(_defaultMetadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(_defaultContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(_defaultContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(_defaultCacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(_defaultContentType, destinationProperties.ContentType);
+                Assert.AreEqual(_defaultFileCreatedOn, destinationProperties.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(_defaultFileLastWrittenOn, destinationProperties.SmbProperties.FileLastWrittenOn);
+                Assert.AreEqual(_defaultFileChangedOn, destinationProperties.SmbProperties.FileChangedOn);
+            }
+            else //(transferPropertiesTestType == TransferPropertiesTestType.Default ||
+                 //transferPropertiesTestType == TransferPropertiesTestType.Preserve)
+            {
+                BlobProperties sourceProperties = await sourceClient.GetPropertiesAsync();
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NewProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
+                Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
+                Assert.AreEqual(sourceProperties.CreatedOn, destinationProperties.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(sourceProperties.LastModified, destinationProperties.SmbProperties.FileLastWrittenOn);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/BlockBlobToShareFileTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/BlockBlobToShareFileTests.cs
@@ -98,7 +98,8 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             BlockBlobClient blobClient = container.GetBlockBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/BlockBlobToShareFileTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/BlockBlobToShareFileTests.cs
@@ -17,6 +17,10 @@ using Azure.Storage.DataMovement.Files.Shares;
 using DMBlob::Azure.Storage.DataMovement.Blobs;
 using Azure.Storage.Files.Shares.Tests;
 using NUnit.Framework;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Files.Shares.Models;
+using Azure.Storage.Test;
+using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 {
@@ -35,6 +39,14 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         public const int MaxReliabilityRetries = 5;
         private const string _fileResourcePrefix = "test-file-";
         private const string _expectedOverwriteExceptionMessage = "Cannot overwrite file.";
+        private const string _defaultContentType = "text/plain";
+        private const string _defaultContentLanguage = "en-US";
+        private const string _defaultContentDisposition = "inline";
+        private const string _defaultCacheControl = "no-cache";
+        private readonly Metadata _defaultMetadata = DataProvider.BuildMetadata();
+        private readonly DateTimeOffset _defaultFileCreatedOn = new DateTimeOffset(2024, 4, 1, 9, 5, 55, default);
+        private readonly DateTimeOffset _defaultFileLastWrittenOn = new DateTimeOffset(2024, 4, 1, 12, 16, 6, default);
+        private readonly DateTimeOffset _defaultFileChangedOn = new DateTimeOffset(2024, 4, 1, 13, 30, 3, default);
         protected readonly object _serviceVersion;
 
         public BlockBlobToShareFileTests(
@@ -190,46 +202,59 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             return InstrumentClientOptions(options);
         }
 
-        protected override Task VerifyPropertiesCopyAsync(
+        protected override async Task VerifyPropertiesCopyAsync(
             DataTransfer transfer,
             TransferPropertiesTestType transferPropertiesTestType,
             TestEventsRaised testEventsRaised,
             BlockBlobClient sourceClient,
             ShareFileClient destinationClient)
         {
-            throw new NotImplementedException();
-        }
+            // Verify completion
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(DataTransferState.Completed, transfer.TransferStatus.State);
+            // Verify Copy - using original source File and Copying the destination
+            await testEventsRaised.AssertSingleCompletedCheck();
+            using Stream sourceStream = await sourceClient.OpenReadAsync();
+            using Stream destinationStream = await destinationClient.OpenReadAsync();
+            Assert.AreEqual(sourceStream, destinationStream);
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_DefaultProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+            if (transferPropertiesTestType == TransferPropertiesTestType.NoPreserve)
+            {
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_PreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                Assert.IsEmpty(destinationProperties.Metadata);
+                Assert.IsNull(destinationProperties.ContentDisposition);
+                Assert.IsNull(destinationProperties.ContentLanguage);
+                Assert.IsNull(destinationProperties.CacheControl);
+            }
+            else if (transferPropertiesTestType == TransferPropertiesTestType.NewProperties)
+            {
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NoPreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                Assert.That(_defaultMetadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(_defaultContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(_defaultContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(_defaultCacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(_defaultContentType, destinationProperties.ContentType);
+                Assert.AreEqual(_defaultFileCreatedOn, destinationProperties.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(_defaultFileLastWrittenOn, destinationProperties.SmbProperties.FileLastWrittenOn);
+                Assert.AreEqual(_defaultFileChangedOn, destinationProperties.SmbProperties.FileChangedOn);
+            }
+            else //(transferPropertiesTestType == TransferPropertiesTestType.Default ||
+                 //transferPropertiesTestType == TransferPropertiesTestType.Preserve)
+            {
+                BlobProperties sourceProperties = await sourceClient.GetPropertiesAsync();
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NewProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
+                Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
+                Assert.AreEqual(sourceProperties.CreatedOn, destinationProperties.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(sourceProperties.LastModified, destinationProperties.SmbProperties.FileLastWrittenOn);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/PageBlobToShareFileTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/PageBlobToShareFileTests.cs
@@ -18,6 +18,10 @@ using DMBlob::Azure.Storage.DataMovement.Blobs;
 using NUnit.Framework;
 using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Shared;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Files.Shares.Models;
+using Azure.Storage.Test;
+using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 {
@@ -36,6 +40,14 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         public const int MaxReliabilityRetries = 5;
         private const string _fileResourcePrefix = "test-file-";
         private const string _expectedOverwriteExceptionMessage = "Cannot overwrite file.";
+        private const string _defaultContentType = "text/plain";
+        private const string _defaultContentLanguage = "en-US";
+        private const string _defaultContentDisposition = "inline";
+        private const string _defaultCacheControl = "no-cache";
+        private readonly Metadata _defaultMetadata = DataProvider.BuildMetadata();
+        private readonly DateTimeOffset _defaultFileCreatedOn = new DateTimeOffset(2024, 4, 1, 9, 5, 55, default);
+        private readonly DateTimeOffset _defaultFileLastWrittenOn = new DateTimeOffset(2024, 4, 1, 12, 16, 6, default);
+        private readonly DateTimeOffset _defaultFileChangedOn = new DateTimeOffset(2024, 4, 1, 13, 30, 3, default);
         protected readonly object _serviceVersion;
 
         public PageBlobToShareFileTests(
@@ -207,46 +219,59 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             return InstrumentClientOptions(options);
         }
 
-        protected override Task VerifyPropertiesCopyAsync(
+        protected override async Task VerifyPropertiesCopyAsync(
             DataTransfer transfer,
             TransferPropertiesTestType transferPropertiesTestType,
             TestEventsRaised testEventsRaised,
             PageBlobClient sourceClient,
             ShareFileClient destinationClient)
         {
-            throw new NotImplementedException();
-        }
+            // Verify completion
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(DataTransferState.Completed, transfer.TransferStatus.State);
+            // Verify Copy - using original source File and Copying the destination
+            await testEventsRaised.AssertSingleCompletedCheck();
+            using Stream sourceStream = await sourceClient.OpenReadAsync();
+            using Stream destinationStream = await destinationClient.OpenReadAsync();
+            Assert.AreEqual(sourceStream, destinationStream);
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_DefaultProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+            if (transferPropertiesTestType == TransferPropertiesTestType.NoPreserve)
+            {
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_PreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                Assert.IsEmpty(destinationProperties.Metadata);
+                Assert.IsNull(destinationProperties.ContentDisposition);
+                Assert.IsNull(destinationProperties.ContentLanguage);
+                Assert.IsNull(destinationProperties.CacheControl);
+            }
+            else if (transferPropertiesTestType == TransferPropertiesTestType.NewProperties)
+            {
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NoPreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                Assert.That(_defaultMetadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(_defaultContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(_defaultContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(_defaultCacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(_defaultContentType, destinationProperties.ContentType);
+                Assert.AreEqual(_defaultFileCreatedOn, destinationProperties.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(_defaultFileLastWrittenOn, destinationProperties.SmbProperties.FileLastWrittenOn);
+                Assert.AreEqual(_defaultFileChangedOn, destinationProperties.SmbProperties.FileChangedOn);
+            }
+            else //(transferPropertiesTestType == TransferPropertiesTestType.Default ||
+                 //transferPropertiesTestType == TransferPropertiesTestType.Preserve)
+            {
+                BlobProperties sourceProperties = await sourceClient.GetPropertiesAsync();
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NewProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
+                Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
+                Assert.AreEqual(sourceProperties.CreatedOn, destinationProperties.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(sourceProperties.LastModified, destinationProperties.SmbProperties.FileLastWrittenOn);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/PageBlobToShareFileTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/PageBlobToShareFileTests.cs
@@ -100,7 +100,8 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             bool createResource = false,
             string objectName = null,
             BlobClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             PageBlobClient blobClient = container.GetPageBlobClient(objectName);

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToAppendBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToAppendBlobTests.cs
@@ -41,10 +41,16 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         private const string _blobResourcePrefix = "test-blob-";
         private const string _expectedOverwriteExceptionMessage = "BlobAlreadyExists";
         private const string _defaultContentType = "text/plain";
-        private const string _defaultContentLanguage = "en-US";
+        private readonly string[] _defaultContentLanguage = new[] { "en-US", "en-CA" };
         private const string _defaultContentDisposition = "inline";
         private const string _defaultCacheControl = "no-cache";
+        private const string _defaultPermissions = "O:S-1-5-21-2127521184-1604012920-1887927527-21560751G:S-1-5-21-2127521184-1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200a9;;;S-1-5-21-397955417-626881126-188441444-3053964)S:NO_ACCESS_CONTROL";
+        private const NtfsFileAttributes _defaultFileAttributes = NtfsFileAttributes.None;
+        private const NtfsFileAttributes _defaultDirectoryAttributes = NtfsFileAttributes.Directory;
         private readonly Metadata _defaultMetadata = DataProvider.BuildMetadata();
+        private readonly DateTimeOffset _defaultFileCreatedOn = new DateTimeOffset(2024, 4, 1, 9, 5, 55, default);
+        private readonly DateTimeOffset _defaultFileLastWrittenOn = new DateTimeOffset(2024, 4, 1, 12, 16, 6, default);
+        private readonly DateTimeOffset _defaultFileChangedOn = new DateTimeOffset(2024, 4, 1, 13, 30, 3, default);
         protected readonly object _serviceVersion;
 
         public ShareFileToAppendBlobTests(
@@ -124,7 +130,8 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
                 {
                     ContentDisposition = new("attachment"),
                     ContentLanguage = new("en-US"),
-                    CacheControl = new("no-cache")
+                    CacheControl = new("no-cache"),
+                    Metadata = new(_defaultMetadata)
                 };
             }
             else if (type == TransferPropertiesTestType.NoPreserve)
@@ -133,7 +140,8 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
                 {
                     ContentDisposition = new(false),
                     ContentLanguage = new(false),
-                    CacheControl = new(false)
+                    CacheControl = new(false),
+                    Metadata = new(false),
                 };
             }
             else if (type == TransferPropertiesTestType.Preserve)
@@ -142,7 +150,8 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
                 {
                     ContentDisposition = new(true),
                     ContentLanguage = new(true),
-                    CacheControl = new(true)
+                    CacheControl = new(true),
+                    Metadata = new(true),
                 };
             }
             return new AppendBlobStorageResource(objectClient, options);
@@ -157,7 +166,8 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             bool createResource = false,
             string objectName = null,
             ShareClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             ShareFileClient fileClient = container.GetRootDirectoryClient().GetFileClient(objectName);
@@ -167,7 +177,31 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
                 {
                     throw new InvalidOperationException($"Cannot create share file without size specified. Either set {nameof(createResource)} to false or specify a {nameof(objectLength)}.");
                 }
-                await fileClient.CreateAsync(objectLength.Value);
+                ShareFileHttpHeaders httpHeaders = default;
+                Metadata metadata = default;
+                FileSmbProperties smbProperties = default;
+                if (propertiesTestType != TransferPropertiesTestType.NewProperties)
+                {
+                    httpHeaders = new ShareFileHttpHeaders()
+                    {
+                        ContentLanguage = _defaultContentLanguage,
+                        ContentDisposition = _defaultContentDisposition,
+                        CacheControl = _defaultCacheControl
+                    };
+                    metadata = _defaultMetadata;
+                    smbProperties = new FileSmbProperties()
+                    {
+                        FileAttributes = _defaultFileAttributes,
+                        FileCreatedOn = _defaultFileCreatedOn,
+                        FileChangedOn = _defaultFileChangedOn,
+                        FileLastWrittenOn = _defaultFileLastWrittenOn,
+                    };
+                }
+                await fileClient.CreateAsync(
+                    maxSize: objectLength.Value,
+                    httpHeaders: httpHeaders,
+                    metadata: metadata,
+                    smbProperties: smbProperties);
 
                 if (contents != default)
                 {
@@ -250,10 +284,10 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             {
                 BlobProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-                Assert.IsEmpty(destinationProperties.Metadata);
                 Assert.IsNull(destinationProperties.ContentDisposition);
                 Assert.IsNull(destinationProperties.ContentLanguage);
                 Assert.IsNull(destinationProperties.CacheControl);
+                Assert.IsEmpty(destinationProperties.Metadata);
 
                 GetBlobTagResult destinationTags = await destinationClient.GetTagsAsync();
                 Assert.IsEmpty(destinationTags.Tags);
@@ -276,7 +310,7 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 
                 Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
                 Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
-                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(string.Join(",", sourceProperties.ContentLanguage), destinationProperties.ContentLanguage);
                 Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
                 Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
             }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToBlockBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToBlockBlobTests.cs
@@ -40,10 +40,16 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         private const string _blobResourcePrefix = "test-blob-";
         private const string _expectedOverwriteExceptionMessage = "BlobAlreadyExists";
         private const string _defaultContentType = "text/plain";
-        private const string _defaultContentLanguage = "en-US";
+        private readonly string[] _defaultContentLanguage = new[] { "en-US", "en-CA" };
         private const string _defaultContentDisposition = "inline";
         private const string _defaultCacheControl = "no-cache";
+        private const string _defaultPermissions = "O:S-1-5-21-2127521184-1604012920-1887927527-21560751G:S-1-5-21-2127521184-1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200a9;;;S-1-5-21-397955417-626881126-188441444-3053964)S:NO_ACCESS_CONTROL";
+        private const NtfsFileAttributes _defaultFileAttributes = NtfsFileAttributes.None;
+        private const NtfsFileAttributes _defaultDirectoryAttributes = NtfsFileAttributes.Directory;
         private readonly Metadata _defaultMetadata = DataProvider.BuildMetadata();
+        private readonly DateTimeOffset _defaultFileCreatedOn = new DateTimeOffset(2024, 4, 1, 9, 5, 55, default);
+        private readonly DateTimeOffset _defaultFileLastWrittenOn = new DateTimeOffset(2024, 4, 1, 12, 16, 6, default);
+        private readonly DateTimeOffset _defaultFileChangedOn = new DateTimeOffset(2024, 4, 1, 13, 30, 3, default);
         protected readonly object _serviceVersion;
 
         public ShareFileToBlockBlobTests(
@@ -105,30 +111,32 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             BlockBlobStorageResourceOptions options = default;
             if (type == TransferPropertiesTestType.NewProperties)
             {
-                options = new BlockBlobStorageResourceOptions
+                options = new()
                 {
-                    AccessTier = AccessTier.Cool,
                     ContentDisposition = new("attachment"),
                     ContentLanguage = new("en-US"),
-                    CacheControl = new("no-cache")
+                    CacheControl = new("no-cache"),
+                    Metadata = new(_defaultMetadata)
                 };
             }
             else if (type == TransferPropertiesTestType.NoPreserve)
             {
-                options = new BlockBlobStorageResourceOptions
+                options = new()
                 {
                     ContentDisposition = new(false),
                     ContentLanguage = new(false),
-                    CacheControl = new(false)
+                    CacheControl = new(false),
+                    Metadata = new(false),
                 };
             }
             else if (type == TransferPropertiesTestType.Preserve)
             {
-                options = new BlockBlobStorageResourceOptions
+                options = new()
                 {
                     ContentDisposition = new(true),
                     ContentLanguage = new(true),
-                    CacheControl = new(true)
+                    CacheControl = new(true),
+                    Metadata = new(true),
                 };
             }
             return new BlockBlobStorageResource(objectClient, options);
@@ -143,7 +151,8 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             bool createResource = false,
             string objectName = null,
             ShareClientOptions options = null,
-            Stream contents = null)
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default)
         {
             objectName ??= GetNewObjectName();
             ShareFileClient fileClient = container.GetRootDirectoryClient().GetFileClient(objectName);
@@ -153,7 +162,31 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
                 {
                     throw new InvalidOperationException($"Cannot create share file without size specified. Either set {nameof(createResource)} to false or specify a {nameof(objectLength)}.");
                 }
-                await fileClient.CreateAsync(objectLength.Value);
+                ShareFileHttpHeaders httpHeaders = default;
+                Metadata metadata = default;
+                FileSmbProperties smbProperties = default;
+                if (propertiesTestType != TransferPropertiesTestType.NewProperties)
+                {
+                    httpHeaders = new ShareFileHttpHeaders()
+                    {
+                        ContentLanguage = _defaultContentLanguage,
+                        ContentDisposition = _defaultContentDisposition,
+                        CacheControl = _defaultCacheControl
+                    };
+                    metadata = _defaultMetadata;
+                    smbProperties = new FileSmbProperties()
+                    {
+                        FileAttributes = _defaultFileAttributes,
+                        FileCreatedOn = _defaultFileCreatedOn,
+                        FileChangedOn = _defaultFileChangedOn,
+                        FileLastWrittenOn = _defaultFileLastWrittenOn,
+                    };
+                }
+                await fileClient.CreateAsync(
+                    maxSize: objectLength.Value,
+                    httpHeaders: httpHeaders,
+                    metadata: metadata,
+                    smbProperties: smbProperties);
 
                 if (contents != default)
                 {
@@ -262,7 +295,7 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 
                 Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
                 Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
-                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(string.Join(",", sourceProperties.ContentLanguage), destinationProperties.ContentLanguage);
                 Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
                 Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
             }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToBlockBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToBlockBlobTests.cs
@@ -18,6 +18,9 @@ using Azure.Storage.DataMovement.Files.Shares;
 using DMBlob::Azure.Storage.DataMovement.Blobs;
 using Azure.Storage.Files.Shares.Tests;
 using NUnit.Framework;
+using Azure.Storage.Files.Shares.Models;
+using Azure.Storage.Test;
+using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 {
@@ -36,6 +39,11 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         public const int MaxReliabilityRetries = 5;
         private const string _blobResourcePrefix = "test-blob-";
         private const string _expectedOverwriteExceptionMessage = "BlobAlreadyExists";
+        private const string _defaultContentType = "text/plain";
+        private const string _defaultContentLanguage = "en-US";
+        private const string _defaultContentDisposition = "inline";
+        private const string _defaultCacheControl = "no-cache";
+        private readonly Metadata _defaultMetadata = DataProvider.BuildMetadata();
         protected readonly object _serviceVersion;
 
         public ShareFileToBlockBlobTests(
@@ -207,46 +215,57 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             return InstrumentClientOptions(options);
         }
 
-        protected override Task VerifyPropertiesCopyAsync(
+        protected override async Task VerifyPropertiesCopyAsync(
             DataTransfer transfer,
             TransferPropertiesTestType transferPropertiesTestType,
             TestEventsRaised testEventsRaised,
             ShareFileClient sourceClient,
             BlockBlobClient destinationClient)
         {
-            throw new NotImplementedException();
-        }
+            // Verify completion
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(DataTransferState.Completed, transfer.TransferStatus.State);
+            // Verify Copy - using original source File and Copying the destination
+            await testEventsRaised.AssertSingleCompletedCheck();
+            using Stream sourceStream = await sourceClient.OpenReadAsync();
+            using Stream destinationStream = await destinationClient.OpenReadAsync();
+            Assert.AreEqual(sourceStream, destinationStream);
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_DefaultProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+            if (transferPropertiesTestType == TransferPropertiesTestType.NoPreserve)
+            {
+                BlobProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_PreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                Assert.IsEmpty(destinationProperties.Metadata);
+                Assert.IsNull(destinationProperties.ContentDisposition);
+                Assert.IsNull(destinationProperties.ContentLanguage);
+                Assert.IsNull(destinationProperties.CacheControl);
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NoPreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                GetBlobTagResult destinationTags = await destinationClient.GetTagsAsync();
+                Assert.IsEmpty(destinationTags.Tags);
+            }
+            else if (transferPropertiesTestType == TransferPropertiesTestType.NewProperties)
+            {
+                BlobProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NewProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
+                Assert.That(_defaultMetadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(_defaultContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(_defaultContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(_defaultCacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(_defaultContentType, destinationProperties.ContentType);
+            }
+            else //(transferPropertiesTestType == TransferPropertiesTestType.Default ||
+                 //transferPropertiesTestType == TransferPropertiesTestType.Preserve)
+            {
+                ShareFileProperties sourceProperties = await sourceClient.GetPropertiesAsync();
+                BlobProperties destinationProperties = await destinationClient.GetPropertiesAsync();
+
+                Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToPageBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToPageBlobTests.cs
@@ -18,6 +18,10 @@ using DMBlob::Azure.Storage.DataMovement.Blobs;
 using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Shared;
 using NUnit.Framework;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Files.Shares.Models;
+using Azure.Storage.Test;
+using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 {
@@ -36,6 +40,11 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         public const int MaxReliabilityRetries = 5;
         private const string _blobResourcePrefix = "test-blob-";
         private const string _expectedOverwriteExceptionMessage = "BlobAlreadyExists";
+        private const string _defaultContentType = "text/plain";
+        private const string _defaultContentLanguage = "en-US";
+        private const string _defaultContentDisposition = "inline";
+        private const string _defaultCacheControl = "no-cache";
+        private readonly Metadata _defaultMetadata = DataProvider.BuildMetadata();
         protected readonly object _serviceVersion;
 
         public ShareFileToPageBlobTests(
@@ -221,46 +230,57 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             return InstrumentClientOptions(options);
         }
 
-        protected override Task VerifyPropertiesCopyAsync(
+        protected override async Task VerifyPropertiesCopyAsync(
             DataTransfer transfer,
             TransferPropertiesTestType transferPropertiesTestType,
             TestEventsRaised testEventsRaised,
             ShareFileClient sourceClient,
             PageBlobClient destinationClient)
         {
-            throw new NotImplementedException();
-        }
+            // Verify completion
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(DataTransferState.Completed, transfer.TransferStatus.State);
+            // Verify Copy - using original source File and Copying the destination
+            await testEventsRaised.AssertSingleCompletedCheck();
+            using Stream sourceStream = await sourceClient.OpenReadAsync();
+            using Stream destinationStream = await destinationClient.OpenReadAsync();
+            Assert.AreEqual(sourceStream, destinationStream);
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_DefaultProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+            if (transferPropertiesTestType == TransferPropertiesTestType.NoPreserve)
+            {
+                BlobProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_PreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                Assert.IsEmpty(destinationProperties.Metadata);
+                Assert.IsNull(destinationProperties.ContentDisposition);
+                Assert.IsNull(destinationProperties.ContentLanguage);
+                Assert.IsNull(destinationProperties.CacheControl);
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NoPreserveProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
-        }
+                GetBlobTagResult destinationTags = await destinationClient.GetTagsAsync();
+                Assert.IsEmpty(destinationTags.Tags);
+            }
+            else if (transferPropertiesTestType == TransferPropertiesTestType.NewProperties)
+            {
+                BlobProperties destinationProperties = await destinationClient.GetPropertiesAsync();
 
-        [Test]
-        [Ignore("Not implemented yet")]
-        public override Task SourceObjectToDestinationObject_NewProperties()
-        {
-            Assert.Fail("Feature not implemented yet for this source and destination resource.");
-            return Task.CompletedTask;
+                Assert.That(_defaultMetadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(_defaultContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(_defaultContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(_defaultCacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(_defaultContentType, destinationProperties.ContentType);
+            }
+            else //(transferPropertiesTestType == TransferPropertiesTestType.Default ||
+                 //transferPropertiesTestType == TransferPropertiesTestType.Preserve)
+            {
+                ShareFileProperties sourceProperties = await sourceClient.GetPropertiesAsync();
+                BlobProperties destinationProperties = await destinationClient.GetPropertiesAsync();
+
+                Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_34fa84b61a"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_2ce88bf195"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -94,7 +94,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             bool createResource = false,
             string objectName = null,
             ShareClientOptions options = null,
-            Stream contents = null)
+            Stream contents = null,
+            TransferPropertiesTestType propertiesTestType = default)
             => CreateFileClientAsync(
                 container,
                 objectLength,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
@@ -62,6 +62,8 @@ namespace Azure.Storage.DataMovement
         internal const int LongSizeInBytes = 8;
         internal const int IntSizeInBytes = 4;
         internal const int GuidSizeInBytes = 16;
+        internal const string StringTypeStr = "string";
+        internal const string StringArrayTypeStr = "string[]";
 
         /// <summary>
         /// Constants used for job plan files.

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
@@ -125,5 +125,8 @@ namespace Azure.Storage
         public static ArgumentException NoResourceProviderFound(bool isSource, string providerId)
             => new ArgumentException($"Unable to find resource provider for transfer {(isSource ? "source" : "destination")} with provider id: {providerId}. " +
                 $"Please ensure you have registered the required resource provider with TransferManagerOptions.ResumeProviders.");
+
+        public static ArgumentException UnexpectedPropertyType(string propertyName, params string[] expectedTypes)
+            => new ArgumentException($"Unexpected property type encountered for storage resource property {propertyName}: {string.Join(",", (string[])expectedTypes)}");
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferCopyTestBase.cs
@@ -99,7 +99,8 @@ namespace Azure.Storage.DataMovement.Tests
             bool createResource = false,
             string objectName = default,
             TSourceClientOptions options = default,
-            Stream contents = default);
+            Stream contents = default,
+            TransferPropertiesTestType propertiesTestType = default);
 
         /// <summary>
         /// Gets the specific storage resource from the given TSourceObjectClient


### PR DESCRIPTION
Mainly this was ensuring that the Single Transfer Share File to/from Blob transfers maintained properties that were preservable/settable. Which just contained a lot of test updates.

One change that had to be made was ensuring that Content Language and Content Encoding property type was converted properly from object to string array to string. Since Blobs accepts these as a `string` while Shares accept this value as a `string[]`