### PR TITLE
[Storage] [WebJobs] Added test for Blob Path for various blob names to check for blob name validation

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Bumped version of Azure.Storage.Blobs to resolve issue where Blob Path was being truncated at '#' character.
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobPathTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobPathTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Storage.Blobs;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests
+{
+    public class BlobPathTests
+    {
+        [Test]
+        [TestCase("blobName")]
+        [TestCase("blob_Name")]
+        [TestCase("blob_Nam/e324324.txt")]
+        [TestCase("!*'();[]:@&%=+$,/#äÄöÖüÜß")]
+        public void BlobPathTryParseAbsUrl(string blobName)
+        {
+            string uriStr = "https://account.blob.core.windows.net/container/" + blobName;
+            if (BlobPath.TryParseAbsUrl(uriStr, out BlobPath path))
+            {
+                Assert.AreEqual(blobName, path.BlobName);
+            }
+            else
+            {
+                Assert.Fail("Failed to parse blob name");
+            }
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 5.0.0-beta.4 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 5.0.0-beta.3 (2021-03-09)
 - This release contains bug fixes to improve quality.
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.0.0-beta.4 (Unreleased)
+## 5.0.0-beta.3 (Unreleased)
 
 ### Features Added
 
@@ -9,9 +9,6 @@
 ### Bugs Fixed
 
 ### Other Changes
-
-## 5.0.0-beta.3 (2021-03-09)
-- This release contains bug fixes to improve quality.
 
 ## 5.0.0-beta.2 (2021-02-09)
 - This release contains bug fixes to improve quality.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-
+- When grabbing Queue Metrics for amount of messages, will now use the QueueTriggerMetrics.QueueLength instead of the ApproximateMessagesCount for less stale metrics.
 ### Other Changes
 
 ## 5.3.0 (2024-04-18)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
@@ -1,14 +1,7 @@
 # Release History
 
 ## 5.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+Please refer to [`Microsoft.Azure.WebJobs.Extension.Storage.Blobs`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md) and [`Microsoft.Azure.WebJobs.Extension.Storage.Queues`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md) for detailed list of changes.
 
 ## 5.3.0 (2024-04-18)
 Please refer to [`Microsoft.Azure.WebJobs.Extension.Storage.Blobs`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md) and [`Microsoft.Azure.WebJobs.Extension.Storage.Queues`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md) for detailed list of changes.


### PR DESCRIPTION
This is related to https://github.com/Azure/azure-sdk-for-net/pull/44941

This adds tests to ensure that we have correctly taken in blob names and not truncated them. This is dependent on the fix made in Azure.Storage.Blobs.

TODO: update Packages.Data.props Azure.Storage.Blobs version v12.21.0 when it releases, to ensure webjobs will take on this fix as well.

Other changes:
Updated change log to include this fix and also other fixes that occurred between the previous release and the upcoming release.
