### PR TITLE
[EngSys] Remove baseline error

### DIFF
--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -43,7 +43,6 @@ anand-rengasamy is an invalid user. Ensure the user exists, is public member of 
 alex-frankel is not a public member of Azure.
 filizt is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 sgellock is not a public member of Azure.
-maertendMSFT is not a public member of Azure.
 wangyuantao is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 bowgong is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 areddish is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.


### PR DESCRIPTION
# Summary

The focus of these changes is to remove a baseline error suppression for an account that is no longer an active Microsoft contributor.