### PR TITLE
[Extensions] Bump KeyVault Dependencies

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -121,7 +121,7 @@
     <PackageReference Update="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0-beta.1" />
     <PackageReference Update="Azure.Monitor.Query" Version="1.1.0" />
     <PackageReference Update="Azure.Identity" Version="1.12.0" />
-    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageReference Update="Azure.Storage.Common" Version="12.20.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -122,8 +122,8 @@
     <PackageReference Update="Azure.Monitor.Query" Version="1.1.0" />
     <PackageReference Update="Azure.Identity" Version="1.12.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
-    <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.2.0" />
-    <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.2.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.6.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageReference Update="Azure.Storage.Common" Version="12.20.1" />
     <PackageReference Update="Azure.Storage.Blobs" Version="12.21.1" />
     <PackageReference Update="Azure.Storage.Queues" Version="12.19.1" />
@@ -267,8 +267,8 @@
     <PackageReference Update="Azure.ResourceManager.EventHubs" Version="1.0.0" />
     <PackageReference Update="Azure.ResourceManager.ContainerRegistry" Version="1.1.0" />
     <PackageReference Update="Azure.Search.Documents" Version="11.2.0" />
-    <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.4.0" />
-    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0-beta.4" />
+    <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.6.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Update="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.8.0" />
     <PackageReference Update="BenchmarkDotNet" Version="0.13.4" />

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.2 (2024-08-16)
 
 ### Other Changes
+
+- Updated reference to `Azure.Security.KeyVault.Secrets` v4.6.0 to mitigate a reported SSRF vulnerability.
 
 ## 1.3.1 (2024-02-12)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
@@ -4,7 +4,7 @@
     <Description>Azure Key Vault configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);azure;keyvault</PackageTags>
-    <Version>1.4.0-beta.1</Version>
+    <Version>1.3.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.1</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0102</NoWarn>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.4 (2024-08-16)
 
 ### Other Changes
+
+- Updated reference to `Azure.Security.KeyVault.Keys` v4.6.0 to mitigate a reported SSRF vulnerability.
 
 ## 1.2.3 (2024-02-12)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Microsoft Azure Key Vault key encryption support.</Description>
     <PackageTags>aspnetcore;dataprotection;azure;keyvault</PackageTags>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.2.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.3</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>


### PR DESCRIPTION
# Summary

The focus of these changes is to update references to `Azure.Security.KeyVault.Secrets` and `Azure.Security.KeyVault.Keys` to version 4.6.0 to mitigate a reported SSRF vulnerability.