### PR TITLE
Azure OpenAI: 2.0.0-beta.4 release (compatibility bump to OpenAI 2.0.0-beta.10)

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Release History
 
-## 2.0.0-beta.4 (Unreleased)
+## 2.0.0-beta.4 (2024-08-30)
 
-### Features Added
+This small release increments library compatibility to the latest `OpenAI 2.0.0-beta.10`. Prior to this update, interactions with the two breaking changes described below prevented full interoperability.
 
 ### Breaking Changes
 
-### Bugs Fixed
-
-### Other Changes
+- `AudioClient`'s `GenerateSpeechFromText()` method is renamed to `GenerateSpeech()`
+- `OpenAIFileInfo`'s `SizeInBytes` is now of type `int?` (previously `long?`)
 
 ## 2.0.0-beta.3 (2024-08-23)
 

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -5,7 +5,8 @@
       Azure OpenAI's official extension package for using OpenAI's .NET library with the Azure OpenAI Service.
     </Description>
     <AssemblyTitle>Azure.AI.OpenAI Client Library</AssemblyTitle>
-    <Version>2.0.0-beta.4</Version>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix>beta.4</VersionSuffix>
     <PackageTags>Microsoft Azure OpenAI</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -56,7 +57,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="OpenAI" VersionOverride="2.0.0-beta.9" />
+        <PackageReference Include="OpenAI" VersionOverride="2.0.0-beta.10" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Audio/AzureAudioClient.Protocol.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Audio/AzureAudioClient.Protocol.cs
@@ -41,14 +41,14 @@ internal partial class AzureAudioClient : AudioClient
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public override ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null)
+    public override ClientResult GenerateSpeech(BinaryContent content, RequestOptions options = null)
     {
         using PipelineMessage message = CreateGenerateSpeechFromTextRequestMessage(content, options);
         return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public override async Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions options = null)
+    public override async Task<ClientResult> GenerateSpeechAsync(BinaryContent content, RequestOptions options = null)
     {
         using PipelineMessage message = CreateGenerateSpeechFromTextRequestMessage(content, options);
         PipelineResponse response = await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false);

--- a/sdk/openai/Azure.AI.OpenAI/tests/AudioTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/AudioTests.cs
@@ -37,7 +37,7 @@ public class AudioTests(bool isAsync) : AoaiTestBase<AudioClient>(isAsync)
     public async Task TextToSpeechWorks()
     {
         AudioClient audioClient = GetTestClient("tts");
-        BinaryData ttsData = await audioClient.GenerateSpeechFromTextAsync(
+        BinaryData ttsData = await audioClient.GenerateSpeechAsync(
             "hello, world!",
             GeneratedSpeechVoice.Alloy);
         Assert.That(ttsData, Is.Not.Null);

--- a/sdk/openai/Azure.AI.OpenAI/tests/Azure.AI.OpenAI.Tests.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Azure.AI.OpenAI.Tests.csproj
@@ -15,8 +15,6 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="Azure.ResourceManager" />
-    <PackageReference Include="Azure.ResourceManager.CognitiveServices" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #45706 by incrementing version compatibility.