### PR TITLE
Update GenerateAndBuildLib.ps1

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -846,15 +846,22 @@ function GeneratePackage()
     if ( $serviceType -eq "resource-manager" ) {
         $ciFilePath = "sdk/$service/ci.mgmt.yml"
     }
-    $generatedSDKPackages.Add(@{packageName="$packageName";
-                                result=$result;
-                                path=@("$path", "$ciFilePath");
-                                packageFolder="$projectFolder";
-                                artifacts=$artifacts;
-                                apiViewArtifact=$apiViewArtifact;
-                                language=".Net";
-                                changelog= $changelog;
-                                installInstructions = $installInstructions})
+
+    $packageDetails = @{
+        packageName="$packageName";
+        result=$result;
+        path=@("$path", "$ciFilePath");
+        packageFolder="$projectFolder";
+        artifacts=$artifacts;
+        apiViewArtifact=$apiViewArtifact;
+        language=".Net";
+        changelog=$changelog
+    }
+    
+    if ($installInstructions -ne $null) {
+        $packageDetails['installInstructions'] = $installInstructions
+    }    
+    $generatedSDKPackages.Add($packageDetails)
 }
 function UpdateExistingSDKByInputFiles()
 {


### PR DESCRIPTION
Don't set 'installInstructions' when it's null, otherwise it would fail the schema validation of 'generateOutput'.
This is the schema: https://github.com/Azure/azure-rest-api-specs/blob/edf14cc0a577f6b9c4e3ce018cec0c383e64b7b0/documentation/sdkautomation/InstallInstructionScriptOutputSchema.json#L17

Refer to https://github.com/Azure/azure-sdk-tools/issues/8561 for details.