### PR TITLE
Azure OpenAI: remove incorrect 'purpose' check on FileClient.GetFiles()

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Removed an inappropriate null check in `FileClient.GetFiles()` (azure-sdk-for-net 44912)
+
 ### Other Changes
 
 ## 2.0.0-beta.2 (2024-06-14)

--- a/sdk/openai/Azure.AI.OpenAI/assets.json
+++ b/sdk/openai/Azure.AI.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/openai/Azure.AI.OpenAI",
-  "Tag": "net/openai/Azure.AI.OpenAI_fc99a87ba7"
+  "Tag": "net/openai/Azure.AI.OpenAI_b36dc0424a"
 }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Files/AzureFileClient.Protocol.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Files/AzureFileClient.Protocol.cs
@@ -67,8 +67,6 @@ internal partial class AzureFileClient : FileClient
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override ClientResult GetFiles(string purpose, RequestOptions options)
     {
-        Argument.AssertNotNullOrEmpty(purpose, nameof(purpose));
-
         using PipelineMessage message = CreateGetFilesRequestMessage(purpose, options);
         return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
     }
@@ -76,8 +74,6 @@ internal partial class AzureFileClient : FileClient
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override async Task<ClientResult> GetFilesAsync(string purpose, RequestOptions options)
     {
-        Argument.AssertNotNullOrEmpty(purpose, nameof(purpose));
-
         using PipelineMessage message = CreateGetFilesRequestMessage(purpose, options);
         return ClientResult.FromResponse(await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false));
     }

--- a/sdk/openai/Azure.AI.OpenAI/tests/FileTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/FileTests.cs
@@ -31,4 +31,12 @@ public class FileTests : AoaiTestBase<FileClient>
         bool deleted = await client.DeleteFileAsync(file);
         Assert.IsTrue(deleted);
     }
+
+    [RecordedTest]
+    public async Task CanListFiles()
+    {
+        FileClient client = GetTestClient();
+        OpenAIFileInfoCollection files = await client.GetFilesAsync();
+        Assert.That(files, Has.Count.GreaterThan(0));
+    }
 }


### PR DESCRIPTION
Closes #44912 -- many thanks to @SergeyMenshykh for the report!