### PR TITLE
[AzureMonitorDistro] add force flush to aspnetcore tests

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/AspNetCoreInstrumentationTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/AspNetCoreInstrumentationTests.cs
@@ -121,10 +121,14 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
                 {
                     // Ignore exceptions
                 }
-
-                WaitForActivityExport(activities);
-                WaitForActivityExport(telemetryItems, x => x.Name == "Request");
             }
+
+            // SHUTDOWN
+            var tracerProvider = _factory.Factories.Last().Services.GetRequiredService<TracerProvider>();
+            tracerProvider.ForceFlush();
+
+            WaitForActivityExport(activities);
+            WaitForActivityExport(telemetryItems, x => x.Name == "Request");
 
             // ASSERT
             _telemetryOutput.Write(telemetryItems);


### PR DESCRIPTION
Tests MAY fail to collect telemetry.
Explicitly calling Flush increases likelihood of test passing.