### PR TITLE
[Storage] [DataMovement] Changed DataMovement Blobs and File Shares to use package dependency

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -128,6 +128,7 @@
     <PackageReference Update="Azure.Storage.Common" Version="12.20.0" />
     <PackageReference Update="Azure.Storage.Blobs" Version="12.21.0" />
     <PackageReference Update="Azure.Storage.Queues" Version="12.19.0" />
+    <PackageReference Update="Azure.Storage.Files.Shares" Version="12.19.0" />
     <PackageReference Update="Azure.AI.OpenAI" Version="2.0.0-beta.1" />
     <PackageReference Update="Azure.ResourceManager" Version="1.12.0" />
     <PackageReference Update="Azure.ResourceManager.AppConfiguration" Version="1.3.2" />

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -19,8 +19,8 @@
     <PackageId />
   </PropertyGroup>
   <ItemGroup>
-    <!--<PackageReference Include="Azure.Storage.Blobs" />-->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <!-- <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" /> -->
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/Azure.Storage.DataMovement.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/Azure.Storage.DataMovement.Files.Shares.csproj
@@ -20,8 +20,8 @@
     <PackageId />
   </PropertyGroup>
   <ItemGroup>
-    <!--<PackageReference Include="Azure.Storage.Files.Shares" />-->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Files.Shares\src\Azure.Storage.Files.Shares.csproj" />
+    <PackageReference Include="Azure.Storage.Files.Shares" />
+    <!-- <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Files.Shares\src\Azure.Storage.Files.Shares.csproj" />-->
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Changed DataMovement Blobs and File Shares to use package dependency
Added File Shares to packages.data.props file as well, since this is a dependency used in the DataMovement package