### PR TITLE
Wire up SubscriptionConfigurationFilePaths

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -115,6 +115,8 @@ jobs:
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
           EnvVars: ${{ parameters.EnvVars }}
+          SubscriptionConfigurationFilePaths: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePaths }}
+
       - pwsh: |
           $project = "${{ parameters.Project }}"
           $directory = "${{ parameters.ServiceDirectory }}"


### PR DESCRIPTION
After merging eng/common changes, those changes need to be wired up. 

Tested in: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3902164&view=results on [this change](https://github.com/Azure/azure-sdk-for-net/compare/main...acs/federated-identity)