### PR TITLE
[AzureMonitor] misc test refactor

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/SharedTestVars.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/SharedTestVars.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
+{
+    public static class SharedTestVars
+    {
+        public const string TestServiceName = nameof(TestServiceName);
+        public const string TestServiceNamespace = nameof(TestServiceNamespace);
+        public const string TestServiceInstance = nameof(TestServiceInstance);
+        public const string TestServiceVersion = nameof(TestServiceVersion);
+        public const string TestRoleName = $"[{TestServiceNamespace}]/{TestServiceName}";
+
+        public static Dictionary<string, object> TestResourceAttributes => _testResourceAttributes;
+
+        private static readonly Dictionary<string, object> _testResourceAttributes = new()
+        {
+            { "service.name", TestServiceName },
+            { "service.namespace", TestServiceNamespace },
+            { "service.instance.id", TestServiceInstance },
+            { "service.version", TestServiceVersion }
+        };
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/SqlClientTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/SqlClientTests.cs
@@ -37,16 +37,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
 
         private readonly FakeSqlClientDiagnosticSource _fakeSqlClientDiagnosticSource = new FakeSqlClientDiagnosticSource();
 
-        private const string TestServiceName = nameof(TestServiceName), TestServiceNamespace = nameof(TestServiceNamespace), TestServiceInstance = nameof(TestServiceInstance), TestServiceVersion = nameof(TestServiceVersion);
-        private const string TestRoleName = $"[{TestServiceNamespace}]/{TestServiceName}";
-        private readonly Dictionary<string, object> _testResourceAttributes = new()
-        {
-            { "service.name", TestServiceName },
-            { "service.namespace", TestServiceNamespace },
-            { "service.instance.id", TestServiceInstance },
-            { "service.version", TestServiceVersion }
-        };
-
         [Theory]
         [InlineData(SqlDataBeforeExecuteCommand, SqlDataWriteCommandError)]
         [InlineData(SqlDataBeforeExecuteCommand, SqlDataWriteCommandError, false)]
@@ -75,7 +65,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
                 .UseAzureMonitor(x => x.ConnectionString = testConnectionString)
                 .WithTracing(x => x.AddInMemoryExporter(activities))
                 // Custom resources must be added AFTER AzureMonitor to override the included ResourceDetectors.
-                .ConfigureResource(x => x.AddAttributes(_testResourceAttributes));
+                .ConfigureResource(x => x.AddAttributes(SharedTestVars.TestResourceAttributes));
             serviceCollection.Configure<SqlClientTraceInstrumentationOptions>(options =>
             {
                 options.RecordException = recordException;
@@ -172,7 +162,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
                 .UseAzureMonitor(x => x.ConnectionString = testConnectionString)
                 .WithTracing(x => x.AddInMemoryExporter(activities))
                 // Custom resources must be added AFTER AzureMonitor to override the included ResourceDetectors.
-                .ConfigureResource(x => x.AddAttributes(_testResourceAttributes));
+                .ConfigureResource(x => x.AddAttributes(SharedTestVars.TestResourceAttributes));
             serviceCollection.Configure<SqlClientTraceInstrumentationOptions>(options =>
             {
                 options.SetDbStatementForText = captureTextCommandContent;
@@ -264,9 +254,9 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
             // TELEMETRY ITEM
             Assert.Equal(5, telemetryItem.Tags.Count);
             Assert.Contains(telemetryItem.Tags, kvp => kvp.Key == "ai.operation.id" && kvp.Value == activity.TraceId.ToHexString());
-            Assert.Contains(telemetryItem.Tags, kvp => kvp.Key == "ai.cloud.role" && kvp.Value == TestRoleName);
-            Assert.Contains(telemetryItem.Tags, kvp => kvp.Key == "ai.application.ver" && kvp.Value == TestServiceVersion);
-            Assert.Contains(telemetryItem.Tags, kvp => kvp.Key == "ai.cloud.roleInstance" && kvp.Value == TestServiceInstance);
+            Assert.Contains(telemetryItem.Tags, kvp => kvp.Key == "ai.cloud.role" && kvp.Value == SharedTestVars.TestRoleName);
+            Assert.Contains(telemetryItem.Tags, kvp => kvp.Key == "ai.application.ver" && kvp.Value == SharedTestVars.TestServiceVersion);
+            Assert.Contains(telemetryItem.Tags, kvp => kvp.Key == "ai.cloud.roleInstance" && kvp.Value == SharedTestVars.TestServiceInstance);
             Assert.Contains(telemetryItem.Tags, kvp => kvp.Key == "ai.internal.sdkVersion");
 
             // TELEMETRY DATA

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/ActivityEventTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/ActivityEventTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.DocumentTests
             var activitySourceName = $"activitySourceName{uniqueTestId}";
             using var activitySource = new ActivitySource(activitySourceName);
             // TODO: Replace this ActivityListener with an OpenTelemetry provider.
-            var listener = new ActivityListener
+            using var listener = new ActivityListener
             {
                 ShouldListenTo = _ => true,
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
@@ -87,7 +87,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.DocumentTests
             var activitySourceName = $"activitySourceName{uniqueTestId}";
             using var activitySource = new ActivitySource(activitySourceName);
             // TODO: Replace this ActivityListener with an OpenTelemetry provider.
-            var listener = new ActivityListener
+            using var listener = new ActivityListener
             {
                 ShouldListenTo = _ => true,
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/HttpClientDependecyTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/HttpClientDependecyTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.DocumentTests
             var activitySourceName = $"activitySourceName{uniqueTestId}";
             using var activitySource = new ActivitySource(activitySourceName);
             // TODO: Replace this ActivityListener with an OpenTelemetry provider.
-            var listener = new ActivityListener
+            using var listener = new ActivityListener
             {
                 ShouldListenTo = _ => true,
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/RequestTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/RequestTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.DocumentTests
             var activitySourceName = $"activitySourceName{uniqueTestId}";
             using var activitySource = new ActivitySource(activitySourceName);
             // TODO: Replace this ActivityListener with an OpenTelemetry provider.
-            var listener = new ActivityListener
+            using var listener = new ActivityListener
             {
                 ShouldListenTo = _ => true,
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/SqlClientDependencyTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/SqlClientDependencyTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.DocumentTests
             var activitySourceName = $"activitySourceName{uniqueTestId}";
             using var activitySource = new ActivitySource(activitySourceName);
             // TODO: Replace this ActivityListener with an OpenTelemetry provider.
-            var listener = new ActivityListener
+            using var listener = new ActivityListener
             {
                 ShouldListenTo = _ => true,
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,


### PR DESCRIPTION
## Changes
- move Resource Attributes to `SharedTestVars.cs`
  This was introduced with the SqlClientTests and will be referenced in the AspNetCore and HttpClient tests
- properly dispose `ActivityListener` in LiveMetrics tests.
  This was causing side effects in other tests.