### PR TITLE
Set up some code owners for the Remote Rendering service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -677,6 +677,9 @@
 # PRLabel: %Mixed Reality
 /sdk/objectanchors/                                                @crtreasu @rgarcia @JoshLove-msft
 
+# PRLabel: %Remote Rendering
+/sdk/remoterendering/                                              @FlorianBorn71 @MichaelZp0 @ChristopherManthei
+
 # ServiceLabel: %Mixed Reality
 # ServiceOwners:                                                   @crtreasu @rgarcia
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -680,6 +680,9 @@
 # PRLabel: %Remote Rendering
 /sdk/remoterendering/                                              @FlorianBorn71 @MichaelZp0 @ChristopherManthei
 
+#ServiceLabel: %Remote Rendering
+#ServiceOwners:                                                    @FlorianBorn71 @MichaelZp0 @ChristopherManthei
+
 # ServiceLabel: %Mixed Reality
 # ServiceOwners:                                                   @crtreasu @rgarcia
 


### PR DESCRIPTION
The Remote Rendering service did not have proper code owners assigned so it always fell back to @jsquire