### PR TITLE
[AzureMonitorExporter] cleanup leftover RPC code

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An OpenTelemetry .NET distro that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry ASP.NET Core Distro</AssemblyTitle>
@@ -23,10 +23,10 @@
     <!-- Depending on monthly deliverables, we may switch between PackageReference or ProjectReference. Keeping both here to make the switch easier. -->
 
     <!-- FOR PUBLIC RELEASES, MUST USE PackageReference. THIS REQUIRES A STAGGERED RELEASE IF SHIPPING A NEW EXPORTER. -->
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <!--<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />-->
 
     <!-- FOR LOCAL DEV, ProjectReference IS PREFERRED. -->
-    <!--<ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />-->
+    <ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
   </ItemGroup>
 
   <!-- Shared sources from Azure.Core -->

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/DataCollection/DocumentHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/DataCollection/DocumentHelper.cs
@@ -151,10 +151,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.DataCollection
                     remoteDependencyDocument.CommandName = messagingUrl;
 
                     break;
-                case OperationType.Rpc:
-                    // remoteDependencyDocument.Name = activity.DisplayName;
-                    // remoteDependencyDocument.CommandName = AzMonList.GetTagValue(ref liveMetricsTagsProcessor.Tags, SemanticConventions.AttributeRpcService)?.ToString();
-                    // remoteDependencyDocument.ResultCode = AzMonList.GetTagValue(ref liveMetricsTagsProcessor.Tags, SemanticConventions.AttributeRpcStatus)?.ToString();
                 default:
                     // Unknown or Manual or Unexpected Dependency Type
                     remoteDependencyDocument.Name = activity.DisplayName;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/SemanticConventions.cs
@@ -58,11 +58,6 @@ internal static class SemanticConventions
     public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
     public const string AttributeDbMongoDbCollection = "db.mongodb.collection";
 
-    public const string AttributeRpcSystem = "rpc.system";
-    public const string AttributeRpcService = "rpc.service";
-    public const string AttributeRpcMethod = "rpc.method";
-    public const string AttributeRpcGrpcStatusCode = "rpc.grpc.status_code";
-
     public const string AttributeMessageType = "message.type";
     public const string AttributeMessageId = "message.id";
     public const string AttributeMessageCompressedSize = "message.compressed_size";

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -31,9 +31,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 case OperationType.Db:
                     SetDbDependencyProperties(ref activityTagsProcessor.MappedTags);
                     break;
-                case OperationType.Rpc:
-                    SetRpcDependencyProperties(ref activityTagsProcessor.MappedTags);
-                    break;
                 case OperationType.Messaging:
                     SetMessagingDependencyProperties(activity, ref activityTagsProcessor.MappedTags);
                     break;
@@ -101,14 +98,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             {
                 Properties.Add(SemanticConventions.AttributeDbName, sanitizedDbName);
             }
-        }
-
-        private void SetRpcDependencyProperties(ref AzMonList rpcTagObjects)
-        {
-            var rpcAttributeTagObjects = AzMonList.GetTagValues(ref rpcTagObjects, SemanticConventions.AttributeRpcService, SemanticConventions.AttributeRpcSystem, SemanticConventions.AttributeRpcStatus);
-            Data = rpcAttributeTagObjects[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
-            Type = rpcAttributeTagObjects[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
-            ResultCode = rpcAttributeTagObjects[2]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_ResultCode_MaxLength);
         }
 
         private void SetMessagingDependencyProperties(Activity activity, ref AzMonList messagingTagObjects)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -52,12 +52,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             SemanticConventions.AttributeComponent,
             "otel.status_code",
 
-            // required - RPC
-            // SemanticConventions.AttributeRpcService,
-            // SemanticConventions.AttributeRpcSystem,
-            // SemanticConventions.AttributeRpcStatus,
-            // SemanticConventions.AttributeEndpointAddress,
-
             // required - Messaging
             SemanticConventions.AttributeMessagingSystem,
             SemanticConventions.AttributeMessagingDestinationName,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -391,10 +391,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         var dbSystem = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString();
                         return AzMonListExtensions.s_dbSystems.Contains(dbSystem) ? "SQL" : dbSystem?.Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
                     }
-                case OperationType.Rpc:
-                    {
-                        return AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeRpcSystem)?.ToString();
-                    }
                 case OperationType.Messaging:
                     {
                         return AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeMessagingSystem)?.ToString();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
@@ -107,11 +107,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
         public const string AttributeDbMongoDbCollection = "db.mongodb.collection";
 
-        public const string AttributeRpcMethod = "rpc.method";
-        public const string AttributeRpcStatus = "rpc.grpc.status_code";
-        public const string AttributeRpcService = "rpc.service";
-        public const string AttributeRpcSystem = "rpc.system";
-
         public const string AttributeMessageType = "message.type";
         public const string AttributeMessageId = "message.id";
         public const string AttributeMessageCompressedSize = "message.compressed_size";


### PR DESCRIPTION
Follow up to #45316

We have a lot of leftover code that was attempting to map RPC attributes. Since we don't support RPC today, these need to be removed.
