### PR TITLE
Remove duplicate credential instantiation line in ACS Email README

### DIFF
--- a/sdk/communication/Azure.Communication.Email/README.md
+++ b/sdk/communication/Azure.Communication.Email/README.md
@@ -38,8 +38,7 @@ Alternatively, Email clients can also be authenticated using a valid token crede
 
 ```C# Snippet:Azure_Communication_Email_CreateEmailClientWithToken
 string endpoint = "<endpoint_url>";
-TokenCredential tokenCredential = new DefaultAzureCredential();
-tokenCredential = new DefaultAzureCredential();
+var tokenCredential = new DefaultAzureCredential();
 EmailClient emailClient = new EmailClient(new Uri(endpoint), tokenCredential);
 ```
 ## Examples

--- a/sdk/communication/Azure.Communication.Email/tests/EmailClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/EmailClientLiveTestBase.cs
@@ -46,11 +46,10 @@ namespace Azure.Communication.Email.Tests
             }
             else
             {
+                tokenCredential = new DefaultAzureCredential();
                 #region Snippet:Azure_Communication_Email_CreateEmailClientWithToken
                 //@@ string endpoint = "<endpoint_url>";
-                //@@ TokenCredential tokenCredential = new DefaultAzureCredential();
-                /*@@*/
-                tokenCredential = new DefaultAzureCredential();
+                //@@ var tokenCredential = new DefaultAzureCredential();
                 //@@ EmailClient emailClient = new EmailClient(new Uri(endpoint), tokenCredential);
                 #endregion Snippet:Azure_Communication_Email_CreateEmailClientWithToken
             }


### PR DESCRIPTION
Fix this confusing sample code:
https://github.com/Azure/azure-sdk-for-net/blob/f23ba3aa507e4b72d25582a252a804fc665a643d/sdk/communication/Azure.Communication.Email/README.md#L40-L43

/cc: @IEvangelist
