### PR TITLE
[Storage] Add CHANGELOG for Fixed WrapKeyInternal to correctly call WrapKey in sync flow

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bugs Fixed
 - Fixed \[BUG\] BlobContainerClient(connectionString, blobContainerName, options) ctor to set clientSideEncryptionOptions #44623
+- Fixed \[BUG\] WrapKeyInternal to correctly call WrapKey in sync flow #42160
 
 ## 12.21.1 (2024-07-25)
 


### PR DESCRIPTION
Added CHANGELOG for this bugfix PR: https://github.com/Azure/azure-sdk-for-net/pull/45352
