### PR TITLE
[AzureMonitorExporter] add default value for SDK version string

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
@@ -115,7 +115,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 #elif ASP_NET_CORE_DISTRO
                 AzureMonitorAspNetCoreEventSource.Log.SdkVersionCreateFailed(ex);
 #endif
-                return "dotnetU:otelU:extU"; // 'U' for Unknown
+
+                // Return a default value in case of failure.
+                // We don't think this will ever happen.
+                // We will monitor internal telemetry and if we detect this we may explore an alternative approach to collecting version numbers.
+                return "dotnetu:otelu:extu"; // 'u' for Unknown
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
@@ -21,7 +21,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     internal static class SdkVersionUtils
     {
         private static string? s_prefix;
-        internal static string? s_sdkVersion = GetSdkVersion();
+        internal static string s_sdkVersion = GetSdkVersion();
         internal static bool s_isDistro = false;
 
         internal static string? SdkVersionPrefix
@@ -86,7 +86,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
         }
 
-        private static string? GetSdkVersion()
+        private static string GetSdkVersion()
         {
             try
             {
@@ -115,7 +115,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 #elif ASP_NET_CORE_DISTRO
                 AzureMonitorAspNetCoreEventSource.Log.SdkVersionCreateFailed(ex);
 #endif
-                return null;
+                return "dotnetU:otelU:extU"; // 'U' for Unknown
             }
         }
     }


### PR DESCRIPTION
This PR replaces the null with a default string.

Currently we get the assembly version of libraries at runtime. We don't expect this to fail.
We're adding this default value to explicitly detect if this does fail.
We will monitor internal telemetry and if this is detected, we'll investigate alternative methods for collecting version numbers.

IE: Exporter version could be collected at compile time. .NET version can be collected from env vars.
