### PR TITLE
[AzureMonitorDistro] bug fix for LiveMetrics values for "server name" and "role name"

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -15,6 +15,9 @@
   `APPLICATIONINSIGHTS_CONNECTION_STRING` is present in `IConfiguration`.
   ([#45292](https://github.com/Azure/azure-sdk-for-net/pull/45292))
 
+* Fixed a bug where LiveMetrics displays "UNKNOWN_INSTANCE" and "UNKNOWN_NAME" for "server name" and "role name" respectively.
+  ([]())
+
 ### Other Changes
 
 ## 1.3.0-beta.1 (2024-07-12)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -16,7 +16,7 @@
   ([#45292](https://github.com/Azure/azure-sdk-for-net/pull/45292))
 
 * Fixed a bug where LiveMetrics displays "UNKNOWN_INSTANCE" and "UNKNOWN_NAME" for "server name" and "role name" respectively.
-  ([]())
+  ([#45433](https://github.com/Azure/azure-sdk-for-net/pull/45433))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsActivityProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsActivityProcessor.cs
@@ -10,14 +10,14 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics
 {
     internal sealed class LiveMetricsActivityProcessor : BaseProcessor<Activity>
     {
-        private LiveMetricsResource? _resource;
         private readonly Manager _manager;
-
-        internal LiveMetricsResource? LiveMetricsResource => _resource ??= ParentProvider?.GetResource().CreateAzureMonitorResource();
 
         internal LiveMetricsActivityProcessor(Manager manager)
         {
             _manager = manager;
+
+            // Resource is not available at sdk initialization and must be read later.
+            manager.LiveMetricsResourceFunc ??= () => ParentProvider?.GetResource().CreateAzureMonitorResource();
         }
 
         public override void OnEnd(Activity activity)
@@ -26,12 +26,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics
             if (!_manager.ShouldCollect())
             {
                 return;
-            }
-
-            // Resource is not available at initialization and must be set later.
-            if (_manager.LiveMetricsResource == null && LiveMetricsResource != null)
-            {
-                _manager.LiveMetricsResource = LiveMetricsResource;
             }
 
             if (activity.Kind == ActivityKind.Server || activity.Kind == ActivityKind.Consumer)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsLogProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/LiveMetricsLogProcessor.cs
@@ -11,14 +11,14 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics
     internal class LiveMetricsLogProcessor : BaseProcessor<LogRecord>
     {
         private bool _disposed;
-        private LiveMetricsResource? _resource;
         private readonly Manager _manager;
-
-        internal LiveMetricsResource? LiveMetricsResource => _resource ??= ParentProvider?.GetResource().CreateAzureMonitorResource();
 
         public LiveMetricsLogProcessor(Manager manager)
         {
             _manager = manager;
+
+            // Resource is not available at sdk initialization and must be read later.
+            manager.LiveMetricsResourceFunc ??= () => ParentProvider?.GetResource().CreateAzureMonitorResource();
         }
 
         public override void OnEnd(LogRecord data)
@@ -27,12 +27,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics
             if (!_manager.ShouldCollect())
             {
                 return;
-            }
-
-            // Resource is not available at initialization and must be set later.
-            if (_manager.LiveMetricsResource == null && LiveMetricsResource != null)
-            {
-                _manager.LiveMetricsResource = LiveMetricsResource;
             }
 
             if (data.Exception is null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
@@ -23,6 +23,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
 
         public MonitoringDataPoint GetDataPoint()
         {
+            LiveMetricsResource ??= LiveMetricsResourceFunc?.Invoke();
+
             var dataPoint = new MonitoringDataPoint(
                 version: SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength),
                 invariantVersion: 5,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
@@ -23,13 +23,13 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
 
         public MonitoringDataPoint GetDataPoint()
         {
-            LiveMetricsResource ??= LiveMetricsResourceFunc?.Invoke();
+            _liveMetricsResource ??= LiveMetricsResourceFunc?.Invoke();
 
             var dataPoint = new MonitoringDataPoint(
                 version: SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength),
                 invariantVersion: 5,
-                instance: LiveMetricsResource?.RoleInstance ?? "UNKNOWN_INSTANCE",
-                roleName: LiveMetricsResource?.RoleName ?? "UNKNOWN_NAME",
+                instance: _liveMetricsResource?.RoleInstance ?? "UNKNOWN_INSTANCE",
+                roleName: _liveMetricsResource?.RoleName ?? "UNKNOWN_NAME",
                 machineName: Environment.MachineName, // TODO: MOVE TO PLATFORM
                 streamId: _streamId,
                 isWebApp: false,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
@@ -23,13 +23,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
 
         public MonitoringDataPoint GetDataPoint()
         {
-            _liveMetricsResource ??= LiveMetricsResourceFunc?.Invoke();
-
             var dataPoint = new MonitoringDataPoint(
                 version: SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength),
                 invariantVersion: 5,
-                instance: _liveMetricsResource?.RoleInstance ?? "UNKNOWN_INSTANCE",
-                roleName: _liveMetricsResource?.RoleName ?? "UNKNOWN_NAME",
+                instance: LiveMetricsResource?.RoleInstance ?? "UNKNOWN_INSTANCE",
+                roleName: LiveMetricsResource?.RoleName ?? "UNKNOWN_NAME",
                 machineName: Environment.MachineName, // TODO: MOVE TO PLATFORM
                 streamId: _streamId,
                 isWebApp: false,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.cs
@@ -35,7 +35,9 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
             }
         }
 
-        public LiveMetricsResource? LiveMetricsResource { get; set; }
+        private LiveMetricsResource? LiveMetricsResource { get; set; }
+
+        public Func<LiveMetricsResource?>? LiveMetricsResourceFunc { get; set; }
 
         internal static ConnectionVars InitializeConnectionVars(AzureMonitorOptions options, IPlatform platform)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.cs
@@ -17,6 +17,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
         private readonly ConnectionVars _connectionVars;
         private readonly bool _isAadEnabled;
         private readonly string _streamId = Guid.NewGuid().ToString(); // StreamId should be unique per application instance.
+        private LiveMetricsResource? _liveMetricsResource;
         private bool _disposedValue;
 
         public Manager(AzureMonitorOptions options, IPlatform platform)
@@ -34,8 +35,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
                 InitializeState();
             }
         }
-
-        private LiveMetricsResource? LiveMetricsResource { get; set; }
 
         public Func<LiveMetricsResource?>? LiveMetricsResourceFunc { get; set; }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.cs
@@ -36,6 +36,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
             }
         }
 
+        private LiveMetricsResource? LiveMetricsResource => _liveMetricsResource ??= LiveMetricsResourceFunc?.Invoke();
+
         public Func<LiveMetricsResource?>? LiveMetricsResourceFunc { get; set; }
 
         internal static ConnectionVars InitializeConnectionVars(AzureMonitorOptions options, IPlatform platform)


### PR DESCRIPTION
Fixed a bug where the LiveMetrics UX would display "UNKNOWN_INSTANCE" and "UNKNOWN_NAME" for the "Server name" and "Role name". This was due to a condition where LiveMetrics started sending heartbeat metrics before the SDK had fully initialized.


### Changes
- update `ActivityProcessor` and `LogProcessor` classes
  These classes will no longer wait to initialize the LiveMetricsResource within their `OnEnd` methods.
  Instead these will set a delegate on the `Manager` class.
- update `Manager` class.
  This will now use the delegate to initialize it's own LiveMetricsResource when needed.


### Repro

This can be reproduced using a Console app that never creates telemetry.
Before this change, the SDK would wait for the first batch of telemetry to initialize the LiveMetricsResource.
Without telemetry, this never gets initialized.

```csharp
namespace ConsoleApp1
{
    using Azure.Monitor.OpenTelemetry.AspNetCore;
    using Microsoft.Extensions.DependencyInjection;
    using OpenTelemetry.Trace;

    internal class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine("Hello, World!");

            var serviceCollection = new ServiceCollection();
            serviceCollection.AddOpenTelemetry().UseAzureMonitor(x => x.ConnectionString = "...");
            using var serviceProvider = serviceCollection.BuildServiceProvider();

            // We must resolve the TracerProvider here to ensure that it is initialized.
            // In a normal app, the OpenTelemetry.Extensions.Hosting package would handle this.
            var tracerProvider = serviceProvider.GetRequiredService<TracerProvider>();


            _ = Console.ReadKey();
        }
    }
}

```


![image](https://github.com/user-attachments/assets/23e2ca94-cee1-452e-87ff-3e32212de587)
