### PR TITLE
Adding some verbose output to help diagnose something going awry with docs gen

### DIFF
--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -86,26 +86,35 @@ if ($LibType -eq 'management') {
 Write-Verbose "Package Location ${PackageLocation}"
 
 Write-Verbose "Create Directories Required for Doc Generation"
+Write-Verbose "Creating ApiDir '$ApiDir'"
 mkdir $ApiDir
+Write-Verbose "Creating ApiDependenciesDir '$ApiDependenciesDir'"
 mkdir $ApiDependenciesDir
+Write-Verbose "Creating XmlOutDir '$XmlOutDir'"
 mkdir $XmlOutDir
+Write-Verbose "Creating YamlOutDir '$YamlOutDir'"
 mkdir $YamlOutDir
+Write-Verbose "Creating DocOutDir '$DocOutDir'"
 mkdir $DocOutDir
 
 if ($LibType -eq 'client') { 
     Write-Verbose "Build Packages for Doc Generation - Client"
+    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir /p:TargetFramework=netstandard2.0"
     dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir /p:TargetFramework=netstandard2.0
 
     Write-Verbose "Include client Dependencies"
+    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:TargetFramework=netstandard2.0 /p:CopyLocalLockFileAssemblies=true"
     dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:TargetFramework=netstandard2.0 /p:CopyLocalLockFileAssemblies=true
 }
 
 if ($LibType -eq 'management') {
     # Management Package
     Write-Verbose "Build Packages for Doc Generation - Management"
+    Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false"
     dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false
 
     Write-Verbose "Include Management Dependencies"
+    Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false"
     dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false
 }
 

--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -99,12 +99,20 @@ mkdir $DocOutDir
 
 if ($LibType -eq 'client') { 
     Write-Verbose "Build Packages for Doc Generation - Client"
-    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir /p:TargetFramework=netstandard2.0"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir /p:TargetFramework=netstandard2.0
+    # JRS-ORIGINAL
+    # Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir /p:TargetFramework=netstandard2.0"
+    # dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir /p:TargetFramework=netstandard2.0
+    # JRS-ORIGINAL
+    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir"
+    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir
 
     Write-Verbose "Include client Dependencies"
-    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:TargetFramework=netstandard2.0 /p:CopyLocalLockFileAssemblies=true"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:TargetFramework=netstandard2.0 /p:CopyLocalLockFileAssemblies=true
+    # JRS-ORIGINAL
+    # Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:TargetFramework=netstandard2.0 /p:CopyLocalLockFileAssemblies=true"
+    # dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:TargetFramework=netstandard2.0 /p:CopyLocalLockFileAssemblies=true
+    # JRS-ORIGINAL
+    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
+    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
 }
 
 if ($LibType -eq 'management') {


### PR DESCRIPTION
**The problem:**
This script was initially hardcoded to netstandard2.0 for client libraries which worked until it didn't. There are exceptions to this and, unfortunately, this step would fail when they were encountered, creating a zip full of nothing but the landing page, and pass the step. This was hardly ideal as almost nobody really looks at a passing step and, for the record, this has been this way for roughly 4 years.

**The fix:**
Remove the TargetFramework option for the dotnet build command. What ends up doing is building the libraries for each targeted framework defined in the .cspoj file and producing the docs from these. Because, in general, the Azure SDK libraries do not have different API surfaces for different targets (any differences would be internal which wouldn't end up in docs anyways) the resulting docs are the same. I tested this against Azure.Core which builds libraries for 4 different target frameworks (net472, net461, netstandard2.0 and net6.0) and then used Beyond Compare to binary diff what was produced against builds with and without my changes. I found the following:

- The resulting docs produced were identical.
- The build time increase was like 10 seconds longer for Azure.Core, building all 4 libraries. For things with only one target there was no noticeable difference.

**Additional changes:**

- Instead of letting something fail and log a pass, I'm changing this to log a warning. It won't fail the pipeline but will at least give an indication of a problem. Being that this is for GitHub.IO docs a warning is sufficient.
- When checking the library type (client vs management), if a 3rd type were added this would effectively do nothing and I'd like it to complain.

**Additional information:**
It's worth noting that producing management docs are already did exactly what I'm changing client to do, not passing in the TargetFramework to the build option. This change removes any hardcoded TargetFramework from this script which will make it resilient if the TargetFramework changes.

I'm running [net - core - ci](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3958193&view=results) and [net - extension-wcf - ci](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3958198&view=results) pipelines against the latest refs/merge of this PR for sanity.