### PR TITLE
[AzureMonitorDistro] disable LogForwarder tests in net6 and MacOS

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
@@ -148,7 +148,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             Assert.False(logAzureFilterCalled);
         }
 
+#if NET6_0
+        [ConditionallySkipOSFact(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+#else
         [Fact]
+#endif
         public async Task DistroLogForwarderAppliesWildCardFilter()
         {
             var builder = WebApplication.CreateBuilder();
@@ -169,7 +173,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             await AssertContentContains(transport.Requests.Single(), "TestWarningEvent: hello", LogLevel.Warning);
         }
 
+#if NET6_0
+        [ConditionallySkipOSFact(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+#else
         [Fact]
+#endif
         public async Task SettingCustomLoggingFilterResetsDefaultWarningLevel()
         {
             var builder = WebApplication.CreateBuilder();
@@ -205,7 +213,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             await AssertContentContains(transport.Requests.Single(), "TestInfoEvent: hello two", LogLevel.Information);
         }
 
+#if NET6_0
+        [ConditionallySkipOSFact(platformToSkip: "macos", reason: "This test consistently exceeds 1 hour runtime limit when running on MacOS & Net60")]
+#else
         [Fact]
+#endif
         public async Task CustomLoggingFilterOverridesDefaultWarningAndCapturesErrorLogs()
         {
             var builder = WebApplication.CreateBuilder();


### PR DESCRIPTION
Follow up to #45649, new tests were added in this class.
Related to #44423.

An unknown issue in the LogForwarder test class causes these tests to exceed the 1 hour runtime limit and fail.
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4074943&view=logs&j=5ee5fa9b-185c-52bc-0624-8e87d1d5c9f8

This only affects MacOS & Net6. Net6 will read end of life in a few months. When the CI is updated to drop Net6, these conditions can be removed.