### PR TITLE
Fix a few `Azure.Provisioning` issues

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/api/Azure.Provisioning.AppConfiguration.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/api/Azure.Provisioning.AppConfiguration.netstandard2.0.cs
@@ -156,6 +156,7 @@ namespace Azure.Provisioning.AppConfiguration
         public Azure.Provisioning.BicepValue<int> SoftDeleteRetentionInDays { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.AppConfiguration.AppConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.AppConfiguration.AppConfigurationBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.AppConfiguration.AppConfigurationStore FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppConfiguration.AppConfigurationStoreApiKey> GetKeys() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
@@ -230,7 +230,8 @@ public partial class AppConfigurationStore : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this AppConfigurationStore.
+    /// Assign a role to a principal that grants access to this
+    /// AppConfigurationStore.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
@@ -221,8 +221,9 @@ public partial class AppConfigurationStore : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(AppConfigurationBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -238,8 +239,9 @@ public partial class AppConfigurationStore : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(AppConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
@@ -228,4 +228,20 @@ public partial class AppConfigurationStore : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this AppConfigurationStore.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(AppConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/tests/BasicAppConfigurationTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/tests/BasicAppConfigurationTests.cs
@@ -20,13 +20,6 @@ public class BasicAppConfigurationTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Config Store location."
-                    };
-
                 BicepParameter featureFlagKey =
                     new(nameof(featureFlagKey), typeof(string))
                     {
@@ -37,7 +30,6 @@ public class BasicAppConfigurationTests(bool async)
                 AppConfigurationStore configStore =
                     new(nameof(configStore), AppConfigurationStore.ResourceVersions.V2022_05_01)
                     {
-                        Location = location,
                         SkuName = "Standard",
                     };
 
@@ -64,11 +56,11 @@ public class BasicAppConfigurationTests(bool async)
             })
         .Compare(
             """
-            @description('Config Store location.')
-            param location string = resourceGroup().location
-
             @description('Specifies the key of the feature flag.')
             param featureFlagKey string = 'FeatureFlagSample'
+
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
 
             resource configStore 'Microsoft.AppConfiguration/configurationStores@2022-05-01' = {
                 name: take('configStore-${uniqueString(resourceGroup().id)}', 50)
@@ -85,7 +77,7 @@ public class BasicAppConfigurationTests(bool async)
             }
 
             resource featureFlag 'Microsoft.AppConfiguration/configurationStores/keyValues@2022-05-01' = {
-                name: '.appconfig.featureflag~2FFeatureFlagSample'
+                name: '.appconfig.featureflag~2F${featureFlagKey}'
                 properties: {
                     contentType: 'application/vnd.microsoft.appconfig.ff+json;charset=utf-8'
                     value: string(flag)

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.netstandard2.0.cs
@@ -740,6 +740,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppVnetConfiguration> VnetConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppContainers.ContainerAppWorkloadProfile> WorkloadProfiles { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.AppContainers.AppContainersBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.AppContainers.AppContainersBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
@@ -249,8 +249,9 @@ public partial class ContainerAppManagedEnvironment : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(AppContainersBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -266,8 +267,9 @@ public partial class ContainerAppManagedEnvironment : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(AppContainersBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
@@ -258,7 +258,7 @@ public partial class ContainerAppManagedEnvironment : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this
+    /// Assign a role to a principal that grants access to this
     /// ContainerAppManagedEnvironment.
     /// </summary>
     /// <param name="role">The role to grant.</param>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
@@ -256,4 +256,21 @@ public partial class ContainerAppManagedEnvironment : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this
+    /// ContainerAppManagedEnvironment.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(AppContainersBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/tests/BasicAppContainersTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/tests/BasicAppContainersTests.cs
@@ -21,13 +21,6 @@ public class BasicAppContainersTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Service location."
-                    };
-
                 BicepParameter containerImage =
                     new(nameof(containerImage), typeof(string))
                     {
@@ -38,14 +31,12 @@ public class BasicAppContainersTests(bool async)
                 OperationalInsightsWorkspace logAnalytics =
                     new(nameof(logAnalytics))
                     {
-                        Location = location,
                         Sku = new OperationalInsightsWorkspaceSku { Name = OperationalInsightsWorkspaceSkuName.PerGB2018 }
                     };
 
                 ContainerAppManagedEnvironment env =
                     new(nameof(env))
                     {
-                        Location = location,
                         AppLogsConfiguration =
                             new ContainerAppLogsConfiguration
                             {
@@ -61,7 +52,6 @@ public class BasicAppContainersTests(bool async)
                 ContainerApp app =
                     new(nameof(app))
                     {
-                        Location = location,
                         ManagedEnvironmentId = env.Id,
                         Configuration =
                             new ContainerAppConfiguration
@@ -106,11 +96,11 @@ public class BasicAppContainersTests(bool async)
             })
         .Compare(
             """
-            @description('Service location.')
-            param location string = resourceGroup().location
-
             @description('Specifies the docker container image to deploy.')
             param containerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
 
             resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
                 name: take('logAnalytics-${uniqueString(resourceGroup().id)}', 63)

--- a/sdk/provisioning/Azure.Provisioning.AppService/tests/BasicAppServiceTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/tests/BasicAppServiceTests.cs
@@ -23,17 +23,9 @@ public class BasicAppServiceTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Service location."
-                    };
-
                 StorageAccount storage =
                     new(nameof(storage))
                     {
-                        Location = location,
                         Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
                         Kind = StorageKind.Storage,
                         EnableHttpsTrafficOnly = true,
@@ -43,7 +35,6 @@ public class BasicAppServiceTests(bool async)
                 AppServicePlan hostingPlan =
                     new(nameof(hostingPlan), "2021-03-01")
                     {
-                        Location = location,
                         Sku =
                             new AppServiceSkuDescription
                             {
@@ -55,7 +46,6 @@ public class BasicAppServiceTests(bool async)
                 ApplicationInsightsComponent appInsights =
                     new(nameof(appInsights))
                     {
-                        Location = location,
                         Kind = "web",
                         ApplicationType = ApplicationInsightsApplicationType.Web,
                         RequestSource = ComponentRequestSource.Rest
@@ -70,7 +60,6 @@ public class BasicAppServiceTests(bool async)
                 WebSite functionApp =
                     new(nameof(functionApp))
                     {
-                        Location = location,
                         Name = funcAppName,
                         Kind = "functionapp",
                         Identity = new ManagedServiceIdentity { ManagedServiceIdentityType = ManagedServiceIdentityType.SystemAssigned },
@@ -124,7 +113,7 @@ public class BasicAppServiceTests(bool async)
             })
         .Compare(
             """
-            @description('Service location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/api/Azure.Provisioning.ApplicationInsights.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/api/Azure.Provisioning.ApplicationInsights.netstandard2.0.cs
@@ -67,6 +67,7 @@ namespace Azure.Provisioning.ApplicationInsights
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Guid> TenantId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> WorkspaceResourceId { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.ApplicationInsights.ApplicationInsightsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.ApplicationInsights.ApplicationInsightsBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsComponent FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
@@ -337,8 +337,9 @@ public partial class ApplicationInsightsComponent : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(ApplicationInsightsBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -354,8 +355,9 @@ public partial class ApplicationInsightsComponent : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(ApplicationInsightsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
@@ -346,7 +346,7 @@ public partial class ApplicationInsightsComponent : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this
+    /// Assign a role to a principal that grants access to this
     /// ApplicationInsightsComponent.
     /// </summary>
     /// <param name="role">The role to grant.</param>

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
@@ -344,4 +344,21 @@ public partial class ApplicationInsightsComponent : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this
+    /// ApplicationInsightsComponent.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(ApplicationInsightsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/tests/BasicApplicationInsightsTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/tests/BasicApplicationInsightsTests.cs
@@ -20,17 +20,9 @@ public class BasicApplicationInsightsTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Service location."
-                    };
-
                 ApplicationInsightsComponent appInsights =
                     new(nameof(appInsights))
                     {
-                        Location = location,
                         Kind = "web",
                         ApplicationType = ApplicationInsightsApplicationType.Web,
                         RequestSource = ComponentRequestSource.Rest
@@ -41,7 +33,7 @@ public class BasicApplicationInsightsTests(bool async)
             })
         .Compare(
             """
-            @description('Service location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource appInsights 'Microsoft.Insights/components@2020-02-02' = {

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/api/Azure.Provisioning.CognitiveServices.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/api/Azure.Provisioning.CognitiveServices.netstandard2.0.cs
@@ -25,6 +25,7 @@ namespace Azure.Provisioning.CognitiveServices
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CognitiveServices.CognitiveServicesSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.CognitiveServices.CognitiveServicesBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.CognitiveServices.CognitiveServicesBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.CognitiveServices.CognitiveServicesAccount FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.CognitiveServices.ServiceAccountApiKeys GetKeys() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccount.cs
@@ -190,4 +190,20 @@ public partial class CognitiveServicesAccount : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this CognitiveServicesAccount.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(CognitiveServicesBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccount.cs
@@ -183,8 +183,9 @@ public partial class CognitiveServicesAccount : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(CognitiveServicesBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -200,8 +201,9 @@ public partial class CognitiveServicesAccount : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(CognitiveServicesBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccount.cs
@@ -192,7 +192,8 @@ public partial class CognitiveServicesAccount : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this CognitiveServicesAccount.
+    /// Assign a role to a principal that grants access to this
+    /// CognitiveServicesAccount.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/tests/BasicCognitiveServicesTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/tests/BasicCognitiveServicesTests.cs
@@ -21,16 +21,9 @@ public class BasicCognitiveServicesTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location
-                    };
-
                 CognitiveServicesAccount account =
                     new(nameof(account))
                     {
-                        Location = location,
                         Identity = new ManagedServiceIdentity { ManagedServiceIdentityType = ManagedServiceIdentityType.SystemAssigned },
                         Kind = "TextTranslation",
                         Sku = new CognitiveServicesSku { Name = "S1" },
@@ -47,6 +40,7 @@ public class BasicCognitiveServicesTests(bool async)
             })
         .Compare(
             """
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource account 'Microsoft.CognitiveServices/accounts@2022-12-01' = {

--- a/sdk/provisioning/Azure.Provisioning.Communication/tests/BasicCommunicationTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/tests/BasicCommunicationTests.cs
@@ -23,25 +23,23 @@ public class BasicCommunicationTests(bool async)
                 BicepParameter location =
                     new(nameof(location), typeof(string))
                     {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Service location."
+                        Value = "global"
                     };
 
                 CommunicationService comm =
                     new(nameof(comm), "2023-03-31")
                     {
-                        Location = new StringLiteral("global"),
+                        Location = location,
                         DataLocation = "unitedstates"
                     };
             })
         .Compare(
             """
-            @description('Service location.')
-            param location string = resourceGroup().location
+            param location string = 'global'
 
             resource comm 'Microsoft.Communication/communicationServices@2023-03-31' = {
                 name: take('comm-${uniqueString(resourceGroup().id)}', 63)
-                location: 'global'
+                location: location
                 properties: {
                     dataLocation: 'unitedstates'
                 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/api/Azure.Provisioning.ContainerRegistry.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/api/Azure.Provisioning.ContainerRegistry.netstandard2.0.cs
@@ -469,6 +469,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryZoneRedundancy> ZoneRedundancy { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.ContainerRegistry.ContainerRegistryBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.ContainerRegistry.ContainerRegistryBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.ContainerRegistry.ContainerRegistryService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
@@ -260,7 +260,8 @@ public partial class ContainerRegistryService : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this ContainerRegistryService.
+    /// Assign a role to a principal that grants access to this
+    /// ContainerRegistryService.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
@@ -251,8 +251,9 @@ public partial class ContainerRegistryService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(ContainerRegistryBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -268,8 +269,9 @@ public partial class ContainerRegistryService : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(ContainerRegistryBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
@@ -258,4 +258,20 @@ public partial class ContainerRegistryService : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this ContainerRegistryService.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(ContainerRegistryBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/tests/BasicContainerRegistryTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/tests/BasicContainerRegistryTests.cs
@@ -20,17 +20,9 @@ public class BasicContainerRegistryTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Service location."
-                    };
-
                 ContainerRegistryService registry =
                     new(nameof(registry))
                     {
-                        Location = location,
                         Sku = new ContainerRegistrySku { Name = ContainerRegistrySkuName.Standard },
                         IsAdminUserEnabled = false,
                         Tags = { { "displayName", "ContainerRegistry" } }
@@ -41,7 +33,7 @@ public class BasicContainerRegistryTests(bool async)
             })
         .Compare(
             """
-            @description('Service location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/api/Azure.Provisioning.ContainerService.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/api/Azure.Provisioning.ContainerService.netstandard2.0.cs
@@ -310,6 +310,7 @@ namespace Azure.Provisioning.ContainerService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.UpgradeOverrideSettings> UpgradeOverrideSettings { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.ManagedClusterWindowsProfile> WindowsProfile { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.ManagedClusterWorkloadAutoScalerProfile> WorkloadAutoScalerProfile { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.ContainerService.ContainerServiceBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.ContainerService.ContainerServiceBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.ContainerService.ContainerServiceManagedCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
@@ -688,7 +688,7 @@ public partial class ContainerServiceManagedCluster : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this
+    /// Assign a role to a principal that grants access to this
     /// ContainerServiceManagedCluster.
     /// </summary>
     /// <param name="role">The role to grant.</param>

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
@@ -686,4 +686,21 @@ public partial class ContainerServiceManagedCluster : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this
+    /// ContainerServiceManagedCluster.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(ContainerServiceBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
@@ -679,8 +679,9 @@ public partial class ContainerServiceManagedCluster : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(ContainerServiceBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -696,8 +697,9 @@ public partial class ContainerServiceManagedCluster : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(ContainerServiceBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/tests/BasicContainerServiceTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/tests/BasicContainerServiceTests.cs
@@ -21,11 +21,6 @@ public class BasicContainerServiceTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location
-                    };
                 BicepParameter dnsPrefix = new(nameof(dnsPrefix), typeof(string));
                 BicepParameter linuxAdminUsername = new(nameof(linuxAdminUsername), typeof(string));
                 BicepParameter sshRsaPublicKey = new(nameof(sshRsaPublicKey), typeof(string));
@@ -33,7 +28,6 @@ public class BasicContainerServiceTests(bool async)
                 ContainerServiceManagedCluster aks =
                     new(nameof(aks))
                     {
-                        Location = location,
                         ClusterIdentity = new ManagedClusterIdentity { ResourceIdentityType = ManagedServiceIdentityType.SystemAssigned },
                         DnsPrefix = dnsPrefix,
                         LinuxProfile =
@@ -61,14 +55,15 @@ public class BasicContainerServiceTests(bool async)
             })
         .Compare(
             """
-            param location string = resourceGroup().location
-
             param dnsPrefix string
 
             param linuxAdminUsername string
 
             param sshRsaPublicKey string
 
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+            
             resource aks 'Microsoft.ContainerService/managedClusters@2023-08-01' = {
                 name: take('aks-${uniqueString(resourceGroup().id)}', 63)
                 location: location

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/api/Azure.Provisioning.CosmosDB.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/api/Azure.Provisioning.CosmosDB.netstandard2.0.cs
@@ -93,7 +93,8 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_09_15;
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
-            public static readonly string V2024_05_15_preview;
+            public static readonly string V2024_08_15;
+            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CassandraClusterBackupSchedule : Azure.Provisioning.Primitives.ProvisioningConstruct
@@ -441,6 +442,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.CosmosDB.CosmosDBVirtualNetworkRule> VirtualNetworkRules { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.CosmosDB.CosmosDBAccountLocation> WriteLocations { get { throw null; } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.CosmosDB.CosmosDBBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.CosmosDB.CosmosDBBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.CosmosDB.CosmosDBAccount FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.CosmosDB.CosmosDBAccountKeyList GetKeys() { throw null; }
@@ -472,7 +474,8 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_09_15;
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
-            public static readonly string V2024_05_15_preview;
+            public static readonly string V2024_08_15;
+            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBAccountBackupPolicy : Azure.Provisioning.Primitives.ProvisioningConstruct

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraCluster.cs
@@ -85,9 +85,14 @@ public partial class CassandraCluster : Resource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-15-preview.
+        /// 2024-09-01-preview.
         /// </summary>
-        public static readonly string V2024_05_15_preview = "2024-05-15-preview";
+        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
+
+        /// <summary>
+        /// 2024-08-15.
+        /// </summary>
+        public static readonly string V2024_08_15 = "2024-08-15";
 
         /// <summary>
         /// 2024-05-15.

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
@@ -606,8 +606,9 @@ public partial class CosmosDBAccount : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(CosmosDBBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -622,8 +623,9 @@ public partial class CosmosDBAccount : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(CosmosDBBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
@@ -443,9 +443,14 @@ public partial class CosmosDBAccount : Resource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-15-preview.
+        /// 2024-09-01-preview.
         /// </summary>
-        public static readonly string V2024_05_15_preview = "2024-05-15-preview";
+        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
+
+        /// <summary>
+        /// 2024-08-15.
+        /// </summary>
+        public static readonly string V2024_08_15 = "2024-08-15";
 
         /// <summary>
         /// 2024-05-15.
@@ -607,5 +612,21 @@ public partial class CosmosDBAccount : Resource
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
+        };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this CosmosDBAccount.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(CosmosDBBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
         };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
@@ -615,7 +615,7 @@ public partial class CosmosDBAccount : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this CosmosDBAccount.
+    /// Assign a role to a principal that grants access to this CosmosDBAccount.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/tests/BasicEventGridTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/tests/BasicEventGridTests.cs
@@ -23,18 +23,11 @@ public class BasicEventGridTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Service location."
-                    };
                 BicepParameter webhookUri = new(nameof(webhookUri), typeof(string));
 
                 StorageAccount storage =
                     new(nameof(storage))
                     {
-                        Location = location,
                         Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
                         Kind = StorageKind.StorageV2,
                         AllowBlobPublicAccess = false,
@@ -44,7 +37,6 @@ public class BasicEventGridTests(bool async)
                 SystemTopic topic =
                     new(nameof(topic))
                     {
-                        Location = location,
                         Identity = new ManagedServiceIdentity { ManagedServiceIdentityType = ManagedServiceIdentityType.SystemAssigned },
                         Source = storage.Id,
                         TopicType = "Microsoft.Storage.StorageAccounts"
@@ -66,11 +58,11 @@ public class BasicEventGridTests(bool async)
             })
         .Compare(
             """
-            @description('Service location.')
-            param location string = resourceGroup().location
-
             param webhookUri string
 
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+            
             resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
                 name: take('storage${uniqueString(resourceGroup().id)}', 24)
                 kind: 'StorageV2'

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/api/Azure.Provisioning.EventHubs.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/api/Azure.Provisioning.EventHubs.netstandard2.0.cs
@@ -174,6 +174,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.EventHubs.EventHubsCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -312,6 +313,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> ZoneRedundant { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.EventHubs.EventHubsNamespace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
@@ -164,8 +164,9 @@ public partial class EventHubsCluster : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(EventHubsBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -181,8 +182,9 @@ public partial class EventHubsCluster : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(EventHubsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
@@ -173,7 +173,8 @@ public partial class EventHubsCluster : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this EventHubsCluster.
+    /// Assign a role to a principal that grants access to this
+    /// EventHubsCluster.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
@@ -171,4 +171,20 @@ public partial class EventHubsCluster : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this EventHubsCluster.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(EventHubsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
@@ -284,7 +284,8 @@ public partial class EventHubsNamespace : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this EventHubsNamespace.
+    /// Assign a role to a principal that grants access to this
+    /// EventHubsNamespace.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
@@ -282,4 +282,20 @@ public partial class EventHubsNamespace : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this EventHubsNamespace.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(EventHubsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
@@ -275,8 +275,9 @@ public partial class EventHubsNamespace : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(EventHubsBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -292,8 +293,9 @@ public partial class EventHubsNamespace : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(EventHubsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/tests/BasicEventHubsTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/tests/BasicEventHubsTests.cs
@@ -21,19 +21,12 @@ public class BasicEventHubsTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Hub location."
-                    };
                 BicepParameter hubName = new(nameof(hubName), typeof(string)) { Value = "orders" };
                 BicepParameter groupName = new(nameof(groupName), typeof(string)) { Value = "managers" };
 
                 EventHubsNamespace ns =
                     new(nameof(ns))
                     {
-                        Location = location,
                         Sku = new EventHubsSku
                         {
                             Name = EventHubsSkuName.Standard,
@@ -59,13 +52,13 @@ public class BasicEventHubsTests(bool async)
             })
         .Compare(
             """
-            @description('Hub location.')
-            param location string = resourceGroup().location
-
             param hubName string = 'orders'
 
             param groupName string = 'managers'
 
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+            
             resource ns 'Microsoft.EventHub/namespaces@2017-04-01' = {
                 name: take('ns-${uniqueString(resourceGroup().id)}', 256)
                 location: location

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/api/Azure.Provisioning.KeyVault.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/api/Azure.Provisioning.KeyVault.netstandard2.0.cs
@@ -327,6 +327,7 @@ namespace Azure.Provisioning.KeyVault
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KeyVault.KeyVaultProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.KeyVault.KeyVaultBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.KeyVault.KeyVaultBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.KeyVault.KeyVaultService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
@@ -169,4 +169,20 @@ public partial class KeyVaultService : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this KeyVaultService.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(KeyVaultBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
@@ -162,8 +162,9 @@ public partial class KeyVaultService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(KeyVaultBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -178,8 +179,9 @@ public partial class KeyVaultService : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(KeyVaultBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
@@ -171,7 +171,7 @@ public partial class KeyVaultService : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this KeyVaultService.
+    /// Assign a role to a principal that grants access to this KeyVaultService.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/tests/BasicKeyVaultTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/tests/BasicKeyVaultTests.cs
@@ -26,12 +26,6 @@ public class BasicKeyVaultTests(bool async)
                         Value = KeyVaultSkuName.Standard,
                         Description = "Vault type"
                     };
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "Vault location."
-                    };
                 BicepParameter secretValue =
                     new(nameof(secretValue), typeof(string))
                     {
@@ -52,7 +46,6 @@ public class BasicKeyVaultTests(bool async)
                 KeyVaultService kv =
                     new(nameof(kv))
                     {
-                        Location = location,
                         Properties =
                             new KeyVaultProperties
                             {
@@ -99,15 +92,15 @@ public class BasicKeyVaultTests(bool async)
             @description('Vault type')
             param skuName string = 'standard'
 
-            @description('Vault location.')
-            param location string = resourceGroup().location
-
             @secure()
             @description('Specifies the value of the secret that you want to create.')
             param secretValue string
 
             @description('Specifies the object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault.')
             param objectId string
+
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
 
             var tenantId = subscription().tenantId
 

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/api/Azure.Provisioning.Kubernetes.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/api/Azure.Provisioning.Kubernetes.netstandard2.0.cs
@@ -23,6 +23,7 @@ namespace Azure.Provisioning.Kubernetes
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> TotalCoreCount { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> TotalNodeCount { get { throw null; } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Kubernetes.KubernetesBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Kubernetes.KubernetesBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.Kubernetes.ConnectedCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
@@ -230,8 +230,9 @@ public partial class ConnectedCluster : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(KubernetesBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -247,8 +248,9 @@ public partial class ConnectedCluster : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(KubernetesBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
@@ -237,4 +237,20 @@ public partial class ConnectedCluster : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this ConnectedCluster.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(KubernetesBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
@@ -239,7 +239,8 @@ public partial class ConnectedCluster : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this ConnectedCluster.
+    /// Assign a role to a principal that grants access to this
+    /// ConnectedCluster.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/api/Azure.Provisioning.KubernetesConfiguration.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/api/Azure.Provisioning.KubernetesConfiguration.netstandard2.0.cs
@@ -62,6 +62,7 @@ namespace Azure.Provisioning.KubernetesConfiguration
         public Azure.Provisioning.BicepList<Azure.Provisioning.KubernetesConfiguration.KubernetesClusterExtensionStatus> Statuses { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.KubernetesConfiguration.KubernetesClusterExtension FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
@@ -199,6 +200,7 @@ namespace Azure.Provisioning.KubernetesConfiguration
         public Azure.Provisioning.BicepList<Azure.Provisioning.KubernetesConfiguration.KubernetesObjectStatus> Statuses { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> StatusUpdatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.KubernetesConfiguration.KubernetesFluxConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesClusterExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesClusterExtension.cs
@@ -234,4 +234,21 @@ public partial class KubernetesClusterExtension : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this
+    /// KubernetesClusterExtension.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(KubernetesConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesClusterExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesClusterExtension.cs
@@ -236,7 +236,7 @@ public partial class KubernetesClusterExtension : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this
+    /// Assign a role to a principal that grants access to this
     /// KubernetesClusterExtension.
     /// </summary>
     /// <param name="role">The role to grant.</param>

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesClusterExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesClusterExtension.cs
@@ -227,8 +227,9 @@ public partial class KubernetesClusterExtension : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(KubernetesConfigurationBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -244,8 +245,9 @@ public partial class KubernetesClusterExtension : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(KubernetesConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
@@ -229,8 +229,9 @@ public partial class KubernetesFluxConfiguration : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(KubernetesConfigurationBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -246,8 +247,9 @@ public partial class KubernetesFluxConfiguration : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(KubernetesConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
@@ -238,7 +238,7 @@ public partial class KubernetesFluxConfiguration : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this
+    /// Assign a role to a principal that grants access to this
     /// KubernetesFluxConfiguration.
     /// </summary>
     /// <param name="role">The role to grant.</param>

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
@@ -236,4 +236,21 @@ public partial class KubernetesFluxConfiguration : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this
+    /// KubernetesFluxConfiguration.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(KubernetesConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/tests/BasicOperationalInsightsTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/tests/BasicOperationalInsightsTests.cs
@@ -20,17 +20,9 @@ public class BasicOperationalInsightsTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The workspace location."
-                    };
-
                 OperationalInsightsWorkspace workspace =
                     new(nameof(workspace))
                     {
-                        Location = location,
                         Sku = new OperationalInsightsWorkspaceSku
                         {
                             Name = OperationalInsightsWorkspaceSkuName.PerGB2018
@@ -40,7 +32,7 @@ public class BasicOperationalInsightsTests(bool async)
             })
         .Compare(
             """
-            @description('The workspace location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/BasicPostgreSqlTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/BasicPostgreSqlTests.cs
@@ -20,12 +20,6 @@ public class BasicPostgreSqlTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The database location."
-                    };
                 BicepParameter adminLogin =
                     new(nameof(adminLogin), typeof(string))
                     {
@@ -51,7 +45,6 @@ public class BasicPostgreSqlTests(bool async)
                 PostgreSqlFlexibleServer server =
                     new(nameof(server))
                     {
-                        Location = location,
                         Sku =
                             new PostgreSqlFlexibleServerSku
                             {
@@ -98,9 +91,6 @@ public class BasicPostgreSqlTests(bool async)
             })
         .Compare(
             """
-            @description('The database location.')
-            param location string = resourceGroup().location
-
             @description('The administrator username of the server.')
             param adminLogin string
 
@@ -114,6 +104,9 @@ public class BasicPostgreSqlTests(bool async)
             @description('The AAD admin Object ID.')
             param aadAdminOid string
 
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+            
             resource server 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
                 name: take('server${uniqueString(resourceGroup().id)}', 24)
                 location: location

--- a/sdk/provisioning/Azure.Provisioning.Redis/api/Azure.Provisioning.Redis.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/api/Azure.Provisioning.Redis.netstandard2.0.cs
@@ -270,6 +270,7 @@ namespace Azure.Provisioning.Redis
         public Azure.Provisioning.BicepDictionary<string> TenantSettings { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.UpdateChannel> UpdateChannel { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> Zones { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Redis.RedisBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Redis.RedisBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.Redis.RedisResource FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.Redis.RedisAccessKeys GetKeys() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
@@ -284,8 +284,9 @@ public partial class RedisResource : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(RedisBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{RedisBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{RedisBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -300,8 +301,9 @@ public partial class RedisResource : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(RedisBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{RedisBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{RedisBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
@@ -291,4 +291,20 @@ public partial class RedisResource : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this RedisResource.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(RedisBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{RedisBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
@@ -293,7 +293,7 @@ public partial class RedisResource : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this RedisResource.
+    /// Assign a role to a principal that grants access to this RedisResource.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.Redis/tests/BasicRedisTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/tests/BasicRedisTests.cs
@@ -20,17 +20,9 @@ public class BasicRedisTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The cache location."
-                    };
-
                 RedisResource cache =
                     new(nameof(cache), "2020-06-01")
                     {
-                        Location = location,
                         EnableNonSslPort = false,
                         MinimumTlsVersion = RedisTlsVersion.Tls1_2,
                         Sku =
@@ -44,7 +36,7 @@ public class BasicRedisTests(bool async)
             })
         .Compare(
             """
-            @description('The cache location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource cache 'Microsoft.Cache/redis@2020-06-01' = {

--- a/sdk/provisioning/Azure.Provisioning.Search/api/Azure.Provisioning.Search.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/api/Azure.Provisioning.Search.netstandard2.0.cs
@@ -128,6 +128,7 @@ namespace Azure.Provisioning.Search
         public Azure.Provisioning.BicepValue<string> StatusDetails { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Search.SearchBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Search.SearchBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.Search.SearchService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchService.cs
@@ -377,7 +377,7 @@ public partial class SearchService : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this SearchService.
+    /// Assign a role to a principal that grants access to this SearchService.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchService.cs
@@ -375,4 +375,20 @@ public partial class SearchService : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this SearchService.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(SearchBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{SearchBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchService.cs
@@ -368,8 +368,9 @@ public partial class SearchService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(SearchBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{SearchBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{SearchBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -384,8 +385,9 @@ public partial class SearchService : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(SearchBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{SearchBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{SearchBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.Search/tests/BasicSearchTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/tests/BasicSearchTests.cs
@@ -20,17 +20,9 @@ public class BasicSearchTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The Search service location."
-                    };
-
                 SearchService search =
                     new(nameof(search))
                     {
-                        Location = location,
                         SearchSkuName = SearchServiceSkuName.Standard,
                         ReplicaCount = 1,
                         PartitionCount = 1,
@@ -39,7 +31,7 @@ public class BasicSearchTests(bool async)
             })
         .Compare(
             """
-            @description('The Search service location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource search 'Microsoft.Search/searchServices@2023-11-01' = {

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/api/Azure.Provisioning.ServiceBus.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/api/Azure.Provisioning.ServiceBus.netstandard2.0.cs
@@ -201,6 +201,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.ServiceBus.ServiceBusBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.ServiceBus.ServiceBusBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.ServiceBus.ServiceBusNamespace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespace.cs
@@ -248,4 +248,20 @@ public partial class ServiceBusNamespace : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this ServiceBusNamespace.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(ServiceBusBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespace.cs
@@ -241,8 +241,9 @@ public partial class ServiceBusNamespace : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(ServiceBusBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -258,8 +259,9 @@ public partial class ServiceBusNamespace : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(ServiceBusBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespace.cs
@@ -250,7 +250,8 @@ public partial class ServiceBusNamespace : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this ServiceBusNamespace.
+    /// Assign a role to a principal that grants access to this
+    /// ServiceBusNamespace.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/tests/BasicServiceBusTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/tests/BasicServiceBusTests.cs
@@ -20,12 +20,6 @@ public class BasicServiceBusTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The SB location."
-                    };
                 BicepParameter queueName =
                     new(nameof(queueName), typeof(string))
                     {
@@ -36,7 +30,6 @@ public class BasicServiceBusTests(bool async)
                 ServiceBusNamespace sb =
                     new(nameof(sb), ServiceBusNamespace.ResourceVersions.V2021_11_01)
                     {
-                        Location = location,
                         Sku = new ServiceBusSku { Name = ServiceBusSkuName.Standard },
                     };
 
@@ -63,12 +56,12 @@ public class BasicServiceBusTests(bool async)
             })
         .Compare(
             """
-            @description('The SB location.')
-            param location string = resourceGroup().location
-
             @description('The name of the SB queue.')
             param queueName string = 'orders'
 
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+            
             resource sb 'Microsoft.ServiceBus/namespaces@2021-11-01' = {
                 name: take('sb-${uniqueString(resourceGroup().id)}', 50)
                 location: location

--- a/sdk/provisioning/Azure.Provisioning.SignalR/api/Azure.Provisioning.SignalR.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/api/Azure.Provisioning.SignalR.netstandard2.0.cs
@@ -211,6 +211,7 @@ namespace Azure.Provisioning.SignalR
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.SignalR.SignalRUpstreamTemplate> UpstreamTemplates { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.SignalR.SignalRBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.SignalR.SignalRBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.SignalR.SignalRService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.SignalR.SignalRKeys GetKeys() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
@@ -284,7 +284,7 @@ public partial class SignalRService : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this SignalRService.
+    /// Assign a role to a principal that grants access to this SignalRService.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
@@ -275,8 +275,9 @@ public partial class SignalRService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(SignalRBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -291,8 +292,9 @@ public partial class SignalRService : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(SignalRBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
@@ -282,4 +282,20 @@ public partial class SignalRService : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this SignalRService.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(SignalRBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.SignalR/tests/BasicSignalRTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/tests/BasicSignalRTests.cs
@@ -21,13 +21,7 @@ public class BasicSignalRTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The SignalR service location."
-                    };
-                BicepParameter endpointName =
+               BicepParameter endpointName =
                     new(nameof(endpointName), typeof(string))
                     {
                         Value = "mySignalRService.55e432ab-7428-3695-b637-de57b20d40e5"
@@ -36,7 +30,6 @@ public class BasicSignalRTests(bool async)
                 SignalRService signalr =
                     new(nameof(signalr), "2022-02-01")
                     {
-                        Location = location,
                         Sku = new SignalRResourceSku { Name = "Standard_S1", Capacity = 1 },
                         Kind = SignalRServiceKind.SignalR,
                         Identity = new ManagedServiceIdentity { ManagedServiceIdentityType = ManagedServiceIdentityType.SystemAssigned },
@@ -92,11 +85,11 @@ public class BasicSignalRTests(bool async)
             })
         .Compare(
             """
-            @description('The SignalR service location.')
-            param location string = resourceGroup().location
-
             param endpointName string = 'mySignalRService.55e432ab-7428-3695-b637-de57b20d40e5'
 
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+            
             resource signalr 'Microsoft.SignalRService/signalR@2022-02-01' = {
                 name: take('signalr-${uniqueString(resourceGroup().id)}', 63)
                 location: location

--- a/sdk/provisioning/Azure.Provisioning.Sql/api/Azure.Provisioning.Sql.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/api/Azure.Provisioning.Sql.netstandard2.0.cs
@@ -1741,6 +1741,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ServerWorkspaceFeature> WorkspaceFeature { get { throw null; } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Sql.SqlBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Sql.SqlBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.Sql.SqlServer FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
@@ -267,7 +267,7 @@ public partial class SqlServer : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this SqlServer.
+    /// Assign a role to a principal that grants access to this SqlServer.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
@@ -265,4 +265,20 @@ public partial class SqlServer : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this SqlServer.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(SqlBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{SqlBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
@@ -258,8 +258,9 @@ public partial class SqlServer : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(SqlBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{SqlBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{SqlBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -274,8 +275,9 @@ public partial class SqlServer : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(SqlBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{SqlBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{SqlBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.Sql/tests/BasicSqlTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/tests/BasicSqlTests.cs
@@ -26,12 +26,6 @@ public class BasicSqlTests(bool async)
                         Value = "SampleDB",
                         Description = "The name of the SQL Database."
                     };
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The SQL Server location."
-                    };
                 BicepParameter adminLogin =
                     new(nameof(adminLogin), typeof(string))
                     {
@@ -47,7 +41,6 @@ public class BasicSqlTests(bool async)
                 SqlServer sql =
                     new(nameof(sql))
                     {
-                        Location = location,
                         AdministratorLogin = adminLogin,
                         AdministratorLoginPassword = adminPass
                     };
@@ -57,7 +50,6 @@ public class BasicSqlTests(bool async)
                     {
                         Parent = sql,
                         Name = dbName,
-                        Location = location,
                         Sku = new SqlSku { Name = "Standard", Tier = "Standard" }
                     };
             })
@@ -66,15 +58,15 @@ public class BasicSqlTests(bool async)
             @description('The name of the SQL Database.')
             param dbName string = 'SampleDB'
 
-            @description('The SQL Server location.')
-            param location string = resourceGroup().location
-
             @description('The administrator username of the SQL logical server.')
             param adminLogin string
 
             @secure()
             @description('The administrator password of the SQL logical server.')
             param adminPass string
+
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
 
             resource sql 'Microsoft.Sql/servers@2021-11-01' = {
                 name: take('sql-${uniqueString(resourceGroup().id)}', 63)

--- a/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.netstandard2.0.cs
@@ -725,6 +725,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.StorageAccountSkuConversionStatus> StorageAccountSkuConversionStatus { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
+        public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Storage.StorageBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment AssignRole(Azure.Provisioning.Storage.StorageBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
         public static Azure.Provisioning.Storage.StorageAccount FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.StorageAccountKey> GetKeys() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccount.cs
@@ -576,8 +576,9 @@ public partial class StorageAccount : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(StorageBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{identity.ResourceName}_{StorageBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{identity.ResourceName}_{StorageBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
@@ -592,8 +593,9 @@ public partial class StorageAccount : Resource
     /// <param name="principalId">The principal to assign to.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment AssignRole(StorageBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
-        new($"{principalId.Compile()}_{StorageBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        new($"{ResourceName}_{StorageBuiltInRole.GetBuiltInRoleName(role)}")
         {
+            Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
             Scope = new IdentifierExpression(ResourceName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccount.cs
@@ -585,7 +585,7 @@ public partial class StorageAccount : Resource
         };
 
     /// <summary>
-    /// Assign a role to an that grants access to this StorageAccount.
+    /// Assign a role to a principal that grants access to this StorageAccount.
     /// </summary>
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccount.cs
@@ -583,4 +583,20 @@ public partial class StorageAccount : Resource
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
         };
+
+    /// <summary>
+    /// Assign a role to an that grants access to this StorageAccount.
+    /// </summary>
+    /// <param name="role">The role to grant.</param>
+    /// <param name="principalType">The type of the principal to assign to.</param>
+    /// <param name="principalId">The principal to assign to.</param>
+    /// <returns>The <see cref="RoleAssignment"/>.</returns>
+    public RoleAssignment AssignRole(StorageBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>
+        new($"{principalId.Compile()}_{StorageBuiltInRole.GetBuiltInRoleName(role)}_{ResourceName}")
+        {
+            Scope = new IdentifierExpression(ResourceName),
+            PrincipalType = principalType,
+            RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
+            PrincipalId = principalId
+        };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/tests/BasicStorageTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/tests/BasicStorageTests.cs
@@ -22,10 +22,13 @@ public class BasicStorageTests(bool async)
         await test.Define(StorageResources.CreateAccount("storage"))
         .Compare(
             """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
             resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
                 name: take('storage${uniqueString(resourceGroup().id)}', 24)
                 kind: 'StorageV2'
-                location: resourceGroup().location
+                location: location
                 sku: {
                     name: 'Standard_LRS'
                 }
@@ -51,10 +54,13 @@ public class BasicStorageTests(bool async)
             })
         .Compare(
             """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
             resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
                 name: take('storage${uniqueString(resourceGroup().id)}', 24)
                 kind: 'StorageV2'
-                location: resourceGroup().location
+                location: location
                 sku: {
                     name: 'Standard_LRS'
                 }
@@ -86,10 +92,13 @@ public class BasicStorageTests(bool async)
             })
         .Compare(
             """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
             resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
                 name: take('storage${uniqueString(resourceGroup().id)}', 24)
                 kind: 'StorageV2'
-                location: resourceGroup().location
+                location: location
                 sku: {
                     name: 'Standard_LRS'
                 }
@@ -101,7 +110,7 @@ public class BasicStorageTests(bool async)
 
             resource id 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
                 name: take('id-${uniqueString(resourceGroup().id)}', 128)
-                location: resourceGroup().location
+                location: location
             }
 
             resource id_StorageBlobDataReader_storage 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
@@ -131,10 +140,13 @@ public class BasicStorageTests(bool async)
             })
         .Compare(
             """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
             resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
                 name: take('storage${uniqueString(resourceGroup().id)}', 24)
                 kind: 'StorageV2'
-                location: resourceGroup().location
+                location: location
                 sku: {
                     name: 'Standard_LRS'
                 }
@@ -169,17 +181,10 @@ public class BasicStorageTests(bool async)
                         Value = StorageSkuName.StandardLrs,
                         Description = "Storage Account type"
                     };
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The storage account location."
-                    };
 
                 StorageAccount sa =
                     new(nameof(sa))
                     {
-                        Location = location,
                         Sku = new StorageSku { Name = storageAccountType },
                         Kind = StorageKind.StorageV2
                     };
@@ -192,7 +197,7 @@ public class BasicStorageTests(bool async)
             @description('Storage Account type')
             param storageAccountType string = 'Standard_LRS'
 
-            @description('The storage account location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
@@ -227,17 +232,9 @@ public class BasicStorageTests(bool async)
                         Description = "The container name."
                     };
 
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "The storage account location."
-                    };
-
                 StorageAccount sa =
                     new(nameof(sa))
                     {
-                        Location = location,
                         Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
                         Kind = StorageKind.StorageV2,
                         AccessTier = StorageAccountAccessTier.Hot
@@ -255,7 +252,7 @@ public class BasicStorageTests(bool async)
             @description('The container name.')
             param containerName string = 'mycontainer'
 
-            @description('The storage account location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
@@ -298,16 +295,10 @@ public class BasicStorageTests(bool async)
                         Value = StorageSkuName.StandardLrs,
                         Description = "Storage Account type"
                     };
-                BicepParameter location = new(nameof(location), typeof(string))
-                {
-                    Value = BicepFunction.GetResourceGroup().Location,
-                    Description = "The storage account location."
-                };
 
                 StorageAccount sa =
                     new(nameof(sa))
                     {
-                        Location = location,
                         Sku = new StorageSku { Name = storageAccountType },
                         Kind = StorageKind.Storage,
                         Encryption =
@@ -330,7 +321,7 @@ public class BasicStorageTests(bool async)
             @description('Storage Account type')
             param storageAccountType string = 'Standard_LRS'
 
-            @description('The storage account location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/tests/BasicWebPubSubTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/tests/BasicWebPubSubTests.cs
@@ -21,17 +21,9 @@ public class BasicWebPubSubTests(bool async)
         await test.Define(
             ctx =>
             {
-                BicepParameter location =
-                    new(nameof(location), typeof(string))
-                    {
-                        Value = BicepFunction.GetResourceGroup().Location,
-                        Description = "WebPubSub location."
-                    };
-
-                WebPubSubService webpubsub =
+               WebPubSubService webpubsub =
                     new(nameof(webpubsub), "2021-10-01")
                     {
-                        Location = location,
                         Sku =
                             new BillingInfoSku
                             {
@@ -79,7 +71,7 @@ public class BasicWebPubSubTests(bool async)
             })
         .Compare(
             """
-            @description('WebPubSub location.')
+            @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
             resource webpubsub 'Microsoft.SignalRService/webPubSub@2021-10-01' = {

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -105,7 +105,8 @@ namespace Azure.Provisioning
     {
         protected BicepVariable(string name, Azure.Provisioning.Expressions.Expression type, Azure.Provisioning.BicepValue<object>? value, Azure.Provisioning.ProvisioningContext? context = null) : base (default(string), default(Azure.Provisioning.ProvisioningContext)) { }
         public BicepVariable(string name, System.Type type, Azure.Provisioning.ProvisioningContext? context = null) : base (default(string), default(Azure.Provisioning.ProvisioningContext)) { }
-        protected Azure.Provisioning.Expressions.Expression BicepType { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public Azure.Provisioning.Expressions.Expression BicepType { get { throw null; } }
         public string? Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<object> Value { get { throw null; } set { } }
         protected internal override System.Collections.Generic.IEnumerable<Azure.Provisioning.Expressions.Statement> Compile(Azure.Provisioning.ProvisioningContext? context = null) { throw null; }
@@ -119,7 +120,7 @@ namespace Azure.Provisioning
         public virtual Azure.Provisioning.ProvisioningPlan Build(Azure.Provisioning.ProvisioningContext? context = null) { throw null; }
         protected internal override System.Collections.Generic.IEnumerable<Azure.Provisioning.Expressions.Statement> Compile(Azure.Provisioning.ProvisioningContext? context = null) { throw null; }
         protected internal System.Collections.Generic.IDictionary<string, System.Collections.Generic.IEnumerable<Azure.Provisioning.Expressions.Statement>> CompileModules(Azure.Provisioning.ProvisioningContext? context = null) { throw null; }
-        protected internal override System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> GetResources() { throw null; }
+        public override System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> GetResources() { throw null; }
         public virtual void Remove(Azure.Provisioning.Primitives.Provisionable resource) { }
         protected internal override void Resolve(Azure.Provisioning.ProvisioningContext? context = null) { }
         protected internal override void Validate(Azure.Provisioning.ProvisioningContext? context = null) { }
@@ -136,6 +137,7 @@ namespace Azure.Provisioning
         public Azure.Provisioning.Infrastructure DefaultInfrastructure { get { throw null; } set { } }
         public System.Func<Azure.Provisioning.Infrastructure> DefaultInfrastructureProvider { get { throw null; } set { } }
         public string? DefaultSubscriptionId { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Azure.Provisioning.Primitives.InfrastructureResolver> InfrastructureResolvers { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.Provisioning.Primitives.PropertyResolver> PropertyResolvers { get { throw null; } set { } }
         public static Azure.Provisioning.Primitives.ProvisioningContextProvider Provider { get { throw null; } set { } }
         public System.Random Random { get { throw null; } set { } }
@@ -812,9 +814,10 @@ namespace Azure.Provisioning.Primitives
         public string PropertyName { get { throw null; } }
         public override string ToString() { throw null; }
     }
-    public partial class DynamicResourceNameResolver : Azure.Provisioning.Primitives.ResourceNameResolver
+    public partial class DynamicResourceNamePropertyResolver : Azure.Provisioning.Primitives.ResourceNamePropertyResolver
     {
-        public DynamicResourceNameResolver() { }
+        public DynamicResourceNamePropertyResolver() { }
+        protected virtual Azure.Provisioning.BicepValue<string> GetUniqueSuffix(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.Resource resource) { throw null; }
         public override Azure.Provisioning.BicepValue<string>? ResolveName(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.Resource resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements) { throw null; }
     }
     public partial class FreshProvisioningContextProvider : Azure.Provisioning.Primitives.ProvisioningContextProvider
@@ -826,6 +829,13 @@ namespace Azure.Provisioning.Primitives
     {
         TClient CreateClient(Azure.Provisioning.ProvisioningDeployment deployment, Azure.Core.TokenCredential credential, TOptions? options = null);
     }
+    public abstract partial class InfrastructureResolver
+    {
+        protected InfrastructureResolver() { }
+        public System.Collections.Generic.IEnumerable<Azure.Provisioning.Infrastructure> GetNestedInfrastructure(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Infrastructure infrastructure) { throw null; }
+        public virtual void ResolveInfrastructure(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Infrastructure infrastructure) { }
+        public virtual System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> ResolveResources(Azure.Provisioning.ProvisioningContext context, System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> resources) { throw null; }
+    }
     public partial class LocalProvisioningContextProvider : Azure.Provisioning.Primitives.ProvisioningContextProvider
     {
         public LocalProvisioningContextProvider(System.Func<Azure.Provisioning.ProvisioningContext>? contextFactory = null) { }
@@ -834,6 +844,7 @@ namespace Azure.Provisioning.Primitives
     public partial class LocationPropertyResolver : Azure.Provisioning.Primitives.PropertyResolver
     {
         public LocationPropertyResolver() { }
+        protected virtual Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> GetDefaultLocation(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.ProvisioningConstruct construct) { throw null; }
         public override void ResolveProperties(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.ProvisioningConstruct construct) { }
     }
     public partial class ModuleImport : Azure.Provisioning.Primitives.NamedProvisioningConstruct
@@ -856,6 +867,11 @@ namespace Azure.Provisioning.Primitives
         public NoImplicitProvisioningContextProvider() { }
         public override Azure.Provisioning.ProvisioningContext GetProvisioningContext() { throw null; }
     }
+    public partial class OrderingInfrastructureResolver : Azure.Provisioning.Primitives.InfrastructureResolver
+    {
+        public OrderingInfrastructureResolver() { }
+        public override System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> ResolveResources(Azure.Provisioning.ProvisioningContext context, System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> resources) { throw null; }
+    }
     public abstract partial class PropertyResolver
     {
         protected PropertyResolver() { }
@@ -865,7 +881,7 @@ namespace Azure.Provisioning.Primitives
     {
         internal Provisionable() { }
         protected internal abstract System.Collections.Generic.IEnumerable<Azure.Provisioning.Expressions.Statement> Compile(Azure.Provisioning.ProvisioningContext? context = null);
-        protected internal virtual System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> GetResources() { throw null; }
+        public virtual System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> GetResources() { throw null; }
         protected internal virtual void Resolve(Azure.Provisioning.ProvisioningContext? context = null) { }
         protected internal virtual void Validate(Azure.Provisioning.ProvisioningContext? context = null) { }
     }
@@ -876,6 +892,8 @@ namespace Azure.Provisioning.Primitives
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public Azure.Provisioning.Infrastructure? ParentInfrastructure { get { throw null; } }
         protected internal override System.Collections.Generic.IEnumerable<Azure.Provisioning.Expressions.Statement> Compile(Azure.Provisioning.ProvisioningContext? context = null) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> GetResources() { throw null; }
         protected internal void OverrideWithExpression(Azure.Provisioning.Expressions.Expression reference) { }
         protected internal override void Resolve(Azure.Provisioning.ProvisioningContext? context = null) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -912,6 +930,13 @@ namespace Azure.Provisioning.Primitives
         Period = 32,
         Parentheses = 64,
     }
+    public abstract partial class ResourceNamePropertyResolver : Azure.Provisioning.Primitives.PropertyResolver
+    {
+        protected ResourceNamePropertyResolver() { }
+        public abstract Azure.Provisioning.BicepValue<string>? ResolveName(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.Resource resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements);
+        public override void ResolveProperties(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.ProvisioningConstruct construct) { }
+        protected static string SanitizeText(string text, Azure.Provisioning.Primitives.ResourceNameCharacters validCharacters) { throw null; }
+    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceNameRequirements
     {
@@ -920,13 +945,6 @@ namespace Azure.Provisioning.Primitives
         public int MaxLength { get { throw null; } }
         public int MinLength { get { throw null; } }
         public Azure.Provisioning.Primitives.ResourceNameCharacters ValidCharacters { get { throw null; } }
-    }
-    public abstract partial class ResourceNameResolver : Azure.Provisioning.Primitives.PropertyResolver
-    {
-        protected ResourceNameResolver() { }
-        public abstract Azure.Provisioning.BicepValue<string>? ResolveName(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.Resource resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements);
-        public override void ResolveProperties(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.ProvisioningConstruct construct) { }
-        protected static string SanitizeText(string text, Azure.Provisioning.Primitives.ResourceNameCharacters validCharacters) { throw null; }
     }
     public partial class ResourceReference<T> where T : Azure.Provisioning.Primitives.Resource
     {
@@ -940,9 +958,9 @@ namespace Azure.Provisioning.Primitives
         public SharedProvisioningContextProvider(Azure.Provisioning.ProvisioningContext? context = null) { }
         public override Azure.Provisioning.ProvisioningContext GetProvisioningContext() { throw null; }
     }
-    public partial class StaticResourceNameResolver : Azure.Provisioning.Primitives.ResourceNameResolver
+    public partial class StaticResourceNamePropertyResolver : Azure.Provisioning.Primitives.ResourceNamePropertyResolver
     {
-        public StaticResourceNameResolver() { }
+        public StaticResourceNamePropertyResolver() { }
         public override Azure.Provisioning.BicepValue<string>? ResolveName(Azure.Provisioning.ProvisioningContext context, Azure.Provisioning.Primitives.Resource resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements) { throw null; }
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/BicepVariable.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/BicepVariable.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Primitives;
 
@@ -27,7 +28,8 @@ public class BicepVariable : NamedProvisioningConstruct
     /// <summary>
     /// Gets the Bicep type of the value.
     /// </summary>
-    protected Expression BicepType { get; }
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Expression BicepType { get; }
 
     /// <summary>
     /// Creates a new BicepVariable.

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
@@ -37,7 +37,7 @@ public static class BicepFunction
                 text.GetArgument(i) switch
                 {
                     BicepValue v => v,
-                    BicepVariable v => v.Value,
+                    BicepVariable v => BicepSyntax.Var(v.ResourceName),
                     var a => new BicepValue<object>(a?.ToString() ?? "")
                 };
         };

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepTypeMapping.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepTypeMapping.cs
@@ -109,6 +109,7 @@ internal static class BicepTypeMapping
             BicepValue v when (v.Kind == BicepValueKind.Expression) => v.Expression!,
             BicepValue v when (v.Source is not null) => v.Source.GetReference(),
             BicepValue v when (v.Kind == BicepValueKind.Literal) => ToBicep(v.GetLiteralValue()),
+            BicepValue v when (v.Self is not null) => v.Self.GetReference(),
             BicepValue v when (v.Kind == BicepValueKind.Unset) => BicepSyntax.Null(),
             _ => throw new InvalidOperationException($"Cannot convert {value} to a Bicep expression.")
         };

--- a/sdk/provisioning/Azure.Provisioning/src/Infrastructure.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Infrastructure.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Primitives;
 
@@ -28,10 +29,18 @@ public class Infrastructure(string name) : Provisionable
     // Placeholder until we get module splitting handled
     private Infrastructure? _parent = null;
 
-    // TODO: Figure out the right way to expose ethis publicly
-    protected internal override IEnumerable<Provisionable> GetResources() => _resources;
+    /// <inheritdoc/>
+    public override IEnumerable<Provisionable> GetResources() => _resources;
     private readonly List<Provisionable> _resources = [];
 
+    /// <summary>
+    /// Adds a provisionable construct to this Infrastructure.
+    /// </summary>
+    /// <param name="resource">The provisionable construct to add.</param>
+    /// <remarks>
+    /// This will remove any existing association between this provisionable
+    /// construct and other Infrastructure instances.
+    /// </remarks>
     public virtual void Add(Provisionable resource)
     {
         if (resource is ProvisioningConstruct construct &&
@@ -57,8 +66,17 @@ public class Infrastructure(string name) : Provisionable
             _resources.Add(nested);
             nested._parent = this;
         }
+
+        // Ensure all cases are covered
+        Debug.Assert(
+            resource is ProvisioningConstruct || resource is Infrastructure,
+            $"{nameof(Infrastructure)} needs to be updated if you add a new fork in the hierarchy derived from {nameof(Provisionable)}!");
     }
 
+    /// <summary>
+    /// Remove a provisionable construct from this Infrastructure.
+    /// </summary>
+    /// <param name="resource">The provisionable construct to remove.</param>
     public virtual void Remove(Provisionable resource)
     {
         if (resource is ProvisioningConstruct construct &&
@@ -75,6 +93,7 @@ public class Infrastructure(string name) : Provisionable
         }
     }
 
+    /// <inheritdoc/>
     protected internal override void Validate(ProvisioningContext? context = null)
     {
         context ??= ProvisioningContext.Provider.GetProvisioningContext();
@@ -82,6 +101,7 @@ public class Infrastructure(string name) : Provisionable
         foreach (Provisionable resource in GetResources()) { resource.Validate(context); }
     }
 
+    /// <inheritdoc/>
     protected internal override void Resolve(ProvisioningContext? context = default)
     {
         context ??= ProvisioningContext.Provider.GetProvisioningContext();
@@ -89,8 +109,14 @@ public class Infrastructure(string name) : Provisionable
 
         Provisionable[] cached = [.. GetResources()]; // Copy so Resolve can mutate
         foreach (Provisionable resource in cached) { resource.Resolve(context); }
+
+        foreach (InfrastructureResolver resolver in context.InfrastructureResolvers)
+        {
+            resolver.ResolveInfrastructure(context, this);
+        }
     }
 
+    /// <inheritdoc/>
     protected internal override IEnumerable<Statement> Compile(ProvisioningContext? context = default)
     {
         context ??= ProvisioningContext.Provider.GetProvisioningContext();
@@ -99,7 +125,15 @@ public class Infrastructure(string name) : Provisionable
         {
             statements.Add(new TargetScopeStatement(TargetScope));
         }
-        foreach (Provisionable resource in GetResources())
+
+        // Customize the resources before compiling them
+        IEnumerable<Provisionable> resources = GetResources();
+        foreach (InfrastructureResolver resolver in context.InfrastructureResolvers)
+        {
+            resources = resolver.ResolveResources(context, resources);
+        }
+
+        foreach (Provisionable resource in resources)
         {
             if (resource is ProvisioningConstruct construct)
             {
@@ -118,6 +152,11 @@ public class Infrastructure(string name) : Provisionable
         return statements;
     }
 
+    /// <summary>
+    /// Compile this infrastructure into a set of bicep modules.
+    /// </summary>
+    /// <param name="context">Provisioning context/</param>
+    /// <returns>Dictionary mapping module names to module definitions.</returns>
     protected internal IDictionary<string, IEnumerable<Statement>> CompileModules(ProvisioningContext? context = default)
     {
         // This API shape will eventually help us grow into compiling multiple
@@ -125,9 +164,32 @@ public class Infrastructure(string name) : Provisionable
         context ??= ProvisioningContext.Provider.GetProvisioningContext();
         Dictionary<string, IEnumerable<Statement>> modules = [];
         modules.Add(Name, Compile(context));
+
+        // Optionally add any nested modules
+        List<Infrastructure> nested = [];
+        foreach (InfrastructureResolver resolver in context.InfrastructureResolvers)
+        {
+            nested.AddRange(resolver.GetNestedInfrastructure(context, this));
+        }
+        foreach (Infrastructure infra in nested)
+        {
+            modules.Add(infra.Name, infra.Compile(context));
+        }
+
         return modules;
     }
 
+    /// <summary>
+    /// Compose all the resources into a concrete <see cref="ProvisioningPlan"/>
+    /// that can be compiled into Bicep, deployed, etc.
+    /// </summary>
+    /// <param name="context">
+    /// The provisioning context to use for composing resources.
+    /// </param>
+    /// <returns>
+    /// A <see cref="ProvisioningPlan"/> that can be compiled into Bicep,
+    /// deployed, etc.
+    /// </returns>
     public virtual ProvisioningPlan Build(ProvisioningContext? context = default)
     {
         context ??= ProvisioningContext.Provider.GetProvisioningContext();

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/InfrastructureResolver.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/InfrastructureResolver.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.Provisioning.Primitives;
+
+/// <summary>
+/// An infrastructure resolver attempts to resolve the values of any unset
+/// properties or resources in <see cref="Infrastructure"/>.  This can be
+/// useful for defaulting common values, implementing organization policies, or
+/// other scenarios where you want to uniformly configure all the resources in
+/// a deployment.
+/// </summary>
+public abstract class InfrastructureResolver
+{
+    /// <summary>
+    /// Resolve any properties of the infrastructure.
+    /// </summary>
+    /// <param name="context">The current provisioning context.</param>
+    /// <param name="infrastructure">The infrastructure to resolve properties of.</param>
+    public virtual void ResolveInfrastructure(
+        ProvisioningContext context,
+        Infrastructure infrastructure)
+    {
+    }
+
+    /// <summary>
+    /// Process the collection of resources in the infrastructure.
+    /// </summary>
+    /// <param name="context">The current provisioning context.</param>
+    /// <param name="resources">The existing resources to resolve.</param>
+    public virtual IEnumerable<Provisionable> ResolveResources(
+        ProvisioningContext context,
+        IEnumerable<Provisionable> resources) =>
+        resources;
+
+    /// <summary>
+    /// Gets any nested infrastructure that should be composed separately.
+    /// </summary>
+    /// <param name="context">The current provisioning context.</param>
+    /// <param name="infrastructure">
+    /// The infrastructure to inspect for any nested infrastructure.
+    /// </param>
+    /// <returns></returns>
+    public IEnumerable<Infrastructure> GetNestedInfrastructure(
+        ProvisioningContext context,
+        Infrastructure infrastructure) =>
+        [];
+}

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/LocationPropertyResolver.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/LocationPropertyResolver.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Core;
 using Azure.Provisioning.Expressions;
+using Azure.Provisioning.Resources;
 
 namespace Azure.Provisioning.Primitives;
 
@@ -16,10 +21,99 @@ public class LocationPropertyResolver : PropertyResolver
         // We only need to set a location if one doesn't already exist
         if (construct.ProvisioningProperties.TryGetValue("Location", out BicepValue? location) &&
             location.Kind == BicepValueKind.Unset &&
-            !location.IsOutput)
+            !location.IsOutput &&
+            (construct is not Resource r || !r.IsExistingResource))
         {
-            // Default the location to the resource group's location
-            construct.SetProvisioningProperty(location, BicepFunction.GetResourceGroup().Location);
+            BicepParameter param = GetOrCreateLocationParameter(context, construct);
+            construct.SetProvisioningProperty(location, (BicepValue<string>)param);
         }
+    }
+
+    /// <summary>
+    /// Gets the default location for a construct.
+    /// </summary>
+    /// <param name="context">The provisioning context for this construct.</param>
+    /// <param name="construct">The construct with an unset Location property.</param>
+    /// <returns>A unique dynamic name suffix for the resource.</returns>
+    /// <remarks>
+    /// This defaults to `resourceGroup().location` for most resources and
+    /// `deployment().location` for resource groups.  This can be overridden to
+    /// provide a different default location.
+    /// </remarks>
+    protected virtual BicepValue<AzureLocation> GetDefaultLocation(ProvisioningContext context, ProvisioningConstruct construct) =>
+        construct is not ResourceGroup ?
+            BicepFunction.GetResourceGroup().Location :
+            BicepFunction.GetDeployment().Location;
+
+    /// <summary>
+    /// Find or inject a parameter for the location property.
+    /// </summary>
+    /// <param name="context">The provisioning context for this construct.</param>
+    /// <param name="construct">The construct with an unset Location property.</param>
+    /// <returns></returns>
+    private BicepParameter GetOrCreateLocationParameter(
+        ProvisioningContext context,
+        ProvisioningConstruct construct)
+    {
+        // Get the default value for the location
+        BicepValue<AzureLocation> location = GetDefaultLocation(context, construct);
+        string expression = location.Compile().ToString();
+
+        // Try to find an existing location param with the same value
+        Infrastructure infra = construct.ParentInfrastructure ??
+            throw new InvalidOperationException($"Construct {construct} must be added to an {nameof(Infrastructure)} instance before resolving properties.");
+        IDictionary<string, BicepParameter> existing =
+            infra.GetResources()
+            .OfType<BicepParameter>()
+            .Where(p => p.ResourceName.StartsWith("location"))
+            .ToDictionary(p => p.ResourceName);
+        foreach (BicepParameter p in existing.Values)
+        {
+            if (p.BicepType is TypeExpression type &&
+                type.Type == typeof(string) &&
+                p.Value.Compile().ToString() == expression)
+            {
+                return p;
+            }
+        }
+
+        // Try to call the param location, but make it unique if that name is
+        // already taken
+        string name = "location";
+        if (existing.ContainsKey(name))
+        {
+            bool increment = true;
+
+            // Optionally specialize to the resource
+            if (construct is NamedProvisioningConstruct resource)
+            {
+                name = $"{name}_{resource.ResourceName}";
+                increment = existing.ContainsKey(name);
+            }
+
+            // Otherwise add the next available numeric suffix (i.e., location_2)
+            if (increment)
+            {
+                for (int i = 2;; i++)
+                {
+                    string proposed = $"{name}_{i}";
+                    if (!existing.ContainsKey(proposed))
+                    {
+                        name = proposed;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Create and add the param
+        BicepParameter param =
+            new(name, typeof(string))
+            {
+                Description = "The location for the resource(s) to be deployed.",
+                Value = location
+            };
+        infra.Add(param); // TODO: Add up top
+        return param;
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/OrderingInfrastructureResolver.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/OrderingInfrastructureResolver.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Azure.Provisioning.Primitives;
+
+/// <summary>
+/// Moves all the <see cref="BicepParameter"/>s to the top and all
+/// <see cref="BicepOutput"/>s to the bottom of the <see cref="Infrastructure"/>.
+/// </summary>
+public class OrderingInfrastructureResolver : InfrastructureResolver
+{
+    /// <inheritdoc />
+    public override IEnumerable<Provisionable> ResolveResources(
+        ProvisioningContext context,
+        IEnumerable<Provisionable> resources) =>
+        resources.OrderBy(construct =>
+            construct switch
+            {
+                BicepParameter => 0,
+                BicepOutput => 2,
+                _ => 1
+            });
+}

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/Provisionable.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/Provisionable.cs
@@ -21,7 +21,7 @@ public abstract class Provisionable
     /// be the object itself for everything but <see cref="Infrastructure"/>.
     /// </summary>
     /// <returns>Any resources represented by this object.</returns>
-    protected internal virtual IEnumerable<Provisionable> GetResources() { yield return this; }
+    public virtual IEnumerable<Provisionable> GetResources() { yield return this; }
 
     /// <summary>
     /// Resolve any resources or properties that were not explicitly specified.

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisioningConstruct.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisioningConstruct.cs
@@ -16,7 +16,7 @@ public abstract class NamedProvisioningConstruct : ProvisioningConstruct
 {
     /// <summary>
     /// Gets the the Bicep name of the resource.  This can be used to refer to
-    /// the resource in expressions, but isn't the Azuree name of the resource.
+    /// the resource in expressions, but isn't the Azure name of the resource.
     /// </summary>
     public string ResourceName { get; private set; }
 
@@ -44,6 +44,10 @@ public abstract class ProvisioningConstruct(ProvisioningContext? context = defau
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public Infrastructure? ParentInfrastructure { get; internal set; }
+
+    /// <inheritdoc />
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override IEnumerable<Provisionable> GetResources() => base.GetResources();
 
     /// <summary>
     /// Gets the properties of the construct.

--- a/sdk/provisioning/Azure.Provisioning/src/ProvisioningContext.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/ProvisioningContext.cs
@@ -75,11 +75,20 @@ public class ProvisioningContext
     /// </summary>
     public IList<PropertyResolver> PropertyResolvers { get; set; } =
     [
-        new DynamicResourceNameResolver(),
+        new DynamicResourceNamePropertyResolver(),
         new LocationPropertyResolver(),
     ];
     // TODO: Do we want to make this less mutable like AddPipelinePolicy to
     // maintain more control over how people are able to modify these?
+
+    /// <summary>
+    /// Gets or sets the collection of <see cref="InfrastructureResolver"/>s to
+    /// apply to any <see cref="Infrastructure"/> being composed.
+    /// </summary>
+    public IList<InfrastructureResolver> InfrastructureResolvers { get; set; } =
+    [
+        new OrderingInfrastructureResolver(),
+    ];
 
     #region Creating Clients
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning/tests/ProvisioningTestBase.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/ProvisioningTestBase.cs
@@ -20,7 +20,7 @@ using NUnit.Framework;
 namespace Azure.Provisioning.Tests;
 
 [AsyncOnly]
-[LiveOnly] // Ignore tests in the CI for now
+// [LiveOnly] // Ignore tests in the CI for now
 public class ProvisioningTestBase : ManagementRecordedTestBase<ProvisioningTestEnvironment>
 {
     public bool SkipTools { get; set; }

--- a/sdk/provisioning/Azure.Provisioning/tests/ProvisioningTestBase.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/ProvisioningTestBase.cs
@@ -20,7 +20,7 @@ using NUnit.Framework;
 namespace Azure.Provisioning.Tests;
 
 [AsyncOnly]
-// [LiveOnly] // Ignore tests in the CI for now
+[LiveOnly] // Ignore tests in the CI for now
 public class ProvisioningTestBase : ManagementRecordedTestBase<ProvisioningTestEnvironment>
 {
     public bool SkipTools { get; set; }

--- a/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
@@ -201,8 +201,8 @@ internal class SampleTests(bool async)
                 tags: tags
             }
 
-            resource mi_AcrPull_acr 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-                name: guid(resourceGroup().id, 'mi_AcrPull_acr')
+            resource acr_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+                name: guid(acr.id, mi.properties.principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
                 properties: {
                     principalId: mi.properties.principalId
                     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
@@ -243,8 +243,8 @@ internal class SampleTests(bool async)
                 tags: tags
             }
 
-            resource mi_Contributor_cae 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-                name: guid(resourceGroup().id, 'mi_Contributor_cae')
+            resource cae_mi_Contributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+                name: guid(cae.id, mi.properties.principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c'))
                 properties: {
                     principalId: mi.properties.principalId
                     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')

--- a/sdk/provisioning/Generator/src/Model/Resource.cs
+++ b/sdk/provisioning/Generator/src/Model/Resource.cs
@@ -286,6 +286,27 @@ public class Resource(Specification spec, Type armType)
                                 writer.WriteLine($"PrincipalId = identity.PrincipalId");
                             }
                         }
+
+                        if (fence.RequiresSeparator) { writer.WriteLine(); }
+                        writer.WriteLine($"/// <summary>");
+                        writer.WriteWrapped($"Assign a role to an that grants access to this {Name}.");
+                        writer.WriteLine($"/// </summary>");
+                        writer.WriteLine($"/// <param name=\"role\">The role to grant.</param>");
+                        writer.WriteLine($"/// <param name=\"principalType\">The type of the principal to assign to.</param>");
+                        writer.WriteLine($"/// <param name=\"principalId\">The principal to assign to.</param>");
+                        writer.WriteLine($"/// <returns>The <see cref=\"RoleAssignment\"/>.</returns>");
+                        writer.WriteLine($"public RoleAssignment AssignRole({Spec!.Name}BuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>");
+                        using (writer.Scope())
+                        {
+                            writer.WriteLine($"new($\"{{principalId.Compile()}}_{{{Spec!.Name}BuiltInRole.GetBuiltInRoleName(role)}}_{{ResourceName}}\")");
+                            using (writer.Scope("{", "};"))
+                            {
+                                writer.WriteLine($"Scope = new IdentifierExpression(ResourceName),");
+                                writer.WriteLine($"PrincipalType = principalType,");
+                                writer.WriteLine($"RoleDefinitionId = BicepFunction.GetSubscriptionResourceId(\"Microsoft.Authorization/roleDefinitions\", role.ToString()),");
+                                writer.WriteLine($"PrincipalId = principalId");
+                            }
+                        }
                     }
                 }
 

--- a/sdk/provisioning/Generator/src/Model/Resource.cs
+++ b/sdk/provisioning/Generator/src/Model/Resource.cs
@@ -277,9 +277,12 @@ public class Resource(Specification spec, Type armType)
                         writer.WriteLine($"public RoleAssignment AssignRole({Spec!.Name}BuiltInRole role, UserAssignedIdentity identity) =>");
                         using (writer.Scope())
                         {
-                            writer.WriteLine($"new($\"{{identity.ResourceName}}_{{{Spec!.Name}BuiltInRole.GetBuiltInRoleName(role)}}_{{ResourceName}}\")");
+                            writer.WriteLine($"new($\"{{ResourceName}}_{{identity.ResourceName}}_{{{Spec!.Name}BuiltInRole.GetBuiltInRoleName(role)}}\")");
                             using (writer.Scope("{", "};"))
                             {
+                                writer.Write($"Name = BicepFunction.CreateGuid(");
+                                if (Properties.Any(p => p.Name == "Id")) { writer.Write("Id, "); }
+                                writer.WriteLine($"identity.PrincipalId, BicepFunction.GetSubscriptionResourceId(\"Microsoft.Authorization/roleDefinitions\", role.ToString())),");
                                 writer.WriteLine($"Scope = new IdentifierExpression(ResourceName),");
                                 writer.WriteLine($"PrincipalType = RoleManagementPrincipalType.ServicePrincipal,");
                                 writer.WriteLine($"RoleDefinitionId = BicepFunction.GetSubscriptionResourceId(\"Microsoft.Authorization/roleDefinitions\", role.ToString()),");
@@ -298,9 +301,12 @@ public class Resource(Specification spec, Type armType)
                         writer.WriteLine($"public RoleAssignment AssignRole({Spec!.Name}BuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId) =>");
                         using (writer.Scope())
                         {
-                            writer.WriteLine($"new($\"{{principalId.Compile()}}_{{{Spec!.Name}BuiltInRole.GetBuiltInRoleName(role)}}_{{ResourceName}}\")");
+                            writer.WriteLine($"new($\"{{ResourceName}}_{{{Spec!.Name}BuiltInRole.GetBuiltInRoleName(role)}}\")");
                             using (writer.Scope("{", "};"))
                             {
+                                writer.Write($"Name = BicepFunction.CreateGuid(");
+                                if (Properties.Any(p => p.Name == "Id")) { writer.Write("Id, "); }
+                                writer.WriteLine($"principalId, BicepFunction.GetSubscriptionResourceId(\"Microsoft.Authorization/roleDefinitions\", role.ToString())),");
                                 writer.WriteLine($"Scope = new IdentifierExpression(ResourceName),");
                                 writer.WriteLine($"PrincipalType = principalType,");
                                 writer.WriteLine($"RoleDefinitionId = BicepFunction.GetSubscriptionResourceId(\"Microsoft.Authorization/roleDefinitions\", role.ToString()),");

--- a/sdk/provisioning/Generator/src/Model/Resource.cs
+++ b/sdk/provisioning/Generator/src/Model/Resource.cs
@@ -289,7 +289,7 @@ public class Resource(Specification spec, Type armType)
 
                         if (fence.RequiresSeparator) { writer.WriteLine(); }
                         writer.WriteLine($"/// <summary>");
-                        writer.WriteWrapped($"Assign a role to an that grants access to this {Name}.");
+                        writer.WriteWrapped($"Assign a role to a principal that grants access to this {Name}.");
                         writer.WriteLine($"/// </summary>");
                         writer.WriteLine($"/// <param name=\"role\">The role to grant.</param>");
                         writer.WriteLine($"/// <param name=\"principalType\">The type of the principal to assign to.</param>");


### PR DESCRIPTION
Fix a few `Azure.Provisioning` issues including using params for `Location`, changing the entropy source for RGs, avoiding `Location` on `existing` resources, sorting params/outputs, fixing params in interpolation, adding an overload of `AssignRole` not tied to user assigned identities, and making a few helpful APIs public.  This also adds back part of the `InfrastructureResolver` module splitting prototype to sort params/outputs generically.
