### PR TITLE
[Storage] Method overload OpenReadAsync()/OpenRead() to correctly handle the allowBlobModifications flag for Blobs, DataLake, and FileShare

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed \[BUG\] Method overload BlobBaseClient.OpenReadAsync()/OpenRead() to correctly handle the allowBlobModifications flag #45516
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_f805dd22f1"
+  "Tag": "net/storage/Azure.Storage.Blobs_66e593a51d"
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -2994,11 +2994,14 @@ namespace Azure.Storage.Blobs.Specialized
             long position = 0,
             int? bufferSize = default,
             CancellationToken cancellationToken = default)
-                => OpenRead(
-                    position,
-                    bufferSize,
-                    allowBlobModifications ? new BlobRequestConditions() : null,
-                    cancellationToken);
+                => OpenReadInternal(
+                    position: position,
+                    bufferSize: bufferSize,
+                    conditions: allowBlobModifications ? new BlobRequestConditions() : null,
+                    allowModifications: allowBlobModifications,
+                    transferValidationOverride: default,
+                    async: false,
+                    cancellationToken: cancellationToken).EnsureCompleted();
 
         /// <summary>
         /// Opens a stream for reading from the blob.  The stream will only download
@@ -3072,12 +3075,14 @@ namespace Azure.Storage.Blobs.Specialized
             long position = 0,
             int? bufferSize = default,
             CancellationToken cancellationToken = default)
-                => await OpenReadAsync(
-                    position,
-                    bufferSize,
-                    allowBlobModifications ? new BlobRequestConditions() : null,
-                    cancellationToken)
-                    .ConfigureAwait(false);
+                => await OpenReadInternal(
+                    position: position,
+                    bufferSize: bufferSize,
+                    conditions: allowBlobModifications ? new BlobRequestConditions() : null,
+                    allowModifications: allowBlobModifications,
+                    transferValidationOverride: default,
+                    async: true,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Opens a stream for reading from the blob.  The stream will only download

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientOpenReadTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientOpenReadTests.cs
@@ -85,6 +85,9 @@ namespace Azure.Storage.Blobs.Tests
                 Conditions = conditions
             });
 
+        protected override async Task<Stream> OpenReadAsyncOverload(TBlobClient client, int? bufferSize = null, long position = 0, bool allowModifications = false)
+            => await client.OpenReadAsync(allowModifications, position, bufferSize);
+
         public override async Task AssertExpectedExceptionOpenReadModifiedAsync(Task readTask)
             => await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
                 readTask,

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/OpenReadTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/OpenReadTestBase.cs
@@ -103,6 +103,16 @@ namespace Azure.Storage.Test.Shared
             TRequestConditions conditions = default,
             bool allowModifications = false);
 
+        /// <summary>
+        /// Calls the 1:1 download method for the given resource client.
+        /// </summary>
+        /// <param name="client">Client to call the download on.</param>
+        protected abstract Task<Stream> OpenReadAsyncOverload(
+            TResourceClient client,
+            int? bufferSize = default,
+            long position = default,
+            bool allowModifications = false);
+
         protected abstract Task<string> SetupLeaseAsync(TResourceClient client, string leaseId, string garbageLeaseId);
         protected abstract Task<string> GetMatchConditionAsync(TResourceClient client, string match);
         protected abstract TRequestConditions BuildRequestConditions(AccessConditionParameters parameters, bool lease = true);
@@ -627,6 +637,432 @@ namespace Azure.Storage.Test.Shared
 
             // Act
             Stream openReadStream = await OpenReadAsync(client, bufferSize: bufferSize);
+            int readbytes = initalPosition;
+            while (readbytes > 0)
+            {
+                readbytes -= await openReadStream.ReadAsync(new byte[readbytes], 0, readbytes);
+            }
+
+            openReadStream.Position = position;
+
+            using MemoryStream outputStream = new MemoryStream();
+            await openReadStream.CopyToAsync(outputStream);
+
+            // Assert
+            Assert.AreEqual(expectedData.Length, outputStream.ToArray().Length);
+            TestHelper.AssertSequenceEqual(expectedData, outputStream.ToArray());
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload()
+        {
+            int size = Constants.KB;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            // Act
+            Stream outputStream = await OpenReadAsyncOverload(client);
+            byte[] outputBytes = new byte[size];
+            await outputStream.ReadAsync(outputBytes, 0, size);
+
+            // Assert
+            Assert.AreEqual(data.Length, outputStream.Length);
+            TestHelper.AssertSequenceEqual(data, outputBytes);
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload_BufferSize()
+        {
+            int size = Constants.KB;
+            int bufferSize = size / 8;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            // Act
+            Stream outputStream = await OpenReadAsyncOverload(client, bufferSize: bufferSize);
+            byte[] outputBytes = new byte[size];
+            int downloadedBytes = 0;
+
+            while (downloadedBytes < size)
+            {
+                downloadedBytes += await outputStream.ReadAsync(outputBytes, downloadedBytes, size / 4);
+            }
+
+            // Assert
+            Assert.AreEqual(data.Length, outputStream.Length);
+            TestHelper.AssertSequenceEqual(data, outputBytes);
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload_OffsetAndBufferSize()
+        {
+            int size = Constants.KB;
+            int bufferSize = size / 8;
+            int position = size / 2;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            byte[] expected = new byte[size];
+            Array.Copy(data, position, expected, position, size - position);
+
+            // Act
+            Stream outputStream = await OpenReadAsyncOverload(client, bufferSize: bufferSize, position: position);
+            byte[] outputBytes = new byte[size];
+
+            int downloadedBytes = position;
+
+            while (downloadedBytes < size)
+            {
+                downloadedBytes += await outputStream.ReadAsync(outputBytes, downloadedBytes, size / 4);
+            }
+
+            // Assert
+            Assert.AreEqual(data.Length, outputStream.Length);
+            TestHelper.AssertSequenceEqual(expected, outputBytes);
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload_Error()
+        {
+            // Arrange
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+
+            // Act
+            await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
+                OpenReadAsyncOverload(client),
+                e => Assert.AreEqual(OpenReadAsync_Error_Code, e.ErrorCode));
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload_StrangeOffsetsTest()
+        {
+            // Arrange
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            int size = Constants.KB;
+            int bufferSize = 157;
+            byte[] expectedData = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(expectedData));
+
+            Stream outputStream = await OpenReadAsyncOverload(client, bufferSize: bufferSize);
+            byte[] actualData = new byte[size];
+            int offset = 0;
+
+            // Act
+            int count = 0;
+            int readBytes = -1;
+            while (readBytes != 0)
+            {
+                for (count = 6; count < 37; count += 6)
+                {
+                    readBytes = await outputStream.ReadAsync(actualData, offset, count);
+                    if (readBytes == 0)
+                    {
+                        break;
+                    }
+                    offset += readBytes;
+                }
+            }
+
+            // Assert
+            TestHelper.AssertSequenceEqual(expectedData, actualData);
+        }
+
+        [RecordedTest]
+        public virtual async Task OpenReadAsyncOverload_Modified()
+        {
+            int size = Constants.KB;
+            int bufferSize = size / 2;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            // Act
+            Stream outputStream = await OpenReadAsyncOverload(client, bufferSize: bufferSize);
+            byte[] outputBytes = new byte[size];
+            await outputStream.ReadAsync(outputBytes, 0, size / 2);
+
+            // Modify the blob.
+            await ModifyDataAsync(client, new MemoryStream(GetRandomBuffer(size)), ModifyDataMode.Replace);
+
+            // Assert
+            await AssertExpectedExceptionOpenReadModifiedAsync(outputStream.ReadAsync(outputBytes, size / 2, size / 2));
+        }
+
+        [RecordedTest]
+        [Ignore("Don't want to record 1 GB of data.")]
+        public async Task OpenReadAsyncOverload_LargeData()
+        {
+            // Arrange
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+            int length = 1 * Constants.GB;
+            byte[] expectedData = GetRandomBuffer(length);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            using Stream stream = new MemoryStream(expectedData);
+            await StageDataAsync(client, stream);
+
+            Stream outputStream = await OpenReadAsyncOverload(client);
+            int readSize = 8 * Constants.MB;
+            byte[] actualData = new byte[readSize];
+            int offset = 0;
+
+            // Act
+            for (int i = 0; i < length / readSize; i++)
+            {
+                int actualRead = await outputStream.ReadAsync(actualData, 0, readSize);
+                for (int j = 0; j < actualRead; j++)
+                {
+                    // Assert
+                    if (actualData[j] != expectedData[offset + j])
+                    {
+                        Assert.Fail($"Index {offset + j} does not match.  Expected: {expectedData[offset + j]} Actual: {actualData[j]}");
+                    }
+                }
+                offset += actualRead;
+            }
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload_CopyReadStreamToAnotherStream()
+        {
+            // Arrange
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+            long size = 4 * Constants.MB;
+            byte[] expectedData = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(expectedData));
+
+            MemoryStream outputStream = new MemoryStream();
+
+            // Act
+            using Stream blobStream = await OpenReadAsyncOverload(client);
+            await blobStream.CopyToAsync(outputStream);
+
+            TestHelper.AssertSequenceEqual(expectedData, outputStream.ToArray());
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload_InvalidParameterTests()
+        {
+            int size = Constants.KB;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+            Stream stream = await OpenReadAsyncOverload(client);
+
+            // Act
+            await TestHelper.AssertExpectedExceptionAsync<ArgumentNullException>(
+                stream.ReadAsync(buffer: null, offset: 0, count: 10),
+                new ArgumentNullException("buffer", "buffer cannot be null."));
+
+            await TestHelper.AssertExpectedExceptionAsync<ArgumentOutOfRangeException>(
+                stream.ReadAsync(buffer: new byte[10], offset: -1, count: 10),
+                new ArgumentOutOfRangeException("offset", "offset cannot be less than 0."));
+
+            await TestHelper.AssertExpectedExceptionAsync<ArgumentOutOfRangeException>(
+                stream.ReadAsync(buffer: new byte[10], offset: 11, count: 10),
+                new ArgumentOutOfRangeException("offset", "offset cannot exceed buffer length."));
+
+            await TestHelper.AssertExpectedExceptionAsync<ArgumentOutOfRangeException>(
+                stream.ReadAsync(buffer: new byte[10], offset: 1, count: -1),
+                new ArgumentOutOfRangeException("count", "count cannot be less than 0."));
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload_Seek_PositionUnchanged()
+        {
+            int size = Constants.KB;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            // Act
+            Stream outputStream = await OpenReadAsyncOverload(client);
+            byte[] outputBytes = new byte[size];
+            outputStream.Seek(0, SeekOrigin.Begin);
+
+            Assert.AreEqual(0, outputStream.Position);
+
+            await outputStream.ReadAsync(outputBytes, 0, size);
+
+            // Assert
+            Assert.AreEqual(data.Length, outputStream.Length);
+            TestHelper.AssertSequenceEqual(data, outputBytes);
+        }
+
+        [RecordedTest]
+        public async Task OpenReadAsyncOverload_Seek_NegativeNewPosition()
+        {
+            int size = Constants.KB;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            // Act
+            Stream outputStream = await OpenReadAsyncOverload(client);
+            TestHelper.AssertExpectedException<ArgumentException>(
+                () => outputStream.Seek(-10, SeekOrigin.Begin),
+                new ArgumentException("New offset cannot be less than 0.  Value was -10", "offset"));
+        }
+
+        [RecordedTest]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task OpenReadAsyncOverload_Seek_NewPositionGreaterThanResourceLength(bool allowModifications)
+        {
+            int size = Constants.KB;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            // Act
+            Stream outputStream = await OpenReadAsyncOverload(client, allowModifications: allowModifications);
+            TestHelper.AssertExpectedException<ArgumentException>(
+                () => outputStream.Seek(1025, SeekOrigin.Begin),
+                new ArgumentException("You cannot seek past the last known length of the underlying blob or file.", "offset"));
+
+            Assert.AreEqual(size, outputStream.Length);
+        }
+
+        [RecordedTest]
+        [TestCase(0, SeekOrigin.Begin)]
+        [TestCase(10, SeekOrigin.Begin)]
+        [TestCase(-10, SeekOrigin.Current)]
+        [TestCase(0, SeekOrigin.Current)]
+        [TestCase(10, SeekOrigin.Current)]
+        [TestCase(0, SeekOrigin.End)]
+        [TestCase(-10, SeekOrigin.End)]
+        public async Task OpenReadAsyncOverload_Seek_Position(long offset, SeekOrigin origin)
+        {
+            int size = Constants.KB;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            var data = GetRandomBuffer(size);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            Stream outputStream = await OpenReadAsyncOverload(client);
+            int readBytes = 512;
+            await outputStream.ReadAsync(new byte[readBytes], 0, readBytes);
+            Assert.AreEqual(512, outputStream.Position);
+
+            // Act
+            outputStream.Seek(offset, origin);
+
+            // Assert
+            if (origin == SeekOrigin.Begin)
+            {
+                Assert.AreEqual(offset, outputStream.Position);
+            }
+            else if (origin == SeekOrigin.Current)
+            {
+                Assert.AreEqual(readBytes + offset, outputStream.Position);
+            }
+            else
+            {
+                Assert.AreEqual(size + offset, outputStream.Position);
+            }
+
+            Assert.AreEqual(size, outputStream.Length);
+        }
+
+        [RecordedTest]
+        // lower position within _buffer
+        [TestCase(-50)]
+        // higher position within _buffer
+        [TestCase(50)]
+        // lower position below _buffer
+        [TestCase(-100)]
+        // higher position above _buffer
+        [TestCase(100)]
+        public async Task OpenReadAsyncOverload_Seek(long offset)
+        {
+            int size = Constants.KB;
+            int bufferSize = 128;
+            int initalPosition = 450;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            byte[] data = GetRandomBuffer(size);
+            byte[] expectedData = new byte[size - (initalPosition + offset)];
+            Array.Copy(data, initalPosition + offset, expectedData, 0, size - (initalPosition + offset));
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            // Act
+            Stream openReadStream = await OpenReadAsyncOverload(client, bufferSize: bufferSize);
+            int readbytes = initalPosition;
+            while (readbytes > 0)
+            {
+                readbytes -= await openReadStream.ReadAsync(new byte[readbytes], 0, readbytes);
+            }
+
+            openReadStream.Seek(offset, SeekOrigin.Current);
+
+            using MemoryStream outputStream = new MemoryStream();
+            await openReadStream.CopyToAsync(outputStream);
+
+            // Assert
+            Assert.AreEqual(expectedData.Length, outputStream.ToArray().Length);
+            Assert.AreEqual(size, openReadStream.Length);
+            TestHelper.AssertSequenceEqual(expectedData, outputStream.ToArray());
+        }
+
+        [RecordedTest]
+        // lower position within _buffer
+        [TestCase(400)]
+        // higher positiuon within _buffer
+        [TestCase(500)]
+        // lower position below _buffer
+        [TestCase(250)]
+        // higher position above _buffer
+        [TestCase(550)]
+        public async Task OpenReadAsyncOverload_SetPosition(long position)
+        {
+            int size = Constants.KB;
+            int bufferSize = 128;
+            int initalPosition = 450;
+            await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            // Arrange
+            byte[] data = GetRandomBuffer(size);
+            byte[] expectedData = new byte[size - position];
+            Array.Copy(data, position, expectedData, 0, size - position);
+            TResourceClient client = GetResourceClient(disposingContainer.Container);
+            await StageDataAsync(client, new MemoryStream(data));
+
+            // Act
+            Stream openReadStream = await OpenReadAsyncOverload(client, bufferSize: bufferSize);
             int readbytes = initalPosition;
             while (readbytes > 0)
             {

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/OpenReadTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/OpenReadTestBase.cs
@@ -654,7 +654,7 @@ namespace Azure.Storage.Test.Shared
         }
 
         [RecordedTest]
-        public async Task OpenReadAsyncOverload_allowModifications()
+        public async Task OpenReadAsyncOverload_AllowModifications()
         {
             int size = Constants.KB;
             await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
@@ -684,7 +684,7 @@ namespace Azure.Storage.Test.Shared
         }
 
         [RecordedTest]
-        public async Task OpenReadAsyncOverload_notAllowModifications()
+        public async Task OpenReadAsyncOverload_NotAllowModifications()
         {
             int size = Constants.KB;
             await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();

--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed \[BUG\] Method overload DataLakeFileClient.OpenReadAsync()/OpenRead() to correctly handle the allowBlobModifications flag #45516
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/assets.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.DataLake",
-  "Tag": "net/storage/Azure.Storage.Files.DataLake_186c14971d"
+  "Tag": "net/storage/Azure.Storage.Files.DataLake_275c4dcbac"
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -4947,8 +4947,27 @@ namespace Azure.Storage.Files.DataLake
             long position = 0,
             int? bufferSize = default,
             CancellationToken cancellationToken = default)
-                => allowfileModifications ? OpenRead(position, bufferSize, new DataLakeRequestConditions(), cancellationToken)
-                : OpenRead(position, bufferSize, null, cancellationToken);
+        {
+            DiagnosticScope scope = ClientConfiguration.ClientDiagnostics.CreateScope($"{nameof(DataLakeFileClient)}.{nameof(OpenRead)}");
+            try
+            {
+                scope.Start();
+                return _blockBlobClient.OpenRead(
+                allowfileModifications,
+                position,
+                bufferSize,
+                cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+            finally
+            {
+                scope.Dispose();
+            }
+        }
 
         /// <summary>
         /// Opens a stream for reading from the file.  The stream will only download
@@ -5035,8 +5054,27 @@ namespace Azure.Storage.Files.DataLake
             long position = 0,
             int? bufferSize = default,
             CancellationToken cancellationToken = default)
-                => await (allowfileModifications ? OpenReadAsync(position, bufferSize, new DataLakeRequestConditions(), cancellationToken)
-                : OpenReadAsync(position, bufferSize, null, cancellationToken)).ConfigureAwait(false);
+        {
+            DiagnosticScope scope = ClientConfiguration.ClientDiagnostics.CreateScope($"{nameof(DataLakeFileClient)}.{nameof(OpenRead)}");
+            try
+            {
+                scope.Start();
+                return await _blockBlobClient.OpenReadAsync(
+                allowfileModifications,
+                position,
+                bufferSize,
+                cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+            finally
+            {
+                scope.Dispose();
+            }
+        }
         #endregion OpenRead
 
         #region OpenWrite

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeFileClientOpenReadTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeFileClientOpenReadTests.cs
@@ -92,6 +92,9 @@ namespace Azure.Storage.Files.DataLake.Tests
                 Conditions = conditions
             });
 
+        protected override async Task<Stream> OpenReadAsyncOverload(DataLakeFileClient client, int? bufferSize = null, long position = 0, bool allowModifications = false)
+            => await client.OpenReadAsync(allowModifications, position, bufferSize);
+
         protected override async Task StageDataAsync(DataLakeFileClient client, Stream data)
         {
             using Stream writeStream = await client.OpenWriteAsync( overwrite: true);

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed \[BUG\] Method overload ShareFileClient.OpenReadAsync()/OpenRead() to correctly handle the allowBlobModifications flag #45516
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.Files.Shares_14e0fa0c22"
+  "Tag": "net/storage/Azure.Storage.Files.Shares_e7f070af73"
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -2706,11 +2706,14 @@ namespace Azure.Storage.Files.Shares
             long position = 0,
             int? bufferSize = default,
             CancellationToken cancellationToken = default)
-                => OpenRead(
-                    position,
-                    bufferSize,
-                    allowfileModifications ? new ShareFileRequestConditions() : null,
-                    cancellationToken);
+                => OpenReadInteral(
+                    position: position,
+                    bufferSize: bufferSize,
+                    conditions: allowfileModifications ? new ShareFileRequestConditions() : null,
+                    allowModifications: allowfileModifications,
+                    transferValidationOverride: default,
+                    async: false,
+                    cancellationToken: cancellationToken).EnsureCompleted();
 
         /// <summary>
         /// Opens a stream for reading from the file.  The stream will only download
@@ -2796,11 +2799,14 @@ namespace Azure.Storage.Files.Shares
             long position = 0,
             int? bufferSize = default,
             CancellationToken cancellationToken = default)
-                => await OpenReadAsync(
-                    position,
-                    bufferSize,
-                    allowfileModifications ? new ShareFileRequestConditions() : null,
-                    cancellationToken).ConfigureAwait(false);
+                => await OpenReadInteral(
+                    position: position,
+                    bufferSize: bufferSize,
+                    conditions: allowfileModifications ? new ShareFileRequestConditions() : null,
+                    allowModifications: allowfileModifications,
+                    transferValidationOverride: default,
+                    async: true,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Opens a stream for reading from the file.  The stream will only download

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareFileClientOpenReadTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareFileClientOpenReadTests.cs
@@ -97,6 +97,9 @@ namespace Azure.Storage.Files.Shares.Tests
                 Conditions = conditions
             });
 
+        protected override async Task<Stream> OpenReadAsyncOverload(ShareFileClient client, int? bufferSize = null, long position = 0, bool allowModifications = false)
+            => await client.OpenReadAsync(allowModifications, position, bufferSize);
+
         protected override async Task StageDataAsync(ShareFileClient client, Stream data)
         {
             await client.CreateAsync(data.Length);


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/45516
