### PR TITLE
Add Scenario tests for ComputeFleet

### DIFF
--- a/sdk/computefleet/Azure.ResourceManager.ComputeFleet/assets.json
+++ b/sdk/computefleet/Azure.ResourceManager.ComputeFleet/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/computefleet/Azure.ResourceManager.ComputeFleet",
-  "Tag": ""
+  "Tag": "net/computefleet/Azure.ResourceManager.ComputeFleet_18fc3c7f41"
 }

--- a/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/Azure.ResourceManager.ComputeFleet.Tests.csproj
+++ b/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/Azure.ResourceManager.ComputeFleet.Tests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.ResourceManager.ComputeFleet.csproj" />
+    <PackageReference Include="Azure.ResourceManager.Compute" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(AzureCoreTestFramework)" />
   </ItemGroup>
 </Project>

--- a/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/ComputeFleetManagementTestBase.cs
+++ b/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/ComputeFleetManagementTestBase.cs
@@ -6,6 +6,9 @@ using Azure.Core.TestFramework;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.TestFramework;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Azure.ResourceManager.ComputeFleet.Tests
@@ -14,6 +17,11 @@ namespace Azure.ResourceManager.ComputeFleet.Tests
     {
         protected ArmClient Client { get; private set; }
         protected SubscriptionResource DefaultSubscription { get; private set; }
+
+        protected AzureLocation DefaultLocation => AzureLocation.EastUS2;
+
+        protected ResourceGroupResource _resourceGroup;
+        protected GenericResourceCollection _genericResourceCollection;
 
         protected ComputeFleetManagementTestBase(bool isAsync, RecordedTestMode mode)
         : base(isAsync, mode)
@@ -32,12 +40,110 @@ namespace Azure.ResourceManager.ComputeFleet.Tests
             DefaultSubscription = await Client.GetDefaultSubscriptionAsync().ConfigureAwait(false);
         }
 
-        protected async Task<ResourceGroupResource> CreateResourceGroup(SubscriptionResource subscription, string rgNamePrefix, AzureLocation location)
+        protected async Task<ResourceGroupResource> CreateResourceGroup(SubscriptionResource subscription)
         {
-            string rgName = Recording.GenerateAssetName(rgNamePrefix);
-            ResourceGroupData input = new ResourceGroupData(location);
+            string rgName = Recording.GenerateAssetName("testFleetRG-");
+            ResourceGroupData input = new ResourceGroupData(DefaultLocation);
             var lro = await subscription.GetResourceGroups().CreateOrUpdateAsync(WaitUntil.Completed, rgName, input);
             return lro.Value;
+        }
+
+        protected async Task<GenericResource> CreateVirtualNetwork()
+        {
+            var ip = await CreatePublicIPAddress();
+            var nat = await CreateNatGateway(ip.Data.Id);
+            var nsg = await CreateNetworkSecurityGroups();
+            var vnetName = Recording.GenerateAssetName("testVNet-");
+            var subnetName = Recording.GenerateAssetName("testSubnet-");
+            ResourceIdentifier vnetId = new ResourceIdentifier($"{_resourceGroup.Id}/providers/Microsoft.Network/virtualNetworks/{vnetName}");
+            var addressSpaces = new Dictionary<string, object>()
+            {
+                { "addressPrefixes", new List<string>() { "10.0.0.0/16" } }
+            };
+            var subnet = new Dictionary<string, object>()
+            {
+                { "name", subnetName },
+                { "properties", new Dictionary<string, object>()
+                {
+                    { "addressPrefix", "10.0.2.0/24" },
+                    { "networkSecurityGroup", new Dictionary<string, object>()
+                        {
+                            {"id", nsg.Data.Id.ToString() }
+                        }
+                    },
+                    { "natGateway", new Dictionary<string, object>()
+                        {
+                            {"id", nat.Data.Id.ToString() }
+                        }
+                    }
+                } }
+            };
+            var subnets = new List<object>() { subnet };
+            var input = new GenericResourceData(DefaultLocation)
+            {
+                Properties = BinaryData.FromObjectAsJson(new Dictionary<string, object>()
+                {
+                    { "addressSpace", addressSpaces },
+                    { "subnets", subnets }
+                })
+            };
+            var operation = await _genericResourceCollection.CreateOrUpdateAsync(WaitUntil.Completed, vnetId, input);
+            return operation.Value;
+        }
+
+        protected ResourceIdentifier GetSubnetId(GenericResource vnet)
+        {
+            var properties = vnet.Data.Properties.ToObjectFromJson() as Dictionary<string, object>;
+            var subnets = properties["subnets"] as IEnumerable<object>;
+            var subnet = subnets.First() as IDictionary<string, object>;
+            return new ResourceIdentifier(subnet["id"] as string);
+        }
+
+        protected async Task<GenericResource> CreateNetworkSecurityGroups()
+        {
+            var networkSecurityGroups = Recording.GenerateAssetName("testVNetSecurityGroups-");
+            ResourceIdentifier networkSecurityGroupsId = new ResourceIdentifier($"{_resourceGroup.Id}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroups}");
+            var input = new GenericResourceData(DefaultLocation){};
+            var operation = await _genericResourceCollection.CreateOrUpdateAsync(WaitUntil.Completed, networkSecurityGroupsId, input);
+            return operation.Value;
+        }
+
+        protected async Task<GenericResource> CreatePublicIPAddress()
+        {
+            var publicIPAddressName = Recording.GenerateAssetName("testPublicIP-");
+            ResourceIdentifier publicIPAddress = new ResourceIdentifier($"{_resourceGroup.Id}/providers/Microsoft.Network/publicIPAddresses/{publicIPAddressName}");
+            var input = new GenericResourceData(DefaultLocation) {
+                Sku = new() { Name = "Standard" },
+                Properties = BinaryData.FromObjectAsJson(new Dictionary<string, object>()
+                {
+                    { "publicIPAllocationMethod", "Static"}
+                })
+            };
+            var operation = await _genericResourceCollection.CreateOrUpdateAsync(WaitUntil.Completed, publicIPAddress, input);
+            return operation.Value;
+        }
+
+        protected async Task<GenericResource> CreateNatGateway(ResourceIdentifier publicIp)
+        {
+            var natName = Recording.GenerateAssetName("testNatGateway-");
+            ResourceIdentifier nat = new ResourceIdentifier($"{_resourceGroup.Id}/providers/Microsoft.Network/natGateways/{natName}");
+            var input = new GenericResourceData(DefaultLocation)
+            {
+                Sku = new() { Name = "Standard" },
+                Properties = BinaryData.FromObjectAsJson(new Dictionary<string, object>()
+                {
+                    { "publicIpAddresses", new List<object>()
+                        {
+                            new Dictionary<string, object>()
+                            {
+                                { "id", publicIp.ToString() }
+                            }
+                        }
+                    }
+                })
+            };
+            var operation = await _genericResourceCollection.CreateOrUpdateAsync(WaitUntil.Completed, nat, input);
+            return operation.Value;
         }
     }
 }

--- a/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/Scenario/ComputeFleetCRUDTests.cs
+++ b/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/Scenario/ComputeFleetCRUDTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.ComputeFleet.Tests
+{
+    internal class ComputeFleetCRUDTests : ComputeFleetTestBase
+    {
+        public ComputeFleetCRUDTests(bool isAsync)
+            : base(isAsync)
+        {
+        }
+
+        [TestCase]
+        public async Task TestCreateComputeFleet()
+        {
+            var computeFleetCollection = await GetComputeFleetCollectionAsync();
+            var vnet = await CreateVirtualNetwork();
+            var computeFleetName = Recording.GenerateAssetName("testFleetViaSDK-");
+            var computeFleetData = GetBasicComputeFleetData(DefaultLocation, computeFleetName, GetSubnetId(vnet));
+
+            // Create the compute fleet
+            var createFleetResult = await computeFleetCollection.CreateOrUpdateAsync(WaitUntil.Completed, computeFleetName, computeFleetData);
+            Assert.AreEqual(computeFleetName, createFleetResult.Value.Data.Name);
+            Assert.AreEqual(DefaultLocation, createFleetResult.Value.Data.Location);
+
+            // Get the compute fleet
+            var getComputeFleet = await computeFleetCollection.GetAsync(computeFleetName);
+            Assert.AreEqual(computeFleetName, getComputeFleet.Value.Data.Name);
+
+            // Delete the compute fleet
+            await createFleetResult.Value.DeleteAsync(WaitUntil.Completed);
+        }
+    }
+}

--- a/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/Scenario/ComputeFleetTestBase.cs
+++ b/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/Scenario/ComputeFleetTestBase.cs
@@ -153,17 +153,6 @@ namespace Azure.ResourceManager.ComputeFleet.Tests
                 }
             };
         }
-
-        private static void AddSkus(ComputeFleetData computeFleetData, List<string> skuNames)
-        {
-            foreach (var skuName in skuNames)
-            {
-                computeFleetData.Properties.VmSizesProfile.Add(new ComputeFleetVmSizeProfile
-                {
-                    Name = skuName
-                });
-            }
-        }
         #endregion
     }
 }

--- a/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/Scenario/ComputeFleetTestBase.cs
+++ b/sdk/computefleet/Azure.ResourceManager.ComputeFleet/tests/Scenario/ComputeFleetTestBase.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.ResourceManager.ComputeFleet.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Azure.ResourceManager.ComputeFleet.Tests
+{
+    public class ComputeFleetTestBase: ComputeFleetManagementTestBase
+    {
+        private const string dummySSHKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com";
+
+        public ComputeFleetTestBase(bool isAsync)
+            : base(isAsync)
+        {
+        }
+
+        public ComputeFleetTestBase(bool isAsync, RecordedTestMode mode)
+            : base(isAsync, mode)
+        {
+        }
+
+        protected async Task<ComputeFleetCollection> GetComputeFleetCollectionAsync()
+        {
+            _genericResourceCollection = Client.GetGenericResources();
+            _resourceGroup = await CreateResourceGroup(DefaultSubscription);
+            return _resourceGroup.GetComputeFleets();
+        }
+
+        #region ComputeFleetData
+
+        public static ComputeFleetData GetBasicComputeFleetData(
+            AzureLocation location,
+            string computerNamePrefix,
+            ResourceIdentifier subnetId,
+            int capacity = 2,
+            string adminUsername = "adminuser",
+            string allocationStrategy = "LowestPrice")
+        {
+            var storageProfile = new ComputeFleetVmssStorageProfile()
+            {
+                OSDisk = new(ComputeFleetDiskCreateOptionType.FromImage)
+                {
+                    Caching = ComputeFleetCachingType.ReadWrite,
+                    ManagedDisk = new()
+                    {
+                        StorageAccountType = ComputeFleetStorageAccountType.StandardLrs
+                    }
+                },
+                ImageReference = new()
+                {
+                    Publisher = "Canonical",
+                    Offer = "UbuntuServer",
+                    Sku = "16.04-LTS",
+                    Version = "latest"
+                }
+            };
+
+            var osProfile = new ComputeFleetVmssOSProfile()
+            {
+                ComputerNamePrefix = computerNamePrefix,
+                AdminUsername = adminUsername,
+                LinuxConfiguration = new ComputeFleetLinuxConfiguration()
+                {
+                    IsPasswordAuthenticationDisabled = true,
+                    Ssh = new()
+                    {
+                        PublicKeys =
+                        {
+                            new()
+                            {
+                                Path = $"/home/{adminUsername}/.ssh/authorized_keys",
+                                KeyData = dummySSHKey
+                            }
+                        }
+                    }
+                }
+            };
+
+            var computeFleetVmssIPConfiguration = new ComputeFleetVmssIPConfiguration()
+            {
+                Name = "internalIpConfig",
+                Properties = new()
+                {
+                    Subnet = new()
+                    {
+                        Id = subnetId
+                    }
+                }
+            };
+
+            var computefleetVmssNetworkConfiguration = new ComputeFleetVmssNetworkConfiguration()
+            {
+                Name = "exampleNic",
+                Properties = new ComputeFleetVmssNetworkConfigurationProperties(
+                    new List<ComputeFleetVmssIPConfiguration>()
+                    {
+                        computeFleetVmssIPConfiguration
+                    })
+                {
+                    IsPrimary = true,
+                    IsAcceleratedNetworkingEnabled = false
+                }
+            };
+
+            var networkProfile = new ComputeFleetVmssNetworkProfile()
+            {
+                NetworkInterfaceConfigurations =
+                {
+                    computefleetVmssNetworkConfiguration
+                },
+                NetworkApiVersion = "2022-07-01"
+            };
+
+            var computeProfile = new ComputeFleetComputeProfile()
+            {
+                ComputeApiVersion = "2023-09-01",
+                PlatformFaultDomainCount = 1,
+                BaseVirtualMachineProfile = new()
+                {
+                    StorageProfile = storageProfile,
+                    OSProfile = osProfile,
+                    NetworkProfile = networkProfile
+                }
+            };
+
+            return new ComputeFleetData(location:location)
+            {
+                Properties = new ComputeFleetProperties(
+                    vmSizesProfile: new List<ComputeFleetVmSizeProfile>() {
+                        new("Standard_D2s_v3"),
+                        new("Standard_D4s_v3"),
+                        new("Standard_E2s_v3")
+                    },
+                    computeProfile: computeProfile)
+                {
+                    SpotPriorityProfile = new()
+                    {
+                        Capacity = capacity,
+                        AllocationStrategy = allocationStrategy,
+                        EvictionPolicy = "Delete",
+                        IsMaintainEnabled = false
+                    },
+                    RegularPriorityProfile = new()
+                    {
+                        Capacity = capacity,
+                        MinCapacity = capacity,
+                        AllocationStrategy = allocationStrategy,
+                    }
+                }
+            };
+        }
+
+        private static void AddSkus(ComputeFleetData computeFleetData, List<string> skuNames)
+        {
+            foreach (var skuName in skuNames)
+            {
+                computeFleetData.Properties.VmSizesProfile.Add(new ComputeFleetVmSizeProfile
+                {
+                    Name = skuName
+                });
+            }
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Adding CRUD Test for Compute Fleet

Recordings have been [uploaded](https://github.com/Azure/azure-sdk-assets/releases/tag/net%2Fcomputefleet%2FAzure.ResourceManager.ComputeFleet_18fc3c7f41) to assets repo.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
