### PR TITLE
Skip project reference tests for openai

### DIFF
--- a/sdk/openai/ci.yml
+++ b/sdk/openai/ci.yml
@@ -31,6 +31,9 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: openai
+    # Skip project reference tests
+    MatrixFilters:
+      - AdditionalTestArguments=^(?!.*UseProjectReferenceToAzureClients=true)
     ArtifactName: packages
     Artifacts:
     - name: Azure.AI.OpenAI

--- a/sdk/openai/tests.yml
+++ b/sdk/openai/tests.yml
@@ -5,3 +5,6 @@ extends:
   parameters:
     ServiceDirectory: openai
     SupportedClouds: 'Public'
+    # Skip project reference tests
+    MatrixFilters:
+      - AdditionalTestArguments=^(?!.*UseProjectReferenceToAzureClients=true)


### PR DESCRIPTION
From @annelo-msft:

> We have an unfortunate cross-repo dependency in the System.ClientModel <- 3p OAI <- Azure OAI .NET library situation today.  We've addressed part of it by [pinning the 3p OAI dependency](https://github.com/Azure/azure-sdk-for-net/pull/44708) AOAI takes to a specific version.
 
> This solved the SCM <- ... <- AOAI package dependency issue, but our CI's that add in a project reference for Core libraries are still blocking [an SCM PR](https://github.com/Azure/azure-sdk-for-net/pull/44825) I was hoping to merge last week.
 
> Jesse mentioned that we might be able to add a build file to the AOAI directory that didn't generate the pipelines for the project-reference versions in AOAI, at least for now while we work around this issue (eventually, we'll remove the version pinning because SCM and 3p OAI will be out of beta and not making breaking changes anymore).