### PR TITLE
exclude batch track1 tools folder from doc-warden

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -20,6 +20,7 @@ omitted_paths:
   - sdk/resourcemanager/*
   - src/*
   - tools/*
+  - sdk/batch/Microsoft.Azure.Batch/tools/*
 
 language: net
 root_check_enabled: True

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -20,7 +20,7 @@ omitted_paths:
   - sdk/resourcemanager/*
   - src/*
   - tools/*
-  - sdk/batch/Microsoft.Azure.Batch/tools/*
+  - sdk/**/tools/*
 
 language: net
 root_check_enabled: True


### PR DESCRIPTION
`doc-warden` will scan `sdk/batch/Microsoft.Azure.Batch/tools` folder, which will fail the CI: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3996739&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=a880e989-7d1a-5c96-a41f-d540b383cc43&l=24
![image](https://github.com/user-attachments/assets/495e5de9-a905-4ef9-992b-8ddb9e9a21a1)

That folder is for batch to host their own tools, so let's exclude that folder.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
