### PR TITLE
Use eng/common template for create-tags-and-git-release

### DIFF
--- a/eng/pipelines/templates/jobs/mgmt-release.yml
+++ b/eng/pipelines/templates/jobs/mgmt-release.yml
@@ -39,21 +39,13 @@ jobs:
 
       - ${{ if and(eq(parameters.ShouldPublishToNuget, 'true'), eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net')) }}:
 
-        - task: Powershell@2
-          displayName: 'Verify Package Tags and Create Git Releases'
-          inputs:
-            filePath: ${{ parameters.BuildToolsPath }}/scripts/create-tags-and-git-release.ps1
-            arguments: >
-              -artifactLocation '$(PIPELINE.WORKSPACE)/packages'
-              -workingDirectory $(System.DefaultWorkingDirectory)
-              -packageRepository 'Nuget'
-              -releaseSha '$(Build.SourceVersion)'
-              -repoOwner 'Azure'
-              -repoName 'azure-sdk-for-net'
-            pwsh: true
-          env:
-            GH_TOKEN: $(azuresdk-github-pat)
-          condition: and(succeeded(), ne(variables['SkipCreateTagAndGitRelease'], 'true'))
+        - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+          parameters:
+            ArtifactLocation: '$(PIPELINE.WORKSPACE)/packages'
+            WorkingDirectory: $(System.DefaultWorkingDirectory)
+            PackageRepository: Nuget
+            ReleaseSha: $(Build.SourceVersion)
+            RepoId: Azure/azure-sdk-for-net
 
         - template: pipelines/steps/publish-symbols.yml@azure-sdk-build-tools
           displayName: 'Upload Symbols'

--- a/eng/pipelines/templates/jobs/mgmt-release.yml
+++ b/eng/pipelines/templates/jobs/mgmt-release.yml
@@ -42,10 +42,8 @@ jobs:
         - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
           parameters:
             ArtifactLocation: '$(PIPELINE.WORKSPACE)/packages'
-            WorkingDirectory: $(System.DefaultWorkingDirectory)
             PackageRepository: Nuget
             ReleaseSha: $(Build.SourceVersion)
-            RepoId: Azure/azure-sdk-for-net
 
         - template: pipelines/steps/publish-symbols.yml@azure-sdk-build-tools
           displayName: 'Upload Symbols'

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -105,7 +105,6 @@ stages:
                             ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}
                             PackageRepository: Nuget
                             ReleaseSha: $(Build.SourceVersion)
-                            RepoId: Azure/azure-sdk-for-net
 
             - ${{if ne(artifact.skipPublishPackage, 'true')}}:
               - deployment: PublishPackage


### PR DESCRIPTION
Prefer the template in eng/common over the script in build-tools