### PR TITLE
Add Update Remove-Item command line options

### DIFF
--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -140,7 +140,7 @@ if ($LibType -eq 'client') {
 }
 
 Write-Verbose "Remove all unneeded artifacts from build output directory"
-Remove-Item –Path "${ApiDir}/*" -Include * -Exclude "${ArtifactName}.dll", "${ArtifactName}.xml"
+Remove-Item –Path "${ApiDir}/*" -Include * -Exclude "${ArtifactName}.dll", "${ArtifactName}.xml" -Recurse -Force
 
 Write-Verbose "Initialize Frameworks File"
 & "${MDocTool}" fx-bootstrap "${FrameworkDir}"


### PR DESCRIPTION
The cause of this would be my PR from [7/12](https://github.com/Azure/azure-sdk-for-net/pull/44965). It would appear that the Remove-Item now requires the -Recurse and -Force options, since the removal of the TargetFramework which now builds for all targets.

The pipeline that hit this failure was net - identity. I'm running [net - identity - ci](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3962316&view=results) and [net - core - ci](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3962351&view=results), both of which already successfully passed the generation steps.

I've also used Beyond Compare to do binary diff the produced docs and, outside of the file timestamps, the contents are identical.