### PR TITLE
[System.ClientModel] Removes the implicit cast from string to ApiKeyCredential

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 ### Breaking Changes
 
-- Removed implicit cast from `string` to `ApiKeyCredential`.
-
 ### Bugs Fixed
 
 ### Other Changes
+
+- Removed implicit cast from `string` to `ApiKeyCredential`.
 
 ## 1.1.0-beta.7 (2024-08-14)
 

--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Removed implicit cast from `string` to `ApiKeyCredential`.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -4,7 +4,7 @@ namespace System.ClientModel
     {
         public ApiKeyCredential(string key) { }
         public void Deconstruct(out string key) { throw null; }
-        public static implicit operator System.ClientModel.ApiKeyCredential (string key) { throw null; }
+        public static System.ClientModel.ApiKeyCredential FromEnvironmentVariable(string variable) { throw null; }
         public void Update(string key) { }
     }
     public abstract partial class AsyncCollectionResult<T> : System.ClientModel.ClientResult, System.Collections.Generic.IAsyncEnumerable<T>

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -4,7 +4,6 @@ namespace System.ClientModel
     {
         public ApiKeyCredential(string key) { }
         public void Deconstruct(out string key) { throw null; }
-        public static System.ClientModel.ApiKeyCredential FromEnvironmentVariable(string variable) { throw null; }
         public void Update(string key) { }
     }
     public abstract partial class AsyncCollectionResult<T> : System.ClientModel.ClientResult, System.Collections.Generic.IAsyncEnumerable<T>

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -4,7 +4,7 @@ namespace System.ClientModel
     {
         public ApiKeyCredential(string key) { }
         public void Deconstruct(out string key) { throw null; }
-        public static implicit operator System.ClientModel.ApiKeyCredential (string key) { throw null; }
+        public static System.ClientModel.ApiKeyCredential FromEnvironmentVariable(string variable) { throw null; }
         public void Update(string key) { }
     }
     public abstract partial class AsyncCollectionResult<T> : System.ClientModel.ClientResult, System.Collections.Generic.IAsyncEnumerable<T>

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -4,7 +4,6 @@ namespace System.ClientModel
     {
         public ApiKeyCredential(string key) { }
         public void Deconstruct(out string key) { throw null; }
-        public static System.ClientModel.ApiKeyCredential FromEnvironmentVariable(string variable) { throw null; }
         public void Update(string key) { }
     }
     public abstract partial class AsyncCollectionResult<T> : System.ClientModel.ClientResult, System.Collections.Generic.IAsyncEnumerable<T>

--- a/sdk/core/System.ClientModel/src/Convenience/ApiKeyCredential.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ApiKeyCredential.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.ClientModel.Internal;
-using System.Security;
 using System.Threading;
 
 namespace System.ClientModel;
@@ -65,40 +64,5 @@ public class ApiKeyCredential
         Argument.AssertNotNullOrEmpty(key, nameof(key));
 
         Volatile.Write(ref _key, key);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ApiKeyCredential"/> class
-    /// from the value stored in the specified environment variable.
-    /// </summary>
-    /// <param name="variable">
-    /// The name of the environment variable where the API key is stored.
-    /// </param>
-    /// <returns></returns>
-    /// <exception cref="System.ArgumentNullException">
-    /// Thrown when the <paramref name="variable"/> is null.
-    /// </exception>
-    /// <exception cref="System.ArgumentException">
-    /// Thrown when the <paramref name="variable"/> is empty.
-    /// </exception>
-    /// <exception cref="ArgumentException">
-    /// Thrown when the environment variable is not found.
-    /// </exception>
-    /// <exception cref="SecurityException">
-    /// Thrown when the caller does not have the required permission to perform
-    /// this operation.
-    /// </exception>
-    public static ApiKeyCredential FromEnvironmentVariable(string variable)
-    {
-        Argument.AssertNotNullOrEmpty(variable, nameof(variable));
-
-        string? key = Environment.GetEnvironmentVariable(variable);
-
-        if (string.IsNullOrEmpty(key))
-        {
-            throw new ArgumentException($"Environment variable '{variable}' not found.");
-        }
-
-        return new ApiKeyCredential(key);
     }
 }

--- a/sdk/core/System.ClientModel/src/Convenience/ApiKeyCredential.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ApiKeyCredential.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ClientModel.Internal;
+using System.Security;
 using System.Threading;
 
 namespace System.ClientModel;
@@ -66,6 +67,38 @@ public class ApiKeyCredential
         Volatile.Write(ref _key, key);
     }
 
-    /// <summary> Converts a string to an <see cref="ApiKeyCredential"/>. </summary>
-    public static implicit operator ApiKeyCredential(string key) => new(key);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApiKeyCredential"/> class
+    /// from the value stored in the specified environment variable.
+    /// </summary>
+    /// <param name="variable">
+    /// The name of the environment variable where the API key is stored.
+    /// </param>
+    /// <returns></returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown when the <paramref name="variable"/> is null.
+    /// </exception>
+    /// <exception cref="System.ArgumentException">
+    /// Thrown when the <paramref name="variable"/> is empty.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the environment variable is not found.
+    /// </exception>
+    /// <exception cref="SecurityException">
+    /// Thrown when the caller does not have the required permission to perform
+    /// this operation.
+    /// </exception>
+    public static ApiKeyCredential FromEnvironmentVariable(string variable)
+    {
+        Argument.AssertNotNullOrEmpty(variable, nameof(variable));
+
+        string? key = Environment.GetEnvironmentVariable(variable);
+
+        if (string.IsNullOrEmpty(key))
+        {
+            throw new ArgumentException($"Environment variable '{variable}' not found.");
+        }
+
+        return new ApiKeyCredential(key);
+    }
 }

--- a/sdk/core/System.ClientModel/tests/Pipeline/ApiKeyAuthenticationPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ApiKeyAuthenticationPolicyTests.cs
@@ -17,20 +17,6 @@ public class ApiKeyAuthenticationPolicyTests : SyncAsyncTestBase
     }
 
     [Test]
-    public void CreateFromEnvironmentVariable()
-    {
-        string variableName = "TEST_KEY_NAME";
-        string variableValue = "test_key_value";
-        Environment.SetEnvironmentVariable(variableName, variableValue);
-
-        ApiKeyCredential credential = ApiKeyCredential.FromEnvironmentVariable(variableName);
-        Assert.That(credential, Is.Not.Null);
-
-        credential.Deconstruct(out string deconstructed);
-        Assert.That(deconstructed, Is.EqualTo(variableValue));
-    }
-
-    [Test]
     public async Task HeaderPolicySetsKey()
     {
         string keyValue = "test_key";

--- a/sdk/core/System.ClientModel/tests/Pipeline/ApiKeyAuthenticationPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ApiKeyAuthenticationPolicyTests.cs
@@ -17,16 +17,17 @@ public class ApiKeyAuthenticationPolicyTests : SyncAsyncTestBase
     }
 
     [Test]
-    public void CanImplicitlyCastApiKeyCredential()
+    public void CreateFromEnvironmentVariable()
     {
-        string keyValue = "test_key";
-        ApiKeyCredential credential1 = new(keyValue);
-        ApiKeyCredential credential2 = keyValue;
+        string variableName = "TEST_KEY_NAME";
+        string variableValue = "test_key_value";
+        Environment.SetEnvironmentVariable(variableName, variableValue);
 
-        credential1.Deconstruct(out string deconstructed1);
-        credential2.Deconstruct(out string deconstructed2);
+        ApiKeyCredential credential = ApiKeyCredential.FromEnvironmentVariable(variableName);
+        Assert.That(credential, Is.Not.Null);
 
-        Assert.AreEqual(deconstructed1, deconstructed2);
+        credential.Deconstruct(out string deconstructed);
+        Assert.That(deconstructed, Is.EqualTo(variableValue));
     }
 
     [Test]


### PR DESCRIPTION
Removes the implicit cast from `string` to `ApiKeyCredential` because it's confusing and doesn't version well.