### PR TITLE
Remove broken links from Core changelogs to address link checker issue

### DIFF
--- a/sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson/CHANGELOG.md
+++ b/sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson/CHANGELOG.md
@@ -16,11 +16,11 @@
 
 Thank you to our developer community members who helped to make the Microsoft.Spatial converters better with their contributions to this release:
 
-- Jack Bond ([GitHub](https://github.com/jackbond))
+- Jack Bond
 
 ### Features Added
 
-- Added converter support for the following types ([#24367](https://github.com/Azure/azure-sdk-for-net/issues/24367)):
+- Added converter support for the following types:
   - GeographyLineString
   - GeographyPolygon
   - GeographyMultiPoint

--- a/sdk/core/Microsoft.Azure.Core.Spatial/CHANGELOG.md
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/CHANGELOG.md
@@ -16,11 +16,11 @@
 
 Thank you to our developer community members who helped to make the Microsoft.Spatial converters better with their contributions to this release:
 
-- Jack Bond ([GitHub](https://github.com/jackbond))
+- Jack Bond
 
 ### Features Added
 
-- Added converter support for the following types ([#24367](https://github.com/Azure/azure-sdk-for-net/issues/24367)):
+- Added converter support for the following types:
   - GeographyLineString
   - GeographyPolygon
   - GeographyMultiPoint


### PR DESCRIPTION
Core pipeline has been broken since June 19 due to this: https://dev.azure.com/azure-sdk/internal/_build?definitionId=1180&_a=summary

Most current link verification build logs: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3954002&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=dd675559-a318-5a24-ceb9-2be155cbafeb