### PR TITLE
[MachineLearning] Fix deserialize for `ResourceType` in `MachineLearningEnvironmentContainerData` & `MachineLearningDataContainerData`

### DIFF
--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/Azure.ResourceManager.MachineLearning.sln
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/Azure.ResourceManager.MachineLearning.sln
@@ -7,10 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Machi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.MachineLearning.Tests", "tests\Azure.ResourceManager.MachineLearning.Tests.csproj", "{738C0769-57F8-439C-8078-54498A030BA0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{8052009B-2126-44A3-88CD-4F3B17894C64}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{33DCCE3D-E2EB-49F3-A8FE-D7B43917719E}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.MachineLearning.Samples", "samples\Azure.ResourceManager.MachineLearning.Samples.csproj", "{E9AE2035-2479-4B96-88E6-5D137397F398}"
 EndProject
 Global

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/CHANGELOG.md
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bugs Fixed
 
+- Fix the responsed error type "data" to "Microsoft.MachineLearningServices/registries/data" in `MachineLearningDataContainerData`.
+- Fix the responsed error type "environments" to "Microsoft.MachineLearningServices/registries/environments" in `MachineLearningEnvironmentContainerData`.
+- Override the `ValidateResourceId` method in `MachineLearningEnvironmentContainerResource` and `MachineLearningDataContainerResource` to ovoid checking the wrong resource id.
+
 ### Other Changes
 
 ## 1.2.0 (2024-09-06)

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/CHANGELOG.md
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/CHANGELOG.md
@@ -1,18 +1,13 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.1 (2024-09-14)
 
 ### Bugs Fixed
 
-- Fix the responsed error type "data" to "Microsoft.MachineLearningServices/registries/data" in `MachineLearningDataContainerData`.
-- Fix the responsed error type "environments" to "Microsoft.MachineLearningServices/registries/environments" in `MachineLearningEnvironmentContainerData`.
-- Override the `ValidateResourceId` method in `MachineLearningEnvironmentContainerResource` and `MachineLearningDataContainerResource` to ovoid checking the wrong resource id.
-
-### Other Changes
+- Fixed issue https://github.com/Azure/azure-sdk-for-net/issues/45884.
+    - Handle incorrect returned ResourceType of "Microsoft.MachineLearningServices/registries/data" in `MachineLearningDataContainerData`.
+    - Handle incorrect returned ResourceType of "Microsoft.MachineLearningServices/registries/environments" in `MachineLearningEnvironmentContainerData`.
+    - Override the `ValidateResourceId` method in `MachineLearningEnvironmentContainerResource` and `MachineLearningDataContainerResource` to avoid validation exception.
 
 ## 1.2.0 (2024-09-06)
 

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Azure.ResourceManager.MachineLearning.csproj
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Azure.ResourceManager.MachineLearning.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.2.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.0</ApiCompatVersion>
     <Description>Microsoft Azure management client SDK for Azure resource provider Microsoft.MachineLearningServices.</Description>

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningDataContainerData.Serialization.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningDataContainerData.Serialization.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.ResourceManager.MachineLearning
+{
+    // Fix the responsed error type "data" to "Microsoft.MachineLearningServices/registries/data"
+    // Issue:https://github.com/Azure/azure-sdk-for-net/issues/45884
+    [CodeGenSerialization(nameof(ResourceType), DeserializationValueHook = nameof(DeserializeTypeValue))]
+    public partial class MachineLearningDataContainerData
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DeserializeTypeValue(JsonProperty property, ref ResourceType type)
+        {
+            var propVal = property.Value.GetString();
+            type = propVal == "data" ? new ResourceType("Microsoft.MachineLearningServices/registries/data") : new ResourceType(propVal);
+        }
+    }
+}

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningDataContainerData.Serialization.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningDataContainerData.Serialization.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Azure.Core;
@@ -18,7 +19,14 @@ namespace Azure.ResourceManager.MachineLearning
         private static void DeserializeTypeValue(JsonProperty property, ref ResourceType type)
         {
             var propVal = property.Value.GetString();
-            type = propVal == "data" ? new ResourceType("Microsoft.MachineLearningServices/registries/data") : new ResourceType(propVal);
+            try
+            {
+                type = new ResourceType(propVal);
+            }
+            catch (Exception)
+            {
+                type = new ResourceType("Microsoft.MachineLearningServices/registries/data");
+            }
         }
     }
 }

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningDataContainerResource.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningDataContainerResource.cs
@@ -3,12 +3,7 @@
 
 #nullable disable
 
-using System;
-using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.Pipeline;
 
 namespace Azure.ResourceManager.MachineLearning
 {

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningDataContainerResource.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningDataContainerResource.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.ResourceManager.MachineLearning
+{
+    // Override the "ValidateResourceId" method since the resource id is not correctly formatted
+    // Issue:https://github.com/Azure/azure-sdk-for-net/issues/45884
+    public partial class MachineLearningDataContainerResource
+    {
+        internal static void ValidateResourceId(ResourceIdentifier id)
+        {
+        }
+    }
+}

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerData.Serialization.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerData.Serialization.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Azure.Core;
@@ -18,7 +19,14 @@ namespace Azure.ResourceManager.MachineLearning
         private static void DeserializeTypeValue(JsonProperty property, ref ResourceType type)
         {
             var propVal = property.Value.GetString();
-            type = propVal == "environments" ? new ResourceType("Microsoft.MachineLearningServices/registries/environments") : new ResourceType(propVal);
+            try
+            {
+                type = new ResourceType(propVal);
+            }
+            catch (Exception)
+            {
+                type = new ResourceType("Microsoft.MachineLearningServices/registries/environments");
+            }
         }
     }
 }

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerData.Serialization.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerData.Serialization.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Azure.ResourceManager.MachineLearning.Models;
+using Azure.ResourceManager.Models;
+
+namespace Azure.ResourceManager.MachineLearning
+{
+    // Fix the responsed error type "environments" to "Microsoft.MachineLearningServices/registries/environments"
+    // Issue:https://github.com/Azure/azure-sdk-for-net/issues/45884
+    [CodeGenSerialization(nameof(ResourceType), DeserializationValueHook = nameof(DeserializeTypeValue))]
+    public partial class MachineLearningEnvironmentContainerData
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DeserializeTypeValue(JsonProperty property, ref ResourceType type)
+        {
+            var propVal = property.Value.GetString();
+            type = propVal == "environments" ? new ResourceType("Microsoft.MachineLearningServices/registries/environments") : new ResourceType(propVal);
+        }
+    }
+}

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerData.Serialization.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerData.Serialization.cs
@@ -3,15 +3,9 @@
 
 #nullable disable
 
-using System;
-using System.ClientModel.Primitives;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.Json;
 using Azure.Core;
-using Azure.ResourceManager.MachineLearning.Models;
-using Azure.ResourceManager.Models;
 
 namespace Azure.ResourceManager.MachineLearning
 {

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerResource.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerResource.cs
@@ -3,12 +3,7 @@
 
 #nullable disable
 
-using System;
-using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.Pipeline;
 
 namespace Azure.ResourceManager.MachineLearning
 {

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerResource.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Customized/MachineLearningEnvironmentContainerResource.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.ResourceManager.MachineLearning
+{
+    // Override the "ValidateResourceId" method since the resource id is not correctly formatted
+    // Issue:https://github.com/Azure/azure-sdk-for-net/issues/45884
+    public partial class MachineLearningEnvironmentContainerResource
+    {
+        internal static void ValidateResourceId(ResourceIdentifier id)
+        {
+        }
+    }
+}

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Generated/MachineLearningDataContainerData.Serialization.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Generated/MachineLearningDataContainerData.Serialization.cs
@@ -115,7 +115,7 @@ namespace Azure.ResourceManager.MachineLearning
                 }
                 if (property.NameEquals("type"u8))
                 {
-                    type = new ResourceType(property.Value.GetString());
+                    DeserializeTypeValue(property, ref type);
                     continue;
                 }
                 if (property.NameEquals("systemData"u8))

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Generated/MachineLearningDataContainerResource.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Generated/MachineLearningDataContainerResource.cs
@@ -82,12 +82,6 @@ namespace Azure.ResourceManager.MachineLearning
             }
         }
 
-        internal static void ValidateResourceId(ResourceIdentifier id)
-        {
-            if (id.ResourceType != ResourceType)
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Invalid resource type {0} expected {1}", id.ResourceType, ResourceType), nameof(id));
-        }
-
         /// <summary> Gets a collection of MachineLearningDataVersionResources in the MachineLearningDataContainer. </summary>
         /// <returns> An object representing collection of MachineLearningDataVersionResources and their operations over a MachineLearningDataVersionResource. </returns>
         public virtual MachineLearningDataVersionCollection GetMachineLearningDataVersions()

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Generated/MachineLearningEnvironmentContainerData.Serialization.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Generated/MachineLearningEnvironmentContainerData.Serialization.cs
@@ -115,7 +115,7 @@ namespace Azure.ResourceManager.MachineLearning
                 }
                 if (property.NameEquals("type"u8))
                 {
-                    type = new ResourceType(property.Value.GetString());
+                    DeserializeTypeValue(property, ref type);
                     continue;
                 }
                 if (property.NameEquals("systemData"u8))

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Generated/MachineLearningEnvironmentContainerResource.cs
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearning/src/Generated/MachineLearningEnvironmentContainerResource.cs
@@ -82,12 +82,6 @@ namespace Azure.ResourceManager.MachineLearning
             }
         }
 
-        internal static void ValidateResourceId(ResourceIdentifier id)
-        {
-            if (id.ResourceType != ResourceType)
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Invalid resource type {0} expected {1}", id.ResourceType, ResourceType), nameof(id));
-        }
-
         /// <summary> Gets a collection of MachineLearningEnvironmentVersionResources in the MachineLearningEnvironmentContainer. </summary>
         /// <returns> An object representing collection of MachineLearningEnvironmentVersionResources and their operations over a MachineLearningEnvironmentVersionResource. </returns>
         public virtual MachineLearningEnvironmentVersionCollection GetMachineLearningEnvironmentVersions()


### PR DESCRIPTION
This is a fix for issue: https://github.com/Azure/azure-sdk-for-net/issues/45884
We should remove this once we fixed: https://github.com/Azure/azure-sdk-for-net/issues/45900