### PR TITLE
Only add SubscriptionConfigurationFilePaths if UseFederatedAuth is true

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -115,7 +115,9 @@ jobs:
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
           EnvVars: ${{ parameters.EnvVars }}
-          SubscriptionConfigurationFilePaths: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePaths }}
+          ${{ if parameters.UseFederatedAuth }}:
+            SubscriptionConfigurationFilePaths: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePaths }}
+
 
       - pwsh: |
           $project = "${{ parameters.Project }}"

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -31,6 +31,6 @@ extends:
           # Contains alternate tenant, AAD app and cert info for testing
           - $(sub-config-identity-test-resources)
         ServiceConnection: azure-sdk-tests
-        SubscriptionConfigurationFilePaths:
-          - eng/common/TestResources/sub-config/AzurePublicMsft.json
+    EnvVars:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     UseFederatedAuth: true

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -31,6 +31,6 @@ extends:
           # Contains alternate tenant, AAD app and cert info for testing
           - $(sub-config-identity-test-resources)
         ServiceConnection: azure-sdk-tests
-    EnvVars:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        SubscriptionConfigurationFilePaths:
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json
     UseFederatedAuth: true


### PR DESCRIPTION
(and other test cleanup)

Fixed build (regular build): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3912985&view=results

Fixed build (`UseFederatedAuth: true`): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3912992&view=results -- in this case the failure happens in the [pre-script](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/test-resources-pre.ps1#L27). Unrelated to this change. 