### PR TITLE
Catch exceptions in QueueMetricsProvider and log errors

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                     // ignore transient errors, and return default metrics
                     // E.g. if the queue doesn't exist, we'll return a zero queue length
                     // and scale in
-                    _logger.LogWarning($"Error querying for queue scale status: {ex.Message}");
+                    _logger.LogWarning($"Error querying for queue scale status: {ex.ToString()}");
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Fatal error querying for queue scale status: {ex.Message}");
+                _logger.LogWarning($"Fatal error querying for queue scale status: {ex.ToString()}");
             }
 
             return 0;
@@ -101,12 +101,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                     // ignore transient errors, and return default metrics
                     // E.g. if the queue doesn't exist, we'll return a zero queue length
                     // and scale in
-                    _logger.LogWarning($"Error querying for queue scale status: {ex.Message}");
+                    _logger.LogWarning($"Error querying for queue scale status: {ex.ToString()}");
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Fatal error querying for queue scale status: {ex.Message}");
+                _logger.LogWarning($"Fatal error querying for queue scale status: {ex.ToString()}");
             }
 
             return new QueueTriggerMetrics

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -52,6 +52,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                     _logger.LogWarning($"Error querying for queue scale status: {ex.Message}");
                 }
             }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Fatal error querying for queue scale status: {ex.Message}");
+            }
+
             return 0;
         }
 
@@ -98,6 +103,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                     // and scale in
                     _logger.LogWarning($"Error querying for queue scale status: {ex.Message}");
                 }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Fatal error querying for queue scale status: {ex.Message}");
             }
 
             return new QueueTriggerMetrics


### PR DESCRIPTION
# Contributing to the Azure SDK
Exceptions in queue metrics provider are currently swallowed by the caller of GetMetricsAsync. We should be logging all exceptions thrown in the extension, not just transient failures.

see here: https://msazure.visualstudio.com/Antares/_workitems/edit/29174215

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
