### PR TITLE
Temporarily disable MSDocs publishing for Azure.Messaging.EventGrid.SystemEvents

### DIFF
--- a/sdk/eventgrid/ci.yml
+++ b/sdk/eventgrid/ci.yml
@@ -47,5 +47,10 @@ extends:
       safeName: AzureMessagingEventGridNamespaces
     - name: Azure.Messaging.EventGrid.SystemEvents
       safeName: AzureMessagingEventGridSystemEvents
+      # MSDocs are being temporarily disabled because of an issue with MSDocs generation.
+      # The following issue is being used to track reenabling MSDocs publishing when
+      # the MSDocs issue is fixed.
+      # https://github.com/Azure/azure-sdk-for-net/issues/45032
+      skipPublishDocMs: true
 
 


### PR DESCRIPTION
The reason for disabling this is in the [issue](https://github.com/Azure/azure-sdk-for-net/issues/45032), assigned to me, which is being used to track reenabling this when the MSDocs issue is fixed.