### PR TITLE
[CODEOWNERS] Remove invalid account

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,9 +174,6 @@
 # ServiceLabel: %Bot Service
 # ServiceOwners:                                                   @sgellock
 
-# ServiceLabel: %Cloud Shell
-# ServiceOwners:                                                   @maertendMSFT
-
 # PRLabel: %Cognitive - Language
 /sdk/cognitivelanguage/                                            @quentinRobinson @wangyuantao
 


### PR DESCRIPTION
# Summary

Removing a legacy account that the linter is now flagging as invalid.

## References and resources

- [Linter failure](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3957472&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=8c98ab76-57b2-59d0-3d3a-18dce788f3ba)