### PR TITLE
[WILL NOT BE CHECKED IN] - Test docs nightly branch name change

### DIFF
--- a/eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
+++ b/eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
@@ -6,8 +6,8 @@ parameters:
 steps:
   - pwsh: |
       $branchName = $env:DAILYDOCSBRANCHNAMEOVERRIDE
-      if (!$branchName) { 
-        $branchName = "daily/$(Get-Date -Format 'yyyy-MM-dd')"
+      if (!$branchName) {
+        $branchName = "daily/$(Get-Date -Format 'yyyy-MM-dd')-ignore-build"
       }
       Write-Host "Daily Branch Name: $branchName"
       Write-Host "##vso[task.setvariable variable=${{ parameters.DailyBranchVariableName }};]$branchName"


### PR DESCRIPTION
I need to test the nightly docs branch creation. I'm will only be using the net - template to publish a nightly version to the dev feed. For this I'm going to be setting the SetDevVersion to true and Skip.Analyze to true (otherwise it'll trip over the fact that this PR has common code that needs to be changed in azure-sdk-tools and pushed out)