### PR TITLE
[AzureMonitorDistro] refactor AggregationType

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/AccumulatedValues.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/AccumulatedValues.cs
@@ -13,7 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
     /// </summary>
     internal class AccumulatedValues
     {
-        private readonly AggregationType aggregationType;
+        private readonly AggregationTypeEnum aggregationType;
 
         private SpinLock spinLock = new SpinLock();
 
@@ -25,7 +25,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
 
         private double min = double.MaxValue;
 
-        public AccumulatedValues(string metricId, AggregationType aggregationType)
+        public AccumulatedValues(string metricId, AggregationTypeEnum aggregationType)
         {
             this.MetricId = metricId;
             this.aggregationType = aggregationType;
@@ -44,18 +44,18 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
 
                 switch (this.aggregationType)
                 {
-                    case AggregationType.Avg:
-                    case AggregationType.Sum:
+                    case AggregationTypeEnum.Avg:
+                    case AggregationTypeEnum.Sum:
                         this.sum += value;
                         break;
-                    case AggregationType.Min:
+                    case AggregationTypeEnum.Min:
                         if (value < this.min)
                         {
                             this.min = value;
                         }
 
                         break;
-                    case AggregationType.Max:
+                    case AggregationTypeEnum.Max:
                         if (value > this.max)
                         {
                             this.max = value;
@@ -86,13 +86,13 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
                 count = this.count;
                 switch (this.aggregationType)
                 {
-                    case AggregationType.Avg:
+                    case AggregationTypeEnum.Avg:
                         return this.count != 0 ? this.sum / this.count : 0.0;
-                    case AggregationType.Sum:
+                    case AggregationTypeEnum.Sum:
                         return this.sum;
-                    case AggregationType.Min:
+                    case AggregationTypeEnum.Min:
                         return this.count != 0 ? this.min : 0.0;
-                    case AggregationType.Max:
+                    case AggregationTypeEnum.Max:
                         return this.count != 0 ? this.max : 0.0;
                     default:
                         throw new ArgumentOutOfRangeException(

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/AggregationTypeEnum.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/AggregationTypeEnum.cs
@@ -3,7 +3,7 @@
 
 namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
 {
-    internal enum AggregationType
+    internal enum AggregationTypeEnum
     {
         Avg = 0,
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/CollectionConfiguration.cs
@@ -7,7 +7,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
-    using Azure.Monitor.OpenTelemetry.Exporter.Internals;
     using Azure.Monitor.OpenTelemetry.AspNetCore.Models;
 
     using ExceptionDocument = Models.Exception;
@@ -41,7 +40,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
         #endregion
 
         #region Metadata used by other components
-        private readonly List<Tuple<string, Models.AggregationType?>> telemetryMetadata = new List<Tuple<string, Models.AggregationType?>>();
+        private readonly List<Tuple<string, AggregationType?>> telemetryMetadata = new List<Tuple<string, AggregationType?>>();
         #endregion
 
         public CollectionConfiguration(
@@ -110,7 +109,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
         /// <summary>
         /// Gets Telemetry types only. Used by QuickPulseTelemetryProcessor.
         /// </summary>
-        public IEnumerable<Tuple<string, Models.AggregationType?>> TelemetryMetadata => this.telemetryMetadata;
+        public IEnumerable<Tuple<string, AggregationType?>> TelemetryMetadata => this.telemetryMetadata;
 
         /// <summary>
         /// Gets document streams. Telemetry items are provided by QuickPulseTelemetryProcessor.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/DerivedMetric.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/DerivedMetric.cs
@@ -56,7 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
 
         public string Id => this.info.Id;
 
-        public Models.AggregationType? AggregationType => this.info.Aggregation;  // TODO: this was enum. Need to double check new type is parsed and used correctly.
+        public AggregationType? AggregationType => this.info.Aggregation;  // TODO: this was enum. Need to double check new type is parsed and used correctly.
 
         public bool CheckFilters(TTelemetry document, out CollectionConfigurationError[] errors)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Manager.Metrics.cs
@@ -194,8 +194,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
             Dictionary<string, AccumulatedValues> metricAccumulators = new();
 
             // prepare the accumulators based on the collection configuration
-            IEnumerable<Tuple<string, Models.AggregationType?>> allMetrics = collectionConfiguration.TelemetryMetadata;
-            foreach (Tuple<string, Models.AggregationType?> metricId in allMetrics)
+            IEnumerable<Tuple<string, AggregationType?>> allMetrics = collectionConfiguration.TelemetryMetadata;
+            foreach (Tuple<string, AggregationType?> metricId in allMetrics)
             {
                 var derivedMetricInfoAggregation = metricId.Item2;
                 if (!derivedMetricInfoAggregation.HasValue)
@@ -203,7 +203,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.LiveMetrics
                     continue;
                 }
 
-                if (Enum.TryParse(derivedMetricInfoAggregation.ToString(), out AspNetCore.LiveMetrics.Filtering.AggregationType aggregationType))
+                if (Enum.TryParse(derivedMetricInfoAggregation.ToString(), out AspNetCore.LiveMetrics.Filtering.AggregationTypeEnum aggregationType))
                 {
                     var accumulatedValues = new AccumulatedValues(metricId.Item1, aggregationType);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/Filtering/AccumulatedValuesTest.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/Filtering/AccumulatedValuesTest.cs
@@ -13,10 +13,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
         {
             // ARRANGE
             double[] accumulatedValues = { 1d, 3d };
-            AccumulatedValues accumulatorAverage = new AccumulatedValues("Metric1", AggregationType.Avg);
-            AccumulatedValues accumulatorSum = new AccumulatedValues("Metric1", AggregationType.Sum);
-            AccumulatedValues accumulatorMin = new AccumulatedValues("Metric1", AggregationType.Min);
-            AccumulatedValues accumulatorMax = new AccumulatedValues("Metric1", AggregationType.Max);
+            AccumulatedValues accumulatorAverage = new AccumulatedValues("Metric1", AggregationTypeEnum.Avg);
+            AccumulatedValues accumulatorSum = new AccumulatedValues("Metric1", AggregationTypeEnum.Sum);
+            AccumulatedValues accumulatorMin = new AccumulatedValues("Metric1", AggregationTypeEnum.Min);
+            AccumulatedValues accumulatorMax = new AccumulatedValues("Metric1", AggregationTypeEnum.Max);
 
             // ACT
             ArrayHelpers.ForEach(accumulatedValues, accumulatorAverage.AddValue);
@@ -45,10 +45,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
         public void AccumulatedValuesAggregatesCorrectlyForEmptyDataSet()
         {
             // ARRANGE
-            AccumulatedValues accumulatorAverage = new AccumulatedValues("Metric1", AggregationType.Avg);
-            AccumulatedValues accumulatorSum = new AccumulatedValues("Metric1", AggregationType.Sum);
-            AccumulatedValues accumulatorMin = new AccumulatedValues("Metric1", AggregationType.Min);
-            AccumulatedValues accumulatorMax = new AccumulatedValues("Metric1", AggregationType.Max);
+            AccumulatedValues accumulatorAverage = new AccumulatedValues("Metric1", AggregationTypeEnum.Avg);
+            AccumulatedValues accumulatorSum = new AccumulatedValues("Metric1", AggregationTypeEnum.Sum);
+            AccumulatedValues accumulatorMin = new AccumulatedValues("Metric1", AggregationTypeEnum.Min);
+            AccumulatedValues accumulatorMax = new AccumulatedValues("Metric1", AggregationTypeEnum.Max);
 
             // ACT
             double avg = accumulatorAverage.CalculateAggregation(out long avgCount);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/Filtering/DerivedMetricTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/Filtering/DerivedMetricTests.cs
@@ -9,7 +9,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
     using Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering;
     using Azure.Monitor.OpenTelemetry.AspNetCore.Models;
     using Xunit;
-    using AggregationType = Models.AggregationType;
     using RequestTelemetry = Azure.Monitor.OpenTelemetry.AspNetCore.Models.Request;
     using TelemetryType = Models.TelemetryType;
 
@@ -26,8 +25,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new[] { new FilterConjunctionGroupInfo(new List<FilterInfo> { filterInfo1, filterInfo2 }) },
                 projection: "Name",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetryThatMustPass = new RequestTelemetry() { Name = "Both the words 'dog' and 'CAT' are here, which satisfies both filters" };
@@ -60,8 +59,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "Name",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetryThatMustPass = new RequestTelemetry() { Name = "Both the words 'dog' and 'CAT' are here, which satisfies both filters" };
@@ -86,8 +85,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: null,
                 projection: "Name",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetryThatMustPass = new RequestTelemetry() { Name = "Both the words 'dog' and 'CAT' are here, which satisfies both filters" };
@@ -121,8 +120,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                         new FilterConjunctionGroupInfo(new[] { filterInfoApple, filterInfoOrange })
                     },
                 projection: "Name",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetryThatMustPass1 = new RequestTelemetry() { Name = "Both the words 'dog' and 'CAT' are here, which satisfies the first OR." };
@@ -167,8 +166,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "Id",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetry = new DocumentMock() { Name = "1.23", Id = "5.67" };
@@ -179,7 +178,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
             double projection = metric.Project(telemetry);
 
             // ASSERT
-            Assert.Equal(Models.AggregationType.Sum, metric.AggregationType);
+            Assert.Equal(AggregationType.Sum, metric.AggregationType);
             Assert.Empty(errors);
             Assert.Equal(5.67d, projection);
         }
@@ -193,8 +192,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "CustomDimensions.Dimension1",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetry = new DocumentMock(new List<KeyValuePairString>() { new("Dimension.1", "1.5") });
@@ -205,7 +204,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
             double projection = metric.Project(telemetry);
 
             // ASSERT
-            Assert.Equal(Models.AggregationType.Sum, metric.AggregationType);
+            Assert.Equal(AggregationType.Sum, metric.AggregationType);
             Assert.Empty(errors);
             Assert.Equal(1.5d, projection);
         }
@@ -219,8 +218,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "CustomMetrics.Metric1",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetry = new DocumentMock() { Metrics = { ["Metric1"] = 1.75d } };
@@ -231,7 +230,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
             double projection = metric.Project(telemetry);
 
             // ASSERT
-            Assert.Equal(Models.AggregationType.Sum, metric.AggregationType);
+            Assert.Equal(AggregationType.Sum, metric.AggregationType);
             Assert.Empty(errors);
             Assert.Equal(1.75d, projection);
         }
@@ -245,8 +244,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "COUNT()",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetry = new RequestTelemetry();
@@ -257,7 +256,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
             double projection = metric.Project(telemetry);
 
             // ASSERT
-            Assert.Equal(Models.AggregationType.Sum, metric.AggregationType);
+            Assert.Equal(AggregationType.Sum, metric.AggregationType);
             Assert.Empty(errors);
             Assert.Equal(1d, projection);
         }
@@ -271,8 +270,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "Duration",
-                aggregation: Models.AggregationType.Avg,
-                backEndAggregation: Models.AggregationType.Avg
+                aggregation: AggregationType.Avg,
+                backEndAggregation: AggregationType.Avg
             );
 
             var telemetry = new DocumentMock() { Duration = TimeSpan.FromMilliseconds(120) };
@@ -283,7 +282,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
             double projection = metric.Project(telemetry);
 
             // ASSERT
-            Assert.Equal(Models.AggregationType.Avg, metric.AggregationType);
+            Assert.Equal(AggregationType.Avg, metric.AggregationType);
             Assert.Empty(errors);
             Assert.Equal(120, projection);
         }
@@ -298,7 +297,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "Duration",
                 aggregation: AggregationType.Avg,
-                backEndAggregation: Models.AggregationType.Avg
+                backEndAggregation: AggregationType.Avg
             );
 
             var durationString = TimeSpan.FromMilliseconds(120).ToString();
@@ -326,8 +325,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new[] { new FilterConjunctionGroupInfo(new[] { filterInfo1, filterInfo2 }) },
                 projection: "Name",
-                aggregation: Models.AggregationType.Avg,
-                backEndAggregation: Models.AggregationType.Avg
+                aggregation: AggregationType.Avg,
+                backEndAggregation: AggregationType.Avg
             );
 
             // ACT
@@ -363,8 +362,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "NonExistentFieldName",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             // ACT, ASSERT
@@ -381,8 +380,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "Id",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             var telemetry = new DocumentMock() { Id = "NotDoubleValue" };
@@ -414,8 +413,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.Filtering
                 telemetryType: TelemetryType.Request.ToString(),
                 filterGroups: new FilterConjunctionGroupInfo[0],
                 projection: "*",
-                aggregation: Models.AggregationType.Sum,
-                backEndAggregation: Models.AggregationType.Sum
+                aggregation: AggregationType.Sum,
+                backEndAggregation: AggregationType.Sum
             );
 
             // ACT, ASSERT


### PR DESCRIPTION
We have two classes named "AggregationType" which causes headaches.
One is a generated model from the swagger, and the other is an enum in the Filtering namespace.
This PR eliminates that naming conflict.

### Changes
- rename `Filtering/AggregationType` to `Filtering/AggregationTypeEnum`
- change use of `Models.AggregationType` to `AggregationType`