### PR TITLE
[Storage] [Tests] Fix OAuth Storage Samples

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/README.md
+++ b/sdk/storage/Azure.Storage.Blobs/README.md
@@ -149,8 +149,8 @@ We fully support both synchronous and asynchronous APIs.
 // Get a temporary path on disk where we can download the file
 string downloadPath = "hello.jpg";
 
-// Download the public blob at https://aka.ms/bloburl
-await new BlobClient(new Uri("https://aka.ms/bloburl")).DownloadToAsync(downloadPath);
+// Download the public MacBeth copy at https://www.gutenberg.org/cache/epub/1533/pg1533.txt
+await new BlobClient(new Uri("https://www.gutenberg.org/cache/epub/1533/pg1533.txt")).DownloadToAsync(downloadPath);
 ```
 
 ## Troubleshooting

--- a/sdk/storage/Azure.Storage.Blobs/samples/Sample01b_HelloWorldAsync.cs
+++ b/sdk/storage/Azure.Storage.Blobs/samples/Sample01b_HelloWorldAsync.cs
@@ -109,12 +109,12 @@ namespace Azure.Storage.Blobs.Samples
             // Get a temporary path on disk where we can download the file
             //@@ string downloadPath = "hello.jpg";
 
-            // Download the public blob at https://aka.ms/bloburl
-            await new BlobClient(new Uri("https://aka.ms/bloburl")).DownloadToAsync(downloadPath);
+            // Download the public MacBeth copy at https://www.gutenberg.org/cache/epub/1533/pg1533.txt
+            await new BlobClient(new Uri("https://www.gutenberg.org/cache/epub/1533/pg1533.txt")).DownloadToAsync(downloadPath);
             #endregion
 
             Assert.IsTrue(File.ReadAllBytes(downloadPath).Length > 0);
-            File.Delete("hello.jpg");
+            File.Delete(downloadPath);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/samples/Sample02_Auth.cs
+++ b/sdk/storage/Azure.Storage.Blobs/samples/Sample02_Auth.cs
@@ -192,12 +192,7 @@ namespace Azure.Storage.Blobs.Samples
         {
             // Create a token credential that can use our Azure Active
             // Directory application to authenticate with Azure Storage
-            TokenCredential credential =
-                new ClientSecretCredential(
-                    ActiveDirectoryTenantId,
-                    ActiveDirectoryApplicationId,
-                    ActiveDirectoryApplicationSecret,
-                    new TokenCredentialOptions() { AuthorityHost = ActiveDirectoryAuthEndpoint });
+            TokenCredential credential = new DefaultAzureCredential();
 
             // Create a client that can authenticate using our token credential
             BlobServiceClient service = new BlobServiceClient(ActiveDirectoryBlobUri, credential);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/samples/Sample01b_HelloWorldAsync.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/samples/Sample01b_HelloWorldAsync.cs
@@ -38,12 +38,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
             try
             {
                 {
-                    TokenCredential tokenCredential =
-                    new ClientSecretCredential(
-                        ActiveDirectoryTenantId,
-                        ActiveDirectoryApplicationId,
-                        ActiveDirectoryApplicationSecret,
-                        new TokenCredentialOptions() { AuthorityHost = ActiveDirectoryAuthEndpoint });
+                    TokenCredential tokenCredential = new DefaultAzureCredential();
 
                     TransferManager transferManager = new TransferManager();
 
@@ -612,12 +607,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
 
             // Create a token credential that can use our Azure Active
             // Directory application to authenticate with Azure Storage
-            TokenCredential credential =
-                new ClientSecretCredential(
-                    ActiveDirectoryTenantId,
-                    ActiveDirectoryApplicationId,
-                    ActiveDirectoryApplicationSecret,
-                    new TokenCredentialOptions() { AuthorityHost = ActiveDirectoryAuthEndpoint });
+            TokenCredential credential = new DefaultAzureCredential();
 
             // Create a client that can authenticate using our token credential
             BlobServiceClient service = new BlobServiceClient(ActiveDirectoryBlobUri, credential);
@@ -882,12 +872,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
 
                 // Create a token credential that can use our Azure Active
                 // Directory application to authenticate with Azure Storage
-                TokenCredential tokenCredential =
-                new ClientSecretCredential(
-                    ActiveDirectoryTenantId,
-                    ActiveDirectoryApplicationId,
-                    ActiveDirectoryApplicationSecret,
-                    new TokenCredentialOptions() { AuthorityHost = ActiveDirectoryAuthEndpoint });
+                TokenCredential tokenCredential = new DefaultAzureCredential();
 
                 // Create transfer manager
                 #region Snippet:SetupTransferManagerForResume

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/samples/Sample01b_HelloWorldAsync.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/samples/Sample01b_HelloWorldAsync.cs
@@ -37,12 +37,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
             try
             {
                 {
-                    TokenCredential tokenCredential =
-                    new ClientSecretCredential(
-                        ActiveDirectoryTenantId,
-                        ActiveDirectoryApplicationId,
-                        ActiveDirectoryApplicationSecret,
-                        new TokenCredentialOptions() { AuthorityHost = ActiveDirectoryAuthEndpoint });
+                    TokenCredential tokenCredential = new DefaultAzureCredential();
 
                     TransferManager transferManager = new TransferManager();
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/samples/Sample02_Auth.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/samples/Sample02_Auth.cs
@@ -182,12 +182,7 @@ namespace Azure.Storage.Files.DataLake.Samples
         {
             // Create a token credential that can use our Azure Active
             // Directory application to authenticate with Azure Storage
-            TokenCredential credential =
-                new ClientSecretCredential(
-                    ActiveDirectoryTenantId,
-                    ActiveDirectoryApplicationId,
-                    ActiveDirectoryApplicationSecret,
-                    new TokenCredentialOptions() { AuthorityHost = ActiveDirectoryAuthEndpoint });
+            TokenCredential credential = new DefaultAzureCredential();
 
             // Create a client that can authenticate using our token credential
             DataLakeServiceClient service = new DataLakeServiceClient(ActiveDirectoryBlobUri, credential);

--- a/sdk/storage/Azure.Storage.Queues/samples/Sample02_Auth.cs
+++ b/sdk/storage/Azure.Storage.Queues/samples/Sample02_Auth.cs
@@ -155,12 +155,7 @@ namespace Azure.Storage.Queues.Samples
         {
             // Create a token credential that can use our Azure Active
             // Directory application to authenticate with Azure Storage
-            TokenCredential credential =
-                new ClientSecretCredential(
-                    ActiveDirectoryTenantId,
-                    ActiveDirectoryApplicationId,
-                    ActiveDirectoryApplicationSecret,
-                    new TokenCredentialOptions() { AuthorityHost = ActiveDirectoryAuthEndpoint });
+            TokenCredential credential = new DefaultAzureCredential();
 
             // Create a client that can authenticate using our token credential
             QueueServiceClient service = new QueueServiceClient(ActiveDirectoryQueueUri, credential);


### PR DESCRIPTION
We recently removed the use of Client Secret Credentials in our Tests, but looks like we missed the samples. This is just to use DefaultAzureCredential over it to fix the samples.