### PR TITLE
Enable WriteCore feature for analysisservices

### DIFF
--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/api/Azure.ResourceManager.Analysis.netstandard2.0.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/api/Azure.ResourceManager.Analysis.netstandard2.0.cs
@@ -45,6 +45,7 @@ namespace Azure.ResourceManager.Analysis
         public string ServerFullName { get { throw null; } }
         public Azure.ResourceManager.Analysis.Models.ServerMonitorMode? ServerMonitorMode { get { throw null; } set { } }
         public Azure.ResourceManager.Analysis.Models.AnalysisState? State { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.AnalysisServerData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.AnalysisServerData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.AnalysisServerData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.AnalysisServerData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.AnalysisServerData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -124,6 +125,7 @@ namespace Azure.ResourceManager.Analysis.Models
         internal AnalysisExistingSku() { }
         public Azure.Core.ResourceType? ResourceType { get { throw null; } }
         public Azure.ResourceManager.Analysis.Models.AnalysisResourceSku Sku { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisExistingSku System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisExistingSku>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisExistingSku>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisExistingSku System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisExistingSku>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -136,6 +138,7 @@ namespace Azure.ResourceManager.Analysis.Models
         public System.Uri DmtsClusterUri { get { throw null; } }
         public string GatewayObjectId { get { throw null; } }
         public string GatewayResourceId { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisGatewayDetails System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisGatewayDetails>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisGatewayDetails>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisGatewayDetails System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisGatewayDetails>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -146,6 +149,7 @@ namespace Azure.ResourceManager.Analysis.Models
     {
         internal AnalysisGatewayStatus() { }
         public Azure.ResourceManager.Analysis.Models.AnalysisStatus? Status { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisGatewayStatus System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisGatewayStatus>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisGatewayStatus>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisGatewayStatus System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisGatewayStatus>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -158,6 +162,7 @@ namespace Azure.ResourceManager.Analysis.Models
         public string FirewallRuleName { get { throw null; } set { } }
         public string RangeEnd { get { throw null; } set { } }
         public string RangeStart { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallRule System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallRule>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallRule>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallRule System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallRule>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -169,6 +174,7 @@ namespace Azure.ResourceManager.Analysis.Models
         public AnalysisIPv4FirewallSettings() { }
         public System.Collections.Generic.IList<Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallRule> FirewallRules { get { throw null; } }
         public bool? IsPowerBIServiceEnabled { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallSettings System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallSettings>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallSettings>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallSettings System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisIPv4FirewallSettings>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -226,6 +232,7 @@ namespace Azure.ResourceManager.Analysis.Models
         public int? Capacity { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
         public Azure.ResourceManager.Analysis.Models.AnalysisSkuTier? Tier { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisResourceSku System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisResourceSku>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisResourceSku>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisResourceSku System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisResourceSku>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -237,6 +244,7 @@ namespace Azure.ResourceManager.Analysis.Models
         public AnalysisServerNameAvailabilityContent() { }
         public string Name { get { throw null; } set { } }
         public string ResourceType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -249,6 +257,7 @@ namespace Azure.ResourceManager.Analysis.Models
         public bool? IsNameAvailable { get { throw null; } }
         public string Message { get { throw null; } }
         public string Reason { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisServerNameAvailabilityResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -267,6 +276,7 @@ namespace Azure.ResourceManager.Analysis.Models
         public Azure.ResourceManager.Analysis.Models.ServerMonitorMode? ServerMonitorMode { get { throw null; } set { } }
         public Azure.ResourceManager.Analysis.Models.AnalysisResourceSku Sku { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisServerPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisServerPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Analysis.Models.AnalysisServerPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.Analysis.Models.AnalysisServerPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Analysis.Models.AnalysisServerPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/assets.json
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/analysisservices/Azure.ResourceManager.Analysis",
-  "Tag": "net/analysisservices/Azure.ResourceManager.Analysis_e6bfde6996"
+  "Tag": "net/analysisservices/Azure.ResourceManager.Analysis_bb87da9ad1"
 }

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/AnalysisServerData.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/AnalysisServerData.Serialization.cs
@@ -21,48 +21,24 @@ namespace Azure.ResourceManager.Analysis
 
         void IJsonModel<AnalysisServerData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisServerData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisServerData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("sku"u8);
             writer.WriteObjectValue(AnalysisSku, options);
-            if (Optional.IsCollectionDefined(Tags))
-            {
-                writer.WritePropertyName("tags"u8);
-                writer.WriteStartObject();
-                foreach (var item in Tags)
-                {
-                    writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
-                }
-                writer.WriteEndObject();
-            }
-            writer.WritePropertyName("location"u8);
-            writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(AsAdministrators))
@@ -119,22 +95,6 @@ namespace Azure.ResourceManager.Analysis
             {
                 writer.WritePropertyName("sku"u8);
                 writer.WriteObjectValue(AnalysisServerSku, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisExistingSku.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisExistingSku.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisExistingSku>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisExistingSku>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisExistingSku)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Sku))
             {
                 writer.WritePropertyName("sku"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisExistingSku IJsonModel<AnalysisExistingSku>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisGatewayDetails.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisGatewayDetails.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisGatewayDetails>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisGatewayDetails>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisGatewayDetails)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(GatewayResourceId))
             {
                 writer.WritePropertyName("gatewayResourceId"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisGatewayDetails IJsonModel<AnalysisGatewayDetails>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisGatewayStatus.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisGatewayStatus.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisGatewayStatus>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisGatewayStatus>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisGatewayStatus)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Status))
             {
                 writer.WritePropertyName("status"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisGatewayStatus IJsonModel<AnalysisGatewayStatus>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisIPv4FirewallRule.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisIPv4FirewallRule.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisIPv4FirewallRule>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisIPv4FirewallRule>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisIPv4FirewallRule)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(FirewallRuleName))
             {
                 writer.WritePropertyName("firewallRuleName"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisIPv4FirewallRule IJsonModel<AnalysisIPv4FirewallRule>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisIPv4FirewallSettings.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisIPv4FirewallSettings.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisIPv4FirewallSettings>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisIPv4FirewallSettings>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisIPv4FirewallSettings)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(FirewallRules))
             {
                 writer.WritePropertyName("firewallRules"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisIPv4FirewallSettings IJsonModel<AnalysisIPv4FirewallSettings>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisResourceSku.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisResourceSku.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisResourceSku>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisResourceSku>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisResourceSku)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             if (Optional.IsDefined(Tier))
@@ -53,7 +61,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisResourceSku IJsonModel<AnalysisResourceSku>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisServerNameAvailabilityContent.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisServerNameAvailabilityContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisServerNameAvailabilityContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisServerNameAvailabilityContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisServerNameAvailabilityContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisServerNameAvailabilityContent IJsonModel<AnalysisServerNameAvailabilityContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisServerNameAvailabilityResult.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisServerNameAvailabilityResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisServerNameAvailabilityResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisServerNameAvailabilityResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisServerNameAvailabilityResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(IsNameAvailable))
             {
                 writer.WritePropertyName("nameAvailable"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisServerNameAvailabilityResult IJsonModel<AnalysisServerNameAvailabilityResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisServerPatch.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisServerPatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisServerPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisServerPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisServerPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Sku))
             {
                 writer.WritePropertyName("sku"u8);
@@ -95,7 +103,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisServerPatch IJsonModel<AnalysisServerPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisServers.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/AnalysisServers.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<AnalysisServers>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AnalysisServers>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AnalysisServers)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("value"u8);
             writer.WriteStartArray();
             foreach (var item in AnalysisResources)
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AnalysisServers IJsonModel<AnalysisServers>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/ExistingResourceResultSkuEnumeration.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/ExistingResourceResultSkuEnumeration.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<ExistingResourceResultSkuEnumeration>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExistingResourceResultSkuEnumeration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExistingResourceResultSkuEnumeration)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExistingResourceResultSkuEnumeration IJsonModel<ExistingResourceResultSkuEnumeration>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/NewResourceResultSkuEnumeration.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/NewResourceResultSkuEnumeration.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<NewResourceResultSkuEnumeration>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<NewResourceResultSkuEnumeration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(NewResourceResultSkuEnumeration)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         NewResourceResultSkuEnumeration IJsonModel<NewResourceResultSkuEnumeration>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/ServerAdministrators.Serialization.cs
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/Generated/Models/ServerAdministrators.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.Analysis.Models
 
         void IJsonModel<ServerAdministrators>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ServerAdministrators>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ServerAdministrators)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(AsAdministratorIdentities))
             {
                 writer.WritePropertyName("members"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.Analysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ServerAdministrators IJsonModel<ServerAdministrators>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/analysisservices/Azure.ResourceManager.Analysis/src/autorest.md
+++ b/sdk/analysisservices/Azure.ResourceManager.Analysis/src/autorest.md
@@ -16,6 +16,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 rename-mapping:
   State: AnalysisState


### PR DESCRIPTION
We need to enable WriteCore feature to analysisservices. Therefore add `use-write-core: true` and do a regen.