### PR TITLE
Update Preview Test Sub to use new connection

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -60,7 +60,7 @@ parameters:
           - eng/common/TestResources/sub-config/AzurePublicMsft.json
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-        ServiceConnection: azure-sdk-tests
+        ServiceConnection: azure-sdk-tests-preview
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'eastus2euap'

--- a/sdk/storage/storage-preview-public-msft.json
+++ b/sdk/storage/storage-preview-public-msft.json
@@ -1,9 +1,0 @@
-{ 
-    "SubscriptionId": "23fddbc8-cb64-4b59-ba97-4c9f77c212e4",
-    "TenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-    "TestApplicationId": "f850650c-1fcf-4489-b46f-71af2e30d360",
-    "TestApplicationOid": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
-    "ProvisionerApplicationId": "f850650c-1fcf-4489-b46f-71af2e30d360",
-    "ProvisionerApplicationOid": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
-    "Environment": "AzureCloud"
-}

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -11,9 +11,7 @@ extends:
     CloudConfig:
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-        ServiceConnection: azure-sdk-tests
-        SubscriptionConfigurationFilePaths:
-          - sdk/storage/storage-preview-public-msft.json
+        ServiceConnection: azure-sdk-tests-preview
       PrivatePreview:
         SubscriptionConfiguration: $(sub-config-storage-test-resources)
     Clouds: Preview


### PR DESCRIPTION
In order to get both deployment and clean-up working we need to have a connection that points at the right subscription. Today azure-sdk-tests points to the name Test Sub but I created azure-sdk-tests-preview connection which points to the Preview Test Sub.

This will fix the clean-up step which is currently failing for things deployed in Preview.
