### PR TITLE
[AzureMonitorExporter] fix rpc attributes

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+* RPC attributes are now correctly exported to Application Insights as custom properties.
+  ([]())
+
 ### Other Changes
 
 ## 1.4.0-beta.1 (2024-07-12)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 * RPC attributes are now correctly exported to Application Insights as custom properties.
-  ([]())
+  ([#45316](https://github.com/Azure/azure-sdk-for-net/pull/45316))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -52,12 +52,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             SemanticConventions.AttributeComponent,
             "otel.status_code",
 
-            SemanticConventions.AttributeRpcService,
             // required - RPC
-            SemanticConventions.AttributeRpcSystem,
-            SemanticConventions.AttributeRpcStatus,
+            // SemanticConventions.AttributeRpcService,
+            // SemanticConventions.AttributeRpcSystem,
+            // SemanticConventions.AttributeRpcStatus,
+            // SemanticConventions.AttributeEndpointAddress,
 
-            SemanticConventions.AttributeEndpointAddress,
             // required - Messaging
             SemanticConventions.AttributeMessagingSystem,
             SemanticConventions.AttributeMessagingDestinationName,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -383,7 +383,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void TagObjects_RpcTagsAreNotMapped()
         {
-            /// As of today (20[24-08-01), The RPC Semantic Convention is still Experimental.
+            /// As of today (2024-08-01), The RPC Semantic Convention is still Experimental.
             /// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-spans.md
             /// We shouldn't have any special handling of these attributes until they are promoted to stable.
             /// Unmapped Tags should pass through to a telemetry item's custom properties.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -103,14 +103,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 [SemanticConventions.AttributeHttpMethod] = "GET",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "8888",
-                [SemanticConventions.AttributeRpcSystem] = "test"
             };
 
             using var activity = CreateTestActivity(tagObjects);
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Http, activityTagsProcessor.activityType);
-            Assert.Equal(6, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(5, activityTagsProcessor.MappedTags.Length);
             Assert.Equal("https", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpScheme));
             Assert.Equal("localhost", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpHost));
             Assert.Equal("8888", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpHostPort));


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/44905
Fixes https://github.com/Azure/azure-sdk-for-net/issues/45288

This PR fixes a bug causing RPC attributes to be dropped.
Now RPC attributes will be included as custom properties in telemetry.

Note: we have no plans to map these attributes to the Application Insights schema until [Semantic Conventions for RPC Spans](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-spans.md) is stabilized.