### PR TITLE
Allow for creation of Table SaS with an Identifier and no expiry

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue that prevented use of stored access policy based SaS Uris by adding a constructor to `TableSasBuilder` that accepts a stored access policy identifier without needing to specify the policy's permissions.
 
 ### Other Changes
 

--- a/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
+++ b/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
@@ -419,6 +419,7 @@ namespace Azure.Data.Tables.Sas
     public partial class TableSasBuilder
     {
         public TableSasBuilder(string tableName, Azure.Data.Tables.Sas.TableSasPermissions permissions, System.DateTimeOffset expiresOn) { }
+        public TableSasBuilder(string tableName, string identifier) { }
         public TableSasBuilder(string tableName, string rawPermissions, System.DateTimeOffset expiresOn) { }
         public TableSasBuilder(System.Uri sasUri) { }
         public System.DateTimeOffset ExpiresOn { get { throw null; } set { } }

--- a/sdk/tables/Azure.Data.Tables/samples/Sample4QueryEntities.md
+++ b/sdk/tables/Azure.Data.Tables/samples/Sample4QueryEntities.md
@@ -117,7 +117,7 @@ while (moreResultsAvailable)
     continuationToken = page.ContinuationToken;
 
     IReadOnlyList<TableEntity> pageResults = page.Values;
-    moreResultsAvailable = pageResults.Any() && continuationToken != null;
+    moreResultsAvailable = continuationToken != null;
 
     // Print out the results for this page.
     foreach (TableEntity result in pageResults)

--- a/sdk/tables/Azure.Data.Tables/src/Sas/TableSasBuilder.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Sas/TableSasBuilder.cs
@@ -39,11 +39,27 @@ namespace Azure.Data.Tables.Sas
         public TableSasBuilder(string tableName, string rawPermissions, DateTimeOffset expiresOn)
         {
             Argument.AssertNotNullOrEmpty(tableName, nameof(tableName));
-            Argument.AssertNotNullOrEmpty(rawPermissions, nameof(tableName));
+            Argument.AssertNotNullOrEmpty(rawPermissions, nameof(rawPermissions));
 
             TableName = tableName;
             ExpiresOn = expiresOn;
             Permissions = rawPermissions.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Initializes an instance of a <see cref="TableSasBuilder"/>.
+        /// </summary>
+        /// <param name="tableName">The name of the table being made accessible with the shared access signature.</param>
+        /// <param name="identifier">The identifier of the stored access policy that defines the permissions and, optionally, expiry of the shared access signature.
+        /// Note: Either the stored access policy specified by the <paramref name="identifier"/> or the created shared access signature must define an expiry.
+        /// If neither define an expiry or both do, authentication will fail.</param>
+        public TableSasBuilder(string tableName, string identifier)
+        {
+            Argument.AssertNotNullOrEmpty(tableName, nameof(tableName));
+            Argument.AssertNotNullOrEmpty(identifier, nameof(identifier));
+
+            TableName = tableName;
+            Identifier = identifier;
         }
 
         /// <summary>

--- a/sdk/tables/Azure.Data.Tables/tests/TableSasBuilderTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableSasBuilderTests.cs
@@ -17,6 +17,7 @@ namespace Azure.Data.Tables.Tests
             Assert.Throws<ArgumentException>(() => new TableSasBuilder(string.Empty, TableSasPermissions.Add, DateTimeOffset.Now));
             Assert.Throws<ArgumentNullException>(() => new TableSasBuilder("table", null, DateTimeOffset.Now));
             Assert.Throws<ArgumentException>(() => new TableSasBuilder("table", string.Empty, DateTimeOffset.Now));
+            Assert.Throws<ArgumentNullException>(() => new TableSasBuilder("table", null));
             Assert.Throws<ArgumentNullException>(() => new TableSasBuilder(null));
         }
 

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample4_QueryEntities.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample4_QueryEntities.cs
@@ -124,7 +124,7 @@ namespace Azure.Data.Tables.Samples
                 continuationToken = page.ContinuationToken;
 
                 IReadOnlyList<TableEntity> pageResults = page.Values;
-                moreResultsAvailable = pageResults.Any() && continuationToken != null;
+                moreResultsAvailable = continuationToken != null;
 
                 // Print out the results for this page.
                 foreach (TableEntity result in pageResults)


### PR DESCRIPTION
Allows for creation of a valid table sas url using a stored access policy identifier without specifying permissions.

also closes #45227