### PR TITLE
[WebPubSubForSocketIO] Update some event design and add more tests

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -116,7 +116,7 @@
     <PackageReference Update="Azure.Messaging.EventHubs" Version="5.11.5" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.21.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.18.1" />
-    <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.3.0" />
+    <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.4.0" />
     <PackageReference Update="Azure.MixedReality.Authentication" version= "1.2.0" />
     <PackageReference Update="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0-beta.1" />
     <PackageReference Update="Azure.Monitor.Query" Version="1.1.0" />

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/README.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/README.md
@@ -106,8 +106,7 @@ public static class SocketIOOutputBindingFunction
         ILogger log)
     {
         string userName = Guid.NewGuid().ToString();
-        await operation.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "new message", new[] { new { username = userName,
-            message = "Hello" } }));
+        await operation.AddAsync(SocketIOAction.CreateSendToNamespaceAction("new message", new[] { new { username = userName, message = "Hello" } }));
         log.LogInformation("Send to namespace finished.");
         return new OkObjectResult("ok");
     }
@@ -153,7 +152,7 @@ public static class SocketIOTriggerFunction
         ILogger log)
     {
         log.LogInformation("Running trigger for: new message");
-        await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "new message", new[] { new { message = request.Parameters } }, new[] { request.SocketId }));
+        await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("new message", new[] { new { message = request.Parameters } }, new[] { request.SocketId }));
     }
 }
 ```
@@ -170,7 +169,7 @@ public static class SocketIOTriggerReturnValueFunction
         ILogger log)
     {
         log.LogInformation("Running trigger for: new message");
-        await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "new message", new[] { new { message = request.Parameters } }, new[] { request.SocketId }));
+        await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("new message", new[] { new { message = request.Parameters } }, new[] { request.SocketId }));
         return new SocketIOMessageResponse(new[] {"ackValue"});
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/api/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.netstandard2.0.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/api/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.netstandard2.0.cs
@@ -4,7 +4,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     public partial class AddSocketToRoomAction : Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SocketIOAction
     {
         public AddSocketToRoomAction() { }
-        public string Namespace { get { throw null; } set { } }
         public string Room { get { throw null; } set { } }
         public string SocketId { get { throw null; } set { } }
     }
@@ -12,14 +11,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     public partial class DisconnectSocketsAction : Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SocketIOAction
     {
         public DisconnectSocketsAction() { }
-        public string Namespace { get { throw null; } set { } }
+        public bool CloseUnderlyingConnection { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> Rooms { get { throw null; } set { } }
     }
     [Newtonsoft.Json.JsonObjectAttribute(NamingStrategyType=typeof(Newtonsoft.Json.Serialization.CamelCaseNamingStrategy))]
     public partial class RemoveSocketFromRoomAction : Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SocketIOAction
     {
         public RemoveSocketFromRoomAction() { }
-        public string Namespace { get { throw null; } set { } }
         public string Room { get { throw null; } set { } }
         public string SocketId { get { throw null; } set { } }
     }
@@ -29,7 +27,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         public SendToNamespaceAction() { }
         public string EventName { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> ExceptRooms { get { throw null; } set { } }
-        public string Namespace { get { throw null; } set { } }
         public System.Collections.Generic.IList<object> Parameters { get { throw null; } set { } }
     }
     [Newtonsoft.Json.JsonObjectAttribute(NamingStrategyType=typeof(Newtonsoft.Json.Serialization.CamelCaseNamingStrategy))]
@@ -38,7 +35,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         public SendToRoomsAction() { }
         public string EventName { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> ExceptRooms { get { throw null; } set { } }
-        public string Namespace { get { throw null; } set { } }
         public System.Collections.Generic.IList<object> Parameters { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> Rooms { get { throw null; } set { } }
     }
@@ -47,7 +43,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     {
         public SendToSocketAction() { }
         public string EventName { get { throw null; } set { } }
-        public string Namespace { get { throw null; } set { } }
         public System.Collections.Generic.IList<object> Parameters { get { throw null; } set { } }
         public string SocketId { get { throw null; } set { } }
     }
@@ -55,12 +50,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     public abstract partial class SocketIOAction
     {
         protected SocketIOAction() { }
-        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.AddSocketToRoomAction CreateAddSocketToRoomAction(string @namespace, string socketId, string room) { throw null; }
-        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.DisconnectSocketsAction CreateDisconnectSocketsAction(string @namespace, System.Collections.Generic.IEnumerable<string> rooms) { throw null; }
-        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.RemoveSocketFromRoomAction CreateRemoveSocketFromRoomAction(string @namespace, string socketId, string room) { throw null; }
-        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SendToNamespaceAction CreateSendToNamespaceAction(string @namespace, string eventName, System.Collections.Generic.IEnumerable<object> parameters, System.Collections.Generic.IList<string> exceptRooms = null) { throw null; }
-        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SendToRoomsAction CreateSendToRoomsAction(string @namespace, System.Collections.Generic.IEnumerable<string> rooms, string eventName, System.Collections.Generic.IEnumerable<object> parameters, System.Collections.Generic.IList<string> exceptRooms = null) { throw null; }
-        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SendToSocketAction CreateSendToSocketAction(string @namespace, string socketId, string eventName, System.Collections.Generic.IEnumerable<object> parameters) { throw null; }
+        public string Namespace { get { throw null; } set { } }
+        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.AddSocketToRoomAction CreateAddSocketToRoomAction(string socketId, string room, string @namespace = "/") { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.DisconnectSocketsAction CreateDisconnectSocketsAction(System.Collections.Generic.IEnumerable<string> rooms, bool closeUnderlyingConnection = false, string @namespace = "/") { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.RemoveSocketFromRoomAction CreateRemoveSocketFromRoomAction(string socketId, string room, string @namespace = "/") { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SendToNamespaceAction CreateSendToNamespaceAction(string eventName, System.Collections.Generic.IEnumerable<object> parameters, System.Collections.Generic.IList<string> exceptRooms = null, string @namespace = "/") { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SendToRoomsAction CreateSendToRoomsAction(System.Collections.Generic.IEnumerable<string> rooms, string eventName, System.Collections.Generic.IEnumerable<object> parameters, System.Collections.Generic.IList<string> exceptRooms = null, string @namespace = "/") { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.SendToSocketAction CreateSendToSocketAction(string socketId, string eventName, System.Collections.Generic.IEnumerable<object> parameters, string @namespace = "/") { throw null; }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
@@ -185,7 +181,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Trigger.Model
     [System.Runtime.Serialization.DataContractAttribute]
     public partial class SocketIOMessageRequest : Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Trigger.Model.SocketIOEventHandlerRequest
     {
-        public SocketIOMessageRequest(string @namespace, string socketId, string payload, System.Collections.Generic.IList<object> arguments) : base (default(string), default(string)) { }
+        public SocketIOMessageRequest(string @namespace, string socketId, string payload, string eventName, System.Collections.Generic.IList<object> arguments) : base (default(string), default(string)) { }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="eventName")]
+        [System.Text.Json.Serialization.JsonPropertyNameAttribute("eventName")]
+        public string EventName { get { throw null; } }
         [System.Runtime.Serialization.DataMemberAttribute(Name="parameters")]
         [System.Text.Json.Serialization.JsonPropertyNameAttribute("parameters")]
         public System.Collections.Generic.IList<object> Parameters { get { throw null; } }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/samples/SampleDev/Function.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/samples/SampleDev/Function.cs
@@ -32,7 +32,7 @@ namespace SampleDev
         {
             log.LogInformation($"C# HTTP trigger function processed a request. {Base64UrlEncoder.Encode("abc")}");
             string userName = Guid.NewGuid().ToString();
-            await operation.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "new message", new[] { new { username = userName,
+            await operation.AddAsync(SocketIOAction.CreateSendToNamespaceAction("new message", new[] { new { username = userName,
                 message = "Hello" } }));
             log.LogInformation("Send to namespace finished.");
             return new OkObjectResult("ok");
@@ -77,7 +77,7 @@ namespace SampleDev
             log.LogInformation("Running trigger for: disconnected");
             if (_store.TryRemove(request.SocketId, out var context))
             {
-                await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "user left", new[] { new { username = context.UserName, numUsers = Interlocked.Decrement(ref _numUsers)} }, new[] {request.SocketId}));
+                await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("user left", new[] { new { username = context.UserName, numUsers = Interlocked.Decrement(ref _numUsers)} }, new[] {request.SocketId}));
             }
         }
 
@@ -92,7 +92,7 @@ namespace SampleDev
 
             if (_store.TryGetValue(request.SocketId, out var context))
             {
-                await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "new message", new[] { new { username = context.UserName, message = request.Parameters } }, new[] { request.SocketId }));
+                await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("new message", new[] { new { username = context.UserName, message = request.Parameters } }, new[] { request.SocketId }));
             }
         }
 
@@ -115,8 +115,8 @@ namespace SampleDev
                 context.AddedUser = true;
                 context.UserName = userName;
 
-                await collector.AddAsync(SocketIOAction.CreateSendToSocketAction("/", request.SocketId, "login", new[] { new { numUsers = _numUsers } }));
-                await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "user joined", new[] { new { username = userName, numUsers = _numUsers } }, new[] { request.SocketId }));
+                await collector.AddAsync(SocketIOAction.CreateSendToSocketAction(request.SocketId, "login", new[] { new { numUsers = _numUsers } }));
+                await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("user joined", new[] { new { username = userName, numUsers = _numUsers } }, new[] { request.SocketId }));
             }
         }
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/AddSocketToRoomAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/AddSocketToRoomAction.cs
@@ -21,10 +21,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         /// Target room name.
         /// </summary>
         public string Room { get; set; }
-
-        /// <summary>
-        /// Target namespace
-        /// </summary>
-        public string Namespace { get; set; }
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/BaseActions/AddConnectionsToGroupsAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/BaseActions/AddConnectionsToGroupsAction.cs
@@ -3,23 +3,24 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using System.Collections.Generic;
 
-namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.BaseActions
 {
     /// <summary>
-    /// Operation to remove socket from a room.
+    /// Operation to add connectionId to a group.
     /// </summary>
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-    public class RemoveSocketFromRoomAction : SocketIOAction
+    internal class AddConnectionsToGroupsAction : WebPubSubAction
     {
         /// <summary>
-        /// Target socketId.
+        /// Target groups
         /// </summary>
-        public string SocketId { get; set; }
+        public IList<string> Groups { get; set; }
 
         /// <summary>
-        /// Target room name.
+        /// The filter
         /// </summary>
-        public string Room { get; set; }
+        public string Filter { get; set; }
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/BaseActions/AddConnectionsToGroupsAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/BaseActions/AddConnectionsToGroupsAction.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.BaseActions
 {
     /// <summary>
-    /// Operation to add connectionId to a group.
+    /// Add filtered connections to multiple groups.
     /// </summary>
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     internal class AddConnectionsToGroupsAction : WebPubSubAction

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/BaseActions/RemoveConnectionsFromGroupsAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/BaseActions/RemoveConnectionsFromGroupsAction.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.BaseActions
 {
     /// <summary>
-    /// Operation to add connectionId to a group.
+    /// Remove filtered connections from multiple groups.
     /// </summary>
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     internal class RemoveConnectionsFromGroupsAction : WebPubSubAction

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/BaseActions/RemoveConnectionsFromGroupsAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/BaseActions/RemoveConnectionsFromGroupsAction.cs
@@ -3,23 +3,24 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using System.Collections.Generic;
 
-namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.BaseActions
 {
     /// <summary>
-    /// Operation to remove socket from a room.
+    /// Operation to add connectionId to a group.
     /// </summary>
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-    public class RemoveSocketFromRoomAction : SocketIOAction
+    internal class RemoveConnectionsFromGroupsAction : WebPubSubAction
     {
         /// <summary>
-        /// Target socketId.
+        /// Target groups.
         /// </summary>
-        public string SocketId { get; set; }
+        public IList<string> Groups { get; set; }
 
         /// <summary>
-        /// Target room name.
+        /// The filter
         /// </summary>
-        public string Room { get; set; }
+        public string Filter { get; set; }
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/DisconnectSocketsAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/DisconnectSocketsAction.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     public class DisconnectSocketsAction : SocketIOAction
     {
         /// <summary>
-        /// Target namespace.
-        /// </summary>
-        public string Namespace { get; set; }
-
-        /// <summary>
         /// Optional target rooms. If not set, disconnect the whole namespace.
         /// </summary>
         public IList<string> Rooms { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Whether to close the underlying client side Engine.IO connection.
+        /// </summary>
+        public bool CloseUnderlyingConnection { get; set; } = false;
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/SendToNamespaceAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/SendToNamespaceAction.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     public class SendToNamespaceAction : SocketIOAction
     {
         /// <summary>
-        /// Target namespace
-        /// </summary>
-        public string Namespace { get; set; }
-
-        /// <summary>
         /// The event name.
         /// </summary>
         public string EventName { get; set; }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/SendToRoomsAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/SendToRoomsAction.cs
@@ -16,11 +16,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     public class SendToRoomsAction : SocketIOAction
     {
         /// <summary>
-        /// Target namespace
-        /// </summary>
-        public string Namespace { get; set; }
-
-        /// <summary>
         /// Target rooms.
         /// </summary>
         public IList<string> Rooms { get; set; } = new List<string>();

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/SendToSocketAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/SendToSocketAction.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     public class SendToSocketAction : SocketIOAction
     {
         /// <summary>
-        /// Target namespace
-        /// </summary>
-        public string Namespace { get; set; }
-
-        /// <summary>
         /// Target socketID.
         /// </summary>
         public string SocketId { get; set; }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/SocketIOAction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Bindings/Output/SocketIOAction.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public abstract class SocketIOAction
     {
+        private const string DefaultNamespace = "/";
+
         internal string ActionName
         {
             get
@@ -25,13 +27,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         }
 
         /// <summary>
+        /// Target namespace. Default is '/'.
+        /// </summary>
+        public string Namespace { get; set; } = DefaultNamespace;
+
+        /// <summary>
         /// Creates an instance of <see cref="AddSocketToRoomAction"></see> for output binding.
         /// </summary>
         /// <param name="namespace">Target namespace.</param>
         /// <param name="socketId">Target socketId.</param>
         /// <param name="room">Target roome.</param>
         /// <returns>An instance of <see cref="AddSocketToRoomAction"></see>.</returns>
-        public static AddSocketToRoomAction CreateAddSocketToRoomAction(string @namespace, string socketId, string room)
+        public static AddSocketToRoomAction CreateAddSocketToRoomAction(string socketId, string room, string @namespace = DefaultNamespace)
         {
             return new AddSocketToRoomAction
             {
@@ -48,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         /// <param name="socketId">Target socketId.</param>
         /// <param name="room">Target roome.</param>
         /// <returns>An instance of <see cref="RemoveSocketFromRoomAction"></see>.</returns>
-        public static RemoveSocketFromRoomAction CreateRemoveSocketFromRoomAction(string @namespace, string socketId, string room)
+        public static RemoveSocketFromRoomAction CreateRemoveSocketFromRoomAction(string socketId, string room, string @namespace = DefaultNamespace)
         {
             return new RemoveSocketFromRoomAction
             {
@@ -62,14 +69,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         /// Creates an instance of <see cref="DisconnectSocketsAction"></see> for output binding.
         /// </summary>
         /// <param name="namespace">Target namespace.</param>
-        /// <param name="rooms">Target rooms</param>
+        /// <param name="rooms">Target rooms, If not set, disconnect the whole namespace.</param>
+        /// <param name="closeUnderlyingConnection">Whether to close the underlying connection.</param>
         /// <returns>An instance of <see cref="DisconnectSocketsAction"></see>.</returns>
-        public static DisconnectSocketsAction CreateDisconnectSocketsAction(string @namespace, IEnumerable<string> rooms)
+        public static DisconnectSocketsAction CreateDisconnectSocketsAction(IEnumerable<string> rooms, bool closeUnderlyingConnection = false, string @namespace = DefaultNamespace)
         {
             return new DisconnectSocketsAction
             {
                 Namespace = @namespace,
-                Rooms = rooms.ToArray(),
+                Rooms = rooms?.ToArray(),
+                CloseUnderlyingConnection = closeUnderlyingConnection,
             };
         }
 
@@ -81,12 +90,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         /// <param name="parameters">SocketIO data.</param>
         /// <param name="exceptRooms">Except rooms</param>
         /// <returns>An instance of <see cref="SendToNamespaceAction"></see>.</returns>
-        public static SendToNamespaceAction CreateSendToNamespaceAction(string @namespace, string eventName, IEnumerable<object> parameters, IList<string> exceptRooms = null)
+        public static SendToNamespaceAction CreateSendToNamespaceAction(string eventName, IEnumerable<object> parameters, IList<string> exceptRooms = null, string @namespace = DefaultNamespace)
         {
             return new SendToNamespaceAction
             {
                 EventName = eventName,
-                Parameters = parameters.ToArray(),
+                Parameters = parameters?.ToArray(),
                 Namespace = @namespace,
                 ExceptRooms = exceptRooms,
             };
@@ -101,12 +110,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         /// <param name="parameters">SocketIO data.</param>
         /// <param name="exceptRooms">Except rooms</param>
         /// <returns>An instance of <see cref="SendToNamespaceAction"></see>.</returns>
-        public static SendToRoomsAction CreateSendToRoomsAction(string @namespace, IEnumerable<string> rooms, string eventName, IEnumerable<object> parameters, IList<string> exceptRooms = null)
+        public static SendToRoomsAction CreateSendToRoomsAction(IEnumerable<string> rooms, string eventName, IEnumerable<object> parameters, IList<string> exceptRooms = null, string @namespace = DefaultNamespace)
         {
             return new SendToRoomsAction
             {
                 EventName = eventName,
-                Parameters = parameters.ToArray(),
+                Parameters = parameters?.ToArray(),
                 Namespace = @namespace,
                 Rooms = rooms.ToArray(),
                 ExceptRooms = exceptRooms,
@@ -121,12 +130,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         /// <param name="eventName">Event name</param>
         /// <param name="parameters">SocketIO data.</param>
         /// <returns>An instance of <see cref="SendToSocketAction"></see>.</returns>
-        public static SendToSocketAction CreateSendToSocketAction(string @namespace, string socketId, string eventName, IEnumerable<object> parameters)
+        public static SendToSocketAction CreateSendToSocketAction(string socketId, string eventName, IEnumerable<object> parameters, string @namespace = DefaultNamespace)
         {
             return new SendToSocketAction
             {
                 EventName = eventName,
-                Parameters = parameters.ToArray(),
+                Parameters = parameters?.ToArray(),
                 SocketId = socketId,
                 Namespace = @namespace,
             };

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/Model/SocketIOMessageRequest.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/Model/SocketIOMessageRequest.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Trigger.Model
     public class SocketIOMessageRequest : SocketIOEventHandlerRequest
     {
         internal const string PayloadProperty = "payload";
+        internal const string EventNameProperty = "eventName";
         internal const string ParametersProperty = "parameters";
 
         /// <summary>
@@ -22,6 +23,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Trigger.Model
         [DataMember(Name = PayloadProperty)]
         [JsonPropertyName(PayloadProperty)]
         public string Payload { get; }
+
+        /// <summary>
+        /// The event name of the message.
+        /// </summary>
+        [DataMember(Name = EventNameProperty)]
+        [JsonPropertyName(EventNameProperty)]
+        public string EventName { get; }
 
         /// <summary>
         /// The parameters of message
@@ -33,9 +41,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Trigger.Model
         /// <summary>
         /// The disconnected event request
         /// </summary>
-        public SocketIOMessageRequest(string @namespace, string socketId, string payload, IList<object> arguments) : base(@namespace, socketId)
+        public SocketIOMessageRequest(string @namespace, string socketId, string payload, string eventName, IList<object> arguments) : base(@namespace, socketId)
         {
             Payload = payload;
+            EventName = eventName;
             Parameters = arguments;
         }
     }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/SocketIOTriggerAttribute.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/SocketIOTriggerAttribute.cs
@@ -17,6 +17,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
 #pragma warning restore CS0618 // Type or member is obsolete
     public class SocketIOTriggerAttribute : Attribute
     {
+        private const string ConnectEventName = "connect";
+        private const string ConnectedEventName = "connected";
+        private const string DisconnectedEventName = "disconnected";
+
         /// <summary>
         /// Attribute used to bind a parameter to an Web PubSub for Socket.IO, when an request is from the service.
         /// </summary>
@@ -98,9 +102,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
 
         private WebPubSubEventType GetEventTypeByEventName(string eventName)
         {
-            if (string.Equals(eventName, "connect", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(eventName, "connected", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(eventName, "disconnected", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(eventName, ConnectEventName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(eventName, ConnectedEventName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(eventName, DisconnectedEventName, StringComparison.OrdinalIgnoreCase))
             {
                 return WebPubSubEventType.System;
             }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/WebPubSubForSocketIOTriggerBinding.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/WebPubSubForSocketIOTriggerBinding.cs
@@ -63,12 +63,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
                 {
                     if (triggerEvent.Request is not SocketIOMessageRequest eventReq)
                     {
-                        throw new InvalidDataException($"Expect incomming event to be {nameof(SocketIOMessageRequest)}, but it's {triggerEvent.Request.GetType()}");
+                        throw new InvalidDataException($"Expect incoming event to be {nameof(SocketIOMessageRequest)}, but it's {triggerEvent.Request.GetType()}");
                     }
 
                     if (eventReq.Parameters == null || eventReq.Parameters.Count != _attribute.ParameterNames.Length)
                     {
-                        throw new ArgumentException($"Parameter length of Incomming data dismatch. Expected to be {_attribute.ParameterNames.Length}, but actually {eventReq.Parameters.Count}. Update the {nameof(SocketIOTriggerAttribute.ParameterNames)} to match the actual data");
+                        throw new ArgumentException($"Parameter length of incoming data dismatch. Expected to be {_attribute.ParameterNames.Length}, but actually {eventReq.Parameters.Count}. Update the {nameof(SocketIOTriggerAttribute.ParameterNames)} to match the actual data");
                     }
 
                     // Add binding data for arguments

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/WebPubSubForSocketIOTriggerBinding.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/WebPubSubForSocketIOTriggerBinding.cs
@@ -63,12 +63,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
                 {
                     if (triggerEvent.Request is not SocketIOMessageRequest eventReq)
                     {
-                        throw new ArgumentException();
+                        throw new InvalidDataException($"Expect incomming event to be {nameof(SocketIOMessageRequest)}, but it's {triggerEvent.Request.GetType()}");
                     }
 
                     if (eventReq.Parameters == null || eventReq.Parameters.Count != _attribute.ParameterNames.Length)
                     {
-                        throw new ArgumentException();
+                        throw new ArgumentException($"Parameter length of Incomming data dismatch. Expected to be {_attribute.ParameterNames.Length}, but actually {eventReq.Parameters.Count}. Update the {nameof(SocketIOTriggerAttribute.ParameterNames)} to match the actual data");
                     }
 
                     // Add binding data for arguments

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/WebPubSubForSocketIOTriggerDispatcher.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Trigger/WebPubSubForSocketIOTriggerDispatcher.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
                             {
                                 throw new InvalidDataException($"Event name dismatch. {context.EventName} from header but {eventName} from payload");
                             }
-                            eventRequest = new SocketIOMessageRequest(context.Namespace, context.SocketId, payload, arguments);
+                            eventRequest = new SocketIOMessageRequest(context.Namespace, context.SocketId, payload, eventName, arguments);
                             break;
                         }
                     default:

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/JobHostEndToEndTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/JobHostEndToEndTests.cs
@@ -37,24 +37,56 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         public async Task TestSocketIOTriggerWithKeyBasedConfig()
         {
             var host = TestHelpers.NewHost(typeof(SocketIOFuncs), configuration: KeyBasedConfiguration);
+            var triggerEvent = CreateTestTriggerEvent();
             var args = new Dictionary<string, object>
             {
-                { "request", CreateTestTriggerEvent() }
+                { "request", triggerEvent }
             };
 
             await host.GetJobHost().CallAsync("SocketIOFuncs.TestSocketIOTrigger", args);
+            Assert.True(triggerEvent.TaskCompletionSource.Task.IsCompleted);
         }
 
         [TestCase]
         public async Task TestSocketIOTriggerWithIdentityBasedConfig()
         {
             var host = TestHelpers.NewHost(typeof(SocketIOFuncs), configuration: IdentityBasedConfiguration);
+            var triggerEvent = CreateTestTriggerEvent();
             var args = new Dictionary<string, object>
             {
-                { "request", CreateTestTriggerEvent() }
+                { "request", triggerEvent }
             };
 
             await host.GetJobHost().CallAsync("SocketIOFuncs.TestSocketIOTrigger", args);
+            Assert.True(triggerEvent.TaskCompletionSource.Task.IsCompleted);
+        }
+
+        [TestCase]
+        public async Task TestSocketIOTriggerWithParam()
+        {
+            var host = TestHelpers.NewHost(typeof(SocketIOFuncs), configuration: IdentityBasedConfiguration);
+            var triggerEvent = CreateTestMessageTriggerEvent();
+            var args = new Dictionary<string, object>
+            {
+                { "request", triggerEvent }
+            };
+
+            await host.GetJobHost().CallAsync("SocketIOFuncs.TestSocketIOTriggerWith2Param", args);
+            Assert.True(triggerEvent.TaskCompletionSource.Task.IsCompleted);
+        }
+
+        [TestCase]
+        public async Task TestSocketIOTriggerWithParamAttr()
+        {
+            var host = TestHelpers.NewHost(typeof(SocketIOFuncs), configuration: IdentityBasedConfiguration);
+            var triggerEvent = CreateTestMessageTriggerEvent();
+            var args = new Dictionary<string, object>
+            {
+                { "request", triggerEvent }
+            };
+
+            await host.GetJobHost().CallAsync("SocketIOFuncs.TestSocketIOTriggerWith2ParamAndParameterAttr", args);
+            Assert.True(triggerEvent.TaskCompletionSource.Task.IsCompleted);
         }
 
         [TestCase]
@@ -69,6 +101,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
             var task = host.GetJobHost().CallAsync("SocketIOFuncs.TestSocketIOTriggerInvalid", args);
             var exception = Assert.ThrowsAsync<FunctionInvocationException>(() => task);
             Assert.AreEqual("Exception while executing function: SocketIOFuncs.TestSocketIOTriggerInvalid", exception.Message);
+        }
+
+        [TestCase]
+        public void TestSocketIOTrigger_InvalidParam()
+        {
+            var host = TestHelpers.NewHost(typeof(SocketIOFuncs), configuration: KeyBasedConfiguration);
+            var args = new Dictionary<string, object>
+            {
+                { "request",CreateTestMessageTriggerEvent() }
+            };
+
+            var task = host.GetJobHost().CallAsync("SocketIOFuncs.TestSocketIOTriggerWith3Param", args);
+            var exception = Assert.ThrowsAsync<FunctionInvocationException>(() => task);
+            Assert.AreEqual("Exception while executing function: SocketIOFuncs.TestSocketIOTriggerWith3Param", exception.Message);
         }
 
         [TestCase]
@@ -115,6 +161,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
             };
         }
 
+        private static SocketIOTriggerEvent CreateTestMessageTriggerEvent()
+        {
+            return new SocketIOTriggerEvent
+            {
+                ConnectionContext = TestContext,
+                Request = new SocketIOMessageRequest("ns", "sid", "42ns/,[\"msgEvent\", \"d1\", \"d2\"]", "msgEvent", new[] { "d1", "d2" }),
+                TaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously)
+            };
+        }
+
         private static SocketIOSocketContext CreateConnectionContext()
         {
             return new SocketIOSocketContext(WebPubSubEventType.User, "message", "testhub", "000000", "/ns", "sid", "sig", "origin", null);
@@ -128,6 +184,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
             {
                 // Valid case use default url for verification.
                 Assert.AreEqual(TestContext, connectionContext);
+            }
+
+            public static void TestSocketIOTriggerWith2Param(
+                [SocketIOTrigger("chat", "msgEvent", parameterNames: new[] {"arg1", "arg2"})] SocketIOMessageRequest request,
+                SocketIOSocketContext connectionContext,
+                string arg1,
+                string arg2)
+            {
+                // Valid case use default url for verification.
+                Assert.AreEqual(TestContext, connectionContext);
+                Assert.AreEqual("msgEvent", request.EventName);
+                Assert.AreEqual("d1", arg1);
+                Assert.AreEqual("d2", arg2);
+            }
+
+            public static void TestSocketIOTriggerWith3Param(
+                [SocketIOTrigger("chat", "msgEvent", parameterNames: new[] { "arg1", "arg2", "arg3" })] SocketIOMessageRequest request,
+                SocketIOSocketContext connectionContext,
+                string arg1,
+                string arg2,
+                string arg3)
+            {
+                // Valid case use default url for verification.
+                Assert.AreEqual(TestContext, connectionContext);
+                Assert.AreEqual("msgEvent", request.EventName);
+                Assert.AreEqual("d1", arg1);
+                Assert.AreEqual("d2", arg2);
+            }
+
+            public static void TestSocketIOTriggerWith2ParamAndParameterAttr(
+                [SocketIOTrigger("chat", "msgEvent")] SocketIOMessageRequest request,
+                SocketIOSocketContext connectionContext,
+                [SocketIOParameter] string arg2,
+                [SocketIOParameter] string arg1)
+            {
+                // Valid case use default url for verification.
+                Assert.AreEqual(TestContext, connectionContext);
+                Assert.AreEqual("msgEvent", request.EventName);
+                Assert.AreEqual("d1", arg2);
+                Assert.AreEqual("d2", arg1);
             }
 
             public static void TestSocketIOTriggerInvalid(
@@ -147,6 +243,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
             {
                 await operation.AddAsync(new SendToNamespaceAction
                 {
+                    EventName = "event",
                     Parameters = new[] { "arg1" },
                     Namespace = "/",
                 });
@@ -157,6 +254,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
             {
                 await operation.AddAsync(new SendToNamespaceAction
                 {
+                    EventName = "event",
                     Parameters = new[] { "arg1" },
                     Namespace = "/",
                 });

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/Samples/SocketIOOutputBindingFunction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/Samples/SocketIOOutputBindingFunction.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests.Samples
             ILogger log)
         {
             string userName = Guid.NewGuid().ToString();
-            await operation.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "new message", new[] { new { username = userName,
-                message = "Hello" } }));
+            await operation.AddAsync(SocketIOAction.CreateSendToNamespaceAction("new message", new[] { new { username = userName, message = "Hello" } }));
             log.LogInformation("Send to namespace finished.");
             return new OkObjectResult("ok");
         }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/Samples/SocketIOTriggerFunction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/Samples/SocketIOTriggerFunction.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests.Samples
             ILogger log)
         {
             log.LogInformation("Running trigger for: new message");
-            await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "new message", new[] { new { message = request.Parameters } }, new[] { request.SocketId }));
+            await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("new message", new[] { new { message = request.Parameters } }, new[] { request.SocketId }));
         }
     }
     #endregion

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/Samples/SocketIOTriggerReturnValueFunction.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/Samples/SocketIOTriggerReturnValueFunction.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests.Samples
             ILogger log)
         {
             log.LogInformation("Running trigger for: new message");
-            await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/", "new message", new[] { new { message = request.Parameters } }, new[] { request.SocketId }));
+            await collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("new message", new[] { new { message = request.Parameters } }, new[] { request.SocketId }));
             return new SocketIOMessageResponse(new[] {"ackValue"});
         }
     }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/SocketIOAsyncCollectorTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/SocketIOAsyncCollectorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,16 +55,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         [Test]
         public async Task SendToRoomTest()
         {
-            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction("/ns", new[] { "rm" }, "event", new string[] {"abc"}));
+            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction(new[] { "rm" }, "event", new string[] {"abc"}, @namespace: "/ns"));
             _service.Verify(x => x.SendToGroupAsync("0~L25z~cm0", It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"event\",\"abc\"]")),
             ContentType.TextPlain, It.IsAny<IList<string>>(), "", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
         }
 
         [Test]
+        public async Task SendToRoomParameterlessTest()
+        {
+            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction(new[] { "rm" }, "event", null, @namespace: "/ns"));
+            _service.Verify(x => x.SendToGroupAsync("0~L25z~cm0", It.Is<RequestContent>(c =>
+            AssertContentData(c, "42/ns,[\"event\"]")),
+            ContentType.TextPlain, It.IsAny<IList<string>>(), "", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
+        }
+
+        [Test]
         public async Task SendToRoomExcludeTest()
         {
-            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction("/ns", new[] { "rm" }, "event", new string[] { "abc" }, new[] {"sid"}));
+            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction(new[] { "rm" }, "event", new string[] { "abc" }, new[] {"sid"}, @namespace: "/ns"));
             _service.Verify(x => x.SendToGroupAsync("0~L25z~cm0", It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"event\",\"abc\"]")),
             ContentType.TextPlain, It.IsAny<IList<string>>(), "not ('0~L25z~c2lk' in groups)", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
@@ -72,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         [Test]
         public async Task SendToRoomWithComplexTest()
         {
-            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction("/ns", new[] { "rm" }, "event", new object[] { 1, "abc" , new { a=1, b=true } }));
+            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction(new[] { "rm" }, "event", new object[] { 1, "abc" , new { a=1, b=true } }, @namespace: "/ns"));
             _service.Verify(x => x.SendToGroupAsync("0~L25z~cm0", It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"event\",1,\"abc\",{\"a\":1,\"b\":true}]")),
             ContentType.TextPlain, It.IsAny<IList<string>>(), "", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
@@ -82,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         public async Task SendToRoomCtsTest()
         {
             using var cts = new CancellationTokenSource(1000);
-            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction("/ns", new[] { "rm" }, "event", new string[] { "abc" }), cts.Token);
+            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction(new[] { "rm" }, "event", new string[] { "abc" }, @namespace: "/ns"), cts.Token);
             _service.Verify(x => x.SendToGroupAsync("0~L25z~cm0", It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"event\",\"abc\"]")), ContentType.TextPlain, It.IsAny<IList<string>>(), "", It.Is<RequestContext>(x => x.CancellationToken == cts.Token)), Times.Once);
         }
@@ -90,10 +100,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         [Test]
         public async Task SendToRoomsTest()
         {
-            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction("/ns", new[] { "rm", "rm2" }, "ev", new string[] { "abc" }));
+            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction(new[] { "rm", "rm2" }, "ev", new string[] { "abc" }, @namespace: "/ns"));
             _service.Verify(x => x.SendToAllAsync(It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"ev\",\"abc\"]")),
             ContentType.TextPlain, It.IsAny<IList<string>>(), It.Is<string>(f => f == "'0~L25z~cm0' in groups or '0~L25z~cm0y' in groups"), It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
+        }
+
+        [Test]
+        public async Task SendToRoomsExceptTest()
+        {
+            await _collector.AddAsync(SocketIOAction.CreateSendToRoomsAction(new[] { "rm", "rm2" }, "ev", new string[] { "abc" }, new[] {"ex1"}, @namespace: "/ns"));
+            _service.Verify(x => x.SendToAllAsync(It.Is<RequestContent>(c =>
+            AssertContentData(c, "42/ns,[\"ev\",\"abc\"]")),
+            ContentType.TextPlain, It.IsAny<IList<string>>(), It.Is<string>(f => f == "'0~L25z~cm0' in groups or '0~L25z~cm0y' in groups and not ('0~L25z~ZXgx' in groups)"), It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
         }
 
         [Test]
@@ -101,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         {
             // Simulate the socket is in local
             _socketLifetimeStore.AddSocket("socket1", "/ns", "conn1");
-            await _collector.AddAsync(SocketIOAction.CreateSendToSocketAction("/ns", "socket1", "event", new string[] { "abc" }));
+            await _collector.AddAsync(SocketIOAction.CreateSendToSocketAction("socket1", "event", new string[] { "abc" }, @namespace: "/ns"));
             _service.Verify(x => x.SendToConnectionAsync("conn1", It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"event\",\"abc\"]")),
             ContentType.TextPlain, It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
@@ -110,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         [Test]
         public async Task SendToGlobalSocketTest()
         {
-            await _collector.AddAsync(SocketIOAction.CreateSendToSocketAction("/ns", "socket1", "event", new string[] { "abc" }));
+            await _collector.AddAsync(SocketIOAction.CreateSendToSocketAction("socket1", "event", new string[] { "abc" }, @namespace: "/ns"));
             _service.Verify(x => x.SendToGroupAsync("0~L25z~c29ja2V0MQ", It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"event\",\"abc\"]")),
             ContentType.TextPlain, It.IsAny<IList<string>>(), null, It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
@@ -119,7 +138,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         [Test]
         public async Task SendToNamespaceTest()
         {
-            await _collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/ns", "event", new string[] { "abc" }));
+            await _collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("event", new string[] { "abc" }, @namespace: "/ns"));
             _service.Verify(x => x.SendToGroupAsync("0~L25z~", It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"event\",\"abc\"]")),
             ContentType.TextPlain, It.IsAny<IList<string>>(), "", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
@@ -128,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         [Test]
         public async Task SendToNamespaceTestExclude()
         {
-            await _collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("/ns", "event", new string[] { "abc" }, new string[] { "sid" }));
+            await _collector.AddAsync(SocketIOAction.CreateSendToNamespaceAction("event", new string[] { "abc" }, new string[] { "sid" }, @namespace: "/ns"));
             _service.Verify(x => x.SendToGroupAsync("0~L25z~", It.Is<RequestContent>(c =>
             AssertContentData(c, "42/ns,[\"event\",\"abc\"]")),
             ContentType.TextPlain, It.IsAny<IList<string>>(), "not ('0~L25z~c2lk' in groups)", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
@@ -138,25 +157,74 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         public async Task AddLocalSocketToRoomTest()
         {
             _socketLifetimeStore.AddSocket("socket1", "/ns", "conn1");
-            await _collector.AddAsync(SocketIOAction.CreateAddSocketToRoomAction("/ns", "socket1", "rm1"));
+            await _collector.AddAsync(SocketIOAction.CreateAddSocketToRoomAction("socket1", "rm1", "/ns"));
             _service.Verify(x => x.AddConnectionToGroupAsync("0~L25z~cm0x", "conn1", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
         }
 
         [Test]
-        public void AddGlobalSocketToRoomTest()
+        public async Task AddGlobalSocketToRoomTest()
         {
-            Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            {
-                await _collector.AddAsync(SocketIOAction.CreateAddSocketToRoomAction("/ns", "socket1", "rm1"));
-            });
+            await _collector.AddAsync(SocketIOAction.CreateAddSocketToRoomAction("socket1", "rm1", "/ns"));
+            _service.Verify(x => x.AddConnectionsToGroupsAsync(It.Is<IEnumerable<string>>(x => x.Contains("0~L25z~cm0x")), "'0~L25z~c29ja2V0MQ' in groups", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
         }
 
         [Test]
         public async Task RemoveLocalSocketToRoomTest()
         {
             _socketLifetimeStore.AddSocket("socket1", "/ns", "conn1");
-            await _collector.AddAsync(SocketIOAction.CreateRemoveSocketFromRoomAction("/ns", "socket1", "rm1"));
+            await _collector.AddAsync(SocketIOAction.CreateRemoveSocketFromRoomAction("socket1", "rm1", "/ns"));
             _service.Verify(x => x.RemoveConnectionFromGroupAsync("0~L25z~cm0x", "conn1", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
+        }
+
+        [Test]
+        public async Task RemoveGlobalSocketToRoomTest()
+        {
+            await _collector.AddAsync(SocketIOAction.CreateRemoveSocketFromRoomAction("socket1", "rm1", "/ns"));
+            _service.Verify(x => x.RemoveConnectionsFromGroupsAsync(It.Is<IEnumerable<string>>(x => x.Contains("0~L25z~cm0x")), "'0~L25z~c29ja2V0MQ' in groups", It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
+        }
+
+        [Test]
+        public async Task DisconnectSocketsTest()
+        {
+            await _collector.AddAsync(SocketIOAction.CreateDisconnectSocketsAction(new[] { "socket1", "socket2" }, false, @namespace: "/ns"));
+            _service.Verify(x => x.SendToAllAsync(It.Is<RequestContent>(c => AssertContentData(c, "41/ns,")),
+                ContentType.TextPlain,
+                It.IsAny<IList<string>>(),
+                It.Is<string>(f => f == "'0~L25z~c29ja2V0MQ' in groups or '0~L25z~c29ja2V0Mg' in groups"),
+                It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
+        }
+
+        [Test]
+        public async Task DisconnectSocketsInDefaultNsTest()
+        {
+            await _collector.AddAsync(SocketIOAction.CreateDisconnectSocketsAction(new[] { "socket1", "socket2" }, false));
+            _service.Verify(x => x.SendToAllAsync(It.Is<RequestContent>(c => AssertContentData(c, "41")),
+                ContentType.TextPlain,
+                It.IsAny<IList<string>>(),
+                It.Is<string>(f => f == "'0~Lw~c29ja2V0MQ' in groups or '0~Lw~c29ja2V0Mg' in groups"),
+                It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
+        }
+
+        [Test]
+        public async Task DisconnectNamespaceTest()
+        {
+            await _collector.AddAsync(SocketIOAction.CreateDisconnectSocketsAction(null, false, @namespace: "/ns"));
+            _service.Verify(x => x.SendToAllAsync(It.Is<RequestContent>(c => AssertContentData(c, "41/ns,")),
+                ContentType.TextPlain,
+                It.IsAny<IList<string>>(),
+                It.Is<string>(f => f == "'0~L25z~' in groups"),
+                It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
+        }
+
+        [Test]
+        public async Task DisconnectSocketsAndCloseConnectionTest()
+        {
+            await _collector.AddAsync(SocketIOAction.CreateDisconnectSocketsAction(new[] { "socket1", "socket2" }, true, @namespace: "/ns"));
+            _service.Verify(x => x.SendToAllAsync(It.Is<RequestContent>(c => AssertContentData(c, "41/ns,{\"close\":true}")),
+                ContentType.TextPlain,
+                It.IsAny<IList<string>>(),
+                It.Is<string>(f => f == "'0~L25z~c29ja2V0MQ' in groups or '0~L25z~c29ja2V0Mg' in groups"),
+                It.Is<RequestContext>(x => x.CancellationToken == default)), Times.Once);
         }
 
         private bool AssertContentData(RequestContent content, string expected)

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/SocketIOTriggerBindingTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/SocketIOTriggerBindingTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
             var triggerEvent = new SocketIOTriggerEvent
             {
                 ConnectionContext = new SocketIOSocketContext(WebPubSubEventType.User, "target", "testchat", "conn1", "ns", "sid", "signature", "origin", null),
-                Request = new SocketIOMessageRequest("ns", "sid", "payload", new object[] { "param1", 2 })
+                Request = new SocketIOMessageRequest("ns", "sid", "payload", "ev", new object[] { "param1", 2 })
             };
 
             var triggerData = await binding.BindAsync(triggerEvent, null);
@@ -252,6 +252,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
                     "namespace",
                     "socketId",
                     "payload",
+                    "ev",
                     new[] { "arg1", "arg2"}),
             };
         }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/UtilitiesTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/UtilitiesTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
+{
+    public class UtilitiesTests
+    {
+        public static IEnumerable<TestCaseData> GenerateRoomFilterTestCases()
+        {
+            const string ns = "ns/";
+
+            yield return new TestCaseData(ns, null, null, false).Returns(string.Empty);
+            yield return new TestCaseData(ns, null, null, true).Returns("'0~bnMv~' in groups");
+            yield return new TestCaseData(ns, new[] { "g1" }, null, false).Returns("'0~bnMv~ZzE' in groups");
+            yield return new TestCaseData(ns, new[] { "g1" }, null, true).Returns("'0~bnMv~ZzE' in groups");
+            yield return new TestCaseData(ns, null, new[] { "g1" }, false).Returns("not ('0~bnMv~ZzE' in groups)");
+            yield return new TestCaseData(ns, null, new[] { "g1" }, true).Returns("'0~bnMv~' in groups and not ('0~bnMv~ZzE' in groups)");
+            yield return new TestCaseData(ns, new[] { "g1", "g2" }, null, false).Returns("'0~bnMv~ZzE' in groups or '0~bnMv~ZzI' in groups");
+            yield return new TestCaseData(ns, null, new[] { "g1", "g2" }, false).Returns("not ('0~bnMv~ZzE' in groups) and not ('0~bnMv~ZzI' in groups)");
+            yield return new TestCaseData(ns, new[] { "g1", "g2" }, new[] { "g3", "g4" }, false).Returns("'0~bnMv~ZzE' in groups or '0~bnMv~ZzI' in groups and not ('0~bnMv~ZzM' in groups) and not ('0~bnMv~ZzQ' in groups)");
+        }
+
+        [TestCaseSource(nameof(GenerateRoomFilterTestCases))]
+        public string GenerateRoomFilter(string @namespace, IList<string> rooms, IList<string> exceptRooms, bool containsNamespace)
+        {
+            return Utilities.GenerateRoomFilter(@namespace, rooms, exceptRooms, containsNamespace);
+        }
+    }
+}


### PR DESCRIPTION
In this PR, I update some event design. Mainly added `closeUnderlyingConnection` to `DisconnectSocketAction` to keep consistent with origional socketio. Also, I move `namespace` to an optional parameter. The default value is "/", which is also the default one in original socketio.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
