### PR TITLE
[DocumentIntelligence] Tests: removing references to Lists and Quota properties

### DIFF
--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/MiscellaneousOperationsLiveTests.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/MiscellaneousOperationsLiveTests.cs
@@ -32,11 +32,6 @@ namespace Azure.AI.DocumentIntelligence.Tests
             Assert.That(resourceDetails.CustomDocumentModels, Is.Not.Null);
             Assert.That(resourceDetails.CustomDocumentModels.Count, Is.GreaterThan(0));
             Assert.That(resourceDetails.CustomDocumentModels.Limit, Is.GreaterThanOrEqualTo(resourceDetails.CustomDocumentModels.Count));
-
-            Assert.That(resourceDetails.CustomNeuralDocumentModelBuilds, Is.Not.Null);
-            Assert.That(resourceDetails.CustomNeuralDocumentModelBuilds.Used, Is.GreaterThanOrEqualTo(0));
-            Assert.That(resourceDetails.CustomNeuralDocumentModelBuilds.Quota, Is.GreaterThanOrEqualTo(resourceDetails.CustomNeuralDocumentModelBuilds.Used));
-            Assert.That(resourceDetails.CustomNeuralDocumentModelBuilds.QuotaResetsOn, Is.GreaterThan(startTime));
         }
 
         #endregion Resource Info

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceClient/DocumentClassifierLiveTests.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceClient/DocumentClassifierLiveTests.cs
@@ -88,7 +88,6 @@ namespace Azure.AI.DocumentIntelligence.Tests
             Assert.That(analyzeResult.Paragraphs, Is.Empty);
             Assert.That(analyzeResult.Tables, Is.Empty);
             Assert.That(analyzeResult.Figures, Is.Empty);
-            Assert.That(analyzeResult.Lists, Is.Empty);
             Assert.That(analyzeResult.Sections, Is.Empty);
             Assert.That(analyzeResult.KeyValuePairs, Is.Empty);
             Assert.That(analyzeResult.Styles, Is.Empty);

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceClient/DocumentModelLiveTests.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceClient/DocumentModelLiveTests.cs
@@ -75,7 +75,6 @@ namespace Azure.AI.DocumentIntelligence.Tests
             Assert.That(result.Paragraphs, Is.Empty);
             Assert.That(result.Tables, Is.Empty);
             Assert.That(result.Figures, Is.Empty);
-            Assert.That(result.Lists, Is.Empty);
             Assert.That(result.Sections, Is.Empty);
             Assert.That(result.KeyValuePairs, Is.Empty);
             Assert.That(result.Styles, Is.Empty);


### PR DESCRIPTION
Properties `ResourceDetails.CustomNeuralDocumentModelBuilds` and `AnalyzeResult.Lists` will be removed in the next service release. Since these properties are referenced in our test project, building our solution will fail once the Document Intelligence typespec is updated.

Currently there's a pull request open in our specs repo to update the Document Intelligence specification to its next version, but the aforementioned issue is making the .NET validation fail, blocking the PR.

The purpose of these changes is removing any references to these properties from our test project.