### PR TITLE
Disable purge protection in search test resources

### DIFF
--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -160,7 +160,7 @@
                         }
                     }
                 ],
-                "enablePurgeProtection": true,
+                "enablePurgeProtection": false,
                 "enableSoftDelete": true,
                 "softDeleteRetentionInDays": 7
             }


### PR DESCRIPTION
If this is not necessary for tests we should turn it off. I'm not sure if search is the problem here but our live test cleanup scripts get pretty gummed up when we try to purge keyvaults that have purge protection enabled. You cannot remove purge protection after it's been set.