### PR TITLE
[Functions] Prevent connection name mistake

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 6.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 6.3.4 (2024-07-25)
 
 ### Other Changes
+
+- When the trigger's connection property is set to a valid connection string instead of an informational name, the mistake will be detected and sensitive information will be redacted from the error message to avoid accidental capture in logs and similar mechanisms.
 
 ## 6.3.3 (2024-06-13)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 // leaking sensitive information.
                 if (IsEventHubsConnectionString(connection))
                 {
-                    connection =  "<< REDACTED >> (a full connection string was incorrectly used instead of a connection name)";
+                    connection =  "<< REDACTED >> (a full connection string was incorrectly used instead of a connection setting name)";
                 }
 
                 // Not found

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
@@ -192,8 +192,16 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             IConfigurationSection connectionSection = _configuration.GetWebJobsConnectionStringSection(connection);
             if (!connectionSection.Exists())
             {
+                // A common mistake is for developers to set their `connection` to a full connection string rather
+                // than an informational name.  If the value validates as a connection string, redact it to prevent
+                // leaking sensitive information.
+                if (IsEventHubsConnectionString(connection))
+                {
+                    connection =  "<< REDACTED >> (a full connection string was incorrectly used instead of a connection name)";
+                }
+
                 // Not found
-                throw new InvalidOperationException($"EventHub account connection string '{connection}' does not exist." +
+                throw new InvalidOperationException($"EventHub account connection '{connection}' does not exist." +
                                                     $"Make sure that it is a defined App Setting.");
             }
 
@@ -212,6 +220,24 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             var credential = _componentFactory.CreateTokenCredential(connectionSection);
 
             return new EventHubsConnectionInformation(fullyQualifiedNamespace, credential);
+        }
+
+        private static bool IsEventHubsConnectionString(string connectionString)
+        {
+            try
+            {
+                var properties = EventHubsConnectionStringProperties.Parse(connectionString);
+
+                return (!string.IsNullOrEmpty(properties.FullyQualifiedNamespace))
+                    || (!string.IsNullOrEmpty(properties.SharedAccessKeyName))
+                    || (!string.IsNullOrEmpty(properties.SharedAccessKey))
+                    || (!string.IsNullOrEmpty(properties.SharedAccessSignature))
+                    || (!string.IsNullOrEmpty(properties.EventHubName));
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static string GenerateCacheKey(EventHubConnection eventHubConnection, string consumerGroup = null) =>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 }
 
                 // Not found
-                throw new InvalidOperationException($"EventHub account connection '{connection}' does not exist." +
+                throw new InvalidOperationException($"EventHub account connection string with name '{connection}' does not exist in the settings. " +
                                                     $"Make sure that it is a defined App Setting.");
             }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>6.4.0-beta.1</Version>
+    <Version>6.3.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>6.3.3</ApiCompatVersion>
     <NoWarn>$(NoWarn);CS1591;SA1636</NoWarn>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsClientFactoryTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsClientFactoryTests.cs
@@ -87,6 +87,19 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         }
 
         [Test]
+        public void FailsWhenConnectionStringUsedAsName()
+        {
+            EventHubOptions options = new EventHubOptions();
+
+            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", ConnectionString));
+            var factory = ConfigurationUtilities.CreateFactory(configuration, options);
+
+            var errorMessage = Assert.Throws<InvalidOperationException>(() => factory.GetEventHubProducerClient("k1", ConnectionString)).Message;
+            StringAssert.DoesNotContain(ConnectionString, errorMessage);
+            StringAssert.Contains("REDACTED", errorMessage);
+        }
+
+        [Test]
         public void ConsumersAndProducersAreCached()
         {
             EventHubOptions options = new EventHubOptions();

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.17.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 5.16.21 (2024-07-25)
 
 ### Other Changes
+
+- When the trigger's connection property is set to a valid connection string instead of an informational name, the mistake will be detected and sensitive information will be redacted from the error message to avoid accidental capture in logs and similar mechanisms.
 
 ## 5.16.1 (2024-06-13)
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.16.21 (2024-07-25)
+## 5.16.2 (2024-07-25)
 
 ### Other Changes
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
@@ -62,8 +62,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config
             IConfigurationSection connectionSection = _configuration.GetWebJobsConnectionStringSectionServiceBus(connectionSetting);
             if (!connectionSection.Exists())
             {
+                // A common mistake is for developers to set their `connection` to a full connection string rather
+                // than an informational name.  If the value validates as a connection string, redact it to prevent
+                // leaking sensitive information.
+                if (IsServiceBusConnectionString(connectionSetting))
+                {
+                    connectionSetting = "<< REDACTED >> (a full connection string was incorrectly used instead of a connection name)";
+                }
+
                 // Not found
-                throw new InvalidOperationException($"Service Bus account connection string '{connectionSetting}' does not exist. " +
+                throw new InvalidOperationException($"Service Bus connection '{connectionSetting}' does not exist. " +
                                                     $"Make sure that it is a defined App Setting.");
             }
 
@@ -83,6 +91,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config
 
                 TokenCredential credential = _componentFactory.CreateTokenCredential(connectionSection);
                 return new ServiceBusConnectionInformation(fullyQualifiedNamespace, credential);
+            }
+        }
+
+        private static bool IsServiceBusConnectionString(string connectionString)
+        {
+            try
+            {
+                var properties = ServiceBusConnectionStringProperties.Parse(connectionString);
+
+                return (!string.IsNullOrEmpty(properties.FullyQualifiedNamespace))
+                    || (!string.IsNullOrEmpty(properties.SharedAccessKeyName))
+                    || (!string.IsNullOrEmpty(properties.SharedAccessKey))
+                    || (!string.IsNullOrEmpty(properties.SharedAccessSignature))
+                    || (!string.IsNullOrEmpty(properties.EntityPath));
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config
                 }
 
                 // Not found
-                throw new InvalidOperationException($"Service Bus connection '{connectionSetting}' does not exist. " +
+                throw new InvalidOperationException($"EventHub account connection string with name '{connectionSetting}' does not exist in the settings. " +
                                                     $"Make sure that it is a defined App Setting.");
             }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config
                 }
 
                 // Not found
-                throw new InvalidOperationException($"EventHub account connection string with name '{connectionSetting}' does not exist in the settings. " +
+                throw new InvalidOperationException($"Service Bus account connection string with name '{connectionSetting}' does not exist in the settings. " +
                                                     $"Make sure that it is a defined App Setting.");
             }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config
                 // leaking sensitive information.
                 if (IsServiceBusConnectionString(connectionSetting))
                 {
-                    connectionSetting = "<< REDACTED >> (a full connection string was incorrectly used instead of a connection name)";
+                    connectionSetting =  "<< REDACTED >> (a full connection string was incorrectly used instead of a connection setting name)";
                 }
 
                 // Not found

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK ServiceBus Extension</Description>
-    <Version>5.17.0-beta.1</Version>
+    <Version>5.16.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <!--Since we are adding a new target for net6.0, we need to temporarily condition on netstandard-->
     <ApiCompatVersion>5.16.1</ApiCompatVersion>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusClientFactoryTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusClientFactoryTests.cs
@@ -1,25 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Messaging.ServiceBus;
-using Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config;
-using Microsoft.Azure.WebJobs.ServiceBus.Tests;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Configuration;
-using Moq;
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Azure.Identity;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Tests.Config
 {
     public class ServiceBusClientFactoryTests
     {
+        private const string ConnectionString = "Endpoint=sb://test89123-ns-x.servicebus.windows.net/;SharedAccessKeyName=ReceiveRule;SharedAccessKey=secretkey";
+
         [Test]
         [TestCase("DefaultConnectionString", "DefaultConectionSettingString", "DefaultConnectionString")]
         [TestCase("DefaultConnectionString", null, "DefaultConnectionString")]
@@ -48,6 +47,54 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Tests.Config
                 factory.CreateClientFromSetting(null);
                 mockProvider.VerifyAll();
             }
+        }
+
+        [Test]
+        public void CreatesClientsFromConfigWithConnectionString()
+        {
+            ServiceBusOptions options = new ServiceBusOptions();
+            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", ConnectionString));
+
+            var factory = ConfigurationUtilities.CreateFactory(configuration, options);
+            var client = factory.CreateClientFromSetting("connection");
+            var adminClient = factory.CreateAdministrationClient("connection");
+
+            Assert.NotNull(client);
+            Assert.NotNull(adminClient);
+            Assert.AreEqual("test89123-ns-x.servicebus.windows.net", client.FullyQualifiedNamespace);
+        }
+
+        [Test]
+        public void CreatesClientsFromConfigWithFullyQualifiedNamespace()
+        {
+            ServiceBusOptions options = new ServiceBusOptions();
+
+            var componentFactoryMock = new Mock<AzureComponentFactory>();
+            componentFactoryMock.Setup(c => c.CreateTokenCredential(
+                    It.Is<IConfiguration>(c=> c["fullyQualifiedNamespace"] != null)))
+                .Returns(new DefaultAzureCredential());
+
+            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection:fullyQualifiedNamespace", "test89123-ns-x.servicebus.windows.net"));
+            var factory = ConfigurationUtilities.CreateFactory(configuration, options, componentFactoryMock.Object);
+            var client = factory.CreateClientFromSetting("connection");
+            var adminClient = factory.CreateAdministrationClient("connection");
+
+            Assert.NotNull(client);
+            Assert.NotNull(adminClient);
+            Assert.AreEqual("test89123-ns-x.servicebus.windows.net", client.FullyQualifiedNamespace);
+        }
+
+        [Test]
+        public void FailsWhenConnectionStringUsedAsName()
+        {
+            ServiceBusOptions options = new ServiceBusOptions();
+
+            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", ConnectionString));
+            var factory = ConfigurationUtilities.CreateFactory(configuration, options);
+
+            var errorMessage = Assert.Throws<InvalidOperationException>(() => factory.CreateClientFromSetting(ConnectionString)).Message;
+            StringAssert.DoesNotContain(ConnectionString, errorMessage);
+            StringAssert.Contains("REDACTED", errorMessage);
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ConfigurationUtilities.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ConfigurationUtilities.cs
@@ -1,8 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Tests
 {
@@ -11,6 +16,19 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Tests
         public static IConfiguration CreateConfiguration(params KeyValuePair<string, string>[] data)
         {
             return new ConfigurationBuilder().AddInMemoryCollection(data).Build();
+        }
+
+        internal static ServiceBusClientFactory CreateFactory(IConfiguration configuration, ServiceBusOptions options, AzureComponentFactory componentFactory = null)
+        {
+            componentFactory ??= Mock.Of<AzureComponentFactory>();
+            var loggerFactory = new NullLoggerFactory();
+            var azureEventSourceLogForwarder = new AzureEventSourceLogForwarder(loggerFactory);
+            return new ServiceBusClientFactory(
+                configuration,
+                componentFactory,
+                new MessagingProvider(Options.Create(options)),
+                azureEventSourceLogForwarder,
+                Options.Create(options));
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to guard against a common error made when configuring a trigger.  With these changes, if the trigger's connection property is set to a valid connection string instead of an
informational name, the mistake will be detected and sensitive information will be redacted from the error message to avoid accidental capture in logs and similar mechanisms.

## References and related

- [[Functions] Logging sanitization for common configuration mistake (#45108)](https://github.com/Azure/azure-sdk-for-net/issues/45108)