### PR TITLE
Update package versions

### DIFF
--- a/samples/AppSecretsConfig/AppSecretsConfig.csproj
+++ b/samples/AppSecretsConfig/AppSecretsConfig.csproj
@@ -6,7 +6,7 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.3" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.4.0" />
   </ItemGroup>
 

--- a/samples/CloudClipboard/CloudClipboard/CloudClipboard.csproj
+++ b/samples/CloudClipboard/CloudClipboard/CloudClipboard.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.3" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />

--- a/samples/CloudClipboard/GarbageCollector/GarbageCollector.csproj
+++ b/samples/CloudClipboard/GarbageCollector/GarbageCollector.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.3" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
   </ItemGroup>
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
 
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Our publish pipeline [fails ](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4103009&view=logs&j=997896c9-acda-580e-e180-6ae890cb75c8&t=c50282b0-2acb-55bb-3103-b9a0c36c4a74)because of 
1. Package 'Azure.Identity' 1.10.3 has a known moderate severity vulnerability
2. Detected package downgrade: System.Text.Json from 6.0.9 to 4.7.2 in digitaltwins

This PR is to update the package versions.
