### PR TITLE
Fix minor typo in ImageAnalysisOptions.cs

### DIFF
--- a/sdk/vision/Azure.AI.Vision.ImageAnalysis/src/Custom/ImageAnalysisOptions.cs
+++ b/sdk/vision/Azure.AI.Vision.ImageAnalysis/src/Custom/ImageAnalysisOptions.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.Vision.ImageAnalysis
         /// <remarks>
         /// If this option is not specified, the default value 'en' is used (English).
         /// See https://aka.ms/cv-languages for a list of supported languages.
-        /// At the moment, only tags can be generated in none-English languages.
+        /// At the moment, only tags can be generated in non-English languages.
         /// </remarks>
         public string Language { get; set; }
 


### PR DESCRIPTION
Just noticed this tiny typo while playing with your SDK.
