### PR TITLE
[Storage] [DataMovement] Fixing constant in BlobSourceCheckpointData to have correct schema size

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobConstants.cs
@@ -19,7 +19,7 @@ namespace Azure.Storage.DataMovement.Blobs
             internal const int SchemaVersion = 2;
 
             internal const int VersionIndex = 0;
-            internal const int DataSize = VersionIndex + OneByte;
+            internal const int DataSize = VersionIndex + IntSizeInBytes;
         }
 
         internal class DestinationCheckpointData

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobSourceCheckpointDataTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobSourceCheckpointDataTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
         {
             BlobSourceCheckpointData data = new();
 
-            using (Stream stream = new MemoryStream(DataMovementBlobConstants.DestinationCheckpointData.VariableLengthStartIndex))
+            using (Stream stream = new MemoryStream(DataMovementBlobConstants.SourceCheckpointData.DataSize))
             {
                 data.Serialize(stream);
                 stream.Position = 0;


### PR DESCRIPTION
Looks like the test and the BlobSourceCheckpointData was not correctly giving the max schema size, which resulted in large failures on our pause and resume tests.

- Updated Constants properly
- Updated test to use proper constant (e.g. the source not the destination)