### PR TITLE
[KeyVault] More sample dependency versions

### DIFF
--- a/sdk/keyvault/samples/sharelink/ShareLink.csproj
+++ b/sdk/keyvault/samples/sharelink/ShareLink.csproj
@@ -16,8 +16,7 @@
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Core" />
+  <ItemGroup>    
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="System.CommandLine" VersionOverride="2.0.0-beta1.21216.1" />
@@ -30,10 +29,9 @@
 
   <ItemGroup Condition="'$(IsSample)' != 'true'">
     <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
-    <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230427.2" PrivateAssets="All" />
-    <PackageReference Update="Azure.Core" Version="1.26.0" />
-    <PackageReference Update="Azure.Identity" Version="1.10.4" />
-    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230427.2" PrivateAssets="All" />    
+    <PackageReference Update="Azure.Identity" Version="1.12.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Update="System.CommandLine" Version="%(VersionOverride)" />
     <PackageReference Update="System.Text.Json" Version="4.6.0" />
   </ItemGroup>

--- a/sdk/keyvault/samples/sharelink/ShareLink.csproj
+++ b/sdk/keyvault/samples/sharelink/ShareLink.csproj
@@ -33,7 +33,7 @@
     <PackageReference Update="Azure.Identity" Version="1.12.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Update="System.CommandLine" Version="%(VersionOverride)" />
-    <PackageReference Update="System.Text.Json" Version="4.6.0" />
+    <PackageReference Update="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsSample)' == 'true'">


### PR DESCRIPTION
# Summary

The focus of these changes is to bump dependency versions used in the Share Link sample, moving to a non-vulnerable Identity version.  Because Core is a transitive dependency, removed the explicit reference.