### PR TITLE
Removing VM size check from Azure Remote Rendering sdk tests

### DIFF
--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/tests/RemoteRenderingLiveTests.cs
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/tests/RemoteRenderingLiveTests.cs
@@ -135,7 +135,6 @@ namespace Azure.MixedReality.RemoteRendering.Tests
 
             StartRenderingSessionOperation startSessionOperation = await client.StartSessionAsync(sessionId, options);
             Assert.IsTrue(startSessionOperation.HasValue);
-            Assert.AreEqual(options.Size, startSessionOperation.Value.Size);
             Assert.AreEqual(sessionId, startSessionOperation.Value.SessionId);
 
             RenderingSession sessionProperties = await client.GetSessionAsync(sessionId);
@@ -151,7 +150,6 @@ namespace Azure.MixedReality.RemoteRendering.Tests
             Assert.IsNotNull(readyRenderingSession.Host);
             Assert.IsNotNull(readyRenderingSession.ArrInspectorPort);
             Assert.IsNotNull(readyRenderingSession.HandshakePort);
-            Assert.AreEqual(readyRenderingSession.Size, options.Size);
 
             UpdateSessionOptions updateOptions2 = new UpdateSessionOptions(TimeSpan.FromMinutes(6));
             Assert.AreEqual(TimeSpan.FromMinutes(6), updateOptions2.MaxLeaseTime);


### PR DESCRIPTION
The check is removed as we currently load-balance the session requests for the testing account specifically to avoid customer impact with regards to regular session availability. So in essence, the sessions the tests will get are not guaranteed to be 'standard' sized. Consequently, there is no point in testing this particular session property.