### PR TITLE
Updated error messages and log config for automation

### DIFF
--- a/eng/scripts/Invoke-GenerateAndBuildV2.ps1
+++ b/eng/scripts/Invoke-GenerateAndBuildV2.ps1
@@ -137,8 +137,8 @@ if ($relatedTypeSpecProjectFolder) {
         if ($LASTEXITCODE) {
           # If Process script call fails, then return with failure to CI and don't need to call GeneratePackage
           Write-Error "[ERROR] Failed to generate typespec project:$typespecFolder. Exit code: $LASTEXITCODE."
-          Write-Error "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
-          Write-Error "[ERROR] If the issue persists after re-running, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+          Write-Error "[ERROR] Please review the detail errors for potential fixes."
+          Write-Error "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
           $generatedSDKPackages.Add(@{
             result = "failed";
             path=@("");

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -608,7 +608,7 @@ Invoke-GenerateAndBuildSDK -readmeAbsolutePath <path-to-readme> -sdkRootPath <pa
 
 #>
 
-$DotNetSupportChannelLink = "https://teams.microsoft.com/l/channel/19%3A7b87fb348f224b37b6206fa9d89a105b%40thread.skype/Language%20-%20DotNet?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId="
+$DotNetSupportChannelLink = "https://aka.ms/azsdk/donet-teams-channel"
 function Invoke-GenerateAndBuildSDK () {
     param(
         [string]$readmeAbsolutePath,
@@ -639,7 +639,7 @@ function Invoke-GenerateAndBuildSDK () {
         if ( !$?) {
             Write-Host "[ERROR] Failed to create sdk project folder.service:$service,package:$package,"
             Write-Host "[ERROR] sdkPath:$sdkRootPath,readme:$readmeFile.exit code: $?."
-            Write-Host "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
+            Write-Host "[ERROR] Please review the detail errors for potential fixes."
             Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
             exit 1
         }
@@ -672,7 +672,7 @@ function Invoke-GenerateAndBuildSDK () {
             if ( !$? ) {
                 Write-Host "[ERROR] Failed to create sdk project folder.service:$service,namespace:$namespace,"
                 Write-Host "[ERROR] sdkPath:$sdkRootPath,readme:$readmeFile,autorestConfigYaml:$autorestConfigYaml.exit code: $?."
-                Write-Host "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
+                Write-Host "[ERROR] Please review the detail errors for potential fixes."
                 Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
                 exit 1
             }
@@ -701,7 +701,7 @@ function Invoke-GenerateAndBuildSDK () {
                         if ( !$? ) {
                             Write-Host "[ERROR] Failed to create sdk project folder.service:$service,namespace:$folder,"
                             Write-Host "[ERROR] sdkPath:$sdkRootPath,readme:$readmeFile. exit code: $?."
-                            Write-Host "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
+                            Write-Host "[ERROR] Please review the detail errors for potential fixes."
                             Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
                             exit 1
                         }
@@ -763,7 +763,7 @@ function GeneratePackage()
         }
         if ( !$?) {
             Write-Host "[ERROR] Failed to generate sdk for package:$packageName. Exit code: $?."
-            Write-Host "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
+            Write-Host "[ERROR] Please review the detail errors for potential fixes."
             Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
             $result = "failed"
             $isGenerateSuccess = $false
@@ -776,7 +776,7 @@ function GeneratePackage()
         dotnet build $srcPath /p:RunApiCompat=$false
         if ( !$?) {
             Write-Host "[ERROR] Failed to build the sdk project: $packageName for service: $service. Exit code: $?."
-            Write-Host "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
+            Write-Host "[ERROR] Please review the detail errors for potential fixes."
             Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
             $result = "failed"
         } else {
@@ -787,7 +787,7 @@ function GeneratePackage()
             dotnet build /p:Scope=$service /p:Project=$packageName /p:RunApiCompat=$false $serviceProjFilePath
             if ( !$? ) {
                 Write-Host "[ERROR] Failed to build sdk solution:$packageName. Exit code: $?."
-                Write-Host "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
+                Write-Host "[ERROR] Please review the detail errors for potential fixes."
                 Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
                 $result = "failed"
             }
@@ -796,7 +796,7 @@ function GeneratePackage()
             dotnet pack $srcPath /p:RunApiCompat=$false
             if ( !$? ) {
                 Write-Host "[ERROR] Failed to pack the sdk package: $packageName for service: $service. Exit code: $?."
-                Write-Host "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
+                Write-Host "[ERROR] Please review the detail errors for potential fixes."
                 Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
                 $result = "failed"
             } else {
@@ -812,7 +812,7 @@ function GeneratePackage()
                     $artifactsPath = (Join-Path "artifacts" "packages" "Release" $packageName)
                     if (-not (Test-Path $artifactsPath)) {
                         Write-Host "[ERROR] Artifact folder not found for $artifactsPath."
-                        Write-Host "[ERROR] Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
+                        Write-Host "[ERROR] Please review the detail errors for potential fixes."
                         Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
                     }
                     else {
@@ -821,8 +821,8 @@ function GeneratePackage()
                 }
                 $apiViewArtifact = ""
                 if ( $artifacts.count -eq 0) {
-                    Write-Host "[ERROR] Failed to generate sdk artifact. Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
-                    Write-Host "[ERROR] If the issue persists after re-running, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+                    Write-Host "[ERROR] Failed to generate sdk artifact. Please review the detail errors for potential fixes."
+                    Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
                 } else {
                     $apiViewArtifact = $artifacts[0]
                 }
@@ -841,8 +841,8 @@ function GeneratePackage()
             Write-Host "Start to export api for $service"
             & $sdkRootPath/eng/scripts/Export-API.ps1 $service
             if ( !$? ) {
-                Write-Host "[ERROR] Failed to export api for sdk. exit code: $?. Please review the detail errors for potential fixes. For guidance, visit https://aka.ms/azsdk/sdk-automation-faq ."
-                Write-Host "[ERROR] If the issue persists after re-running, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+                Write-Host "[ERROR] Failed to export api for sdk. exit code: $?. Please review the detail errors for potential fixes."
+                Write-Host "[ERROR] If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
                 $result = "failed"
             }
             # breaking change validation

--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -3,9 +3,9 @@
   "generateOptions": {
     "generateScript": {
       "path": "pwsh ./eng/scripts/Invoke-GenerateAndBuildV2.ps1",
-      "logPrefix": "DotNet-Sdk-Automation",
+      "logPrefix": ".Net",
       "stderr": {
-        "showInComment": ".*(\\[ERROR\\]|error NU|(?!0\\b)\\d+ Error\\(s\\)|ExternalError).*",
+        "showInComment": ".*(\\[ERROR\\]| error |(?!0\\b)\\d+ Error\\(s\\)|ExternalError).*",
         "scriptError": "\\[ERROR\\]"
       },
       "stdout": {
@@ -15,7 +15,8 @@
   },
   "initOptions": {
     "initScript": {
-      "path": "pwsh ./eng/scripts/Automation-Sdk-Init.ps1"
+      "path": "pwsh ./eng/scripts/Automation-Sdk-Init.ps1",
+      "logPrefix": ".Net"
     }
   },
   "packageOptions": {

--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -5,7 +5,7 @@
       "path": "pwsh ./eng/scripts/Invoke-GenerateAndBuildV2.ps1",
       "logPrefix": ".Net",
       "stderr": {
-        "showInComment": ".*(\\[ERROR\\]| error |(?!0\\b)\\d+ Error\\(s\\)|ExternalError).*",
+        "showInComment": ".*(\\[ERROR\\]|: error|(?!0\\b)\\d+ Error\\(s\\)|ExternalError).*",
         "scriptError": "\\[ERROR\\]"
       },
       "stdout": {

--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -5,11 +5,12 @@
       "path": "pwsh ./eng/scripts/Invoke-GenerateAndBuildV2.ps1",
       "logPrefix": ".Net",
       "stderr": {
-        "showInComment": ".*(\\[ERROR\\]|: error|(?!0\\b)\\d+ Error\\(s\\)|ExternalError).*",
+        "showInComment": ".*(\\[ERROR\\]|ExternalError).*",
         "scriptError": "\\[ERROR\\]"
       },
       "stdout": {
-        "showInComment": "(Start to|\\[ERROR\\]).*"
+        "showInComment": ".*(Start to|\\[ERROR\\]|: error|(?!0\\b)\\d+ Error\\(s\\)).*",
+        "scriptError": "\\[ERROR\\]"
       }
     }
   },


### PR DESCRIPTION
Changes included:
- display the msbuild errors in the check result
- shorten the log prefix in the config
- use the short link for .net teams channel
- remove the faq from the individual message as it has been printed in the first comment of the SDK automation check

Testing PR:
https://github.com/test-repo-billy/azure-rest-api-specs/pull/3421/checks?check_run_id=28345315280