### PR TITLE
[KeyVault] Extensions doc fix

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientBuilderExtensions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientBuilderExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.Azure
         }
 
         /// <summary>
-        /// Registers a <see cref="KeyClient"/> instance with the provided <paramref name="vaultUri"/>
+        /// Registers a <see cref="CryptographyClient "/> instance with the provided <paramref name="vaultUri"/>
         /// </summary>
         /// <typeparam name="TBuilder">The type of builder to extend.</typeparam>
         /// <param name="builder">The builder to extend.</param>
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.Azure
         }
 
         /// <summary>
-        /// Registers a <see cref="KeyClient"/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
+        /// Registers a <see cref="CryptographyClient "/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
         /// </summary>
         /// <typeparam name="TBuilder">The type of builder to extend.</typeparam>
         /// <typeparam name="TConfiguration">The type of configuration to use for the client builder.</typeparam>


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a copy/paste documentation error in the KeyClientBuilderExtensions class.

## References and related

- [AddCryptographyClient documentation states incorrectly that it adds a KeyClient (#45442)](https://github.com/Azure/azure-sdk-for-net/issues/45442)