### PR TITLE
Using federated auth for ACS tests

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/tests.yml
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests.yml
@@ -5,10 +5,13 @@ extends:
   parameters:
     ServiceDirectory: communication
     Project: Azure.Communication.CallAutomation
+    UseFederatedAuth: true
     CloudConfig:
       Public:
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePaths:
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
       Int:
@@ -17,7 +20,7 @@ extends:
           - $(sub-config-communication-int-test-resources-net)
     Clouds: Public
     TestResourceDirectories:
-      - communication/test-resources/
+      - communication/
     EnvVars:
       # SKIP_CALLAUTOMATION_INTERACTION_LIVE_TESTS skips certain CallAutomation tests that required human interactions
       SKIP_CALLAUTOMATION_INTERACTION_LIVE_TESTS: TRUE

--- a/sdk/communication/Azure.Communication.CallAutomation/tests.yml
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests.yml
@@ -14,10 +14,6 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-      Int:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-int-test-resources-common)
-          - $(sub-config-communication-int-test-resources-net)
     Clouds: Public
     TestResourceDirectories:
       - communication/

--- a/sdk/communication/Azure.Communication.CallingServer/tests.yml
+++ b/sdk/communication/Azure.Communication.CallingServer/tests.yml
@@ -5,10 +5,13 @@ extends:
   parameters:
     ServiceDirectory: communication
     Project: Azure.Communication.CallingServer
+    UseFederatedAuth: true
     CloudConfig:
       Public:
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePaths:
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
       Int:
@@ -17,7 +20,7 @@ extends:
           - $(sub-config-communication-int-test-resources-net)
     Clouds: Public
     TestResourceDirectories:
-      - communication/test-resources/
+      - communication/
     EnvVars:
       # SKIP_CALLINGSERVER_INTERACTION_LIVE_TESTS skips certain CallAutomation tests that required human interactions
       SKIP_CALLINGSERVER_INTERACTION_LIVE_TESTS: TRUE

--- a/sdk/communication/Azure.Communication.CallingServer/tests.yml
+++ b/sdk/communication/Azure.Communication.CallingServer/tests.yml
@@ -14,10 +14,6 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-      Int:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-int-test-resources-common)
-          - $(sub-config-communication-int-test-resources-net)
     Clouds: Public
     TestResourceDirectories:
       - communication/

--- a/sdk/communication/Azure.Communication.Chat/tests.yml
+++ b/sdk/communication/Azure.Communication.Chat/tests.yml
@@ -5,10 +5,13 @@ extends:
   parameters:
     ServiceDirectory: communication
     Project: Azure.Communication.Chat
+    UseFederatedAuth: true
     CloudConfig:
       Public:
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePaths:
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
       PPE:
@@ -21,4 +24,4 @@ extends:
           - $(sub-config-communication-int-test-resources-net)
     Clouds: Public,PPE,Int
     TestResourceDirectories:
-      - communication/test-resources/
+      - communication/

--- a/sdk/communication/Azure.Communication.Chat/tests.yml
+++ b/sdk/communication/Azure.Communication.Chat/tests.yml
@@ -14,14 +14,6 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-      PPE:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-ppe-test-resources-common)
-          - $(sub-config-communication-ppe-test-resources-net)
-      Int:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-int-test-resources-common)
-          - $(sub-config-communication-int-test-resources-net)
-    Clouds: Public,PPE,Int
+    Clouds: Public
     TestResourceDirectories:
       - communication/

--- a/sdk/communication/Azure.Communication.Identity/tests.yml
+++ b/sdk/communication/Azure.Communication.Identity/tests.yml
@@ -12,7 +12,8 @@ extends:
         SubscriptionConfigurationFilePaths:
           - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
-          - $(sub-config-communication-services-cloud-test-resources-cte)
+          - $(sub-config-communication-services-cloud-test-resources-common)
+          - $(sub-config-communication-services-cloud-test-resources-net)
     Clouds: Public
     TestResourceDirectories:
       - communication/

--- a/sdk/communication/Azure.Communication.Identity/tests.yml
+++ b/sdk/communication/Azure.Communication.Identity/tests.yml
@@ -5,12 +5,14 @@ extends:
   parameters:
     ServiceDirectory: communication
     Project: Azure.Communication.Identity
+    UseFederatedAuth: true
     CloudConfig:
       Public:
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePaths:
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
-          - $(sub-config-communication-services-cloud-test-resources-common)
-          - $(sub-config-communication-services-cloud-test-resources-net)
+          - $(sub-config-communication-services-cloud-test-resources-cte)
       PPE:
         SubscriptionConfigurations:
           - $(sub-config-communication-ppe-test-resources-common)

--- a/sdk/communication/Azure.Communication.Identity/tests.yml
+++ b/sdk/communication/Azure.Communication.Identity/tests.yml
@@ -13,14 +13,6 @@ extends:
           - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
           - $(sub-config-communication-services-cloud-test-resources-cte)
-      PPE:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-ppe-test-resources-common)
-          - $(sub-config-communication-ppe-test-resources-net)
-      Int:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-int-test-resources-common)
-          - $(sub-config-communication-int-test-resources-net)
-    Clouds: Public,PPE,Int
+    Clouds: Public
     TestResourceDirectories:
       - communication/

--- a/sdk/communication/Azure.Communication.JobRouter/tests.yml
+++ b/sdk/communication/Azure.Communication.JobRouter/tests.yml
@@ -5,10 +5,13 @@ extends:
   parameters:
     ServiceDirectory: communication
     Project: Azure.Communication.JobRouter
+    UseFederatedAuth: true
     CloudConfig:
       Public:
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePaths:
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
       Int:
@@ -17,4 +20,4 @@ extends:
           - $(sub-config-communication-int-test-resources-net)
     Clouds: Public,Int
     TestResourceDirectories:
-      - communication/test-resources/
+      - communication/

--- a/sdk/communication/Azure.Communication.JobRouter/tests.yml
+++ b/sdk/communication/Azure.Communication.JobRouter/tests.yml
@@ -14,10 +14,6 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-      Int:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-int-test-resources-common)
-          - $(sub-config-communication-int-test-resources-net)
-    Clouds: Public,Int
+    Clouds: Public
     TestResourceDirectories:
       - communication/

--- a/sdk/communication/Azure.Communication.Rooms/tests.yml
+++ b/sdk/communication/Azure.Communication.Rooms/tests.yml
@@ -14,10 +14,6 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-      PPE:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-ppe-test-resources-common)
-          - $(sub-config-communication-ppe-test-resources-net)
-    Clouds: Public,PPE
+    Clouds: Public
     TestResourceDirectories:
       - communication/

--- a/sdk/communication/Azure.Communication.Rooms/tests.yml
+++ b/sdk/communication/Azure.Communication.Rooms/tests.yml
@@ -5,10 +5,13 @@ extends:
   parameters:
     ServiceDirectory: communication
     Project: Azure.Communication.Rooms
+    UseFederatedAuth: true
     CloudConfig:
       Public:
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePaths:
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
       PPE:

--- a/sdk/communication/Azure.Communication.ShortCodes/tests.yml
+++ b/sdk/communication/Azure.Communication.ShortCodes/tests.yml
@@ -12,7 +12,6 @@ extends:
         SubscriptionConfigurationFilePaths:
           - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
       Int:

--- a/sdk/communication/Azure.Communication.ShortCodes/tests.yml
+++ b/sdk/communication/Azure.Communication.ShortCodes/tests.yml
@@ -5,8 +5,12 @@ extends:
   parameters:
     ServiceDirectory: communication
     Project: Azure.Communication.ShortCodes
+    UseFederatedAuth: true
     CloudConfig:
       Public:
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePaths:
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json   
         SubscriptionConfigurations:
           - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
@@ -17,4 +21,4 @@ extends:
           - $(sub-config-communication-int-test-resources-net)
     Clouds: Public,Int
     TestResourceDirectories:
-      - communication/test-resources/
+      - communication/

--- a/sdk/communication/Azure.Communication.ShortCodes/tests.yml
+++ b/sdk/communication/Azure.Communication.ShortCodes/tests.yml
@@ -14,10 +14,6 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-      Int:
-        SubscriptionConfigurations:
-          - $(sub-config-communication-int-test-resources-common)
-          - $(sub-config-communication-int-test-resources-net)
-    Clouds: Public,Int
+    Clouds: Public
     TestResourceDirectories:
       - communication/


### PR DESCRIPTION
Changes:
In order to move away from Secret based authentication, we want to adopt FIC.
For the same azure-sdk team has added the support and we need to use service connection for our live test pipelines to access our test resources.