### PR TITLE
Link to conceptual doc in interactive browser broker cred options bag

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
@@ -9,6 +9,7 @@ namespace Azure.Identity.Broker
 {
     /// <summary>
     /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of an embedded web view or the system browser.
+    /// For more information, see <see href="https://aka.ms/azsdk/net/identity/interactive-brokered-auth">Interactive brokered authentication</see>.
     /// </summary>
     public class InteractiveBrowserCredentialBrokerOptions : InteractiveBrowserCredentialOptions, IMsalPublicClientInitializerOptions
     {
@@ -17,7 +18,6 @@ namespace Azure.Identity.Broker
         /// <summary>
         /// Gets or sets whether Microsoft Account (MSA) passthrough is enabled.
         /// </summary>
-        /// <value></value>
         public bool? IsLegacyMsaPassthroughEnabled { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Add a link to the XML docs for customers who need guidance on using the options bag to enable brokered auth.
