### PR TITLE
[Azure.AI.OpenAI] do not set StreamOptions to null

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatClient.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatClient.cs
@@ -36,20 +36,4 @@ internal partial class AzureChatClient : ChatClient
 
     protected AzureChatClient()
     { }
-
-    /// <inheritdoc/>
-    public override AsyncCollectionResult<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
-    {
-        options ??= new();
-        options.StreamOptions = null;
-        return base.CompleteChatStreamingAsync(messages, options, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public override CollectionResult<StreamingChatCompletionUpdate> CompleteChatStreaming(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
-    {
-        options ??= new();
-        options.StreamOptions = null;
-        return base.CompleteChatStreaming(messages, options, cancellationToken);
-    }
 }


### PR DESCRIPTION
At the moment `Azure.AI.OpenAI` explicitly suppresses sending `"stream_options": {"include_usage": true}` in the chat completion requests, which the OpenAI library sends by default (and does not even allow to suppress!).

The result is, when switching from OpenAI to Azure.AI.OpenAI library, the token count information is lost.

The Azure hosted REST API supports `stream_options` just fine, so I am not sure what is the reason behind this suppressing - so I thought it makes sense to open a PR to align these behavior. 

If there is some specific reason behind it, please close this PR, but it would be best to have the main OpenAI library and the Azure.AI.OpenAI library behave identically, as currently users face a broken feature, and one that is important from cost control perspective.