### PR TITLE
enable master crc

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -52,6 +52,7 @@
     <Compile Include="$(AzureStorageSharedSources)BufferExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ChecksumCalculatingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ContentRange.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ContentRangeExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ChecksumExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Constants.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)CompatSwitches.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideDecryptor.cs
@@ -186,7 +186,7 @@ namespace Azure.Storage.Blobs
 
             // did we request the last block?
             // end is inclusive/0-index, so end = n and size = n+1 means we requested the last block
-            if (contentRange.Value.Size - contentRange.Value.End == 1)
+            if (contentRange.Value.TotalResourceLength - contentRange.Value.End == 1)
             {
                 return false;
             }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTransferValidationTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTransferValidationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -1341,7 +1341,7 @@ namespace Azure.Storage.Blobs.Test
         {
             long compareValue = (long)Int32.MaxValue + 1; //Increase max int32 by one
             ContentRange contentRange = ContentRange.Parse($"bytes 0 {compareValue} {compareValue}");
-            Assert.AreEqual((long)Int32.MaxValue + 1, contentRange.Size);
+            Assert.AreEqual((long)Int32.MaxValue + 1, contentRange.TotalResourceLength);
             Assert.AreEqual(0, contentRange.Start);
             Assert.AreEqual((long)Int32.MaxValue + 1, contentRange.End);
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ContentRange.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ContentRange.cs
@@ -82,20 +82,20 @@ namespace Azure.Storage
         public long? End { get; }
 
         /// <summary>
-        /// Size of this range, measured in this instance's <see cref="Unit"/>.
+        /// Size of the entire resource this range is from, measured in this instance's <see cref="Unit"/>.
         /// </summary>
-        public long? Size { get; }
+        public long? TotalResourceLength { get; }
 
         /// <summary>
         /// Unit this range is measured in. Generally "bytes".
         /// </summary>
         public RangeUnit Unit { get; }
 
-        public ContentRange(RangeUnit unit, long? start, long? end, long? size)
+        public ContentRange(RangeUnit unit, long? start, long? end, long? totalResourceLength)
         {
             Start = start;
             End = end;
-            Size = size;
+            TotalResourceLength = totalResourceLength;
             Unit = unit;
         }
 
@@ -113,7 +113,7 @@ namespace Azure.Storage
             string unit = default;
             long? start = default;
             long? end = default;
-            long? size = default;
+            long? resourceSize = default;
 
             try
             {
@@ -136,10 +136,10 @@ namespace Azure.Storage
                 var rawSize = tokens[blobSizeIndex];
                 if (rawSize != WildcardMarker)
                 {
-                    size = long.Parse(rawSize, CultureInfo.InvariantCulture);
+                    resourceSize = long.Parse(rawSize, CultureInfo.InvariantCulture);
                 }
 
-                return new ContentRange(unit, start, end, size);
+                return new ContentRange(unit, start, end, resourceSize);
             }
             catch (IndexOutOfRangeException)
             {
@@ -165,7 +165,7 @@ namespace Azure.Storage
         /// <summary>
         /// Indicates whether this instance and a specified <see cref="RangeUnit"/> are equal
         /// </summary>
-        public bool Equals(ContentRange other) => (other.Start == Start) && (other.End == End) && (other.Unit == Unit) && (other.Size == Size);
+        public bool Equals(ContentRange other) => (other.Start == Start) && (other.End == End) && (other.Unit == Unit) && (other.TotalResourceLength == TotalResourceLength);
 
         /// <summary>
         /// Determines if two <see cref="Unit"/> values are the same.
@@ -185,6 +185,6 @@ namespace Azure.Storage
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override int GetHashCode() => HashCodeBuilder.Combine(Start, End, Size, Unit.GetHashCode());
+        public override int GetHashCode() => HashCodeBuilder.Combine(Start, End, TotalResourceLength, Unit.GetHashCode());
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ContentRangeExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ContentRangeExtensions.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Storage.Cryptography;
+
+internal static class ContentRangeExtensions
+{
+    public static long? GetContentRangeLengthOrDefault(this string contentRange)
+        => string.IsNullOrWhiteSpace(contentRange)
+            ? default : ContentRange.Parse(contentRange).GetRangeLength();
+
+    public static long GetRangeLength(this ContentRange contentRange)
+        => contentRange.End.Value - contentRange.Start.Value + 1;
+}

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -99,7 +99,7 @@ namespace Azure.Storage.DataMovement.Blobs
             ContentRange contentRange = !string.IsNullOrWhiteSpace(result?.Details?.ContentRange) ? ContentRange.Parse(result.Details.ContentRange) : default;
             if (contentRange != default)
             {
-                size = contentRange.Size;
+                size = contentRange.TotalResourceLength;
             }
 
             return new StorageResourceItemProperties(
@@ -151,7 +151,7 @@ namespace Azure.Storage.DataMovement.Blobs
             if (contentRange != default)
             {
                 range = ContentRange.ToHttpRange(contentRange);
-                size = contentRange.Size;
+                size = contentRange.TotalResourceLength;
             }
             else if (result.Details.ContentLength > 0)
             {

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -320,14 +320,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
             ContentRange contentRange = !string.IsNullOrWhiteSpace(info?.Details?.ContentRange) ? ContentRange.Parse(info.Details.ContentRange) : default;
             if (contentRange != default)
             {
-                size = contentRange.Size;
+                size = contentRange.TotalResourceLength;
             }
 
             return new StorageResourceReadStreamResult(
                 content: info?.Content,
                 range: ContentRange.ToHttpRange(contentRange),
                 properties: new StorageResourceItemProperties(
-                    resourceLength: contentRange.Size,
+                    resourceLength: contentRange.TotalResourceLength,
                     eTag: info.Details.ETag,
                     lastModifiedTime: info.Details.LastModified,
                     properties: properties));


### PR DESCRIPTION
- Reenable partitioned download master crc validation.
- Renamed `Size` in `ContentRange` as name was misleading.
- Change partitioned downloader to rely on calculating downloaded length based on Content-Range, as Content-Length is no longer reliable for blob data.
