### PR TITLE
Adjust pending release

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.9.1 (2024-08-06)
+## 12.9.1 (Unreleased)
 
 ### Bugs Fixed
 - Fixed an issue that prevented use of stored access policy based SaS Uris by adding a constructor to `TableSasBuilder` that accepts a stored access policy identifier without needing to specify the policy's permissions.


### PR DESCRIPTION
Due to a pending API View discussion, this release for table didn't happen on the date it was scheduled.

Changing the date to unreleased.
