### PR TITLE
[Schema Registry] Bump Avro Vesion

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -187,7 +187,7 @@
     These are dependencies for Track 2 integration packages
   -->
   <ItemGroup Condition="'$(IsClientLibrary)' == 'true' and $(MSBuildProjectName.StartsWith('Microsoft.'))">
-    <PackageReference Update="Apache.Avro" Version="1.11.0" />
+    <PackageReference Update="Apache.Avro" Version="1.12.0" />
     <PackageReference Update="CloudNative.CloudEvents" Version="2.0.0" />
     <PackageReference Update="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0" />
     <PackageReference Update="Google.Protobuf" Version="3.24.3" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the Avro reference to 1.12.0, which upgrades the Newtonsoft.Json dependency to 13.0.1, resolving a vulnerability in earlier versions.

## References and related

- [[Schema Registry] Bump Apach.Avro dependency version (#43117)](https://github.com/Azure/azure-sdk-for-net/issues/43117)