### PR TITLE
Document env var for setting Azure authority host

### DIFF
--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -214,9 +214,9 @@ var credential = new DefaultAzureCredential(
     });
 ```
 
-    [AzureAuthorityHosts](https://learn.microsoft.com/dotnet/api/azure.identity.azureauthorityhosts?view=azure-dotnet) defines authorities for well-known clouds:
+    [AzureAuthorityHosts](https://learn.microsoft.com/dotnet/api/azure.identity.azureauthorityhosts?view=azure-dotnet) defines authorities for well-known clouds.
 
-1. Set the `AZURE_AUTHORITY_HOST` environment variable to the appropriate authority host URL. For example, `https://login.microsoftonline.us/`.
+1. Set the `AZURE_AUTHORITY_HOST` environment variable to the appropriate authority host URL. For example, `https://login.microsoftonline.us/`. Note that this setting affects all credentials in the environment. Use the previous solution to set the authority host on a specific credential.
 
 Not all credentials require this configuration. Credentials that authenticate through a developer tool, such as `AzureCliCredential`, use that tool's configuration.
 

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -202,11 +202,21 @@ var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), crede
 
 ## Sovereign cloud configuration
 
-By default, credentials authenticate to the Microsoft Entra endpoint for the Azure Public Cloud. To access resources in other clouds, such as Azure US Government or a private cloud, configure credentials with the `AuthorityHost` option. [AzureAuthorityHosts](https://learn.microsoft.com/dotnet/api/azure.identity.azureauthorityhosts?view=azure-dotnet) defines authorities for well-known clouds:
+By default, credentials authenticate to the Microsoft Entra endpoint for the Azure Public Cloud. To access resources in other clouds, such as Azure US Government or a private cloud, use one of the following solutions:
 
-```C# Snippet:AuthenticatingWithAuthorityHost
-var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { AuthorityHost = AzureAuthorityHosts.AzureGovernment });
+1. Configure credentials with the [AuthorityHost](https://learn.microsoft.com/dotnet/api/azure.identity.tokencredentialoptions.authorityhost?view=azure-dotnet#azure-identity-tokencredentialoptions-authorityhost) property. For example:
+
+    ```C# Snippet:AuthenticatingWithAuthorityHost
+var credential = new DefaultAzureCredential(
+    new DefaultAzureCredentialOptions
+    {
+        AuthorityHost = AzureAuthorityHosts.AzureGovernment
+    });
 ```
+
+    [AzureAuthorityHosts](https://learn.microsoft.com/dotnet/api/azure.identity.azureauthorityhosts?view=azure-dotnet) defines authorities for well-known clouds:
+
+1. Set the `AZURE_AUTHORITY_HOST` environment variable to the appropriate authority host URL. For example, `https://login.microsoftonline.us/`.
 
 Not all credentials require this configuration. Credentials that authenticate through a developer tool, such as `AzureCliCredential`, use that tool's configuration.
 

--- a/sdk/identity/Azure.Identity/tests/samples/ReadmeSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/ReadmeSnippets.cs
@@ -66,9 +66,11 @@ namespace Azure.Identity.Samples
         public void AuthenticatingWithAuthorityHost()
         {
             #region Snippet:AuthenticatingWithAuthorityHost
-
-            var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { AuthorityHost = AzureAuthorityHosts.AzureGovernment });
-
+            var credential = new DefaultAzureCredential(
+                new DefaultAzureCredentialOptions
+                {
+                    AuthorityHost = AzureAuthorityHosts.AzureGovernment
+                });
             #endregion
         }
 


### PR DESCRIPTION
Document an alternative approach to setting the `AuthorityHost` property.
