### PR TITLE
SCM: Add support for Retry-After header to default ClientRetryPolicy

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Added support for delaying retrying a request until after the interval specified on a response `Retry-After` header.
+
 ### Other Changes
 
 ## 1.1.0-beta.5 (2024-07-11)

--- a/sdk/core/System.ClientModel/src/Message/PipelineResponseHeaders.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineResponseHeaders.cs
@@ -11,6 +11,8 @@ namespace System.ClientModel.Primitives;
 /// </summary>
 public abstract class PipelineResponseHeaders : IEnumerable<KeyValuePair<string, string>>
 {
+    internal const string RetryAfter = "Retry-After";
+
     /// <summary>
     /// Attempts to retrieve the value associated with the specified header
     /// name.

--- a/sdk/core/System.ClientModel/src/Message/PipelineResponseHeaders.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineResponseHeaders.cs
@@ -11,8 +11,6 @@ namespace System.ClientModel.Primitives;
 /// </summary>
 public abstract class PipelineResponseHeaders : IEnumerable<KeyValuePair<string, string>>
 {
-    internal const string RetryAfter = "Retry-After";
-
     /// <summary>
     /// Attempts to retrieve the value associated with the specified header
     /// name.

--- a/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
@@ -4,7 +4,6 @@
 using System.ClientModel.Internal;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
@@ -4,6 +4,7 @@
 using System.ClientModel.Internal;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -275,7 +276,7 @@ public class ClientRetryPolicy : PipelinePolicy
         double nextDelayMilliseconds = (1 << (tryCount - 1)) * _initialDelay.TotalMilliseconds;
 
         if (message.Response is not null &&
-            message.Response.Headers.TryGetValue("Retry-After", out string? retryAfter) &&
+            message.Response.Headers.TryGetValue(PipelineResponseHeaders.RetryAfter, out string? retryAfter) &&
             double.TryParse(retryAfter, out double retryAfterSeconds))
         {
             double retryAfterMilliseconds = retryAfterSeconds * 1000;

--- a/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
@@ -24,6 +24,7 @@ public class ClientRetryPolicy : PipelinePolicy
 
     private const int DefaultMaxRetries = 3;
     private static readonly TimeSpan DefaultInitialDelay = TimeSpan.FromSeconds(0.8);
+    private const string RetryAfterHeaderName = "Retry-After";
 
     private readonly int _maxRetries;
     private readonly TimeSpan _initialDelay;
@@ -275,14 +276,10 @@ public class ClientRetryPolicy : PipelinePolicy
         double nextDelayMilliseconds = (1 << (tryCount - 1)) * _initialDelay.TotalMilliseconds;
 
         if (message.Response is not null &&
-            message.Response.Headers.TryGetValue(PipelineResponseHeaders.RetryAfter, out string? retryAfter) &&
-            double.TryParse(retryAfter, out double retryAfterSeconds))
+            TryGetRetryAfter(message.Response, out TimeSpan retryAfter) &&
+            retryAfter.TotalMilliseconds > nextDelayMilliseconds)
         {
-            double retryAfterMilliseconds = retryAfterSeconds * 1000;
-            if (retryAfterMilliseconds > nextDelayMilliseconds)
-            {
-                nextDelayMilliseconds = retryAfterMilliseconds;
-            }
+            return retryAfter;
         }
 
         return TimeSpan.FromMilliseconds(nextDelayMilliseconds);
@@ -321,5 +318,27 @@ public class ClientRetryPolicy : PipelinePolicy
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
         }
+    }
+
+    private static bool TryGetRetryAfter(PipelineResponse response, out TimeSpan value)
+    {
+        // See: https://www.rfc-editor.org/rfc/rfc7231#section-7.1.3
+        if (response.Headers.TryGetValue(RetryAfterHeaderName, out string? retryAfter))
+        {
+            if (int.TryParse(retryAfter, out var delaySeconds))
+            {
+                value = TimeSpan.FromSeconds(delaySeconds);
+                return true;
+            }
+
+            if (DateTimeOffset.TryParse(retryAfter, out DateTimeOffset retryAfterDate))
+            {
+                value = retryAfterDate - DateTimeOffset.Now;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
     }
 }

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientRetryPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientRetryPolicyTests.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using ClientModel.Tests;
-using ClientModel.Tests.Mocks;
-using NUnit.Framework;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using ClientModel.Tests;
+using ClientModel.Tests.Mocks;
+using NUnit.Framework;
 
 namespace System.ClientModel.Tests.Pipeline;
 
@@ -131,7 +130,7 @@ public class ClientRetryPolicyTests : SyncAsyncTestBase
     }
 
     [Test]
-    // Retry-After header is larger - wait Retry-After
+    // Retry-After header is larger - wait Retry-After time
     [TestCase("Retry-After", "5", 5000)]
     // Retry-After header is shorter - wait exponential backoff time
     [TestCase("Retry-After", "1", 1600)]

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineResponse.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineResponse.cs
@@ -17,7 +17,7 @@ public class MockPipelineResponse : PipelineResponse
     private Stream? _contentStream;
     private BinaryData? _bufferedContent;
 
-    private readonly PipelineResponseHeaders _headers;
+    private readonly MockResponseHeaders _headers;
 
     private bool _disposed;
 
@@ -35,6 +35,9 @@ public class MockPipelineResponse : PipelineResponse
     public override string ReasonPhrase => _reasonPhrase;
 
     public void SetReasonPhrase(string value) => _reasonPhrase = value;
+
+    public void SetHeader(string name, string value)
+        => _headers.SetHeader(name, value);
 
     public void SetContent(byte[] content)
     {

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockPipelineTransport.cs
@@ -172,7 +172,7 @@ public class MockPipelineTransport : PipelineTransport
         public override BinaryData Content => throw new NotImplementedException();
 
         protected override PipelineResponseHeaders HeadersCore
-            => throw new NotImplementedException();
+            => new MockResponseHeaders();
 
         public override void Dispose() { }
 

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockResponseHeaders.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockResponseHeaders.cs
@@ -16,6 +16,9 @@ public class MockResponseHeaders : PipelineResponseHeaders
         _headers = new Dictionary<string, string>();
     }
 
+    public void SetHeader(string name, string value)
+        => _headers[name] = value;
+
     public override IEnumerator<KeyValuePair<string, string>> GetEnumerator()
     {
         throw new NotImplementedException();

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRetryPolicy.cs
@@ -86,6 +86,11 @@ public class MockRetryPolicy : ClientRetryPolicy
         return base.OnSendingRequestAsync(message);
     }
 
+    public double GetNextDelayMilliseconds(PipelineMessage message, int tryCount)
+    {
+        return GetNextDelay(message, tryCount).TotalMilliseconds;
+    }
+
     protected override TimeSpan GetNextDelay(PipelineMessage message, int tryCount)
     {
         if (_delayFactory is not null)

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRetryPolicy.cs
@@ -87,9 +87,7 @@ public class MockRetryPolicy : ClientRetryPolicy
     }
 
     public double GetNextDelayMilliseconds(PipelineMessage message, int tryCount)
-    {
-        return GetNextDelay(message, tryCount).TotalMilliseconds;
-    }
+        => GetNextDelay(message, tryCount).TotalMilliseconds;
 
     protected override TimeSpan GetNextDelay(PipelineMessage message, int tryCount)
     {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/44222