### PR TITLE
[AppConfig] enable filter by tags tests

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/appconfiguration/Azure.Data.AppConfiguration",
-  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_d2bf969163"
+  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_f252120567"
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -18,7 +18,8 @@ namespace Azure.Data.AppConfiguration.Tests
 {
     [ClientTestFixture(
         ConfigurationClientOptions.ServiceVersion.V1_0,
-        ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
+        ConfigurationClientOptions.ServiceVersion.V2023_10_01,
+        ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
     public class ConfigurationLiveTests : RecordedTestBase<AppConfigurationTestEnvironment>
     {
         private readonly ConfigurationClientOptions.ServiceVersion _serviceVersion;
@@ -579,7 +580,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         // Validates that the expected revisions are retrieved correctly when specifying a list of tags.
-        [Ignore("Requires service V2023_11_01")]
+        [RecordedTest]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task GetRevisionsByTags()
         {
@@ -1597,7 +1598,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
         }
 
-        [Ignore("Requires service V2023_11_01")]
+        [RecordedTest]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task GetBatchSettingByTags()
         {
@@ -1644,7 +1645,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
         }
 
-        [Ignore("Requires service V2023_11_01")]
+        [RecordedTest]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task GetBatchSettingByTagsNoMatchingSettings()
         {
@@ -2209,7 +2210,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
         // Validates that the snapshot is successfully created for the settings that match the key and tags filter. In
         // addition, the settings' filters are validated in the created snapshot.
-        [Ignore("Requires service V2023_11_01")]
+        [RecordedTest]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task CreateSnapshotWithTagsUsingWaitForCompletion()
         {
@@ -2328,7 +2329,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         // Validates that the snapshots are created for the settings that match the key and tags filter.
-        [Ignore("Requires service V2023_11_01")]
+        [RecordedTest]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task CreateSnapshotUsingTags()
         {
@@ -2396,8 +2397,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
         }
 
-        // Validates that a snapshot is created for no settings when the tags filter does not match any setting.
-        [Ignore("Requires service V2023_11_01")]
+        // Validates that a snapshot is not created for a setting when the filter does not match any existing setting.
+        [RecordedTest]
         [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_11_01)]
         public async Task CreateSnapshotUsingTagsNoMatchingSetting()
         {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample12_GetSettingsUsingTags.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -41,6 +40,8 @@ namespace Azure.Data.AppConfiguration.Samples
             }
 
             #endregion
+
+            await client.DeleteConfigurationSettingAsync(betaEndpoint.Key, betaEndpoint.Label);
         }
     }
 }


### PR DESCRIPTION
This PR enables the tests for testing the filter by tags feature and also fixes one of the samples that was [failing](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3989145&view=logs&j=5ee5fa9b-185c-52bc-0624-8e87d1d5c9f8&t=944f46cd-18eb-5a42-4420-427b04f8948f) in the nightly build.