### PR TITLE
CRC reporting: pt 1

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -1552,7 +1552,7 @@ namespace Azure.Storage.Blobs.Specialized
                             forceStructuredMessage,
                             async,
                             cancellationToken);
-                    async ValueTask<(Stream DecodingStream, StructuredMessageDecodingStream.DecodedData DecodedData)> StructuredMessageFactory(
+                    async ValueTask<(Stream DecodingStream, StructuredMessageDecodingStream.RawDecodedData DecodedData)> StructuredMessageFactory(
                         long offset, bool async, CancellationToken cancellationToken)
                     {
                         Response<BlobDownloadStreamingResult> result = await Factory(offset, forceStructuredMessage: true, async, cancellationToken).ConfigureAwait(false);
@@ -1561,11 +1561,12 @@ namespace Azure.Storage.Blobs.Specialized
                     Stream stream;
                     if (response.GetRawResponse().Headers.Contains(Constants.StructuredMessage.StructuredMessageHeader))
                     {
-                        (Stream decodingStream, StructuredMessageDecodingStream.DecodedData decodedData) = StructuredMessageDecodingStream.WrapStream(
+                        (Stream decodingStream, StructuredMessageDecodingStream.RawDecodedData decodedData) = StructuredMessageDecodingStream.WrapStream(
                             response.Value.Content, response.Value.Details.ContentLength);
                         stream = new StructuredMessageDecodingRetriableStream(
                             decodingStream,
                             decodedData,
+                            StructuredMessage.Flags.StorageCrc64,
                             startOffset => StructuredMessageFactory(startOffset, async: false, cancellationToken)
                                 .EnsureCompleted(),
                             async startOffset => await StructuredMessageFactory(startOffset, async: true, cancellationToken)

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageCrc64Composer.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageCrc64Composer.cs
@@ -12,22 +12,52 @@ namespace Azure.Storage
     /// </summary>
     internal static class StorageCrc64Composer
     {
-        public static Memory<byte> Compose(params (byte[] Crc64, long OriginalDataLength)[] partitions)
-        {
-            return Compose(partitions.AsEnumerable());
-        }
+        public static byte[] Compose(params (byte[] Crc64, long OriginalDataLength)[] partitions)
+            => Compose(partitions.AsEnumerable());
 
-        public static Memory<byte> Compose(IEnumerable<(byte[] Crc64, long OriginalDataLength)> partitions)
+        public static byte[] Compose(IEnumerable<(byte[] Crc64, long OriginalDataLength)> partitions)
         {
             ulong result = Compose(partitions.Select(tup => (BitConverter.ToUInt64(tup.Crc64, 0), tup.OriginalDataLength)));
-            return new Memory<byte>(BitConverter.GetBytes(result));
+            return BitConverter.GetBytes(result);
         }
+
+        public static byte[] Compose(params (ReadOnlyMemory<byte> Crc64, long OriginalDataLength)[] partitions)
+            => Compose(partitions.AsEnumerable());
+
+        public static byte[] Compose(IEnumerable<(ReadOnlyMemory<byte> Crc64, long OriginalDataLength)> partitions)
+        {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            ulong result = Compose(partitions.Select(tup => (BitConverter.ToUInt64(tup.Crc64.Span), tup.OriginalDataLength)));
+#else
+            ulong result = Compose(partitions.Select(tup => (System.BitConverter.ToUInt64(tup.Crc64.ToArray(), 0), tup.OriginalDataLength)));
+#endif
+            return BitConverter.GetBytes(result);
+        }
+
+        public static byte[] Compose(
+            ReadOnlySpan<byte> leftCrc64, long leftOriginalDataLength,
+            ReadOnlySpan<byte> rightCrc64, long rightOriginalDataLength)
+        {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            ulong result = Compose(
+                (BitConverter.ToUInt64(leftCrc64), leftOriginalDataLength),
+                (BitConverter.ToUInt64(rightCrc64), rightOriginalDataLength));
+#else
+            ulong result = Compose(
+                (BitConverter.ToUInt64(leftCrc64.ToArray(), 0), leftOriginalDataLength),
+                (BitConverter.ToUInt64(rightCrc64.ToArray(), 0), rightOriginalDataLength));
+#endif
+            return BitConverter.GetBytes(result);
+        }
+
+        public static ulong Compose(params (ulong Crc64, long OriginalDataLength)[] partitions)
+            => Compose(partitions.AsEnumerable());
 
         public static ulong Compose(IEnumerable<(ulong Crc64, long OriginalDataLength)> partitions)
         {
             ulong composedCrc = 0;
             long composedDataLength = 0;
-            foreach (var tup in partitions)
+            foreach ((ulong crc64, long originalDataLength) in partitions)
             {
                 composedCrc = StorageCrc64Calculator.Concatenate(
                     uInitialCrcAB: 0,
@@ -35,9 +65,9 @@ namespace Azure.Storage
                     uFinalCrcA: composedCrc,
                     uSizeA: (ulong) composedDataLength,
                     uInitialCrcB: 0,
-                    uFinalCrcB: tup.Crc64,
-                    uSizeB: (ulong)tup.OriginalDataLength);
-                composedDataLength += tup.OriginalDataLength;
+                    uFinalCrcB: crc64,
+                    uSizeB: (ulong)originalDataLength);
+                composedDataLength += originalDataLength;
             }
             return composedCrc;
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
@@ -93,22 +93,18 @@ internal static class StructuredMessage
         #endregion
 
         #region StreamFooter
+        public static int GetStreamFooterSize(Flags flags)
+            => flags.HasFlag(Flags.StorageCrc64) ? Crc64Length : 0;
+
         public static void ReadStreamFooter(
             ReadOnlySpan<byte> buffer,
-            Span<byte> crc64 = default)
+            Flags flags,
+            out ulong crc64)
         {
-            int expectedBufferSize = 0;
-            if (!crc64.IsEmpty)
-            {
-                Errors.AssertBufferExactSize(crc64, Crc64Length, nameof(crc64));
-                expectedBufferSize += Crc64Length;
-            }
+            int expectedBufferSize = GetSegmentFooterSize(flags);
             Errors.AssertBufferExactSize(buffer, expectedBufferSize, nameof(buffer));
 
-            if (!crc64.IsEmpty)
-            {
-                buffer.Slice(0, Crc64Length).CopyTo(crc64);
-            }
+            crc64 = flags.HasFlag(Flags.StorageCrc64) ? BinaryPrimitives.ReadUInt64LittleEndian(buffer) : default;
         }
 
         public static int WriteStreamFooter(Span<byte> buffer, ReadOnlySpan<byte> crc64 = default)
@@ -193,22 +189,18 @@ internal static class StructuredMessage
         #endregion
 
         #region SegmentFooter
+        public static int GetSegmentFooterSize(Flags flags)
+            => flags.HasFlag(Flags.StorageCrc64) ? Crc64Length : 0;
+
         public static void ReadSegmentFooter(
             ReadOnlySpan<byte> buffer,
-            Span<byte> crc64 = default)
+            Flags flags,
+            out ulong crc64)
         {
-            int expectedBufferSize = 0;
-            if (!crc64.IsEmpty)
-            {
-                Errors.AssertBufferExactSize(crc64, Crc64Length, nameof(crc64));
-                expectedBufferSize += Crc64Length;
-            }
+            int expectedBufferSize = GetSegmentFooterSize(flags);
             Errors.AssertBufferExactSize(buffer, expectedBufferSize, nameof(buffer));
 
-            if (!crc64.IsEmpty)
-            {
-                buffer.Slice(0, Crc64Length).CopyTo(crc64);
-            }
+            crc64 = flags.HasFlag(Flags.StorageCrc64) ? BinaryPrimitives.ReadUInt64LittleEndian(buffer) : default;
         }
 
         public static int WriteSegmentFooter(Span<byte> buffer, ReadOnlySpan<byte> crc64 = default)

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ObserveStructuredMessagePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ObserveStructuredMessagePolicy.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage.Test.Shared
             {
                 byte[] encodedContent;
                 byte[] underlyingContent;
-                StructuredMessageDecodingStream.DecodedData decodedData;
+                StructuredMessageDecodingStream.RawDecodedData decodedData;
                 using (MemoryStream ms = new())
                 {
                     message.Request.Content.WriteTo(ms, default);

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -2287,7 +2287,7 @@ namespace Azure.Storage.Files.Shares
                         }
                         return response;
                     }
-                    async ValueTask<(Stream DecodingStream, StructuredMessageDecodingStream.DecodedData DecodedData)> StructuredMessageFactory(
+                    async ValueTask<(Stream DecodingStream, StructuredMessageDecodingStream.RawDecodedData DecodedData)> StructuredMessageFactory(
                         long offset, bool async, CancellationToken cancellationToken)
                     {
                         Response<ShareFileDownloadInfo> result = await Factory(offset, async, cancellationToken).ConfigureAwait(false);
@@ -2296,11 +2296,12 @@ namespace Azure.Storage.Files.Shares
 
                     if (initialResponse.GetRawResponse().Headers.Contains(Constants.StructuredMessage.StructuredMessageHeader))
                     {
-                        (Stream decodingStream, StructuredMessageDecodingStream.DecodedData decodedData) = StructuredMessageDecodingStream.WrapStream(
+                        (Stream decodingStream, StructuredMessageDecodingStream.RawDecodedData decodedData) = StructuredMessageDecodingStream.WrapStream(
                             initialResponse.Value.Content, initialResponse.Value.ContentLength);
                         initialResponse.Value.Content = new StructuredMessageDecodingRetriableStream(
                             decodingStream,
                             decodedData,
+                            StructuredMessage.Flags.StorageCrc64,
                             startOffset => StructuredMessageFactory(startOffset, async: false, cancellationToken)
                                 .EnsureCompleted(),
                             async startOffset => await StructuredMessageFactory(startOffset, async: true, cancellationToken)


### PR DESCRIPTION
Far too much array pool management for moving CRCs between several objects, bounds checking, etc.. Converted CRC management in structured message to use `ulong`s. This results in much cleaner data tracking as the structured message is consumed, though transient pool borrowing is still required in places.

Retriable crc stream calculates contents as they are read by the caller, validating against a crc after the last bytes are read.

TODO:
- report the final crc in the result object
- perhaps disable some extra crc calculations in the base structured message decoding stream, since the retriable one is doing an overall calculation