### PR TITLE
[Smoke Tests]

### DIFF
--- a/common/SmokeTests/SmokeTest/Update-Dependencies.ps1
+++ b/common/SmokeTests/SmokeTest/Update-Dependencies.ps1
@@ -14,7 +14,8 @@ param(
 
 $packageExcludeSet = @(
     "Microsoft.Azure.WebPubSub.AspNetCore",
-    "Microsoft.WCF.Azure.StorageQueues"
+    "Microsoft.WCF.Azure.StorageQueues",
+    "OpenAI"
 )
 
 function Log-Warning($message) {


### PR DESCRIPTION
# Summary

Exclude the unbranded OpenAI library from smoke testing.
