### PR TITLE
[KeyVault] Sample depedency versions

### DIFF
--- a/sdk/keyvault/samples/getcert/getcert.csproj
+++ b/sdk/keyvault/samples/getcert/getcert.csproj
@@ -19,9 +19,9 @@
 
   <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
   <ItemGroup Condition="'$(IsSample)' != 'true'">
-    <PackageReference Update="Azure.Identity" Version="1.10.4" />
-    <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.1.1" />
-    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.1.1" />
+    <PackageReference Update="Azure.Identity" Version="1.12.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.6.0 />
+    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Update="System.CommandLine" Version="%(VersionOverride)" />
   </ItemGroup>
 

--- a/sdk/keyvault/samples/getcert/getcert.csproj
+++ b/sdk/keyvault/samples/getcert/getcert.csproj
@@ -20,7 +20,7 @@
   <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
   <ItemGroup Condition="'$(IsSample)' != 'true'">
     <PackageReference Update="Azure.Identity" Version="1.12.0" />
-    <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.6.0 />
+    <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Update="System.CommandLine" Version="%(VersionOverride)" />
   </ItemGroup>


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the versions used by the sample.  The current Identity reference is flagged for vulnerabilities.
