### PR TITLE
Fix Microsoft.Bcl.AsyncInterfaces reference in Event Grid

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -19,8 +19,6 @@
     <PackageReference Include="Azure.Messaging.EventGrid" />
     <PackageReference Include="CloudNative.CloudEvents" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" />
-<!-- This is required to prevent version conflict stemming from The CloudNative.CloudEvents.SystemTestJson depending on -->
-<!-- version 5.0.0.-->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
 		<PackageReference Include="Azure.Core"/>
   </ItemGroup>

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" />
 <!-- This is required to prevent version conflict stemming from The CloudNative.CloudEvents.SystemTestJson depending on -->
 <!-- version 5.0.0.-->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
 		<PackageReference Include="Azure.Core"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes a version downgrade issue when updating Microsoft.Bcl.AsyncInterfaces
