### PR TITLE
Azure.Core | Remove unused HttpClient request callback

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other Changes
 
 - Added a new constructor on `AzureEventSourceListener` for callers that don't need the formatted message ([#45191](https://github.com/Azure/azure-sdk-for-net/pull/45191)).
+- Remove unused callback from `HttpRequestMessage` options in `HttpClientTransport` transport.
 
 ## 1.42.0 (2024-08-01)
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -18,8 +18,6 @@ namespace Azure.Core.Pipeline
     /// </summary>
     public partial class HttpClientTransport : HttpPipelineTransport, IDisposable
     {
-        internal const string MessageForServerCertificateCallback = "MessageForServerCertificateCallback";
-
         /// <summary>
         /// A shared instance of <see cref="HttpClientTransport"/> with default parameters.
         /// </summary>
@@ -85,7 +83,6 @@ namespace Azure.Core.Pipeline
 #pragma warning restore CA1801
         {
             using HttpRequestMessage httpRequest = BuildRequestMessage(message);
-            SetPropertiesOrOptions<HttpMessage>(httpRequest, MessageForServerCertificateCallback, message);
             HttpResponseMessage responseMessage;
             Stream? contentStream = null;
             message.ClearResponse();


### PR DESCRIPTION
Per offline discussion with @christothes, we believe this addition to the `HttpRequestMessage` was part of an early design that didn't end up being used for any client implementations.  As we review functionality we want to move into SCM, removing this so it doesn't cause confusion about whether or not it should be ported/maintained/etc.