### PR TITLE
Make request span name settable (via Activity.DisplayName)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -28,8 +28,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 var displayName = activity.DisplayName;
                 if (!string.IsNullOrEmpty(displayName)
                     && !displayName.StartsWith(activity.Source.Name))
-                {   // AspNetCore telemetry usually sets DisplayName to the same value we want for OperationName
-                    // Also, it's important than any user-set DisplayName be used
+                {   // AspNetCore instrumentation sets DisplayName to the same value we want for OperationName
+                    // Also, it's important than any user-set DisplayName be used #44971
                     Tags[ContextTagKeys.AiOperationName.ToString()] = displayName.Truncate(SchemaConstants.Tags_AiOperationName_MaxLength);
                 }
                 else if (activityTagsProcessor.activityType.HasFlag(OperationType.V2))

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -20,6 +20,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         private const string ActivitySourceName = "TelemetryItemTests";
         private const string ActivityName = "TestActivity";
 
+        private const string RequestActivitySourceName = "Microsoft.AspNetCore";
+        private const string RequestActivityName = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
+
         static TelemetryItemTests()
         {
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;
@@ -119,15 +122,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [InlineData(null)]
         public void HttpMethodAndHttpRouteIsUsedForHttpRequestOperationName(string? route)
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
 
             Assert.NotNull(activity);
-            activity.DisplayName = "/getaction";
 
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
             activity.SetTag(SemanticConventions.AttributeHttpRoute, route);
@@ -153,15 +155,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void HttpMethodAndHttpUrlPathIsUsedForHttpRequestOperationName()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
 
             Assert.NotNull(activity);
-            activity.DisplayName = "displayname";
 
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/path?id=1");
@@ -176,9 +177,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void ActivityNameIsUsedByDefaultForRequestOperationName()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
@@ -186,6 +187,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotNull(activity);
             activity.DisplayName = "displayname";
             activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, "GET");
+            activity.SetTag(SemanticConventions.AttributeHttpRoute, "api/test");
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
             var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(new Batch<Activity>(new Activity[] { activity }, 1), null, "instrumentationKey", 1.0f);
@@ -197,9 +199,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void AiLocationIpIsSetAsHttpClientIpForHttpServerSpans()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
@@ -218,9 +220,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void AiUserAgentIsSetAsHttpUserAgent()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
@@ -239,9 +241,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void AiUserAgentIsSetAsUserAgentOriginal()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
@@ -259,9 +261,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void AiLocationIpIsNotSetByDefault()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
@@ -278,9 +280,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void AiUserAgentIsNotTransmittedByDefault()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
@@ -335,15 +337,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void RequestNameMatchesOperationName()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
 
             Assert.NotNull(activity);
-            activity.DisplayName = "displayname";
 
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
             activity.SetTag(SemanticConventions.AttributeHttpRoute, "/api/test");
@@ -361,15 +362,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void RequestNameMatchesOperationNameV2()
         {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using ActivitySource activitySource = new ActivitySource(RequestActivitySourceName);
             using var activity = activitySource.StartActivity(
-                ActivityName,
+                RequestActivityName,
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
 
             Assert.NotNull(activity);
-            activity.DisplayName = "displayname";
 
             activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, "GET");
             activity.SetTag(SemanticConventions.AttributeHttpRoute, "/api/test");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TelemetryCustomization/WebServerTelemetryCustomizationTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TelemetryCustomization/WebServerTelemetryCustomizationTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.TestFramework;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.TelemetryCustomization;
+
+public class WebServerTelemetryCustomizationTests : WebApplicationTestsBase
+{
+    private const string TestServerPort = "9996";
+    private const string TestServerTarget = $"localhost:{TestServerPort}";
+    private const string TestServerUrl = $"http://{TestServerTarget}/";
+
+    public WebServerTelemetryCustomizationTests(ITestOutputHelper output)
+    : base(output)
+    {}
+
+#if !NET462
+    [Fact]
+    public async Task ActivityDisplayName_CanBeSetForRequests()
+    {
+        List<TelemetryItem>? telemetryItems = null;
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddOpenTelemetry()
+            .WithTracing(builder =>
+            {
+                builder.AddAspNetCoreInstrumentation()
+                    .AddProcessor<FixupDisplayNameProcessor>()
+                    .AddAzureMonitorTraceExporterForTest(out telemetryItems);
+            });
+        builder.Services.AddRouting();
+
+        await using var app = builder.Build();
+        app.UseRouting();
+        app.Map("{**path}",
+                context =>
+                {
+                    // Here I'm setting the Activity.DisplayName to something more useful for this specific route
+                    // However, I have to store a value for use by FixupDisplayNameProcessor due to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1948
+                    var activity = context.Features.Get<IHttpActivityFeature>()?.Activity;
+                    if (activity?.IsAllDataRequested == true)
+                    {
+                        var request = context.Request;
+                        var spanName = $"{request.Method.ToUpperInvariant()} {request.Path}";
+                        activity.AddTag(FixupDisplayNameProcessor.OverrideSpanNameTag, spanName);
+                    }
+
+                    context.Response.StatusCode = 200;
+                    return Task.CompletedTask;
+                });
+
+        _ = app.RunAsync(TestServerUrl);
+
+        // ACT
+        using var httpClient = new HttpClient { BaseAddress = new Uri(TestServerUrl) };
+        var res = await httpClient.GetAsync("/foo/bar");
+
+        // SHUTDOWN
+        var tracerProvider = app.Services.GetRequiredService<TracerProvider>();
+        tracerProvider.ForceFlush();
+        tracerProvider.Shutdown();
+
+        // ASSERT
+        Assert.NotNull(telemetryItems);
+        WaitForActivityExport(telemetryItems);
+
+        // Assert
+        Assert.True(telemetryItems.Any(), "test project did not capture telemetry");
+        var telemetryItem = telemetryItems.Last()!;
+        telemetryOutput.Write(telemetryItem);
+
+        AssertRequestTelemetry(
+            telemetryItem: telemetryItem,
+            expectedResponseCode: "200",
+            expectedUrl: TestServerUrl + "foo/bar");
+
+        // BUG: Both of these Asserts fail, b/c the value for both is "GET {**path}",
+        // even though Activity.DisplayName was set to "GET /foo/bar" before the telemetryItem was created
+        Assert.Equal("GET /foo/bar", (telemetryItem.Data.BaseData as RequestData)!.Name);
+        Assert.Equal("GET /foo/bar", telemetryItem.Tags["ai.operation.name"]);
+    }
+#endif
+
+    private class FixupDisplayNameProcessor : BaseProcessor<Activity>
+    {
+        public const string OverrideSpanNameTag = "override.span.name";
+
+        public override void OnEnd(Activity activity)
+        {
+            // Have to set Activity.DisplayName here instead of where I want to due to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1948
+            if (activity.IsAllDataRequested == true)
+            {
+                var overrideSpanName = activity.GetTagItem(OverrideSpanNameTag)?.ToString();
+                if (overrideSpanName != null)
+                {
+                    activity.DisplayName = overrideSpanName;
+                    activity.SetTag(OverrideSpanNameTag, null); // Delete the tag
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a fix for #44971. In short, it must be possible to set the span name; and the otel exporter must not ignore an explicitly set value.

More comments in the code.

Related to: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1948
but this problem is much worse - that issue could be left as is, but this one must be fixed IMO.

fixes: #44971
