### PR TITLE
Improve logging of requests and responses in Azure OpenAI tests

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/tests/Utils/Extensions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Utils/Extensions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 #nullable enable
@@ -70,6 +72,18 @@ namespace Azure.AI.OpenAI.Tests
             return value!;
         }
 
+        public static string? GetFirstValueOrDefault(this PipelineRequestHeaders headers, string key)
+        {
+            IEnumerable<string>? values = null;
+            if (key != null)
+            {
+                headers?.TryGetValues(key, out values);
+            }
+
+            return values?.FirstOrDefault(v => v != null)
+                ?? null;
+        }
+
         public static string? GetFirstValueOrDefault(this PipelineResponseHeaders headers, string key)
         {
             IEnumerable<string>? values = null;
@@ -96,6 +110,46 @@ namespace Azure.AI.OpenAI.Tests
             }
 
             return default!;
+        }
+
+        public static int FillBuffer(this Stream stream, byte[] buffer)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+            else if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer));
+
+            int totalRead = 0;
+            while (totalRead < buffer.Length)
+            {
+                int read = stream.Read(buffer, totalRead, buffer.Length - totalRead);
+                if (read == 0)
+                {
+                    return totalRead;
+                }
+
+                totalRead += read;
+            }
+
+            return totalRead;
+        }
+
+        public static StringBuilder PadRight(this StringBuilder builder, int totalWidth, char paddingChar = ' ')
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+            else if (totalWidth < 0)
+                throw new ArgumentOutOfRangeException(nameof(totalWidth), "Total width must be greater than or equal to 0.");
+            else if (totalWidth == 0)
+                return builder;
+
+            int padding = totalWidth - builder.Length;
+            if (padding > 0)
+            {
+                builder.Append(paddingChar, padding);
+            }
+
+            return builder;
         }
     }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/Utils/TestPipelinePolicy.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Utils/TestPipelinePolicy.cs
@@ -21,25 +21,31 @@ internal partial class TestPipelinePolicy : PipelinePolicy
 
     public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
     {
-        InvokeActions(message);
+        Invoke(message?.Request);
         ProcessNext(message, pipeline, currentIndex);
+        Invoke(message?.Response);
     }
 
-    public override ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    public override async ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
     {
-        InvokeActions(message);
-        return ProcessNextAsync(message, pipeline, currentIndex);
+        Invoke(message?.Request);
+        await ProcessNextAsync(message, pipeline, currentIndex).ConfigureAwait(false);
+        Invoke(message?.Response);
     }
 
-    private void InvokeActions(PipelineMessage message)
+    private void Invoke(PipelineRequest request)
     {
-        if (message?.Request is not null)
+        if (request is not null)
         {
-            _processRequestAction?.Invoke(message.Request);
+            _processRequestAction?.Invoke(request);
         }
-        if (message?.Response is not null)
+    }
+
+    private void Invoke(PipelineResponse response)
+    {
+        if (response is not null)
         {
-            _processResponseAction?.Invoke(message.Response);
+            _processResponseAction?.Invoke(response);
         }
     }
 }


### PR DESCRIPTION
- Adds support for dumping binary data as hex with the corresponding character data to the right
  - Currently it limits the dumping to 256 lines (aka the first 8192 bytes)
- Ensures that all JSON bodies are indented when dumped for improved readability