### PR TITLE
[System.ClientModel] Add AOT compat check

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -58,6 +58,8 @@ extends:
     AOTTestInputs:
     - ArtifactName: Azure.Core
       ExpectedWarningsFilepath: /Azure.Core/tests/compatibility/ExpectedAotWarnings.txt
+    - ArtifactName: System.ClientModel
+      ExpectedWarningsFilepath: None
 
     TestSetupSteps:
     - template: /sdk/storage/tests-install-azurite.yml


### PR DESCRIPTION
Add AOT compatibility ci to System.ClientModel. Validated locally that no warnings are reported for System.ClientModel.