### PR TITLE
DataTransfer Remove Dead Property

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransfer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransfer.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.Common;
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransfer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransfer.cs
@@ -30,11 +30,6 @@ namespace Azure.Storage.DataMovement
         public string Id => _state.Id;
 
         /// <summary>
-        /// The <see cref="TransferManager"/> responsible for this transfer.
-        /// </summary>
-        public TransferManager TransferManager { get; }
-
-        /// <summary>
         /// Defines the current state of the transfer.
         /// </summary>
         internal DataTransferInternalState _state;
@@ -61,7 +56,6 @@ namespace Azure.Storage.DataMovement
             Argument.AssertNotNull(transferManager, nameof(transferManager));
             status ??= new DataTransferStatus();
             _state = new DataTransferInternalState(id, status);
-            TransferManager = transferManager;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.DataMovement/tests/DataTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/DataTransferTests.cs
@@ -28,7 +28,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsFalse(transfer.HasCompleted);
         }
 
@@ -54,7 +53,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsFalse(transfer.HasCompleted);
         }
 
@@ -80,7 +78,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 
@@ -101,7 +98,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 
@@ -140,7 +136,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 


### PR DESCRIPTION
Property was never read outside of tests ensuring it was set. Removing.