### PR TITLE
[Tables] Prepare for v12.9.1 release

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Release History
 
-## 12.10.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 12.9.1 (2024-08-06)
 
 ### Bugs Fixed
 - Fixed an issue that prevented use of stored access policy based SaS Uris by adding a constructor to `TableSasBuilder` that accepts a stored access policy identifier without needing to specify the policy's permissions.
-
-### Other Changes
 
 ## 12.9.0 (2024-07-22)
 

--- a/sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj
+++ b/sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This client library enables working with the Microsoft Azure Table service</Description>
     <AssemblyTitle>Microsoft Azure.Data.Tables client library</AssemblyTitle>
-    <Version>12.10.0-beta.1</Version>
+    <Version>12.9.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>12.9.0</ApiCompatVersion>
     <DefineConstants>TableSDK;$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
Ran the `Prepare-Release.ps1` script for the upcoming August release.

Upcoming version: `12.9.1`