### PR TITLE
Avoid ServiceBusSenderOptions allocations

### DIFF
--- a/sdk/core/Azure.Core.Amqp/tests/AmqpAnnotatedMessageConverterTests.cs
+++ b/sdk/core/Azure.Core.Amqp/tests/AmqpAnnotatedMessageConverterTests.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Azure.Core.Amqp.Shared;
 using Microsoft.Azure.Amqp;
 using Microsoft.Azure.Amqp.Encoding;
 using Microsoft.Azure.Amqp.Framing;
@@ -35,10 +34,10 @@ namespace Azure.Core.Amqp.Tests
             new double[] { 3.1415926 },
             new decimal(3.1415926),
             new decimal[] { new decimal(3.1415926) },
-            DateTimeOffset.Parse("3/24/21").UtcDateTime,
-            new DateTime[] {DateTimeOffset.Parse("3/24/21").UtcDateTime },
-            DateTimeOffset.Parse("3/24/21"),
-            new DateTimeOffset[] {DateTimeOffset.Parse("3/24/21") },
+            DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture).UtcDateTime,
+            new DateTime[] {DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture).UtcDateTime },
+            DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture),
+            new DateTimeOffset[] {DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture) },
             TimeSpan.FromSeconds(5),
             new TimeSpan[] {TimeSpan.FromSeconds(5)},
             new Uri("http://localHost"),
@@ -53,7 +52,7 @@ namespace Azure.Core.Amqp.Tests
             new Dictionary<string, short> {{ "key", 1 } },
             new Dictionary<string, double> {{ "key", 3.1415926 } },
             new Dictionary<string, decimal> {{ "key", new decimal(3.1415926) } },
-            new Dictionary<string, DateTime> {{ "key", DateTimeOffset.Parse("3/24/21").UtcDateTime } },
+            new Dictionary<string, DateTime> {{ "key", DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture).UtcDateTime } },
             // for some reason dictionaries with DateTimeOffset, Timespan, or Uri values are not supported in AMQP lib
             // new Dictionary<string, DateTimeOffset> {{ "key", DateTimeOffset.Parse("3/24/21") } },
             // new Dictionary<string, TimeSpan> {{ "key", TimeSpan.FromSeconds(5) } },
@@ -69,7 +68,7 @@ namespace Azure.Core.Amqp.Tests
             Enumerable.Repeat(new object[] { long.MaxValue }, 2),
             Enumerable.Repeat(new object[] { 1 }, 2),
             Enumerable.Repeat(new object[] { 3.1415926, true }, 2),
-            Enumerable.Repeat(new object[] { DateTimeOffset.Parse("3/24/21").UtcDateTime, true }, 2),
+            Enumerable.Repeat(new object[] { DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture).UtcDateTime, true }, 2),
             new List<IList<object>> { new List<object> { "first", 1}, new List<object> { "second", 2 } }
         };
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - Updated the `Microsoft.Azure.Amqp` dependency to 2.6.7, which contains a fix for decoding messages with a null format code as the body.
 
+- Instances of `ServiceBusSender` created with no explicit `ServiceBusSenderOptions` value allocate less memory.
+
 ## 7.18.0-beta.1 (2024-05-08)
 
 ### Features Added

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -256,7 +255,7 @@ namespace Azure.Messaging.ServiceBus
         ///   The <see cref="ServiceBusClient"/> was constructed with a connection string containing the "EntityPath" token
         ///   that has a different value than the <paramref name="queueOrTopicName"/> value specified here.
         /// </exception>
-        public virtual ServiceBusSender CreateSender(string queueOrTopicName) => CreateSender(queueOrTopicName, new ServiceBusSenderOptions());
+        public virtual ServiceBusSender CreateSender(string queueOrTopicName) => CreateSender(queueOrTopicName, null);
 
         /// <summary>
         /// Creates a <see cref="ServiceBusSender"/> instance that can be used for sending messages to a specific

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -120,10 +119,10 @@ namespace Azure.Messaging.ServiceBus
                 Argument.AssertNotNullOrWhiteSpace(entityPath, nameof(entityPath));
                 connection.ThrowIfClosed();
 
-                options = options?.Clone() ?? new ServiceBusSenderOptions();
+                var identifier = string.IsNullOrEmpty(options?.Identifier) ? DiagnosticUtilities.GenerateIdentifier(EntityPath) : options.Identifier;
 
                 EntityPath = entityPath;
-                Identifier = string.IsNullOrEmpty(options.Identifier) ? DiagnosticUtilities.GenerateIdentifier(EntityPath) : options.Identifier;
+                Identifier = identifier;
                 _connection = connection;
                 _retryPolicy = _connection.RetryOptions.ToRetryPolicy();
                 _innerSender = _connection.CreateTransportSender(
@@ -159,7 +158,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="client">The client instance to use for the sender.</param>
         /// <param name="queueOrTopicName">The name of the queue or topic to send to.</param>
         protected ServiceBusSender(ServiceBusClient client, string queueOrTopicName) :
-            this(queueOrTopicName, client.Connection, new ServiceBusSenderOptions())
+            this(queueOrTopicName, client.Connection, null)
         {
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -3,15 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Azure.Core.Amqp;
 using Azure.Core.Serialization;
 using Azure.Core.Shared;
 using Azure.Messaging.ServiceBus.Amqp;
-using Azure.Messaging.ServiceBus.Primitives;
-using Microsoft.Azure.Amqp.Encoding;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Message
@@ -431,10 +429,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
             new double[] { 3.1415926 },
             new decimal(3.1415926),
             new decimal[] { new decimal(3.1415926) },
-            DateTimeOffset.Parse("3/24/21").UtcDateTime,
-            new DateTime[] {DateTimeOffset.Parse("3/24/21").UtcDateTime },
-            DateTimeOffset.Parse("3/24/21"),
-            new DateTimeOffset[] {DateTimeOffset.Parse("3/24/21") },
+            DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture).UtcDateTime,
+            new DateTime[] {DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture).UtcDateTime },
+            DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture),
+            new DateTimeOffset[] {DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture) },
             TimeSpan.FromSeconds(5),
             new TimeSpan[] {TimeSpan.FromSeconds(5)},
             new Uri("http://localHost"),
@@ -449,7 +447,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
             new Dictionary<string, short> {{ "key", 1 } },
             new Dictionary<string, double> {{ "key", 3.1415926 } },
             new Dictionary<string, decimal> {{ "key", new decimal(3.1415926) } },
-            new Dictionary<string, DateTime> {{ "key", DateTimeOffset.Parse("3/24/21").UtcDateTime } },
+            new Dictionary<string, DateTime> {{ "key", DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture).UtcDateTime } },
             // for some reason dictionaries with DateTimeOffset, Timespan, or Uri values are not supported in AMQP lib
             // new Dictionary<string, DateTimeOffset> {{ "key", DateTimeOffset.Parse("3/24/21") } },
             // new Dictionary<string, TimeSpan> {{ "key", TimeSpan.FromSeconds(5) } },
@@ -494,7 +492,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
             Enumerable.Repeat(new object[] { long.MaxValue }, 2),
             Enumerable.Repeat(new object[] { 1 }, 2),
             Enumerable.Repeat(new object[] { 3.1415926, true }, 2),
-            Enumerable.Repeat(new object[] { DateTimeOffset.Parse("3/24/21").UtcDateTime, true }, 2),
+            Enumerable.Repeat(new object[] { DateTimeOffset.Parse("3/24/21", CultureInfo.InvariantCulture).UtcDateTime, true }, 2),
             new List<IList<object>> { new List<object> { "first", 1}, new List<object> { "second", 2 } }
         };
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -172,7 +172,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
 
             Assert.That(batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The batch should not be locked before sending.");
 
-            var sender = new ServiceBusSender("dummy", mockConnection.Object, new ServiceBusSenderOptions());
+            var sender = new ServiceBusSender("dummy", mockConnection.Object);
             var sendTask = sender.SendMessagesAsync(batch);
 
             Assert.That(() => batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should be locked while sending.");
@@ -281,7 +281,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                         It.IsAny<string>()))
                 .Returns(mockTransportSender.Object);
 
-            var sender = new ServiceBusSender("fake", mockConnection.Object, new ServiceBusSenderOptions());
+            var sender = new ServiceBusSender("fake", mockConnection.Object);
             await sender.CloseAsync(cts.Token);
             mockTransportSender.Verify(transportReceiver => transportReceiver.CloseAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));
         }


### PR DESCRIPTION
- Avoid allocating empty `ServiceBusSenderOptions` instances when creating instances of `ServiceBusSender`.
- Fix tests that fail if the machine they are run on does not use US date formatting (e.g. `en-GB`).

<hr/>

When creating an instance of `ServiceBusSender`, if no options are specified a new empty object options is created:

https://github.com/Azure/azure-sdk-for-net/blob/328c716cef4de42f0e7f829dc904d2a638541670/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs#L259

https://github.com/Azure/azure-sdk-for-net/blob/328c716cef4de42f0e7f829dc904d2a638541670/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs#L162

If the value is `null` one is created anyway, if not it is cloned, which just creates a new instance and copies a single string value, which if the default case has no value to copy:

https://github.com/Azure/azure-sdk-for-net/blob/328c716cef4de42f0e7f829dc904d2a638541670/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs#L123

https://github.com/Azure/azure-sdk-for-net/blob/0608f9624ac15ee870443febaba9c7387ca35cc6/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs#L53-L57

https://github.com/Azure/azure-sdk-for-net/blob/0608f9624ac15ee870443febaba9c7387ca35cc6/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs#L18

The options is then only checked for having an identifier to use, if not a new one is generated:

https://github.com/Azure/azure-sdk-for-net/blob/328c716cef4de42f0e7f829dc904d2a638541670/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs#L126

Instead, the identifier value can be checked in a null-safe way, and the empty instance and clone avoided entirely.
