### PR TITLE
fix(docs): wrong <param> location in `System.ClientModel`

### DIFF
--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/IPersistableModel.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/IPersistableModel.cs
@@ -30,7 +30,7 @@ public interface IPersistableModel<out T>
     /// <summary>
     /// Gets the data interchange format (JSON, Xml, etc) that the model uses when communicating with the service.
     /// </summary>
-    /// <param name="options">The <see cref="ModelReaderWriterOptions"/> to use.</param>
+    /// <param name="options">The <see cref="ModelReaderWriterOptions"/> to consider when serializing and deserializing the model.</param>
     /// <returns>The format that the model uses when communicating with the serivce.</returns>
     string GetFormatFromOptions(ModelReaderWriterOptions options);
 }

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/IPersistableModel.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/IPersistableModel.cs
@@ -29,8 +29,8 @@ public interface IPersistableModel<out T>
 
     /// <summary>
     /// Gets the data interchange format (JSON, Xml, etc) that the model uses when communicating with the service.
-    /// <param name="options">The <see cref="ModelReaderWriterOptions"/> to use.</param>
     /// </summary>
+    /// <param name="options">The <see cref="ModelReaderWriterOptions"/> to use.</param>
     /// <returns>The format that the model uses when communicating with the serivce.</returns>
     string GetFormatFromOptions(ModelReaderWriterOptions options);
 }


### PR DESCRIPTION
This is reported by docs team.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
