### PR TITLE
[AzureMonitor LiveMetrics] exception for livemetrics readme

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -126,6 +126,7 @@ known_content_issues:
   - ['sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/README.md','azure-sdk-tools/issues/404']
   - ['sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/README.md','azure-sdk-tools/issues/404']
   - ['sdk/extensions/Microsoft.Extensions.Azure/README.md','azure-sdk-tools/issues/404']
+  - ['sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/README.md','https://github.com/Azure/azure-sdk-for-net/pull/45550']
   - ['sdk/storage/Azure.Storage.Common/README.md','azure-sdk-tools/issues/404']
   - ['sdk/textanalytics/Azure.AI.TextAnalytics.Legacy.Shared/README.md','https://github.com/Azure/azure-sdk-tools/issues/404']
   - ['sdk/webpubsub/Azure.Messaging.WebPubSub/README.md', 'azure-sdk-tools/issues/404 - requires different name for auth section']


### PR DESCRIPTION
follow up to #45550



This is not a shipping library and has a Readme that doesn't follow best practices.
Adding this exception for my readme so it's not verified during CI