### PR TITLE
[AzureMonitor] refactor event id in demo and tests

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Program.cs
@@ -145,7 +145,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Demo
 
                 _logger?.Log(
                     logLevel: LogLevel.Information,
-                    eventId: 0,
+                    eventId: 1,
                     exception: null,
                     message: "Hello {name}.",
                     args: new object[] { "World" });
@@ -162,7 +162,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Demo
                     {
                         _logger?.Log(
                             logLevel: LogLevel.Error,
-                            eventId: 0,
+                            eventId: 2,
                             exception: ex,
                             message: "Hello {name}.",
                             args: new object[] { "World" });

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -68,6 +68,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             string expectedSeverityLevel,
             string expectedMessage,
             string expectedTypeName,
+            IDictionary<string, string> expectedProperties,
             string expectedCloudRole = "[testNamespace]/testName",
             string expectedCloudInstance = "testInstance",
             string expectedApplicationVersion = "testVersion")
@@ -93,6 +94,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(expectedTypeName, telemetryExceptionDetails.TypeName);
             Assert.True(telemetryExceptionDetails.ParsedStack.Any());
             Assert.Null(telemetryExceptionDetails.Stack);
+
+            foreach (var prop in expectedProperties)
+            {
+                Assert.Equal(prop.Value, telemetryExceptionData.Properties[prop.Key]);
+            }
         }
 
         public static void AssertActivity_As_DependencyTelemetry(

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -66,7 +66,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var logger = loggerFactory.CreateLogger(logCategoryName);
             logger.Log(
                 logLevel: logLevel,
-                eventId: 0,
+                eventId: 1,
                 exception: null,
                 message: "Hello {name}.",
                 args: new object[] { "World" });
@@ -83,7 +83,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 telemetryItem: telemetryItem!,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Hello {name}.",
-                expectedMessageProperties: new Dictionary<string, string> { { "name", "World" }},
+                expectedMessageProperties: new Dictionary<string, string> { { "EventId", "1" }, { "name", "World" }},
                 expectedSpanId: null,
                 expectedTraceId: null);
         }
@@ -126,7 +126,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             {
                 logger.Log(
                     logLevel: logLevel,
-                    eventId: 0,
+                    eventId: 1,
                     exception: ex,
                     message: "Hello {name}.",
                     args: new object[] { "World" });
@@ -144,7 +144,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 telemetryItem: telemetryItem!,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Test Exception",
-                expectedTypeName: "System.Exception");
+                expectedTypeName: "System.Exception",
+                expectedProperties: new Dictionary<string, string> { { "EventId", "1" } });
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -264,7 +264,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
                 logger.Log(
                     logLevel: logLevel,
-                    eventId: 0,
+                    eventId: 1,
                     exception: null,
                     message: "Hello {name}.",
                     args: new object[] { "World" });
@@ -295,7 +295,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 telemetryItem: logTelemetryItem!,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Hello {name}.",
-                expectedMessageProperties: new Dictionary<string, string> { { "name", "World" } },
+                expectedMessageProperties: new Dictionary<string, string> { {"EventId", "1" }, { "name", "World" } },
                 expectedSpanId: spanId,
                 expectedTraceId: traceId);
         }


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/44749#discussion_r1659188154
Existing tests were incorrectly using `0` as the event id.

This PR removes the `0` and validates that EventId is included in telemetry properties.