### PR TITLE
JobBuilder

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobContainerServiceToServiceJobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobContainerServiceToServiceJobTests.cs
@@ -111,9 +111,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
                 It.IsAny<CancellationToken>()))
                 .Returns(GetStorageResourceItemsAsyncEnumerable(blobItems));
             ServiceToServiceTransferJob transferJob = new ServiceToServiceTransferJob(
-                new DataTransfer(
-                    id: transferId,
-                    transferManager: new TransferManager()),
+                new DataTransfer(id: transferId),
                 sourceMock.Object,
                 destinationMock.Object,
                 new DataTransferOptions(),
@@ -167,9 +165,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
                 It.IsAny<CancellationToken>()))
                 .Returns(GetStorageResourceItemsAsyncEnumerable(blobItems));
             ServiceToServiceTransferJob transferJob = new ServiceToServiceTransferJob(
-                new DataTransfer(
-                    id: transferId,
-                    transferManager: new TransferManager()),
+                new DataTransfer(id: transferId),
                 sourceMock.Object,
                 destinationMock.Object,
                 new DataTransferOptions(),

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransfer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransfer.cs
@@ -32,7 +32,7 @@ namespace Azure.Storage.DataMovement
         /// <summary>
         /// The <see cref="TransferManager"/> responsible for this transfer.
         /// </summary>
-        public TransferManager TransferManager { get; }
+        public TransferManager TransferManager { get; internal set; }
 
         /// <summary>
         /// Defines the current state of the transfer.
@@ -50,18 +50,14 @@ namespace Azure.Storage.DataMovement
         /// Constructing a DataTransfer object.
         /// </summary>
         /// <param name="id">The transfer ID of the transfer object.</param>
-        /// <param name="transferManager">Reference to the transfer manager running this transfer.</param>
         /// <param name="status">The Transfer Status of the Transfer. See <see cref="DataTransferStatus"/>.</param>
         internal DataTransfer(
             string id,
-            TransferManager transferManager,
             DataTransferStatus status = default)
         {
             Argument.AssertNotNullOrEmpty(id, nameof(id));
-            Argument.AssertNotNull(transferManager, nameof(transferManager));
             status ??= new DataTransferStatus();
             _state = new DataTransferInternalState(id, status);
-            TransferManager = transferManager;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobBuilder.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobBuilder.cs
@@ -1,0 +1,339 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using System.Threading;
+using System.IO;
+using System.Buffers;
+using Azure.Core.Pipeline;
+
+namespace Azure.Storage.DataMovement;
+
+internal class JobBuilder
+{
+    internal readonly ArrayPool<byte> _arrayPool;
+
+    /// <summary>
+    /// Defines the error handling method to follow when an error is seen. Defaults to
+    /// <see cref="DataTransferErrorMode.StopOnAnyFailure"/>.
+    ///
+    /// See <see cref="DataTransferErrorMode"/>.
+    /// </summary>
+    internal readonly DataTransferErrorMode _errorHandling;
+
+    internal ClientDiagnostics ClientDiagnostics { get; }
+
+    internal JobBuilder(
+        ArrayPool<byte> arrayPool,
+        DataTransferErrorMode errorHandling,
+        ClientDiagnostics clientDiagnostics)
+    {
+        _arrayPool = arrayPool;
+        _errorHandling = errorHandling;
+        ClientDiagnostics = clientDiagnostics;
+    }
+
+    public async Task<(DataTransfer Transfer, TransferJobInternal TransferInternal)> BuildJobAsync(
+        StorageResource sourceResource,
+        StorageResource destinationResource,
+        DataTransferOptions transferOptions,
+        TransferCheckpointer checkpointer,
+        string transferId,
+        bool resumeJob,
+        CancellationToken cancellationToken)
+    {
+        DataTransfer dataTransfer = new(id: transferId);
+        TransferJobInternal transferJobInternal;
+
+        // Single transfer
+        if (sourceResource is StorageResourceItem sourceItem &&
+            destinationResource is StorageResourceItem destationItem)
+        {
+            transferJobInternal = await BuildSingleTransferJob(
+                sourceItem,
+                destationItem,
+                transferOptions,
+                checkpointer,
+                dataTransfer,
+                resumeJob,
+                cancellationToken).ConfigureAwait(false);
+        }
+        // Container transfer
+        else if (sourceResource is StorageResourceContainer sourceContainer &&
+            destinationResource is StorageResourceContainer destinationContainer)
+        {
+            transferJobInternal = await BuildContainerTransferJob(
+                sourceContainer,
+                destinationContainer,
+                transferOptions,
+                checkpointer,
+                dataTransfer,
+                resumeJob,
+                cancellationToken).ConfigureAwait(false);
+        }
+        // Invalid transfer
+        else
+        {
+            throw Errors.InvalidTransferResourceTypes();
+        }
+
+        return (dataTransfer, transferJobInternal);
+    }
+
+    private async Task<TransferJobInternal> BuildSingleTransferJob(
+        StorageResourceItem sourceResource,
+        StorageResourceItem destinationResource,
+        DataTransferOptions transferOptions,
+        TransferCheckpointer checkpointer,
+        DataTransfer dataTransfer,
+        bool resumeJob,
+        CancellationToken cancellationToken)
+    {
+        // If the resource cannot produce a Uri, it means it can only produce a local path
+        // From here we only support an upload job
+        if (sourceResource.IsLocalResource())
+        {
+            if (!destinationResource.IsLocalResource())
+            {
+                // Stream to Uri job (Upload Job)
+                StreamToUriTransferJob streamToUriJob = new StreamToUriTransferJob(
+                    dataTransfer: dataTransfer,
+                    sourceResource: sourceResource,
+                    destinationResource: destinationResource,
+                    transferOptions: transferOptions,
+                    checkpointer: checkpointer,
+                    errorHandling: _errorHandling,
+                    arrayPool: _arrayPool,
+                    clientDiagnostics: ClientDiagnostics);
+
+                if (resumeJob)
+                {
+                    using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
+                        transferId: dataTransfer.Id,
+                        partNumber: 0,
+                        offset: 0,
+                        length: 0,
+                        cancellationToken: cancellationToken).ConfigureAwait(false))
+                    {
+                        streamToUriJob.AppendJobPart(
+                            streamToUriJob.ToJobPartAsync(
+                                stream,
+                                sourceResource,
+                                destinationResource));
+                    }
+                }
+                return streamToUriJob;
+            }
+            else // Invalid argument that both resources do not produce a Uri
+            {
+                throw Errors.InvalidSourceDestinationParams();
+            }
+        }
+        else
+        {
+            // Source is remote
+            if (!destinationResource.IsLocalResource())
+            {
+                // Service to Service Job (Copy job)
+                ServiceToServiceTransferJob serviceToServiceJob = new ServiceToServiceTransferJob(
+                    dataTransfer: dataTransfer,
+                    sourceResource: sourceResource,
+                    destinationResource: destinationResource,
+                    transferOptions: transferOptions,
+                    CheckPointFolderPath: checkpointer,
+                    errorHandling: _errorHandling,
+                    arrayPool: _arrayPool,
+                    clientDiagnostics: ClientDiagnostics);
+
+                if (resumeJob)
+                {
+                    using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
+                        transferId: dataTransfer.Id,
+                        partNumber: 0,
+                        offset: 0,
+                        length: 0,
+                        cancellationToken: cancellationToken).ConfigureAwait(false))
+                    {
+                        serviceToServiceJob.AppendJobPart(
+                            serviceToServiceJob.ToJobPartAsync(
+                                stream,
+                                sourceResource,
+                                destinationResource));
+                    }
+                }
+                return serviceToServiceJob;
+            }
+            else
+            {
+                // Download to local operation
+                // Service to Local job (Download Job)
+                UriToStreamTransferJob uriToStreamJob = new UriToStreamTransferJob(
+                    dataTransfer: dataTransfer,
+                    sourceResource: sourceResource,
+                    destinationResource: destinationResource,
+                    transferOptions: transferOptions,
+                    checkpointer: checkpointer,
+                    errorHandling: _errorHandling,
+                    arrayPool: _arrayPool,
+                    clientDiagnostics: ClientDiagnostics);
+
+                if (resumeJob)
+                {
+                    using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
+                        transferId: dataTransfer.Id,
+                        partNumber: 0,
+                        offset: 0,
+                        length: 0,
+                        cancellationToken: cancellationToken).ConfigureAwait(false))
+                    {
+                        uriToStreamJob.AppendJobPart(
+                            uriToStreamJob.ToJobPartAsync(
+                                stream,
+                                sourceResource,
+                                destinationResource));
+                    }
+                }
+                return uriToStreamJob;
+            }
+        }
+    }
+
+    private async Task<TransferJobInternal> BuildContainerTransferJob(
+        StorageResourceContainer sourceResource,
+        StorageResourceContainer destinationResource,
+        DataTransferOptions transferOptions,
+        TransferCheckpointer checkpointer,
+        DataTransfer dataTransfer,
+        bool resumeJob,
+        CancellationToken cancellationToken)
+    {
+        // If the resource cannot produce a Uri, it means it can only produce a local path
+        // From here we only support an upload job
+        if (sourceResource.IsLocalResource())
+        {
+            if (!destinationResource.IsLocalResource())
+            {
+                // Stream to Uri job (Upload Job)
+                StreamToUriTransferJob streamToUriJob = new StreamToUriTransferJob(
+                    dataTransfer: dataTransfer,
+                    sourceResource: sourceResource,
+                    destinationResource: destinationResource,
+                    transferOptions: transferOptions,
+                    checkpointer: checkpointer,
+                    errorHandling: _errorHandling,
+                    arrayPool: _arrayPool,
+                    clientDiagnostics: ClientDiagnostics);
+
+                if (resumeJob)
+                {
+                    // Iterate through all job parts and append to the job
+                    int jobPartCount = await checkpointer.CurrentJobPartCountAsync(
+                        transferId: dataTransfer.Id,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                    for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
+                    {
+                        using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
+                            transferId: dataTransfer.Id,
+                            partNumber: currentJobPart,
+                            offset: 0,
+                            length: 0,
+                            cancellationToken: cancellationToken).ConfigureAwait(false))
+                        {
+                            streamToUriJob.AppendJobPart(
+                                streamToUriJob.ToJobPartAsync(
+                                    stream,
+                                    sourceResource,
+                                    destinationResource));
+                        }
+                    }
+                }
+                return streamToUriJob;
+            }
+            else // Invalid argument that both resources do not produce a Uri
+            {
+                throw Errors.InvalidSourceDestinationParams();
+            }
+        }
+        else
+        {
+            // Source is remote
+            if (!destinationResource.IsLocalResource())
+            {
+                // Service to Service Job (Copy job)
+                ServiceToServiceTransferJob serviceToServiceJob = new ServiceToServiceTransferJob(
+                    dataTransfer: dataTransfer,
+                    sourceResource: sourceResource,
+                    destinationResource: destinationResource,
+                    transferOptions: transferOptions,
+                    checkpointer: checkpointer,
+                    errorHandling: _errorHandling,
+                    arrayPool: _arrayPool,
+                    clientDiagnostics: ClientDiagnostics);
+
+                if (resumeJob)
+                {
+                    // Iterate through all job parts and append to the job
+                    int jobPartCount = await checkpointer.CurrentJobPartCountAsync(
+                        transferId: dataTransfer.Id,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                    for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
+                    {
+                        using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
+                            transferId: dataTransfer.Id,
+                            partNumber: currentJobPart,
+                            offset: 0,
+                            length: 0,
+                            cancellationToken: cancellationToken).ConfigureAwait(false))
+                        {
+                            serviceToServiceJob.AppendJobPart(
+                                serviceToServiceJob.ToJobPartAsync(
+                                    stream,
+                                    sourceResource,
+                                    destinationResource));
+                        }
+                    }
+                }
+                return serviceToServiceJob;
+            }
+            else
+            {
+                // Download to local operation
+                // Service to Local job (Download Job)
+                UriToStreamTransferJob uriToStreamJob = new UriToStreamTransferJob(
+                    dataTransfer: dataTransfer,
+                    sourceResource: sourceResource,
+                    destinationResource: destinationResource,
+                    transferOptions: transferOptions,
+                    checkpointer: checkpointer,
+                    errorHandling: _errorHandling,
+                    arrayPool: _arrayPool,
+                    clientDiagnostics: ClientDiagnostics);
+
+                if (resumeJob)
+                {
+                    // Iterate through all job parts and append to the job
+                    int jobPartCount = await checkpointer.CurrentJobPartCountAsync(
+                        transferId: dataTransfer.Id,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                    for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
+                    {
+                        using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
+                            transferId: dataTransfer.Id,
+                            partNumber: currentJobPart,
+                            offset: 0,
+                            length: 0,
+                            cancellationToken: cancellationToken).ConfigureAwait(false))
+                        {
+                            uriToStreamJob.AppendJobPart(
+                                uriToStreamJob.ToJobPartAsync(
+                                    stream,
+                                    sourceResource,
+                                    destinationResource));
+                        }
+                    }
+                }
+                return uriToStreamJob;
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
@@ -24,6 +22,8 @@ namespace Azure.Storage.DataMovement
         private readonly IProcessor<JobPartInternal> _partsProcessor;
         private readonly IProcessor<Func<Task>> _chunksProcessor;
 
+        private readonly JobBuilder _jobBuilder;
+
         /// <summary>
         /// Ongoing transfers indexed at the transfer id.
         /// </summary>
@@ -34,27 +34,15 @@ namespace Azure.Storage.DataMovement
         ///
         /// If unspecified will default to LocalTransferCheckpointer at {currentpath}/.azstoragedml
         /// </summary>
-        internal TransferCheckpointer _checkpointer;
+        private readonly TransferCheckpointer _checkpointer;
 
-        internal readonly List<StorageResourceProvider> _resumeProviders;
-
-        /// <summary>
-        /// Defines the error handling method to follow when an error is seen. Defaults to
-        /// <see cref="DataTransferErrorMode.StopOnAnyFailure"/>.
-        ///
-        /// See <see cref="DataTransferErrorMode"/>.
-        /// </summary>
-        internal DataTransferErrorMode _errorHandling;
+        private readonly List<StorageResourceProvider> _resumeProviders;
 
         /// <summary>
         /// Cancels the channels operations when disposing.
         /// </summary>
-        private CancellationTokenSource _cancellationTokenSource = new();
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
         private CancellationToken _cancellationToken => _cancellationTokenSource.Token;
-
-        private readonly ArrayPool<byte> _arrayPool;
-
-        internal ClientDiagnostics ClientDiagnostics { get; }
 
         /// <summary>
         /// Protected constructor for mocking.
@@ -71,12 +59,13 @@ namespace Azure.Storage.DataMovement
             _jobsProcessor = ChannelProcessing.NewProcessor<TransferJobInternal>(parallelism: 1);
             _partsProcessor = ChannelProcessing.NewProcessor<JobPartInternal>(DataMovementConstants.MaxJobPartReaders);
             _chunksProcessor = ChannelProcessing.NewProcessor<Func<Task>>(options?.MaximumConcurrency ?? DataMovementConstants.MaxJobChunkTasks);
+            _jobBuilder = new(
+                ArrayPool<byte>.Shared,
+                options?.ErrorHandling ?? DataTransferErrorMode.StopOnAnyFailure,
+                new ClientDiagnostics(options?.ClientOptions ?? ClientOptions.Default));
             TransferCheckpointStoreOptions checkpointerOptions = options?.CheckpointerOptions != default ? new TransferCheckpointStoreOptions(options.CheckpointerOptions) : default;
             _checkpointer = checkpointerOptions != default ? checkpointerOptions.GetCheckpointer() : CreateDefaultCheckpointer();
             _resumeProviders = options?.ResumeProviders != null ? new(options.ResumeProviders) : new();
-            _arrayPool = ArrayPool<byte>.Shared;
-            _errorHandling = options?.ErrorHandling != default ? options.ErrorHandling : DataTransferErrorMode.StopOnAnyFailure;
-            ClientDiagnostics = new ClientDiagnostics(options?.ClientOptions ?? ClientOptions.Default);
 
             ConfigureProcessorCallbacks();
         }
@@ -88,20 +77,16 @@ namespace Azure.Storage.DataMovement
             IProcessor<TransferJobInternal> jobsProcessor,
             IProcessor<JobPartInternal> partsProcessor,
             IProcessor<Func<Task>> chunksProcessor,
+            JobBuilder jobBuilder,
             TransferCheckpointer checkpointer,
-            ICollection<StorageResourceProvider> resumeProviders,
-            ArrayPool<byte> arrayPool,
-            DataTransferErrorMode errorhandling,
-            ClientDiagnostics clientDiagnostics)
+            ICollection<StorageResourceProvider> resumeProviders)
         {
             _jobsProcessor = jobsProcessor;
             _partsProcessor = partsProcessor;
             _chunksProcessor = chunksProcessor;
-            _checkpointer = checkpointer;
+            _jobBuilder = jobBuilder;
             _resumeProviders = new(resumeProviders);
-            _arrayPool = arrayPool;
-            _errorHandling = errorhandling;
-            ClientDiagnostics = clientDiagnostics;
+            _checkpointer = checkpointer;
 
             ConfigureProcessorCallbacks();
         }
@@ -369,6 +354,7 @@ namespace Azure.Storage.DataMovement
                 false,
                 cancellationToken).ConfigureAwait(false);
 
+            dataTransfer.TransferManager = this;
             return dataTransfer;
         }
 
@@ -380,295 +366,20 @@ namespace Azure.Storage.DataMovement
             bool resumeJob,
             CancellationToken cancellationToken)
         {
-            DataTransfer dataTransfer = new DataTransfer(id: transferId, transferManager: this);
-            _dataTransfers.Add(dataTransfer.Id, dataTransfer);
+            (DataTransfer transfer, TransferJobInternal transferJobInternal) = await _jobBuilder.BuildJobAsync(
+                sourceResource,
+                destinationResource,
+                transferOptions,
+                _checkpointer,
+                transferId,
+                resumeJob,
+                cancellationToken)
+                .ConfigureAwait(false);
 
-            TransferJobInternal transferJobInternal;
-
-            // Single transfer
-            if (sourceResource is StorageResourceItem &&
-                destinationResource is StorageResourceItem)
-            {
-                transferJobInternal = await BuildSingleTransferJob(
-                    (StorageResourceItem)sourceResource,
-                    (StorageResourceItem)destinationResource,
-                    transferOptions,
-                    dataTransfer,
-                    resumeJob).ConfigureAwait(false);
-            }
-            // Container transfer
-            else if (sourceResource is StorageResourceContainer &&
-                destinationResource is StorageResourceContainer)
-            {
-                transferJobInternal = await BuildContainerTransferJob(
-                    (StorageResourceContainer)sourceResource,
-                    (StorageResourceContainer)destinationResource,
-                    transferOptions,
-                    dataTransfer,
-                    resumeJob).ConfigureAwait(false);
-            }
-            // Invalid transfer
-            else
-            {
-                throw Errors.InvalidTransferResourceTypes();
-            }
-            // Queue Job
+            _dataTransfers.Add(transfer.Id, transfer);
             await _jobsProcessor.QueueAsync(transferJobInternal, _cancellationToken).ConfigureAwait(false);
 
-            return dataTransfer;
-        }
-
-        private async Task<TransferJobInternal> BuildSingleTransferJob(
-            StorageResourceItem sourceResource,
-            StorageResourceItem destinationResource,
-            DataTransferOptions transferOptions,
-            DataTransfer dataTransfer,
-            bool resumeJob)
-        {
-            // If the resource cannot produce a Uri, it means it can only produce a local path
-            // From here we only support an upload job
-            if (sourceResource.IsLocalResource())
-            {
-                if (!destinationResource.IsLocalResource())
-                {
-                    // Stream to Uri job (Upload Job)
-                    StreamToUriTransferJob streamToUriJob = new StreamToUriTransferJob(
-                        dataTransfer: dataTransfer,
-                        sourceResource: sourceResource,
-                        destinationResource: destinationResource,
-                        transferOptions: transferOptions,
-                        checkpointer: _checkpointer,
-                        errorHandling: _errorHandling,
-                        arrayPool: _arrayPool,
-                        clientDiagnostics: ClientDiagnostics);
-
-                    if (resumeJob)
-                    {
-                        using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
-                            transferId: dataTransfer.Id,
-                            partNumber: 0,
-                            offset: 0,
-                            length: 0,
-                            cancellationToken: _cancellationToken).ConfigureAwait(false))
-                        {
-                            streamToUriJob.AppendJobPart(
-                                streamToUriJob.ToJobPartAsync(
-                                    stream,
-                                    sourceResource,
-                                    destinationResource));
-                        }
-                    }
-                    return streamToUriJob;
-                }
-                else // Invalid argument that both resources do not produce a Uri
-                {
-                    throw Errors.InvalidSourceDestinationParams();
-                }
-            }
-            else
-            {
-                // Source is remote
-                if (!destinationResource.IsLocalResource())
-                {
-                    // Service to Service Job (Copy job)
-                    ServiceToServiceTransferJob serviceToServiceJob = new ServiceToServiceTransferJob(
-                        dataTransfer: dataTransfer,
-                        sourceResource: sourceResource,
-                        destinationResource: destinationResource,
-                        transferOptions: transferOptions,
-                        CheckPointFolderPath: _checkpointer,
-                        errorHandling: _errorHandling,
-                        arrayPool: _arrayPool,
-                        clientDiagnostics: ClientDiagnostics);
-
-                    if (resumeJob)
-                    {
-                        using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
-                            transferId: dataTransfer.Id,
-                            partNumber: 0,
-                            offset: 0,
-                            length: 0,
-                            cancellationToken: _cancellationToken).ConfigureAwait(false))
-                        {
-                            serviceToServiceJob.AppendJobPart(
-                                serviceToServiceJob.ToJobPartAsync(
-                                    stream,
-                                    sourceResource,
-                                    destinationResource));
-                        }
-                    }
-                    return serviceToServiceJob;
-                }
-                else
-                {
-                    // Download to local operation
-                    // Service to Local job (Download Job)
-                    UriToStreamTransferJob uriToStreamJob = new UriToStreamTransferJob(
-                        dataTransfer: dataTransfer,
-                        sourceResource: sourceResource,
-                        destinationResource: destinationResource,
-                        transferOptions: transferOptions,
-                        checkpointer: _checkpointer,
-                        errorHandling: _errorHandling,
-                        arrayPool: _arrayPool,
-                        clientDiagnostics: ClientDiagnostics);
-
-                    if (resumeJob)
-                    {
-                        using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
-                            transferId: dataTransfer.Id,
-                            partNumber: 0,
-                            offset: 0,
-                            length: 0,
-                            cancellationToken: _cancellationToken).ConfigureAwait(false))
-                        {
-                            uriToStreamJob.AppendJobPart(
-                                uriToStreamJob.ToJobPartAsync(
-                                    stream,
-                                    sourceResource,
-                                    destinationResource));
-                        }
-                    }
-                    return uriToStreamJob;
-                }
-            }
-        }
-
-        private async Task<TransferJobInternal> BuildContainerTransferJob(
-            StorageResourceContainer sourceResource,
-            StorageResourceContainer destinationResource,
-            DataTransferOptions transferOptions,
-            DataTransfer dataTransfer,
-            bool resumeJob)
-        {
-            // If the resource cannot produce a Uri, it means it can only produce a local path
-            // From here we only support an upload job
-            if (sourceResource.IsLocalResource())
-            {
-                if (!destinationResource.IsLocalResource())
-                {
-                    // Stream to Uri job (Upload Job)
-                    StreamToUriTransferJob streamToUriJob = new StreamToUriTransferJob(
-                        dataTransfer: dataTransfer,
-                        sourceResource: sourceResource,
-                        destinationResource: destinationResource,
-                        transferOptions: transferOptions,
-                        checkpointer: _checkpointer,
-                        errorHandling: _errorHandling,
-                        arrayPool: _arrayPool,
-                        clientDiagnostics: ClientDiagnostics);
-
-                    if (resumeJob)
-                    {
-                        // Iterate through all job parts and append to the job
-                        int jobPartCount = await _checkpointer.CurrentJobPartCountAsync(
-                            transferId: dataTransfer.Id,
-                            cancellationToken: _cancellationToken).ConfigureAwait(false);
-                        for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
-                        {
-                            using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
-                                transferId: dataTransfer.Id,
-                                partNumber: currentJobPart,
-                                offset: 0,
-                                length: 0,
-                                cancellationToken: _cancellationToken).ConfigureAwait(false))
-                            {
-                                streamToUriJob.AppendJobPart(
-                                    streamToUriJob.ToJobPartAsync(
-                                        stream,
-                                        sourceResource,
-                                        destinationResource));
-                            }
-                        }
-                    }
-                    return streamToUriJob;
-                }
-                else // Invalid argument that both resources do not produce a Uri
-                {
-                    throw Errors.InvalidSourceDestinationParams();
-                }
-            }
-            else
-            {
-                // Source is remote
-                if (!destinationResource.IsLocalResource())
-                {
-                    // Service to Service Job (Copy job)
-                    ServiceToServiceTransferJob serviceToServiceJob = new ServiceToServiceTransferJob(
-                        dataTransfer: dataTransfer,
-                        sourceResource: sourceResource,
-                        destinationResource: destinationResource,
-                        transferOptions: transferOptions,
-                        checkpointer: _checkpointer,
-                        errorHandling: _errorHandling,
-                        arrayPool: _arrayPool,
-                        clientDiagnostics: ClientDiagnostics);
-
-                    if (resumeJob)
-                    {
-                        // Iterate through all job parts and append to the job
-                        int jobPartCount = await _checkpointer.CurrentJobPartCountAsync(
-                            transferId: dataTransfer.Id,
-                            cancellationToken: _cancellationToken).ConfigureAwait(false);
-                        for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
-                        {
-                            using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
-                                transferId: dataTransfer.Id,
-                                partNumber: currentJobPart,
-                                offset: 0,
-                                length: 0,
-                                cancellationToken: _cancellationToken).ConfigureAwait(false))
-                            {
-                                serviceToServiceJob.AppendJobPart(
-                                    serviceToServiceJob.ToJobPartAsync(
-                                        stream,
-                                        sourceResource,
-                                        destinationResource));
-                            }
-                        }
-                    }
-                    return serviceToServiceJob;
-                }
-                else
-                {
-                    // Download to local operation
-                    // Service to Local job (Download Job)
-                    UriToStreamTransferJob uriToStreamJob = new UriToStreamTransferJob(
-                        dataTransfer: dataTransfer,
-                        sourceResource: sourceResource,
-                        destinationResource: destinationResource,
-                        transferOptions: transferOptions,
-                        checkpointer: _checkpointer,
-                        errorHandling: _errorHandling,
-                        arrayPool: _arrayPool,
-                        clientDiagnostics: ClientDiagnostics);
-
-                    if (resumeJob)
-                    {
-                        // Iterate through all job parts and append to the job
-                        int jobPartCount = await _checkpointer.CurrentJobPartCountAsync(
-                            transferId: dataTransfer.Id,
-                            cancellationToken: _cancellationToken).ConfigureAwait(false);
-                        for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
-                        {
-                            using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
-                                transferId: dataTransfer.Id,
-                                partNumber: currentJobPart,
-                                offset: 0,
-                                length: 0,
-                                cancellationToken: _cancellationToken).ConfigureAwait(false))
-                            {
-                                uriToStreamJob.AppendJobPart(
-                                    uriToStreamJob.ToJobPartAsync(
-                                        stream,
-                                        sourceResource,
-                                        destinationResource));
-                            }
-                        }
-                    }
-                    return uriToStreamJob;
-                }
-            }
+            return transfer;
         }
         #endregion
 
@@ -698,8 +409,10 @@ namespace Azure.Storage.DataMovement
                 DataTransferStatus jobStatus = await _checkpointer.GetJobStatusAsync(transferId).ConfigureAwait(false);
                 _dataTransfers.Add(transferId, new DataTransfer(
                     id: transferId,
-                    transferManager: this,
-                    status: jobStatus));
+                    status: jobStatus)
+                {
+                    TransferManager = this,
+                });
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/DataTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/DataTransferTests.cs
@@ -21,14 +21,12 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
-            TransferManager transferManager = new();
 
             // Act
-            DataTransfer transfer = new DataTransfer(id: transferId, transferManager: transferManager);
+            DataTransfer transfer = new DataTransfer(id: transferId);
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsFalse(transfer.HasCompleted);
         }
 
@@ -44,17 +42,14 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
-            TransferManager transferManager = new();
 
             // Act
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: transferManager,
                 status: new DataTransferStatus(status, hasFailedItems, false));
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsFalse(transfer.HasCompleted);
         }
 
@@ -70,17 +65,14 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
-            TransferManager transferManager = new();
 
             // Act
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: transferManager,
                 status: new DataTransferStatus(state, hasFailedItems, hasSkippedItems));
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 
@@ -89,11 +81,9 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
-            TransferManager transferManager = new();
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: transferManager,
                 status: SuccessfulCompletedStatus);
 
             // Act
@@ -101,7 +91,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 
@@ -113,7 +102,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: new(),
                 status: QueuedStatus);
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 
@@ -128,11 +116,9 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
-            TransferManager transferManager = new();
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: transferManager,
                 status: SuccessfulCompletedStatus);
 
             // Act
@@ -140,7 +126,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
-            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 
@@ -152,7 +137,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: new(),
                 status: QueuedStatus);
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 
@@ -169,7 +153,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: new(),
                 status: InProgressStatus);
 
             // Act
@@ -207,7 +190,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: new(),
                 status: originalStatus);
 
             Assert.AreEqual(originalStatus, transfer.TransferStatus);
@@ -223,7 +205,6 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
-                transferManager: new(),
                 status: InProgressStatus);
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
@@ -50,7 +50,6 @@ namespace Azure.Storage.DataMovement.Tests
         {
             return new DataTransfer(
                 id: Guid.NewGuid().ToString(),
-                transferManager: new(),
                 status: status);
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -1237,7 +1237,7 @@ namespace Azure.Storage.DataMovement.Tests
                     CallBase = true,
                 };
                 transfer.Setup(t => t.CanPause()).Returns(canPause);
-                transfer.Setup(t => t.PauseAsync(_mockingToken)).Returns(Task.CompletedTask);
+                transfer.Setup(t => t.PauseAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
                 if (canPause)
                 {
                     pausable.Add(transfer);
@@ -1253,7 +1253,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             foreach (Mock<DataTransfer> transfer in pausable)
             {
-                transfer.Verify(t => t.PauseAsync(_mockingToken), Times.Once());
+                transfer.Verify(t => t.PauseAsync(It.IsAny<CancellationToken>()), Times.Once());
             }
             foreach (Mock<DataTransfer> transfer in pausable.Concat(unpausable))
             {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/ServiceToServiceJobPartTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/ServiceToServiceJobPartTests.cs
@@ -146,9 +146,7 @@ namespace Azure.Storage.DataMovement.Tests
             Mock<JobPartInternal.QueueChunkDelegate> mockPartQueueChunkTask = GetPartQueueChunkTask();
 
             ServiceToServiceTransferJob job = new(
-                new DataTransfer(
-                    id: transferId,
-                    transferManager: new TransferManager()),
+                new DataTransfer(id: transferId),
                 mockSource.Object,
                 mockDestination.Object,
                 new DataTransferOptions(),
@@ -215,9 +213,7 @@ namespace Azure.Storage.DataMovement.Tests
             Mock<JobPartInternal.QueueChunkDelegate> mockPartQueueChunkTask = GetPartQueueChunkTask();
 
             ServiceToServiceTransferJob job = new(
-                new DataTransfer(
-                    id: transferId,
-                    transferManager: new TransferManager()),
+                new DataTransfer(id: transferId),
                 mockSource.Object,
                 mockDestination.Object,
                 new DataTransferOptions(),

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StreamToUriJobPartTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StreamToUriJobPartTests.cs
@@ -159,9 +159,7 @@ namespace Azure.Storage.DataMovement.Tests
                 destination: mockDestination.Object);
 
             StreamToUriTransferJob job = new(
-                new DataTransfer(
-                    id: transferId,
-                    transferManager: new TransferManager()),
+                new DataTransfer(id: transferId),
                 mockSource.Object,
                 mockDestination.Object,
                 new DataTransferOptions(),
@@ -264,9 +262,7 @@ namespace Azure.Storage.DataMovement.Tests
             Mock<JobPartInternal.QueueChunkDelegate> mockPartQueueChunkTask = MockQueueInternalTasks.GetPartQueueChunkTask();
 
             StreamToUriTransferJob job = new(
-                new DataTransfer(
-                    id: transferId,
-                    transferManager: new TransferManager()),
+                new DataTransfer(id: transferId),
                 mockSource.Object,
                 mockDestination.Object,
                 new DataTransferOptions(),


### PR DESCRIPTION
- Encapsulates job building into a separate class.
- Moves several components of `TransferManager` into new `JobBuilder`.
- There were inconsistencies as to which `CancellationToken` was passed into async methods by the `TransferManager`: the one in the method signature, or the one tied `TransferManager.DisposeAsync()`.
  - Several of these inconsistencies are solved by encapsulation with the new `JobBuilder`.
  - The rest have been unified through `CancellationTokenSource.CreateLinkedTokenSource()`.
  - There is more cancellation token work to be done in the future.