### PR TITLE
Unset the SDKType environment variable for API Docs Gen

### DIFF
--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -105,7 +105,7 @@ mkdir $DocOutDir
 
 if ($LibType -eq 'client') {
     Write-Verbose "Build Packages for Doc Generation - Client"
-    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir
+    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir"
     dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir
     if ($LASTEXITCODE -ne 0) {
         Log-Warning "Build Packages for Doc Generation - Client failed with $LASTEXITCODE please see output above"

--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -122,16 +122,20 @@ if ($LibType -eq 'client') {
 } elseif ($LibType -eq 'management') {
     # Management Package
     Write-Verbose "Build Packages for Doc Generation - Management"
-    Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false"
-    dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false
+    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir"
+    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir
+    # Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false"
+    # dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false
     if ($LASTEXITCODE -ne 0) {
         Log-Warning "Build Packages for Doc Generation - Management failed with $LASTEXITCODE please see output above"
         exit 0
     }
 
     Write-Verbose "Include Management Dependencies"
-    Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false"
-    dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false
+    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
+    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
+    # Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false"
+    # dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false
     if ($LASTEXITCODE -ne 0) {
         Log-Warning "Include Management Dependencies build failed with $LASTEXITCODE please see output above"
         exit 0

--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -32,7 +32,7 @@ Directory Name: PopImport: https://azuresdkartifacts.blob.core.windows.net/azure
 RepoRoot\doc\ApiDocGeneration
 
 #>
- 
+
 [CmdletBinding()]
 Param (
     [Parameter(Mandatory = $True)]
@@ -67,149 +67,164 @@ function UpdateDocIndexFiles([string]$docPath, [string] $mainJsPath) {
     Set-Content -Path $mainJsPath -Value $mainJsContent -NoNewline
 }
 
-Write-Verbose "Name Reccuring paths with variable names"
-if ([System.String]::IsNullOrEmpty($ArtifactsDirectoryName)) {$ArtifactsDirectoryName = $ArtifactName}
-$PackageLocation = "${ServiceDirectory}/${ArtifactsDirectoryName}"
-$FrameworkDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-docs"
-$ApiDir = "${FrameworkDir}/my-api"
-$ApiDependenciesDir = "${FrameworkDir}/dependencies/my-api"
-$XmlOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-xml-output"
-$YamlOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-yaml-output"
-$DocOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/docfx-output/docfx_project"
-$DocOutApiDir = "${DocOutDir}/api"
-$DocOutHtmlDir = "${DocOutDir}/_site"
-$MDocTool = "${BinDirectory}/mdoc/mdoc.exe"
-$DocFxTool = "${BinDirectory}/docfx/docfx.exe"
-$DocCommonGenDir = "${RepoRoot}/eng/common/docgeneration"
-$GACampaignId = "UA-62780441-41"
+$SdkTypeEnvVarValue = $Env:SDKType
+try {
+    if ($SdkTypeEnvVarValue) {
+        Write-Verbose "SDKType environment var was set, unsetting for docs gen"
+        rm Env:SDKType
+    }
+    Write-Verbose "Name Reccuring paths with variable names"
+    if ([System.String]::IsNullOrEmpty($ArtifactsDirectoryName)) {
+        $ArtifactsDirectoryName = $ArtifactName
+    }
+    $PackageLocation = "${ServiceDirectory}/${ArtifactsDirectoryName}"
+    $FrameworkDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-docs"
+    $ApiDir = "${FrameworkDir}/my-api"
+    $ApiDependenciesDir = "${FrameworkDir}/dependencies/my-api"
+    $XmlOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-xml-output"
+    $YamlOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-yaml-output"
+    $DocOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/docfx-output/docfx_project"
+    $DocOutApiDir = "${DocOutDir}/api"
+    $DocOutHtmlDir = "${DocOutDir}/_site"
+    $MDocTool = "${BinDirectory}/mdoc/mdoc.exe"
+    $DocFxTool = "${BinDirectory}/docfx/docfx.exe"
+    $DocCommonGenDir = "${RepoRoot}/eng/common/docgeneration"
+    $GACampaignId = "UA-62780441-41"
 
-if ($LibType -eq 'management') {
-    $ArtifactName = $ArtifactName.Substring($ArtifactName.LastIndexOf('.Management') + 1)
-}
+    if ($LibType -eq 'management') {
+        $ArtifactName = $ArtifactName.Substring($ArtifactName.LastIndexOf('.Management') + 1)
+    }
 
-Write-Verbose "Package Location ${PackageLocation}"
+    Write-Verbose "Package Location ${PackageLocation}"
 
-Write-Verbose "Create Directories Required for Doc Generation"
-Write-Verbose "Creating ApiDir '$ApiDir'"
-mkdir $ApiDir
-Write-Verbose "Creating ApiDependenciesDir '$ApiDependenciesDir'"
-mkdir $ApiDependenciesDir
-Write-Verbose "Creating XmlOutDir '$XmlOutDir'"
-mkdir $XmlOutDir
-Write-Verbose "Creating YamlOutDir '$YamlOutDir'"
-mkdir $YamlOutDir
-Write-Verbose "Creating DocOutDir '$DocOutDir'"
-mkdir $DocOutDir
+    Write-Verbose "Create Directories Required for Doc Generation"
+    Write-Verbose "Creating ApiDir '$ApiDir'"
+    mkdir $ApiDir
+    Write-Verbose "Creating ApiDependenciesDir '$ApiDependenciesDir'"
+    mkdir $ApiDependenciesDir
+    Write-Verbose "Creating XmlOutDir '$XmlOutDir'"
+    mkdir $XmlOutDir
+    Write-Verbose "Creating YamlOutDir '$YamlOutDir'"
+    mkdir $YamlOutDir
+    Write-Verbose "Creating DocOutDir '$DocOutDir'"
+    mkdir $DocOutDir
 
-if ($LibType -eq 'client') { 
-    Write-Verbose "Build Packages for Doc Generation - Client"
-    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir
-    if ($LASTEXITCODE -ne 0) {
-        Log-Warning "Build Packages for Doc Generation - Client failed with $LASTEXITCODE please see output above"
+    if ($LibType -eq 'client') {
+        Write-Verbose "Build Packages for Doc Generation - Client"
+        Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir"
+        dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir
+        if ($LASTEXITCODE -ne 0) {
+            Log-Warning "Build Packages for Doc Generation - Client failed with $LASTEXITCODE please see output above"
+            exit 0
+        }
+
+        Write-Verbose "Include Client Dependencies"
+        Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
+        dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
+        if ($LASTEXITCODE -ne 0) {
+            Log-Warning "Include Client Dependencies build failed with $LASTEXITCODE please see output above"
+            exit 0
+        }
+    } elseif ($LibType -eq 'management') {
+        # Management Package
+        Write-Verbose "Build Packages for Doc Generation - Management"
+        Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false"
+        dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false
+        if ($LASTEXITCODE -ne 0) {
+            Log-Warning "Build Packages for Doc Generation - Management failed with $LASTEXITCODE please see output above"
+            exit 0
+        }
+
+        Write-Verbose "Include Management Dependencies"
+        Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false"
+        dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false
+        if ($LASTEXITCODE -ne 0) {
+            Log-Warning "Include Management Dependencies build failed with $LASTEXITCODE please see output above"
+            exit 0
+        }
+    } else {
+        Log-Warning "'$LibType' is not a supported library type at this time."
         exit 0
     }
 
-    Write-Verbose "Include Client Dependencies"
-    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$PackageLocation /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
-    if ($LASTEXITCODE -ne 0) {
-        Log-Warning "Include Client Dependencies build failed with $LASTEXITCODE please see output above"
-        exit 0
+    Write-Verbose "Remove all unneeded artifacts from build output directory"
+    Remove-Item -Path "${ApiDir}/*" -Include * -Exclude "${ArtifactName}.dll", "${ArtifactName}.xml" -Recurse -Force
+
+    Write-Verbose "Initialize Frameworks File"
+    & "${MDocTool}" fx-bootstrap "${FrameworkDir}"
+
+    Write-Verbose "Include XML Files"
+    & "${BinDirectory}/PopImport/popimport.exe" -f "${FrameworkDir}"
+
+    Write-Verbose "Produce ECMAXML"
+    & "${MDocTool}" update -fx "${FrameworkDir}" -o "${XmlOutDir}" --debug -lang docid -lang vb.net -lang fsharp --delete
+
+    Write-Verbose "Generate YAML"
+    & "${BinDirectory}/ECMA2Yml/ECMA2Yaml.exe" -s "${XmlOutDir}" -o "${YamlOutDir}"
+
+    Write-Verbose "Provision DocFX Directory"
+    & "${DocFxTool}" init -q -o "${DocOutDir}"
+
+    Write-Verbose "Copy over Package ReadMe"
+    $PkgReadMePath = "${RepoRoot}/sdk/${PackageLocation}/README.md"
+    if ([System.IO.File]::Exists($PkgReadMePath)) {
+        Copy-Item $PkgReadMePath -Destination "${DocOutApiDir}/index.md" -Force
     }
-} elseif ($LibType -eq 'management') {
-    # Management Package
-    Write-Verbose "Build Packages for Doc Generation - Management"
-    Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false"
-    dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false
-    if ($LASTEXITCODE -ne 0) {
-        Log-Warning "Build Packages for Doc Generation - Management failed with $LASTEXITCODE please see output above"
-        exit 0
+    else {
+        New-Item "${DocOutApiDir}/index.md" -Force
+        Add-Content -Path "${DocOutApiDir}/index.md" -Value "This Package Contains no Readme."
+        Write-Verbose "Package ReadMe was not found"
     }
 
-    Write-Verbose "Include Management Dependencies"
-    Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false"
-    dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false
-    if ($LASTEXITCODE -ne 0) {
-        Log-Warning "Include Management Dependencies build failed with $LASTEXITCODE please see output above"
-        exit 0
+    Write-Verbose "Make changes to docfx.json and main.js."
+    UpdateDocIndexFiles -docPath "${DocCommonGenDir}/docfx.json" -mainJsPath "${DocCommonGenDir}\templates\matthews\styles\main.js"
+
+    Write-Verbose "Copy over generated yml and other assets"
+    Copy-Item "${YamlOutDir}/*"-Destination "${DocOutApiDir}" -Recurse -Force
+    New-Item -Path "${DocOutDir}" -Name templates -ItemType directory
+    Copy-Item "${DocCommonGenDir}/templates/**" -Destination "${DocOutDir}/templates" -Recurse -Force
+    Copy-Item "${DocCommonGenDir}/docfx.json" -Destination "${DocOutDir}" -Force
+
+    $headerTemplateLocation = "${DocOutDir}/templates/matthews/partials/head.tmpl.partial"
+
+    if (Test-Path $headerTemplateLocation){
+        $headerTemplateContent = Get-Content -Path $headerTemplateLocation -Raw
+        $headerTemplateContent = $headerTemplateContent -replace "GA_CAMPAIGN_ID", $GACampaignId
+        Set-Content -Path $headerTemplateLocation -Value $headerTemplateContent -NoNewline
     }
-} else {
-    Log-Warning "'$LibType' is not a supported library type at this time."
-    exit 0
+
+    Write-Verbose "Create Toc for Site Navigation"
+    New-Item "${DocOutDir}/toc.yml" -Force
+    Add-Content -Path "${DocOutDir}/toc.yml" -Value "- name: ${ArtifactName}`r`n  href: index.md"
+
+    Write-Verbose "Build Doc Content"
+    & "${DocFxTool}" build "${DocOutDir}/docfx.json"
+
+    Write-Verbose "Copy over site Logo"
+    Copy-Item "${DocCommonGenDir}/assets/logo.svg" -Destination "${DocOutHtmlDir}" -Recurse -Force
+
+    # Copy everything inside of /api out.
+    Write-Verbose "Copy index.html and toc.yml out."
+    $destFolder = "${DocOutHtmlDir}/"
+    Copy-Item -Path "${DocOutHtmlDir}/api/index.html" -Destination $destFolder -Confirm:$false -Force
+
+    # Change the relative path inside index.html.
+    Write-Verbose "Make changes on relative path on page index.html."
+    $baseUrl = $destFolder + "index.html"
+    $content = Get-Content -Path $baseUrl -Raw
+    $hrefRegex = "[""']\.\.\/([^""']*)[""']"
+    $tocRegex = "[""'](./)?toc.html[""']"
+    # The order matters for the following mutations. If excutes the latter one, then we will see two same toc.html path.
+    $mutatedContent = $content -replace $tocRegex , "`"./api/toc.html`""
+    $mutatedContent = $mutatedContent -replace $hrefRegex, '"./$1"'
+    Set-Content -Path $baseUrl -Value $mutatedContent -NoNewline
+
+    Write-Verbose "Compress and copy HTML into the staging Area"
+    Compress-Archive -Path "${DocOutHtmlDir}/*" -DestinationPath "${ArtifactStagingDirectory}/${ArtifactName}/${ArtifactName}.docs.zip" -CompressionLevel Fastest
 }
-
-Write-Verbose "Remove all unneeded artifacts from build output directory"
-Remove-Item -Path "${ApiDir}/*" -Include * -Exclude "${ArtifactName}.dll", "${ArtifactName}.xml" -Recurse -Force
-
-Write-Verbose "Initialize Frameworks File"
-& "${MDocTool}" fx-bootstrap "${FrameworkDir}"
-
-Write-Verbose "Include XML Files"
-& "${BinDirectory}/PopImport/popimport.exe" -f "${FrameworkDir}"
-
-Write-Verbose "Produce ECMAXML"
-& "${MDocTool}" update -fx "${FrameworkDir}" -o "${XmlOutDir}" --debug -lang docid -lang vb.net -lang fsharp --delete
-
-Write-Verbose "Generate YAML"
-& "${BinDirectory}/ECMA2Yml/ECMA2Yaml.exe" -s "${XmlOutDir}" -o "${YamlOutDir}"
-
-Write-Verbose "Provision DocFX Directory"
-& "${DocFxTool}" init -q -o "${DocOutDir}"
-
-Write-Verbose "Copy over Package ReadMe"
-$PkgReadMePath = "${RepoRoot}/sdk/${PackageLocation}/README.md"
-if ([System.IO.File]::Exists($PkgReadMePath)) {
-    Copy-Item $PkgReadMePath -Destination "${DocOutApiDir}/index.md" -Force
+finally {
+    if ($SdkTypeEnvVarValue) {
+        Write-Verbose "Restoring SDKType env to $SdkTypeEnvVarValue"
+        Env:SDKType=$SdkTypeEnvVarValue
+    }
 }
-else {
-    New-Item "${DocOutApiDir}/index.md" -Force
-    Add-Content -Path "${DocOutApiDir}/index.md" -Value "This Package Contains no Readme."
-    Write-Verbose "Package ReadMe was not found"
-}
-
-Write-Verbose "Make changes to docfx.json and main.js."
-UpdateDocIndexFiles -docPath "${DocCommonGenDir}/docfx.json" -mainJsPath "${DocCommonGenDir}\templates\matthews\styles\main.js"
-
-Write-Verbose "Copy over generated yml and other assets"
-Copy-Item "${YamlOutDir}/*"-Destination "${DocOutApiDir}" -Recurse -Force
-New-Item -Path "${DocOutDir}" -Name templates -ItemType directory
-Copy-Item "${DocCommonGenDir}/templates/**" -Destination "${DocOutDir}/templates" -Recurse -Force
-Copy-Item "${DocCommonGenDir}/docfx.json" -Destination "${DocOutDir}" -Force
-
-$headerTemplateLocation = "${DocOutDir}/templates/matthews/partials/head.tmpl.partial"
-
-if (Test-Path $headerTemplateLocation){
-    $headerTemplateContent = Get-Content -Path $headerTemplateLocation -Raw
-    $headerTemplateContent = $headerTemplateContent -replace "GA_CAMPAIGN_ID", $GACampaignId
-    Set-Content -Path $headerTemplateLocation -Value $headerTemplateContent -NoNewline
-}
-
-Write-Verbose "Create Toc for Site Navigation"
-New-Item "${DocOutDir}/toc.yml" -Force
-Add-Content -Path "${DocOutDir}/toc.yml" -Value "- name: ${ArtifactName}`r`n  href: index.md"
-
-Write-Verbose "Build Doc Content"
-& "${DocFxTool}" build "${DocOutDir}/docfx.json"
-
-Write-Verbose "Copy over site Logo"
-Copy-Item "${DocCommonGenDir}/assets/logo.svg" -Destination "${DocOutHtmlDir}" -Recurse -Force
-
-# Copy everything inside of /api out.
-Write-Verbose "Copy index.html and toc.yml out."
-$destFolder = "${DocOutHtmlDir}/"
-Copy-Item -Path "${DocOutHtmlDir}/api/index.html" -Destination $destFolder -Confirm:$false -Force
-
-# Change the relative path inside index.html.
-Write-Verbose "Make changes on relative path on page index.html."
-$baseUrl = $destFolder + "index.html"
-$content = Get-Content -Path $baseUrl -Raw
-$hrefRegex = "[""']\.\.\/([^""']*)[""']"
-$tocRegex = "[""'](./)?toc.html[""']"
-# The order matters for the following mutations. If excutes the latter one, then we will see two same toc.html path.
-$mutatedContent = $content -replace $tocRegex , "`"./api/toc.html`""
-$mutatedContent = $mutatedContent -replace $hrefRegex, '"./$1"'
-Set-Content -Path $baseUrl -Value $mutatedContent -NoNewline
-
-Write-Verbose "Compress and copy HTML into the staging Area"
-Compress-Archive -Path "${DocOutHtmlDir}/*" -DestinationPath "${ArtifactStagingDirectory}/${ArtifactName}/${ArtifactName}.docs.zip" -CompressionLevel Fastest  

--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -105,16 +105,16 @@ mkdir $DocOutDir
 
 if ($LibType -eq 'client') {
     Write-Verbose "Build Packages for Doc Generation - Client"
-    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDir
+    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir
+    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir
     if ($LASTEXITCODE -ne 0) {
         Log-Warning "Build Packages for Doc Generation - Client failed with $LASTEXITCODE please see output above"
         exit 0
     }
 
     Write-Verbose "Include Client Dependencies"
-    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
+    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
+    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
     if ($LASTEXITCODE -ne 0) {
         Log-Warning "Include Client Dependencies build failed with $LASTEXITCODE please see output above"
         exit 0

--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -14,9 +14,6 @@ The Name of the servicedirectory, usually the name of the service e.g. core
 .PARAMETER ArtifactsDirectoryName
 Used in the case where the package directory name is different from the package name. e.g in cognitiveservice packages
 
-.PARAMETER LibType
-Specifies if its a client or management library
-
 .PARAMETER RepoRoot
 The root of the Azure-SDK-for-Net Repo
 
@@ -40,8 +37,6 @@ Param (
     [Parameter(Mandatory = $True)]
     $ServiceDirectory,
     $ArtifactsDirectoryName,
-    [ValidateSet('client', 'management')]
-    $LibType = "client",
     $RepoRoot = "${PSScriptRoot}/../..",
     [Parameter(Mandatory = $True)]
     $BinDirectory,
@@ -85,10 +80,6 @@ $DocFxTool = "${BinDirectory}/docfx/docfx.exe"
 $DocCommonGenDir = "${RepoRoot}/eng/common/docgeneration"
 $GACampaignId = "UA-62780441-41"
 
-if ($LibType -eq 'management') {
-    $ArtifactName = $ArtifactName.Substring($ArtifactName.LastIndexOf('.Management') + 1)
-}
-
 Write-Verbose "Package Location ${PackageLocation}"
 
 Write-Verbose "Create Directories Required for Doc Generation"
@@ -103,45 +94,19 @@ mkdir $YamlOutDir
 Write-Verbose "Creating DocOutDir '$DocOutDir'"
 mkdir $DocOutDir
 
-if ($LibType -eq 'client') {
-    Write-Verbose "Build Packages for Doc Generation - Client"
-    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir
-    if ($LASTEXITCODE -ne 0) {
-        Log-Warning "Build Packages for Doc Generation - Client failed with $LASTEXITCODE please see output above"
-        exit 0
-    }
+Write-Verbose "Build Packages for Doc Generation - Client"
+Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir"
+dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir
+if ($LASTEXITCODE -ne 0) {
+    Log-Warning "Build Packages for Doc Generation - Client failed with $LASTEXITCODE please see output above"
+    exit 0
+}
 
-    Write-Verbose "Include Client Dependencies"
-    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
-    if ($LASTEXITCODE -ne 0) {
-        Log-Warning "Include Client Dependencies build failed with $LASTEXITCODE please see output above"
-        exit 0
-    }
-} elseif ($LibType -eq 'management') {
-    # Management Package
-    Write-Verbose "Build Packages for Doc Generation - Management"
-    Write-Verbose "dotnet build '${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDir
-    # Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false"
-    # dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDir -maxcpucount:1 -nodeReuse:false
-    if ($LASTEXITCODE -ne 0) {
-        Log-Warning "Build Packages for Doc Generation - Management failed with $LASTEXITCODE please see output above"
-        exit 0
-    }
-
-    Write-Verbose "Include Management Dependencies"
-    Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
-    dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
-    # Write-Verbose "dotnet msbuild '${RepoRoot}/eng/mgmt.proj' /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false"
-    # dotnet msbuild "${RepoRoot}/eng/mgmt.proj" /p:scope=$PackageLocation /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true -maxcpucount:1 -nodeReuse:false
-    if ($LASTEXITCODE -ne 0) {
-        Log-Warning "Include Management Dependencies build failed with $LASTEXITCODE please see output above"
-        exit 0
-    }
-} else {
-    Log-Warning "'$LibType' is not a supported library type at this time."
+Write-Verbose "Include Client Dependencies"
+Write-Verbose "'${RepoRoot}/eng/service.proj' /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true"
+dotnet build "${RepoRoot}/eng/service.proj" /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName /p:IncludeTests=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:BuildInParallel=false /p:OutputPath=$ApiDependenciesDir /p:CopyLocalLockFileAssemblies=true
+if ($LASTEXITCODE -ne 0) {
+    Log-Warning "Include Client Dependencies build failed with $LASTEXITCODE please see output above"
     exit 0
 }
 

--- a/eng/pipelines/templates/steps/archetype-sdk-docs.yml
+++ b/eng/pipelines/templates/steps/archetype-sdk-docs.yml
@@ -18,7 +18,6 @@ steps:
           -ArtifactName '${{artifact.name}}'
           -ServiceDirectory '${{parameters.ServiceDirectory}}'
           -ArtifactsDirectoryName '${{artifact.directoryName}}'
-          -LibType '${{parameters.LibType}}'
           -RepoRoot $(Build.SourcesDirectory)
           -BinDirectory $(Build.BinariesDirectory)
           -DocGenDir ${{parameters.DocGenerationDir}}


### PR DESCRIPTION
This [PR](https://github.com/Azure/azure-sdk-for-net/pull/44651) set the SDKType for all steps but apparently, this doesn't quite work for the docs gen which seems to be unable to find anything to build when scoped in the manner it was scoping them. The script was passing in <ServiceDirectory>/<ArtifactDirectory> (the PackageLocation variable in the script) for ServiceDirectory parameter. The was split into /p:ServiceDirectory=$ServiceDirectory /p:Project=$ArtifactsDirectoryName. 
The PackageLocation is now only used to get the README.md

The big change was to remove the LibType being passed in. A while back, everything was changed to LibType "client", there is call to script that passes in anything else. Since everything is Taco Bell, we no longer need different commands based upon LibType so the LibType parameter has been removed from the script and from archetype-sdk-docs.yml, the only yml file which calls the script.

Testing: 

- The [core run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3975630&view=results) was automatic for this PR
- [Storage](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3977176&view=results) was run against the refs/merge of this PR since it was previously failing.
- [EventGrid](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3977177&view=results) was run against the refs/merge of this PR since it was previously failing
- I ran [agrifood - mgmt](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3977178&view=results) against the refs/merge just to run something that was a track 2 mgmt, for my sanity