### PR TITLE
[AzureMonitorExporter] Fix DuplicateKeyException when LogRecord contains EventId or EventName in both LogRecord and Attributes

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -10,10 +10,11 @@
 
 * Fixed an issue where a `DuplicateKeyException` could be thrown if `EventId`
   and `EventName` were present in both `LogRecord` (`LogRecord.EventId`,
-  `LogRecord.EventName`) and `LogRecord.Attributes`. The method now checks if
-  these keys exist before attempting to add them, ensuring that `EventId` and
-  `EventName` from `LogRecord.Attributes` are honored and preventing the
-  `LogRecord` from being dropped.
+  `LogRecord.EventName`) and `LogRecord.Attributes`. The method now uses
+  `EventId` and `EventName` from `LogRecord.Attributes` when both are present.
+  If they are not in `LogRecord.Attributes`, it uses the values from
+  `LogRecord.EventId` or `LogRecord.EventName`, preventing the `LogRecord` from
+  being dropped.
   ([#44748](https://github.com/Azure/azure-sdk-for-net/pull/44748))
 
 ### Other Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bugs Fixed
 
+* Fixed an issue where a `DuplicateKeyException` could be thrown if both
+  `LogRecord` and the `LogRecord.Attributes` collection contained `EventId` or
+  `EventName`. The method now checks if these keys exist before attempting to add
+  them, preventing the LogRecord from being dropped.
+  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+
 ### Other Changes
 
 * Enabled support for log collection from Azure SDKs via `Microsoft.Extensions.Logging`.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -8,11 +8,13 @@
 
 ### Bugs Fixed
 
-* Fixed an issue where a `DuplicateKeyException` could be thrown if both
-  `LogRecord` and the `LogRecord.Attributes` collection contained `EventId` or
-  `EventName`. The method now checks if these keys exist before attempting to add
-  them, preventing the LogRecord from being dropped.
-  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+* Fixed an issue where a `DuplicateKeyException` could be thrown if `EventId`
+  and `EventName` were present in both `LogRecord` (`LogRecord.EventId`,
+  `LogRecord.EventName`) and `LogRecord.Attributes`. The method now checks if
+  these keys exist before attempting to add them, ensuring that `EventId` and
+  `EventName` from `LogRecord.Attributes` are honored and preventing the
+  `LogRecord` from being dropped.
+  ([#44748](https://github.com/Azure/azure-sdk-for-net/pull/44748))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -124,12 +124,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             logRecord.ForEachScope(s_processScope, properties);
 
-            if (logRecord.EventId.Id != 0)
+            if (!properties.ContainsKey("EventId") && logRecord.EventId.Id != 0)
             {
                 properties.Add("EventId", logRecord.EventId.Id.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (!string.IsNullOrEmpty(logRecord.EventId.Name))
+            if (!properties.ContainsKey("EventName") && !string.IsNullOrEmpty(logRecord.EventId.Name))
             {
                 properties.Add("EventName", logRecord.EventId.Name!.Truncate(SchemaConstants.KVP_MaxValueLength));
             }


### PR DESCRIPTION
Fixes #44653

If `EventId` and `EventName` are present in both `LogRecord` (`LogRecord.EventId`, `LogRecord.EventName`) and `LogRecord.Attributes`, `EventId` and `EventName` from `LogRecord.Attributes` are honored.
