### PR TITLE
Nightly docs publish should honor skipPublishDocMs

### DIFF
--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -50,7 +50,7 @@ Param (
 )
 
 function Log-Warning($message) {
-    Write-Host "##vso[task.logissue type=warning]$message"
+    Write-Host "##vso[task.logissue type=warning;]$message"
 }
 
 function UpdateDocIndexFiles([string]$docPath, [string] $mainJsPath) {
@@ -140,7 +140,7 @@ if ($LibType -eq 'client') {
 }
 
 Write-Verbose "Remove all unneeded artifacts from build output directory"
-Remove-Item –Path "${ApiDir}/*" -Include * -Exclude "${ArtifactName}.dll", "${ArtifactName}.xml" -Recurse -Force
+Remove-Item -Path "${ApiDir}/*" -Include * -Exclude "${ArtifactName}.dll", "${ArtifactName}.xml" -Recurse -Force
 
 Write-Verbose "Initialize Frameworks File"
 & "${MDocTool}" fx-bootstrap "${FrameworkDir}"

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -334,7 +334,8 @@ stages:
             parameters:
               PackageInfoLocations:
                 - ${{ each artifact in parameters.Artifacts }}:
-                  - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
+                  - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
+                    - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
               WorkingDirectory: $(System.DefaultWorkingDirectory)
               TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
               TargetDocRepoName: ${{parameters.TargetDocRepoName}}


### PR DESCRIPTION
The primary fix here is to make the PublishDocsToNightlyBranch job honor the skipPublishDocMs variable which is honored in the actual Docs.MS publish step for a real, non-nightly, release. I have no idea why this was missing from one and not the other.


There are two secondary, opportunistic fixes in Generate-Api-Docs.ps1
1. The task.logissue type=warning was missing a semicolon.
2. The "-" in the "–Path" wasn't actually dash, VS Code was highlighting this as special character. A normal dash is not a special character.
