### PR TITLE
Add support for providing an object ID to ManagedIdentityCredential.

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Core.Pipeline;
-using System.Linq;
 
 namespace Azure.Identity
 {
@@ -45,6 +45,17 @@ namespace Azure.Identity
             : this(new ManagedIdentityClient(new ManagedIdentityClientOptions { ClientId = clientId, Pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: true), Options = options }))
         {
             _logAccountDetails = options?.Diagnostics?.IsAccountIdentifierLoggingEnabled ?? false;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="ManagedIdentityCredential"/> capable of authenticating a resource with a user-assigned managed identity.
+        /// </summary>
+        /// <param name="options">Options to configure the management of the requests sent to Microsoft Entra ID.</param>
+        public ManagedIdentityCredential(ManagedIdentityCredentialOptions options)
+            : this(new ManagedIdentityClient(new ManagedIdentityClientOptions { ObjectId = options.ObjectId, Pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: true), Options = options }))
+        {
+            _logAccountDetails = options?.Diagnostics?.IsAccountIdentifierLoggingEnabled ?? false;
+            _clientId = options.ObjectId;
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -37,16 +37,35 @@ namespace Azure.Identity
         {
         }
 
-        public ManagedIdentityClient(ManagedIdentityClientOptions options)
+        private void ValidateOptions(ManagedIdentityClientOptions options)
         {
-            if (options.ClientId != null && options.ResourceIdentifier != null)
+            int numberOfIdentifiersSpecified = 0;
+            if (options.ClientId != null)
+            {
+                numberOfIdentifiersSpecified++;
+            }
+            if (options.ResourceIdentifier != null)
+            {
+                numberOfIdentifiersSpecified++;
+            }
+            if (options.ObjectId != null)
+            {
+                numberOfIdentifiersSpecified++;
+            }
+            if (numberOfIdentifiersSpecified > 1)
             {
                 throw new ArgumentException(
-                    $"{nameof(ManagedIdentityClientOptions)} cannot specify both {nameof(options.ResourceIdentifier)} and {nameof(options.ClientId)}.");
+                    $"{nameof(ManagedIdentityClientOptions)} can only specify one of {nameof(options.ResourceIdentifier)}, {nameof(options.ClientId)}, or {nameof(options.ObjectId)}.");
             }
+        }
+
+        public ManagedIdentityClient(ManagedIdentityClientOptions options)
+        {
+            ValidateOptions(options);
 
             ClientId = string.IsNullOrEmpty(options.ClientId) ? null : options.ClientId;
             ResourceIdentifier = string.IsNullOrEmpty(options.ResourceIdentifier) ? null : options.ResourceIdentifier;
+            ObjectId = string.IsNullOrEmpty(options.ObjectId) ? null : options.ObjectId;
             Pipeline = options.Pipeline;
             _enableLegacyMI = options.EnableManagedIdentityLegacyBehavior;
             _isChainedCredential = options.Options?.IsChainedCredential ?? false;
@@ -58,6 +77,8 @@ namespace Azure.Identity
         internal CredentialPipeline Pipeline { get; }
 
         internal protected string ClientId { get; }
+
+        internal protected string ObjectId { get; }
 
         internal ResourceIdentifier ResourceIdentifier { get; }
 

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClientOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClientOptions.cs
@@ -12,6 +12,8 @@ namespace Azure.Identity
 
         public string ClientId { get; set; }
 
+        public string ObjectId { get; set; }
+
         public ResourceIdentifier ResourceIdentifier { get; set; }
 
         public bool PreserveTransport { get; set; }

--- a/sdk/identity/Azure.Identity/src/MsalManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalManagedIdentityClient.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,6 +41,10 @@ namespace Azure.Identity
             if (!string.IsNullOrEmpty(clientOptions?.ClientId))
             {
                 ManagedIdentityId = ManagedIdentityId.WithUserAssignedClientId(clientOptions.ClientId);
+            }
+            if (!string.IsNullOrEmpty(clientOptions?.ObjectId))
+            {
+                ManagedIdentityId = ManagedIdentityId.WithUserAssignedObjectId(clientOptions.ObjectId);
             }
             else if (clientOptions?.ResourceIdentifier != null)
             {


### PR DESCRIPTION
Investigating what it would look like to add this support in .NET, to understand the design in contrast to what we are doing in [C++](https://github.com/Azure/azure-sdk-for-cpp/pull/5910) (as part of https://github.com/Azure/azure-sdk-for-net-pr/issues/2131)

Todo:
- Figure out how `ManagedIdentityCredential` uses the `_clientId` field (it gets set to different Ids).
- What, if anything, needs to change in terms of `_msalConfidentialClient`.
- Add/update tests.
