### PR TITLE
Add InteractiveBrowserCredentialOptions.CustomizeClientAppBuilder

### DIFF
--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -304,6 +304,7 @@ namespace Azure.Identity
         public Azure.Identity.AuthenticationRecord AuthenticationRecord { get { throw null; } set { } }
         public Azure.Identity.BrowserCustomizationOptions BrowserCustomization { get { throw null; } set { } }
         public string ClientId { get { throw null; } set { } }
+        public System.Action<Microsoft.Identity.Client.PublicClientApplicationBuilder> CustomizeClientAppBuilder { get { throw null; } set { } }
         public bool DisableAutomaticAuthentication { get { throw null; } set { } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string LoginHint { get { throw null; } set { } }

--- a/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredentialOptions.cs
@@ -70,5 +70,10 @@ namespace Azure.Identity
         /// The options for customizing the browser for interactive authentication.
         /// </summary>
         public BrowserCustomizationOptions BrowserCustomization { get; set; }
+
+        /// <summary>
+        /// Callback to customize the ClientApplicationBuilder.
+        /// </summary>
+        public Action<PublicClientApplicationBuilder> CustomizeClientAppBuilder { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -24,11 +24,11 @@ namespace Azure.Identity
         {
             RedirectUrl = redirectUrl;
 
-            if (options is IMsalPublicClientInitializerOptions initializerOptions)
+            if (options is IMsalPublicClientInitializerOptions initializerOptions && initializerOptions.BeforeBuildClient != null)
             {
                 _beforeBuildClient.Add(initializerOptions.BeforeBuildClient);
             };
-            if (options is InteractiveBrowserCredentialOptions browserCredentialOptions)
+            if (options is InteractiveBrowserCredentialOptions browserCredentialOptions && browserCredentialOptions.CustomizeClientAppBuilder != null)
             {
                 _beforeBuildClient.Add(browserCredentialOptions.CustomizeClientAppBuilder);
             };


### PR DESCRIPTION
This is an attempt to resolve #44550: Since the update to Microsoft.Identity 4.61.3, it is no longer possible to use an embedded WebView2 form for interactive authentication, as winforms code was removed from Microsoft.Identity. In order to switch to the embedded webview, you have to add the package "Microsoft.Identity.Client.Desktop" and call an extension method ".WithWindowsEmbeddedBrowserSupport".

With the current Azure.Identity implementation, this is not possible. So I added a callback to "InteractiveBrowserCredentialOptions", where I could do further customization in my application:

```
InteractiveBrowserCredentialOptions options = new InteractiveBrowserCredentialOptions
{
  TenantId = myTenant,
  ...
  CustomizeClientAppBuilder = builder =>
  {
    builder.WithWindowsEmbeddedBrowserSupport();
    builder.WithParentActivityOrWindow(() => myFormHandle);
  }
};
```

Something similar already existed internally ("IMsalPublicClientInitializerOptions.BeforeBuildClient"). I first tried to move this property, but got stuck in "Azure.Identity.Broker". So, I kept it. If you consider this pull request acceptable, we could think about further changes. 
Also, "BrowserCustomizationOptions.UseEmbeddedWebView" could be marked "obsolete", as it has no effect any longer.

I fear that @christothes does not like this idea, as we already struggled in the linked issue ;-), but I give it a try anyway. 



I have to admit that the part where I called "WithParentActivityOrWindow" caused an ugly deadlock in "MsalPublicClient.AcquireTokenInteractiveAsync" in my app. I had to call "AppContext.SetSwitch("Azure.Identity.DisableInteractiveBrowserThreadpoolExecution", true);". But this would be a followup discussion.