### PR TITLE
Improve test playback

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/assets.json
+++ b/sdk/openai/Azure.AI.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/openai/Azure.AI.OpenAI",
-  "Tag": "net/openai/Azure.AI.OpenAI_cd63404f01"
+  "Tag": "net/openai/Azure.AI.OpenAI_fc99a87ba7"
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/ImageTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ImageTests.cs
@@ -48,7 +48,7 @@ public class ImageTests : AoaiTestBase<ImageClient>
     public async Task CanCreateSimpleImage()
     {
         ImageClient client = GetTestClient();
-        GeneratedImage image = await client.GenerateImageAsync("a small watermelon", new()
+        GeneratedImage image = await client.GenerateImageAsync("a tabby cat", new()
         {
             Quality = GeneratedImageQuality.Standard,
             Size = GeneratedImageSize.W1024xH1024,
@@ -63,7 +63,7 @@ public class ImageTests : AoaiTestBase<ImageClient>
     public async Task CanGetContentFilterResults()
     {
         ImageClient client = GetTestClient();
-        ClientResult<GeneratedImage> imageResult = await client.GenerateImageAsync("a small watermelon", new()
+        ClientResult<GeneratedImage> imageResult = await client.GenerateImageAsync("a tabby cat", new()
         {
             Quality = GeneratedImageQuality.Standard,
             Size = GeneratedImageSize.W1024xH1024,

--- a/sdk/openai/Azure.AI.OpenAI/tests/Utils/AoaiTestBase.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Utils/AoaiTestBase.cs
@@ -37,6 +37,7 @@ namespace Azure.AI.OpenAI.Tests;
 public class AoaiTestBase<TClient> : RecordedTestBase<AoaiTestEnvironment>
 {
     private const string AZURE_URI_SANITIZER_PATTERN = @"(?<=/(subscriptions|resourceGroups|accounts)/)([^/]+?)(?=(/|$))";
+    private const string SMALL_1x1_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiQAABYkAZsVxhQAAAAMSURBVBhXY2BgYAAAAAQAAVzN/2kAAAAASUVORK5CYII=";
 
     public static readonly DateTimeOffset START_2024 = new DateTimeOffset(2024, 01, 01, 00, 00, 00, TimeSpan.Zero);
     public static readonly DateTimeOffset UNIX_EPOCH =
@@ -100,6 +101,18 @@ public class AoaiTestBase<TClient> : RecordedTestBase<AoaiTestEnvironment>
         RecordingDisabler.DisableBodyRecordingFor<FileClient>(nameof(FileClient.UploadFileAsync));
 
         IgnoredHeaders.Add("x-ms-client-request-id");
+
+        // Data URIs trimmed to prevent the recording from being too large
+        BodyKeySanitizers.Add(new BodyKeySanitizer("$..url")
+        {
+            Regex = @"(?<=data:image/png;base64,)(.+)",
+            Value = SMALL_1x1_PNG
+        });
+        // Base64 encoded images in the response are replaced with a 1x1 black pixel PNG image to ensure valid data
+        BodyKeySanitizers.Add(new BodyKeySanitizer($"..b64_json")
+        {
+            Value = SMALL_1x1_PNG
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
* Reduces test recording size
* Shaves off 25-30 seconds of playback runtime for tests
* Update prompt for image generation to not accidentally trigger content filtering