### PR TITLE
[AzureMonitorDistro] Update AzureEventSourceLogForwarder defaults to warning

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -24,7 +24,7 @@
   via `Microsoft.Extensions.Logging`. For more information, refer to [Logging
   with the Azure SDK for
   .NET](https://learn.microsoft.com/dotnet/azure/sdk/logging).
-  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+  ([#45649](https://github.com/Azure/azure-sdk-for-net/pull/45649))
 
 ## 1.3.0-beta.1 (2024-07-12)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -20,6 +20,12 @@
 
 ### Other Changes
 
+* Updated log collection to default to Warning level and above for Azure SDKs
+  via `Microsoft.Extensions.Logging`. For more information, refer to [Logging
+  with the Azure SDK for
+  .NET](https://learn.microsoft.com/dotnet/azure/sdk/logging).
+  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+
 ## 1.3.0-beta.1 (2024-07-12)
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/AzureSdkCompat/AzureEventSourceLogForwarder.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/AzureSdkCompat/AzureEventSourceLogForwarder.cs
@@ -16,8 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
     {
         internal static readonly AzureEventSourceLogForwarder Noop = new AzureEventSourceLogForwarder(null, null);
         private readonly ILoggerFactory _loggerFactory;
-        private readonly HashSet<string> _eventSourceSet = new();
-        private readonly List<string> _wildcardLoggerPatterns = new();
+        private readonly bool _hasAzureLoggerFilterOptionsRules = false;
 
         private readonly ConcurrentDictionary<string, ILogger> _loggers = new ConcurrentDictionary<string, ILogger>();
 
@@ -31,23 +30,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
 
             foreach (var rule in loggerFilterOptions?.Rules ?? Enumerable.Empty<LoggerFilterRule>())
             {
-                AddRuleToSets(rule.CategoryName);
-            }
-        }
-
-        private void AddRuleToSets(string categoryName)
-        {
-            if (!string.IsNullOrEmpty(categoryName) &&
-                (categoryName.StartsWith("Azure.") || categoryName.StartsWith("Microsoft.Azure.")))
-            {
-                if (categoryName.EndsWith(".*"))
+                if (!string.IsNullOrEmpty(rule.CategoryName) &&
+                    (rule.CategoryName.StartsWith("Azure.") || rule.CategoryName.StartsWith("Microsoft.Azure.")))
                 {
-                    // Add the wildcard prefix (without the ".*")
-                    _wildcardLoggerPatterns.Add(ToEventSourceName(categoryName.Substring(0, categoryName.Length - 2)));
-                }
-                else
-                {
-                    _eventSourceSet.Add(ToEventSourceName(categoryName));
+                    _hasAzureLoggerFilterOptionsRules = true;
                 }
             }
         }
@@ -58,39 +44,9 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
             logger.Log(MapLevel(eventData.Level), new EventId(eventData.EventId, eventData.EventName), new EventSourceEvent(eventData), null, _formatMessage);
         }
 
-        private void LogFilteringEvent(EventWrittenEventArgs eventData)
-        {
-            var logger = _loggers.GetOrAdd(eventData.EventSource.Name, name => _loggerFactory!.CreateLogger(ToLoggerName(name)));
-            var isInEventSourceSet = IsInEventSourceSet(eventData.EventSource.Name);
-            var logLevel = MapLevel(eventData.Level);
-
-            // Log only if the event is not in the event source set or the log level is >= Warning
-            if (isInEventSourceSet || logLevel >= LogLevel.Warning)
-            {
-                logger.Log(logLevel, new EventId(eventData.EventId, eventData.EventName), new EventSourceEvent(eventData), null, _formatMessage);
-            }
-        }
-
-        private bool IsInEventSourceSet(string eventSourceName)
-        {
-            // Check for exact match
-            if (_eventSourceSet.Contains(eventSourceName))
-            {
-                return true;
-            }
-
-            // Check if the eventSourceName starts with any wildcard pattern prefix
-            return _wildcardLoggerPatterns.Count > 0 && _wildcardLoggerPatterns.Any(pattern => eventSourceName.StartsWith(pattern));
-        }
-
         private static string ToLoggerName(string name)
         {
             return name.Replace('-', '.');
-        }
-
-        private static string ToEventSourceName(string name)
-        {
-            return name.Replace('.', '-');
         }
 
         private static LogLevel MapLevel(EventLevel level)
@@ -121,14 +77,9 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
         {
             if (_loggerFactory != null)
             {
-                if (_eventSourceSet.Count == 0 && _wildcardLoggerPatterns.Count == 0)
-                {
-                    _listener ??= new AzureEventSourceListener((e, s) => LogEvent(e), EventLevel.Warning);
-                }
-                else
-                {
-                    _listener ??= new AzureEventSourceListener((e, s) => LogFilteringEvent(e), EventLevel.Verbose);
-                }
+                // Setting even a single custom filter for Azure SDK logs will reset the default warning level and switch to listening at the verbose level.
+                // This gives the customer full control over the log levels for all Azure SDK components.
+                _listener ??= new AzureEventSourceListener((e, s) => LogEvent(e), _hasAzureLoggerFilterOptionsRules ? EventLevel.Verbose : EventLevel.Warning);
             }
 
             return Task.CompletedTask;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/AzureSdkCompat/AzureEventSourceLogForwarder.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/AzureSdkCompat/AzureEventSourceLogForwarder.cs
@@ -14,8 +14,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
 {
     internal sealed class AzureEventSourceLogForwarder : IHostedService, IDisposable
     {
-        internal static readonly AzureEventSourceLogForwarder Noop = new AzureEventSourceLogForwarder(null);
+        internal static readonly AzureEventSourceLogForwarder Noop = new AzureEventSourceLogForwarder(null, null);
         private readonly ILoggerFactory _loggerFactory;
+        private readonly HashSet<string> _eventSourceSet = new();
+        private readonly List<string> _wildcardLoggerPatterns = new();
 
         private readonly ConcurrentDictionary<string, ILogger> _loggers = new ConcurrentDictionary<string, ILogger>();
 
@@ -23,9 +25,31 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
 
         private AzureEventSourceListener _listener;
 
-        public AzureEventSourceLogForwarder(ILoggerFactory loggerFactory)
+        public AzureEventSourceLogForwarder(ILoggerFactory loggerFactory, LoggerFilterOptions loggerFilterOptions)
         {
             _loggerFactory = loggerFactory;
+
+            foreach (var rule in loggerFilterOptions?.Rules ?? Enumerable.Empty<LoggerFilterRule>())
+            {
+                AddRuleToSets(rule.CategoryName);
+            }
+        }
+
+        private void AddRuleToSets(string categoryName)
+        {
+            if (!string.IsNullOrEmpty(categoryName) &&
+                (categoryName.StartsWith("Azure.") || categoryName.StartsWith("Microsoft.Azure.")))
+            {
+                if (categoryName.EndsWith(".*"))
+                {
+                    // Add the wildcard prefix (without the ".*")
+                    _wildcardLoggerPatterns.Add(ToEventSourceName(categoryName.Substring(0, categoryName.Length - 2)));
+                }
+                else
+                {
+                    _eventSourceSet.Add(ToEventSourceName(categoryName));
+                }
+            }
         }
 
         private void LogEvent(EventWrittenEventArgs eventData)
@@ -34,9 +58,39 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
             logger.Log(MapLevel(eventData.Level), new EventId(eventData.EventId, eventData.EventName), new EventSourceEvent(eventData), null, _formatMessage);
         }
 
+        private void LogFilteringEvent(EventWrittenEventArgs eventData)
+        {
+            var logger = _loggers.GetOrAdd(eventData.EventSource.Name, name => _loggerFactory!.CreateLogger(ToLoggerName(name)));
+            var isInEventSourceSet = IsInEventSourceSet(eventData.EventSource.Name);
+            var logLevel = MapLevel(eventData.Level);
+
+            // Log only if the event is not in the event source set or the log level is >= Warning
+            if (isInEventSourceSet || logLevel >= LogLevel.Warning)
+            {
+                logger.Log(logLevel, new EventId(eventData.EventId, eventData.EventName), new EventSourceEvent(eventData), null, _formatMessage);
+            }
+        }
+
+        private bool IsInEventSourceSet(string eventSourceName)
+        {
+            // Check for exact match
+            if (_eventSourceSet.Contains(eventSourceName))
+            {
+                return true;
+            }
+
+            // Check if the eventSourceName starts with any wildcard pattern prefix
+            return _wildcardLoggerPatterns.Count > 0 && _wildcardLoggerPatterns.Any(pattern => eventSourceName.StartsWith(pattern));
+        }
+
         private static string ToLoggerName(string name)
         {
             return name.Replace('-', '.');
+        }
+
+        private static string ToEventSourceName(string name)
+        {
+            return name.Replace('.', '-');
         }
 
         private static LogLevel MapLevel(EventLevel level)
@@ -67,7 +121,14 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
         {
             if (_loggerFactory != null)
             {
-                _listener ??= new AzureEventSourceListener((e, s) => LogEvent(e), EventLevel.Verbose);
+                if (_eventSourceSet.Count == 0 && _wildcardLoggerPatterns.Count == 0)
+                {
+                    _listener ??= new AzureEventSourceListener((e, s) => LogEvent(e), EventLevel.Warning);
+                }
+                else
+                {
+                    _listener ??= new AzureEventSourceListener((e, s) => LogFilteringEvent(e), EventLevel.Verbose);
+                }
             }
 
             return Task.CompletedTask;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -176,7 +176,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                 }
 
                 var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-                return new AzureEventSourceLogForwarder(loggerFactory);
+                var loggerFilterOptions = sp.GetRequiredService<IOptionsMonitor<LoggerFilterOptions>>().CurrentValue;
+                return new AzureEventSourceLogForwarder(loggerFactory, loggerFilterOptions);
             });
 
             // Register Manager as a singleton

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
@@ -27,19 +27,27 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 #else
         [Theory]
 #endif
-        [InlineData(LogLevel.Information, "TestInfoEvent: hello")]
-        [InlineData(LogLevel.Warning, "TestWarningEvent: hello")]
-        [InlineData(LogLevel.Debug, null)]
-        public async Task DistroLogForwarderIsAdded(LogLevel eventLevel, string expectedMessage)
+        [InlineData(false, LogLevel.Debug, null)]
+        [InlineData(false, LogLevel.Information, null)]
+        [InlineData(false, LogLevel.Warning, "TestWarningEvent: hello")]
+        [InlineData(true, LogLevel.Information, "TestInfoEvent: hello")]
+        [InlineData(true, LogLevel.Warning, "TestWarningEvent: hello")]
+        [InlineData(true, LogLevel.Debug, "TestVerboseEvent: hello")]
+        public async Task DistroLogForwarderIsAdded(bool addLoggingFilter, LogLevel eventLevel, string expectedMessage)
         {
             var builder = WebApplication.CreateBuilder();
+            using TestEventSource source = new TestEventSource(addLoggingFilter ? "Azure-LoggingFilter" : "Azure-Test");
+
+            if (addLoggingFilter)
+            {
+                builder.Logging.AddFilter(source.Name.Replace('-', '.'), eventLevel);
+            }
             var transport = new MockTransport(_ => new MockResponse(200).SetContent("ok"));
             SetUpOTelAndLogging(builder, transport, LogLevel.Information);
 
             using var app = builder.Build();
             await app.StartAsync();
 
-            using TestEventSource source = new TestEventSource();
             Assert.True(source.IsEnabled());
             source.LogMessage("hello", eventLevel);
             WaitForRequest(transport);
@@ -79,7 +87,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 
             await app.StartAsync();
 
-            using TestEventSource source = new TestEventSource();
+            using TestEventSource source = new TestEventSource("Azure-Test");
             Assert.True(source.IsEnabled());
             source.LogMessage("hello", eventLevel);
 
@@ -140,6 +148,27 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             Assert.False(logAzureFilterCalled);
         }
 
+        [Fact]
+        public async Task DistroLogForwarderAppliesWildCardFilter()
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.AddFilter("Azure.*", LogLevel.Warning);
+
+            var transport = new MockTransport(_ => new MockResponse(200).SetContent("ok"));
+            SetUpOTelAndLogging(builder, transport, LogLevel.Information);
+
+            using var app = builder.Build();
+            await app.StartAsync();
+
+            using TestEventSource source = new TestEventSource("Azure-Test");
+            Assert.True(source.IsEnabled());
+            source.LogMessage("hello", LogLevel.Warning);
+            WaitForRequest(transport);
+
+            Assert.Single(transport.Requests);
+            await AssertContentContains(transport.Requests.Single(), "TestWarningEvent: hello", LogLevel.Warning);
+        }
+
         private IEnumerable<MockRequest> WaitForRequest(MockTransport transport, Func<MockRequest, bool>? filter = null)
         {
             filter = filter ?? (_ => true);
@@ -161,7 +190,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             contentStream.Position = 0;
             var content = BinaryData.FromStream(contentStream).ToString();
             var jsonMessage = $"\"message\":\"{expectedMessage}\"";
-            var jsonLevel = $"\"severityLevel\":\"{expectedLevel}\"";
+            var level = expectedLevel == LogLevel.Debug ? "Verbose" : expectedLevel.ToString();
+            var jsonLevel = $"\"severityLevel\":\"{level}\"";
             Assert.Contains(jsonMessage, content);
             Assert.Contains(jsonLevel, content);
 
@@ -206,9 +236,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 
         internal class TestEventSource : AzureEventSource
         {
-            private const string EventSourceName = "Azure-Test";
-            public TestEventSource() : base(EventSourceName)
+            private readonly string EventSourceName;
+
+            public TestEventSource(string eventSourceName) : base(eventSourceName)
             {
+                EventSourceName = eventSourceName;
             }
 
             [Event(1, Level = EventLevel.Informational, Message = "TestInfoEvent: {0}")]


### PR DESCRIPTION
The Application Insights .NET SDK captures warning logs by default, and we are aligning with this behavior.