### PR TITLE
Add Azure Health Data Service product slug

### DIFF
--- a/eng/common/scripts/Test-SampleMetadata.ps1
+++ b/eng/common/scripts/Test-SampleMetadata.ps1
@@ -203,6 +203,7 @@ begin {
         "azure-genomics",
         "azure-hdinsight",
         "azure-hdinsight-rserver",
+        "azure-health-data-services",
         "azure-health-insights",
         "azure-hpc-cache",
         "azure-immersive-reader",


### PR DESCRIPTION
Update the product slug allow list to support Azure Health Data Insights. Note the slug already exists at https://review.learn.microsoft.com/help/platform/metadata-taxonomies/product?branch=main. This PR will unblock https://github.com/Azure/azure-sdk-for-net/pull/43913.