### PR TITLE
Do not publish to the nightly MSDocs branch if nightly PublishPackages fails

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -163,7 +163,7 @@ stages:
                             parameters:
                               BuildToolsRepositoryPath: $(Pipeline.Workspace)/azure-sdk-build-tools
                               PackagesPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}
-                              StagingDirectory: $(Build.ArtifactStagingDirectory)/symbols    
+                              StagingDirectory: $(Build.ArtifactStagingDirectory)/symbols
                           - template: /eng/common/pipelines/templates/steps/create-apireview.yml
                             parameters:
                               ArtifactPath: $(Pipeline.Workspace)/packages
@@ -315,7 +315,7 @@ stages:
 
       - job: PublishDocsToNightlyBranch
         dependsOn: PublishPackages
-        condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
+        condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'))))
         pool:
           name: $(LINUXPOOL)
           image: $(LINUXVMIMAGE)


### PR DESCRIPTION
There was an issue with the nightly MSDocs build where it was trying to install a preview version of a library whose nightly publish to the dev feed had failed. As expected, this caused the nightly MSDocs build to fail. The nightly MSDocs publish step depends on nightly PublishPackages step but, for whatever reason, never checked if it succeeded. The MSDocs publish for an official release correctly checks if the publish succeeded.

NET, Java, JS and Python are all getting this same fix.

Testing was just to run [net - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4028975&view=results) with SetDevVersion set to True to produce a nightly release which succeeded.