### PR TITLE
Fix namespaces generation to handle framework targets other than netstandard2.0

### DIFF
--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -58,41 +58,54 @@ $foundError = $false
 foreach ($packageInfoFile in $packageInfoFiles) {
     Write-Host "processing $($packageInfoFile.FullName)"
     $packageInfo = ConvertFrom-Json (Get-Content $packageInfoFile -Raw)
-    # Piece together the artifacts bin directory
-    $artifactsBinDir = Join-Path $repoRoot "artifacts" "bin" $packageInfo.Name $buildConfiguration "netstandard2.0"
+    # Piece together the artifacts bin directory. Note that the artifactsBinDir
+    # directory cannot include the netstandard2.0 because anything not building
+    # with the netstandard2.0 will be in a different subdirectory
+    $artifactsBinDir = Join-Path $repoRoot "artifacts" "bin" $packageInfo.Name $buildConfiguration
     Write-Host "artifactsBinDir=$artifactsBinDir"
     if (Test-Path $artifactsBinDir) {
-        $defaultDll = Join-Path $artifactsBinDir "$($packageInfo.Name).dll"
-        if ($defaultDll -and (Test-Path $defaultDll)) {
-            Write-Host "dll file path: $($defaultDll.FullName)"
-            $namespaces = @(Get-NamespacesFromDll $defaultDll)
-            if ($namespaces.Count -gt 0) {
-                Write-Host "Get-NamespacesFromDll returned the following namespaces:"
-                foreach ($namespace in $namespaces) {
-                    Write-Host "  $namespace"
-                }
-                # If by some reason, the namespaces already exist, overwrite them with
-                # what was just computed
-                if ($packageInfo.PSobject.Properties.Name -contains "Namespaces") {
-                    $packageInfo.Namespaces = $namespaces
-                }
-                else {
-                    $packageInfo = $packageInfo | Add-Member -MemberType NoteProperty -Name Namespaces -Value $namespaces -PassThru
-                }
-                $packageInfoJson = ConvertTo-Json -InputObject $packageInfo -Depth 100
-                Write-Host "The updated packageInfo for $packageInfoFile is:"
-                Write-Host "$packageInfoJson"
-                Set-Content `
-                    -Path $packageInfoFile `
-                    -Value $packageInfoJson
+        $dllName = "$($packageInfo.Name).dll"
+        # This needs to ensure an array is always returned.
+        $foundDlls = @(Get-ChildItem -Path $artifactsBinDir -Recurse -File -Filter $dllName)
+        if (-not $foundDlls) {
+            LogError "$dllName does not exist in any of the subdirectories of $artifactsBinDir"
+            $foundError = $true
+            continue
+        }
+        if ($foundDlls.Length -gt 1) {
+            $errorString = "$dllName was found $($dlls.Length) times in the subdirectories of $artifactsBinDir. Paths found:\n"
+            foreach ($foundDll in $foundDlls) {
+                $errorString = $errorString + "$founDll\n"
+            }
+            LogError $errorString
+            $foundError = $true
+            continue
+        }
+        $defaultDll = $foundDlls[0]
+        Write-Host "dll file path: $($defaultDll.FullName)"
+        $namespaces = @(Get-NamespacesFromDll $defaultDll)
+        if ($namespaces.Count -gt 0) {
+            Write-Host "Get-NamespacesFromDll returned the following namespaces:"
+            foreach ($namespace in $namespaces) {
+                Write-Host "  $namespace"
+            }
+            # If by some reason, the namespaces already exist, overwrite them with
+            # what was just computed
+            if ($packageInfo.PSobject.Properties.Name -contains "Namespaces") {
+                $packageInfo.Namespaces = $namespaces
             }
             else {
-                LogWarning "Unable to get namespaces for $($defaultDll.FullName)"
+                $packageInfo = $packageInfo | Add-Member -MemberType NoteProperty -Name Namespaces -Value $namespaces -PassThru
             }
+            $packageInfoJson = ConvertTo-Json -InputObject $packageInfo -Depth 100
+            Write-Host "The updated packageInfo for $packageInfoFile is:"
+            Write-Host "$packageInfoJson"
+            Set-Content `
+                -Path $packageInfoFile `
+                -Value $packageInfoJson
         }
         else {
-            LogError "$defaultDll didn't exist, unable to get namespaces for $($packageInfo.Name), version=$($packageInfo.Verison)"
-            $foundError = $true
+            LogWarning "Unable to get namespaces for $($defaultDll.FullName)"
         }
     }
     else {

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -72,15 +72,6 @@ foreach ($packageInfoFile in $packageInfoFiles) {
             $foundError = $true
             continue
         }
-        if ($foundDlls.Length -gt 1) {
-            $errorString = "$dllName was found $($foundDlls.Length) times in the subdirectories of $artifactsBinDir. Paths found:\n"
-            foreach ($foundDll in $foundDlls) {
-                $errorString = $errorString + "$founDll\n"
-            }
-            LogError $errorString
-            $foundError = $true
-            continue
-        }
         $defaultDll = $foundDlls[0]
         Write-Host "dll file path: $($defaultDll.FullName)"
         $namespaces = @(Get-NamespacesFromDll $defaultDll)

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -73,7 +73,7 @@ foreach ($packageInfoFile in $packageInfoFiles) {
             continue
         }
         if ($foundDlls.Length -gt 1) {
-            $errorString = "$dllName was found $($dlls.Length) times in the subdirectories of $artifactsBinDir. Paths found:\n"
+            $errorString = "$dllName was found $($foundDlls.Length) times in the subdirectories of $artifactsBinDir. Paths found:\n"
             foreach ($foundDll in $foundDlls) {
                 $errorString = $errorString + "$founDll\n"
             }


### PR DESCRIPTION
Namespace generation was looking for the built dll in the netstandard2.0 subdirectory. Turns out this wasn't correct if the framework target wasn't netstandard2.0, as discovered by the [net - webpubsub - ci pipeline](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3915477&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=e2744c02-d5ab-5ec4-b597-2a76a072b500)

Instead of computing the full directory where the dll, which would be the framework target directory, go one level up and do a search for the .dll.