### PR TITLE
Improve discoverability of token cache doc

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AuthorizationCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AuthorizationCodeCredential.cs
@@ -108,9 +108,9 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token from Microsoft Entra ID, using the specified authorization code to authenticate. Acquired tokens
-        /// are cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential
-        /// instances to optimize cache effectiveness.
+        /// Obtains a token from Microsoft Entra ID, using the specified authorization code to authenticate. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token lifetime and
+        /// refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -122,9 +122,9 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token from Microsoft Entra ID, using the specified authorization code to authenticate. Acquired tokens
-        /// are cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential
-        /// instances to optimize cache effectiveness.
+        /// Obtains a token from Microsoft Entra ID, using the specified authorization code to authenticate. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token lifetime and
+        /// refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/ChainedTokenCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ChainedTokenCredential.cs
@@ -70,8 +70,9 @@ namespace Azure.Identity
 
         /// <summary>
         /// Sequentially calls <see cref="TokenCredential.GetToken"/> on all the specified sources, returning the first successfully obtained
-        /// <see cref="AccessToken"/>. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled
-        /// automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// <see cref="AccessToken"/>. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the
+        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to
+        /// optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -82,8 +83,9 @@ namespace Azure.Identity
 
         /// <summary>
         /// Sequentially calls <see cref="TokenCredential.GetToken"/> on all the specified sources, returning the first successfully obtained
-        /// <see cref="AccessToken"/>. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled
-        /// automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// <see cref="AccessToken"/>. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the
+        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to
+        /// optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
@@ -174,8 +174,8 @@ namespace Azure.Identity
 
         /// <summary>
         /// Obtains a token from Microsoft Entra ID, using the specified X509 certificate to authenticate. Acquired tokens are
-        /// cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential
-        /// instances to optimize cache effectiveness.
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token lifetime
+        /// and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -200,8 +200,8 @@ namespace Azure.Identity
 
         /// <summary>
         /// Obtains a token from Microsoft Entra ID, using the specified X509 certificate to authenticate. Acquired tokens are
-        /// cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential
-        /// instances to optimize cache effectiveness.
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token lifetime
+        /// and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientSecretCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientSecretCredential.cs
@@ -104,7 +104,9 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token from Microsoft Entra ID, using the specified client secret to authenticate. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// Obtains a token from Microsoft Entra ID, using the specified client secret to authenticate. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token lifetime
+        /// and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -128,7 +130,9 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token from Microsoft Entra ID, using the specified client secret to authenticate. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// Obtains a token from Microsoft Entra ID, using the specified client secret to authenticate. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token lifetime
+        /// and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
@@ -101,10 +101,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Sequentially calls <see cref="TokenCredential.GetToken"/> on all the included credentials, returning
-        /// the first successfully obtained <see cref="AccessToken"/>. Acquired tokens are cached by the credential
-        /// instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential
-        /// instances to optimize cache effectiveness.
+        /// Sequentially calls <see cref="TokenCredential.GetToken"/> on all the included credentials, returning the first successfully
+        /// obtained <see cref="AccessToken"/>. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see>
+        /// by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances
+        /// to optimize cache effectiveness.
         /// </summary>
         /// <remarks>
         /// Credentials requiring user interaction, such as <see cref="InteractiveBrowserCredential"/>, are excluded by default.
@@ -119,10 +119,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Sequentially calls <see cref="TokenCredential.GetToken"/> on all the included credentials, returning
-        /// the first successfully obtained <see cref="AccessToken"/>. Acquired tokens are cached by the credential
-        /// instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential
-        /// instances to optimize cache effectiveness.
+        /// Sequentially calls <see cref="TokenCredential.GetToken"/> on all the included credentials, returning the first successfully
+        /// obtained <see cref="AccessToken"/>. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see>
+        /// by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances
+        /// to optimize cache effectiveness.
         /// </summary>
         /// <remarks>
         /// Credentials requiring user interaction, such as <see cref="InteractiveBrowserCredential"/>, are excluded by default.

--- a/sdk/identity/Azure.Identity/src/Credentials/DeviceCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DeviceCodeCredential.cs
@@ -158,9 +158,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token for a user account, authenticating them through the device code authentication flow. Acquired tokens are cached
-        /// by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances
-        /// to optimize cache effectiveness.
+        /// Obtains a token for a user account, authenticating them through the device code authentication flow.
+        /// Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the
+        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse
+        /// credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -172,9 +173,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token for a user account, authenticating them through the device code authentication flow. Acquired tokens are cached
-        /// by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances
-        /// to optimize cache effectiveness.
+        /// Obtains a token for a user account, authenticating them through the device code authentication flow.
+        /// Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the
+        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse
+        /// credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
@@ -126,10 +126,11 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token from Microsoft Entra ID, using the specified client details specified in the environment variables
+        /// Obtains a token from Microsoft Entra ID, using the client details specified in the environment variables
         /// AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET or AZURE_USERNAME and AZURE_PASSWORD to authenticate.
-        /// Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible,
-        /// reuse credential instances to optimize cache effectiveness.
+        /// Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential
+        /// instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances
+        /// to optimize cache effectiveness.
         /// </summary>
         /// <remarks>
         /// If the environment variables AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET are not specified, the default <see cref="AccessToken"/>
@@ -145,10 +146,11 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token from Microsoft Entra ID, using the specified client details specified in the environment variables
+        /// Obtains a token from Microsoft Entra ID, using the client details specified in the environment variables
         /// AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET or AZURE_USERNAME and AZURE_PASSWORD to authenticate.
-        /// Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible,
-        /// reuse credential instances to optimize cache effectiveness.
+        /// Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential
+        /// instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances
+        /// to optimize cache effectiveness.
         /// </summary>
         /// <remarks>
         /// If the environment variables AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET are not specified, the default <see cref="AccessToken"/>

--- a/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredential.cs
@@ -160,9 +160,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> token for a user account silently if the user has already authenticated, otherwise the
-        /// default browser is launched to authenticate the user. Acquired tokens are cached by the credential instance. Token lifetime and
-        /// refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// Silently obtains an <see cref="AccessToken"/> for a user account if the user has already authenticated. Otherwise, the default browser is launched
+        /// to authenticate the user. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the
+        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to
+        /// optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -178,9 +179,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> token for a user account silently if the user has already authenticated, otherwise the
-        /// default browser is launched to authenticate the user. Acquired tokens are cached by the credential instance. Token lifetime and
-        /// refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// Silently obtains an <see cref="AccessToken"/> for a user account if the user has already authenticated. Otherwise, the default browser is launched
+        /// to authenticate the user. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the
+        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to
+        /// optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -197,9 +199,10 @@ namespace Azure.Identity
 
 #if PREVIEW_FEATURE_FLAG
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> token for a user account silently if the user has already authenticated, otherwise the
-        /// default browser is launched to authenticate the user. Acquired tokens are cached by the credential instance. Token lifetime and
-        /// refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// Silently obtains an <see cref="AccessToken"/> for a user account if the user has already authenticated. Otherwise, the default browser is launched
+        /// to authenticate the user. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the
+        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to
+        /// optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -211,9 +214,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> token for a user account silently if the user has already authenticated, otherwise the
-        /// default browser is launched to authenticate the user. Acquired tokens are cached by the credential instance. Token lifetime and
-        /// refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// Silently obtains an <see cref="AccessToken"/> for a user account if the user has already authenticated. Otherwise, the default browser is launched
+        /// to authenticate the user. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the
+        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to
+        /// optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -102,9 +102,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are cached by the credential
-        /// instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache
-        /// effectiveness.
+        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token
+        /// lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize
+        /// cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -116,9 +117,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are cached by the credential
-        /// instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache
-        /// effectiveness.
+        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token
+        /// lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize
+        /// cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/OnBehalfOfCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/OnBehalfOfCredential.cs
@@ -210,10 +210,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Authenticates with Microsoft Entra ID and returns an access token if successful.
-        /// Acquired tokens are cached by the credential instance. Token lifetime and refreshing is
-        /// handled automatically. Where possible, reuse credential instances to optimize cache
-        /// effectiveness.
+        /// Authenticates with Microsoft Entra ID and returns an access token if successful. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance.
+        /// Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances
+        /// to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -223,10 +223,10 @@ namespace Azure.Identity
             GetTokenInternalAsync(requestContext, false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Authenticates with Microsoft Entra ID and returns an access token if successful.
-        /// Acquired tokens are cached by the credential instance. Token lifetime and refreshing is
-        /// handled automatically. Where possible, reuse credential instances to optimize cache
-        /// effectiveness.
+        /// Authenticates with Microsoft Entra ID and returns an access token if successful. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance.
+        /// Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances
+        /// to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/SharedTokenCacheCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/SharedTokenCacheCredential.cs
@@ -88,9 +88,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> token for a user account silently if the user has already authenticated to another Microsoft
-        /// application participating in SSO through a shared MSAL cache. Acquired tokens are cached by the credential instance. Token
-        /// lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// Silently obtains an <see cref="AccessToken"/> for a user account if the user has already authenticated to another Microsoft application
+        /// participating in SSO through a shared MSAL cache. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see>
+        /// by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize
+        /// cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime</param>
@@ -102,9 +103,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> token for a user account silently if the user has already authenticated to another Microsoft
-        /// application participating in SSO through a shared MSAL cache. Acquired tokens are cached by the credential instance. Token
-        /// lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
+        /// Silently obtains an <see cref="AccessToken"/> for a user account if the user has already authenticated to another Microsoft application
+        /// participating in SSO through a shared MSAL cache. Acquired tokens are <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see>
+        /// by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize
+        /// cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredential.cs
@@ -162,30 +162,28 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains a token for a user account, authenticating them using the given username and password. Note: This will fail with an
-        /// <see cref="AuthenticationFailedException"/> if the specified user account has MFA enabled. Acquired tokens are cached by the
-        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to
-        /// optimize cache effectiveness.
+        /// Obtains a token for a user account, authenticating them using the provided username and password. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token lifetime and
+        /// refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>An <see cref="AccessToken"/> which can be used to authenticate service client calls.</returns>
-        /// <exception cref="AuthenticationFailedException">Thrown when the authentication failed.</exception>
+        /// <exception cref="AuthenticationFailedException">Thrown when the authentication failed, particularly if the specified user account has MFA enabled.</exception>
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken = default)
         {
             return GetTokenImplAsync(false, requestContext, cancellationToken).EnsureCompleted();
         }
 
         /// <summary>
-        /// Obtains a token for a user account, authenticating them using the given username and password. Note: This will fail with an
-        /// <see cref="AuthenticationFailedException"/> if the specified user account has MFA enabled. Acquired tokens are cached by the
-        /// credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to
-        /// optimize cache effectiveness.
+        /// Obtains a token for a user account, authenticating them using the provided username and password. Acquired tokens are
+        /// <see href="https://aka.ms/azsdk/net/identity/token-cache">cached</see> by the credential instance. Token lifetime and
+        /// refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>An <see cref="AccessToken"/> which can be used to authenticate service client calls.</returns>
-        /// <exception cref="AuthenticationFailedException">Thrown when the authentication failed.</exception>
+        /// <exception cref="AuthenticationFailedException">Thrown when the authentication failed, particularly if the specified user account has MFA enabled.</exception>
         public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken = default)
         {
             return await GetTokenImplAsync(true, requestContext, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Drive traffic to the token caching doc from either IntelliSense or API ref pages for credentials.