### PR TITLE
Disable public anonymous blob access for live resource tests

### DIFF
--- a/sdk/batch/test-resources.json
+++ b/sdk/batch/test-resources.json
@@ -50,7 +50,7 @@
           "encryption": "[variables('encryption')]",
           "accessTier": "Hot",
           "minimumTlsVersion": "TLS1_2",
-          "allowBlobPublicAccess": true
+          "allowBlobPublicAccess": false
       }
     },
     {

--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -115,7 +115,7 @@
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
                 "minimumTlsVersion": "TLS1_2",
-                "allowBlobPublicAccess": true
+                "allowBlobPublicAccess": false
             }
         },
         {

--- a/sdk/storagecache/test-resources.json
+++ b/sdk/storagecache/test-resources.json
@@ -57,7 +57,7 @@
                 "publicNetworkAccess": "Enabled",
                 "allowCrossTenantReplication": true,
                 "minimumTlsVersion": "TLS1_2",
-                "allowBlobPublicAccess": true,
+                "allowBlobPublicAccess": false,
                 "allowSharedKeyAccess": true,
                 "networkAcls": {
                     "bypass": "AzureServices",


### PR DESCRIPTION
Putting this PR up to help get us in compliance, and to raise any discussions about places where this is necessary for SDK testing