### PR TITLE
Add annotation for NullableResponse

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -118,7 +118,8 @@ namespace Azure
     public abstract partial class NullableResponse<T>
     {
         protected NullableResponse() { }
-        public abstract bool HasValue { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "Value")]
+        public abstract bool HasValue { [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "Value")] get; }
         public abstract T? Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }

--- a/sdk/core/Azure.Core/src/NullableResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/NullableResponseOfT.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Azure
 {
@@ -18,6 +21,9 @@ namespace Azure
         /// <summary>
         /// Gets a value indicating whether the current instance has a valid value of its underlying type.
         /// </summary>
+#if NET5_0_OR_GREATER
+        [MemberNotNullWhen(returnValue: true, member: nameof(Value))]
+#endif
         public abstract bool HasValue { get; }
 
         /// <summary>


### PR DESCRIPTION
Fixes nullability checks for the `NullableResponse` class, so that it no longer needs to be overriden using the [! operator](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-forgiving) each time it's referenced from a file with nullable reference types enabled.

Before:

```csharp
if (response.HasValue) {
    x = response.Value!;
}
```

After:

```csharp
if (response.HasValue) {
    x = response.Value;
}
```

---

Rebase of PR #40136 closed due to inactivity.
