### PR TITLE
Update install-dotnet.yml

### DIFF
--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -17,6 +17,14 @@ steps:
     inputs:
       useGlobalJson: true
       performMultiLevelLookup: true
+  - task: UseDotNet@2 # Temporary - we need this for one of the pipelines
+    displayName: 'Use .NET 7.0 SDK'
+    retryCountOnTaskFailure: 3
+    inputs:
+      # AspNetCore runtime pack can't be installed outside of SDK and we need it for integration tests
+      packageType: sdk
+      performMultiLevelLookup: true
+      version: "7.0.x"
   - task: UseDotNet@2 # We need .NET 6 for azure-sdk-tools and the .NET 6 tests
     condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT')) # Windows supports MultiLevelLookup and doesn't need explicit framework installation
     displayName: 'Use .NET 6.0 SDK'


### PR DESCRIPTION
Adds back the step to download .NET 7 for a management plane pipeline that still needs it.
