### PR TITLE
[Service Bus] Enforce batch limits

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -2,16 +2,24 @@
 
 ## 7.18.0-beta.2 (Unreleased)
 
+### Acknowledgments
+Thank you to our developer community members who helped to make the Service Bus client library better with their contributions to this release:
+
+- Martin Costello _([GitHub](https://github.com/martincostello))_
+
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
-- Fixed an error that caused connection strings using host names without a scheme to fail parsing and be considered invalid.
+- Fixed an issue that caused connection strings using host names without a scheme to fail parsing and be considered invalid.
+
 - Fixed an issue where the scheduled enqueue time was not cleared when creating a new message from a received message.
 
-- Fixed an error that prevented relative URIs from being used with [application properties](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties) in the `ServiceBusMessage.ApplicationProperties` and `ServiceBusReceivedMessage.ApplicationProperties` collections. 
+- Fixed an issue that prevented relative URIs from being used with [application properties](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties) in the `ServiceBusMessage.ApplicationProperties` and `ServiceBusReceivedMessage.ApplicationProperties` collections. 
+
+- Fixed an issue that caused `ServiceBusMessageBatch` to accept more than the allowed 1mb batch limit when sending to Service Bus entities with large message sizes enabled.
 
 ### Other Changes
 
@@ -19,7 +27,8 @@
 
 - Updated the `Microsoft.Azure.Amqp` dependency to 2.6.7, which contains a fix for decoding messages with a null format code as the body.
 
-- Instances of `ServiceBusSender` created with no explicit `ServiceBusSenderOptions` value allocate less memory.
+- Improved efficiency of subclient creation, reducing allocations when no explicit options are passed.  - Fixed deserialization of the lock token to take into account endianness. _(A community contribution, courtesy of [martincostello](https://github.com/martincostello))_
+
 
 ## 7.18.0-beta.1 (2024-05-08)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageBatch.cs
@@ -38,7 +38,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   well as any overhead for the batch itself when sent to the Queue/Topic.
         /// </summary>
         ///
-        public override long MaxSizeInBytes { get; }
+        public override long MaxSizeInBytes => Options.MaxSizeInBytes.Value;
 
         /// <summary>
         ///   The size of the batch, in bytes, as it will be sent to the Queue/Topic
@@ -74,8 +74,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Initializes a new instance of the <see cref="AmqpMessageBatch"/> class.
         /// </summary>
         ///
-        /// <param name="messageConverter">The converter to use for translating <see cref="ServiceBusMessage"/> data into
-        /// an AMQP-specific message.</param>
+        /// <param name="messageConverter">The converter to use for translating <see cref="ServiceBusMessage"/> data into an AMQP-specific message.</param>
         /// <param name="options">The set of options to apply to the batch.</param>
         ///
         public AmqpMessageBatch(AmqpMessageConverter messageConverter,
@@ -86,7 +85,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
             Argument.AssertNotNull(messageConverter, nameof(AmqpMessageConverter));
 
             Options = options;
-            MaxSizeInBytes = options.MaxSizeInBytes.Value;
             _messageConverter = messageConverter;
         }
 
@@ -104,6 +102,15 @@ namespace Azure.Messaging.ServiceBus.Amqp
             Argument.AssertNotNull(message, nameof(message));
             Argument.AssertNotDisposed(_disposed, nameof(ServiceBusMessageBatch));
 
+            // If the batch is full according to the message limit, then
+            // reject the message.
+
+            if ((Options.MaxMessageCount.HasValue)
+                && (_batchMessages.Count >= Options.MaxMessageCount))
+            {
+                return false;
+            }
+
             var amqpMessage = _messageConverter.SBMessageToAmqpMessage(message);
             long size = 0;
 
@@ -112,17 +119,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 // Initialize the size by reserving space for the batch envelope taking into account the properties from the first
                 // message which will be used to populate properties on the batch envelope.
 
-                var messageList = new List<AmqpMessage>();
-                messageList.Add(amqpMessage);
-                var reserveOverheadMessage = _messageConverter.BuildAmqpBatchFromMessages(messageList.AsReadOnly(), forceBatch: true);
+                using var reserveOverheadMessage =
+                    _messageConverter.BuildAmqpBatchFromMessages(new[] { amqpMessage }, forceBatch: true);
 
                 size = _sizeBytes
                     + reserveOverheadMessage.SerializedMessageSize
                     + (amqpMessage.SerializedMessageSize <= MaximumBytesSmallMessage
                         ? OverheadBytesSmallMessage
                         : OverheadBytesLargeMessage);
-
-                reserveOverheadMessage.Dispose();
             }
             else
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -97,7 +97,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   The maximum number of messages to allow in a single batch.
         /// </summary>
         ///
-        internal int MaxMessageCount { get; set; }
+        private int MaxMessageCount { get; set; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="AmqpSender"/> class.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -85,6 +85,21 @@ namespace Azure.Messaging.ServiceBus.Amqp
         private long? MaxMessageSize { get; set; }
 
         /// <summary>
+        ///   The maximum size of an AMQP message batch allowed by the associated
+        ///   sender link.
+        /// </summary>
+        ///
+        /// <value>The maximum message batch size, in bytes.</value>
+        ///
+        private long? MaxBatchSize { get; set; }
+
+        /// <summary>
+        ///   The maximum number of messages to allow in a single batch.
+        /// </summary>
+        ///
+        internal int MaxMessageCount { get; set; }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="AmqpSender"/> class.
         /// </summary>
         ///
@@ -113,6 +128,18 @@ namespace Azure.Messaging.ServiceBus.Amqp
             Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
             Argument.AssertNotNull(connectionScope, nameof(connectionScope));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
+
+            // NOTE:
+            //   This is a temporary work-around until Service Bus exposes a link property for
+            //   the maximum batch size.  The limit for batches differs from the limit for individual
+            //   messages.  Tracked by: https://github.com/Azure/azure-sdk-for-net/issues/44914
+            MaxBatchSize = 1048576;
+
+            // NOTE:
+            //   This is a temporary work-around until Service Bus exposes a link property for
+            //   the maximum batch size.  The limit for batches differs from the limit for individual
+            //   messages.  Tracked by: https://github.com/Azure/azure-sdk-for-net/issues/44916
+            MaxMessageCount = 4500;
 
             _entityPath = entityPath;
             Identifier = identifier;
@@ -180,7 +207,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             // Ensure that maximum message size has been determined; this depends on the underlying
             // AMQP link, so if not set, requesting the link will ensure that it is populated.
 
-            if (!MaxMessageSize.HasValue)
+            if ((!MaxMessageSize.HasValue) || (!MaxBatchSize.HasValue))
             {
                 await _sendLink.GetOrCreateAsync(timeout).ConfigureAwait(false);
             }
@@ -188,9 +215,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
             // Ensure that there was a maximum size populated; if none was provided,
             // default to the maximum size allowed by the link.
 
-            options.MaxSizeInBytes ??= MaxMessageSize;
+            options.MaxSizeInBytes ??= MaxBatchSize;
+            options.MaxMessageCount ??= MaxMessageCount;
 
-            Argument.AssertInRange(options.MaxSizeInBytes.Value, ServiceBusSender.MinimumBatchSizeLimit, MaxMessageSize.Value, nameof(options.MaxSizeInBytes));
+            Argument.AssertInRange(options.MaxSizeInBytes.Value, ServiceBusSender.MinimumBatchSizeLimit, MaxBatchSize.Value, nameof(options.MaxSizeInBytes));
             return new AmqpMessageBatch(_messageConverter, options);
         }
 
@@ -615,6 +643,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 await Task.Delay(15, cancellationToken).ConfigureAwait(false);
                 MaxMessageSize = (long)link.Settings.MaxMessageSize;
+
+                // Update with service metadata when available:
+                //  https://github.com/Azure/azure-sdk-for-net/issues/44914
+                //  https://github.com/Azure/azure-sdk-for-net/issues/44916
+
+                MaxBatchSize = Math.Min(MaxMessageSize.Value, MaxBatchSize.Value);
+                MaxMessageSize = MaxMessageSize;
 
                 ServiceBusEventSource.Log.CreateSendLinkComplete(Identifier);
                 link.Closed += OnSenderLinkClosed;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
@@ -78,19 +78,5 @@ namespace Azure.Messaging.ServiceBus
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
-
-        /// <summary>
-        /// Creates a new copy of the current <see cref="ServiceBusReceiverOptions" />, cloning its attributes into a new instance.
-        /// </summary>
-        ///
-        /// <returns>A new copy of <see cref="ServiceBusReceiverOptions" />.</returns>
-        internal ServiceBusReceiverOptions Clone() =>
-            new ServiceBusReceiverOptions
-            {
-                ReceiveMode = ReceiveMode,
-                PrefetchCount = PrefetchCount,
-                SubQueue = SubQueue,
-                Identifier = Identifier
-            };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/CreateMessageBatchOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/CreateMessageBatchOptions.cs
@@ -18,6 +18,12 @@ namespace Azure.Messaging.ServiceBus
         private long? _maxSizeInBytes;
 
         /// <summary>
+        ///   The maximum number of messages to allow in a single batch.
+        /// </summary>
+        ///
+        internal int? MaxMessageCount { get; set; }
+
+        /// <summary>
         ///   The maximum size to allow for a single batch of messages, in bytes.
         /// </summary>
         ///
@@ -25,9 +31,11 @@ namespace Azure.Messaging.ServiceBus
         ///   The desired limit, in bytes, for the size of the associated service bus message batch.  If <c>null</c>,
         ///   the maximum size allowed by the active transport will be used.
         /// </value>
+        ///
         /// <exception cref="ArgumentOutOfRangeException">
         ///   A negative value is attempted to be set for the property.
         /// </exception>
+        ///
         public long? MaxSizeInBytes
         {
             get => _maxSizeInBytes;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/ServiceBusMessageBatchTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/ServiceBusMessageBatchTests.cs
@@ -7,8 +7,6 @@ using System.Reflection;
 using Azure.Core.Shared;
 using Azure.Messaging.ServiceBus.Amqp;
 using Azure.Messaging.ServiceBus.Core;
-using Azure.Messaging.ServiceBus.Diagnostics;
-using Moq;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Sender


### PR DESCRIPTION
# Summary

The focus of these changes is to add client-side logic to force the maximum size for batches when large message support is enabled and to enforce the undocumented 4,500 message limit for a single batch.   Also riding along are a couple of efficiency improvements to avoid allocating options when creating a sender.

# References and related

- [[BUG] Batch.TryAdd returns true on premium with large message support but sending the batch throws an InvalidOperationException (#44261)](https://github.com/Azure/azure-sdk-for-net/issues/44261)
- [[Service Bus] Apply link metadata for the maximum message batch size (#44914)](https://github.com/Azure/azure-sdk-for-net/issues/44914)
- [[Service Bus] Apply link metadata for the maximum batch message count (#44916)](https://github.com/Azure/azure-sdk-for-net/issues/44916)