### PR TITLE
Remove redundant ToArray() call in GetBlobsAsyncCollection

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs
@@ -65,7 +65,7 @@ namespace Azure.Storage.Blobs.Models
             }
 
             return Page<BlobItem>.FromValues(
-                response.Value.Segment.BlobItems.ToBlobItems().ToArray(),
+                response.Value.Segment.BlobItems.ToBlobItems(),
                 response.Value.NextMarker,
                 response.GetRawResponse());
         }


### PR DESCRIPTION
Addresses an unnecessary `ToArray()` method call in the `GetBlobsAsyncCollection` class.

Issue #45653 