### PR TITLE
Azure Service Bus: Fix copy paste mistake in the release notes

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -44,7 +44,7 @@ Thank you to our developer community members who helped to make the Service Bus 
 
 - Improved efficiency of subclient creation, reducing allocations when no explicit options are passed.
 
-- Fixed deserialization of the lock token to take into account endianness. _(A community contribution, courtesy of [martincostello](https://github.com/martincostello))_
+- Reduced the number of allocations of various option types. _(A community contribution, courtesy of [martincostello](https://github.com/martincostello))_
 
 ## 7.18.0-beta.1 (2024-05-08)
 


### PR DESCRIPTION
@martincostello contributed these two fixes

https://github.com/Azure/azure-sdk-for-net/pull/44856
https://github.com/Azure/azure-sdk-for-net/pull/44885

The release notes seem to be incorrect.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
