### PR TITLE
Enable WriteCore feature for agrifood

### DIFF
--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/api/Azure.ResourceManager.AgFoodPlatform.netstandard2.0.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/api/Azure.ResourceManager.AgFoodPlatform.netstandard2.0.cs
@@ -41,6 +41,7 @@ namespace Azure.ResourceManager.AgFoodPlatform
         public Azure.ResourceManager.AgFoodPlatform.Models.AgFoodPlatformPrivateLinkServiceConnectionState ConnectionState { get { throw null; } set { } }
         public Azure.Core.ResourceIdentifier PrivateEndpointId { get { throw null; } }
         public Azure.ResourceManager.AgFoodPlatform.Models.AgFoodPlatformPrivateEndpointConnectionProvisioningState? ProvisioningState { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateEndpointConnectionData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateEndpointConnectionData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateEndpointConnectionData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateEndpointConnectionData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateEndpointConnectionData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -102,6 +103,7 @@ namespace Azure.ResourceManager.AgFoodPlatform
         public string GroupId { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<string> RequiredMembers { get { throw null; } }
         public System.Collections.Generic.IList<string> RequiredZoneNames { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateLinkResourceData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateLinkResourceData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateLinkResourceData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateLinkResourceData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.AgFoodPlatformPrivateLinkResourceData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -134,6 +136,7 @@ namespace Azure.ResourceManager.AgFoodPlatform
         public string ExtensionCategory { get { throw null; } }
         public string ExtensionId { get { throw null; } }
         public string InstalledExtensionVersion { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.ExtensionData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.ExtensionData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.ExtensionData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.ExtensionData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.ExtensionData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -185,6 +188,7 @@ namespace Azure.ResourceManager.AgFoodPlatform
         public Azure.ResourceManager.AgFoodPlatform.Models.ProvisioningState? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.AgFoodPlatform.Models.PublicNetworkAccess? PublicNetworkAccess { get { throw null; } set { } }
         public Azure.ResourceManager.AgFoodPlatform.Models.SensorIntegration SensorIntegration { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.FarmBeatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.FarmBeatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.FarmBeatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.FarmBeatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.FarmBeatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -255,6 +259,7 @@ namespace Azure.ResourceManager.AgFoodPlatform
         public string FarmBeatsExtensionVersion { get { throw null; } }
         public string PublisherId { get { throw null; } }
         public string TargetResourceType { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.FarmBeatsExtensionData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.FarmBeatsExtensionData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.FarmBeatsExtensionData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.FarmBeatsExtensionData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.FarmBeatsExtensionData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -358,6 +363,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
         public string ActionsRequired { get { throw null; } set { } }
         public string Description { get { throw null; } set { } }
         public Azure.ResourceManager.AgFoodPlatform.Models.AgFoodPlatformPrivateEndpointServiceConnectionStatus? Status { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.AgFoodPlatformPrivateLinkServiceConnectionState System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.AgFoodPlatformPrivateLinkServiceConnectionState>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.AgFoodPlatformPrivateLinkServiceConnectionState>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.AgFoodPlatformPrivateLinkServiceConnectionState System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.AgFoodPlatformPrivateLinkServiceConnectionState>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -381,6 +387,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
     {
         internal ArmAsyncOperation() { }
         public string Status { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.ArmAsyncOperation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.ArmAsyncOperation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.ArmAsyncOperation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.ArmAsyncOperation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.ArmAsyncOperation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -392,6 +399,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
         public CheckNameAvailabilityContent() { }
         public string Name { get { throw null; } set { } }
         public string ResourceType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -422,6 +430,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
         public string Message { get { throw null; } }
         public bool? NameAvailable { get { throw null; } }
         public Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityReason? Reason { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityResponse System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityResponse>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityResponse>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityResponse System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.CheckNameAvailabilityResponse>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -436,6 +445,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
         public System.Collections.Generic.IReadOnlyList<string> CustomParameters { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<string> PlatformParameters { get { throw null; } }
         public Azure.ResourceManager.AgFoodPlatform.Models.UnitSystemsInfo UnitsSupported { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.DetailedInformation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.DetailedInformation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.DetailedInformation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.DetailedInformation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.DetailedInformation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -449,6 +459,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
         public Azure.Core.AzureLocation? Location { get { throw null; } set { } }
         public Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatsUpdateProperties Properties { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -460,6 +471,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
         public FarmBeatsUpdateProperties() { }
         public Azure.ResourceManager.AgFoodPlatform.Models.PublicNetworkAccess? PublicNetworkAccess { get { throw null; } set { } }
         public Azure.ResourceManager.AgFoodPlatform.Models.SensorIntegration SensorIntegration { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatsUpdateProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatsUpdateProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatsUpdateProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatsUpdateProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.FarmBeatsUpdateProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -511,6 +523,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
         public string Enabled { get { throw null; } set { } }
         public Azure.ResponseError ProvisioningInfoError { get { throw null; } set { } }
         public Azure.ResourceManager.AgFoodPlatform.Models.ProvisioningState? ProvisioningState { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.SensorIntegration System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.SensorIntegration>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.SensorIntegration>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.SensorIntegration System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.SensorIntegration>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -522,6 +535,7 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
         internal UnitSystemsInfo() { }
         public string Key { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<string> Values { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.UnitSystemsInfo System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.UnitSystemsInfo>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.AgFoodPlatform.Models.UnitSystemsInfo>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.AgFoodPlatform.Models.UnitSystemsInfo System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AgFoodPlatform.Models.UnitSystemsInfo>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/AgFoodPlatformPrivateEndpointConnectionData.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/AgFoodPlatformPrivateEndpointConnectionData.Serialization.cs
@@ -22,33 +22,22 @@ namespace Azure.ResourceManager.AgFoodPlatform
 
         void IJsonModel<AgFoodPlatformPrivateEndpointConnectionData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AgFoodPlatformPrivateEndpointConnectionData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AgFoodPlatformPrivateEndpointConnectionData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(PrivateEndpoint))
@@ -65,22 +54,6 @@ namespace Azure.ResourceManager.AgFoodPlatform
             {
                 writer.WritePropertyName("provisioningState"u8);
                 writer.WriteStringValue(ProvisioningState.Value.ToString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/AgFoodPlatformPrivateLinkResourceData.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/AgFoodPlatformPrivateLinkResourceData.Serialization.cs
@@ -20,33 +20,22 @@ namespace Azure.ResourceManager.AgFoodPlatform
 
         void IJsonModel<AgFoodPlatformPrivateLinkResourceData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AgFoodPlatformPrivateLinkResourceData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AgFoodPlatformPrivateLinkResourceData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(GroupId))
@@ -73,22 +62,6 @@ namespace Azure.ResourceManager.AgFoodPlatform
                     writer.WriteStringValue(item);
                 }
                 writer.WriteEndArray();
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/ExtensionData.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/ExtensionData.Serialization.cs
@@ -20,37 +20,26 @@ namespace Azure.ResourceManager.AgFoodPlatform
 
         void IJsonModel<ExtensionData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExtensionData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExtensionData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(ETag))
             {
                 writer.WritePropertyName("eTag"u8);
                 writer.WriteStringValue(ETag.Value.ToString());
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -78,22 +67,6 @@ namespace Azure.ResourceManager.AgFoodPlatform
             {
                 writer.WritePropertyName("extensionApiDocsLink"u8);
                 writer.WriteStringValue(ExtensionApiDocsLink);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/FarmBeatData.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/FarmBeatData.Serialization.cs
@@ -21,50 +21,26 @@ namespace Azure.ResourceManager.AgFoodPlatform
 
         void IJsonModel<FarmBeatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FarmBeatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FarmBeatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Identity))
             {
                 writer.WritePropertyName("identity"u8);
                 JsonSerializer.Serialize(writer, Identity);
-            }
-            if (Optional.IsCollectionDefined(Tags))
-            {
-                writer.WritePropertyName("tags"u8);
-                writer.WriteStartObject();
-                foreach (var item in Tags)
-                {
-                    writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
-                }
-                writer.WriteEndObject();
-            }
-            writer.WritePropertyName("location"u8);
-            writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -92,22 +68,6 @@ namespace Azure.ResourceManager.AgFoodPlatform
             {
                 writer.WritePropertyName("privateEndpointConnections"u8);
                 writer.WriteObjectValue(PrivateEndpointConnections, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/FarmBeatsExtensionData.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/FarmBeatsExtensionData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.AgFoodPlatform
 
         void IJsonModel<FarmBeatsExtensionData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FarmBeatsExtensionData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FarmBeatsExtensionData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(TargetResourceType))
@@ -104,22 +93,6 @@ namespace Azure.ResourceManager.AgFoodPlatform
                     writer.WriteObjectValue(item, options);
                 }
                 writer.WriteEndArray();
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/AgFoodPlatformPrivateEndpointConnectionListResult.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/AgFoodPlatformPrivateEndpointConnectionListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<AgFoodPlatformPrivateEndpointConnectionListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AgFoodPlatformPrivateEndpointConnectionListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AgFoodPlatformPrivateEndpointConnectionListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AgFoodPlatformPrivateEndpointConnectionListResult IJsonModel<AgFoodPlatformPrivateEndpointConnectionListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/AgFoodPlatformPrivateLinkResourceListResult.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/AgFoodPlatformPrivateLinkResourceListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<AgFoodPlatformPrivateLinkResourceListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AgFoodPlatformPrivateLinkResourceListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AgFoodPlatformPrivateLinkResourceListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AgFoodPlatformPrivateLinkResourceListResult IJsonModel<AgFoodPlatformPrivateLinkResourceListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/AgFoodPlatformPrivateLinkServiceConnectionState.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/AgFoodPlatformPrivateLinkServiceConnectionState.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<AgFoodPlatformPrivateLinkServiceConnectionState>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AgFoodPlatformPrivateLinkServiceConnectionState>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AgFoodPlatformPrivateLinkServiceConnectionState)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Status))
             {
                 writer.WritePropertyName("status"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AgFoodPlatformPrivateLinkServiceConnectionState IJsonModel<AgFoodPlatformPrivateLinkServiceConnectionState>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/ArmAsyncOperation.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/ArmAsyncOperation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<ArmAsyncOperation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ArmAsyncOperation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ArmAsyncOperation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Status))
             {
                 writer.WritePropertyName("status"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ArmAsyncOperation IJsonModel<ArmAsyncOperation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/CheckNameAvailabilityContent.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/CheckNameAvailabilityContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<CheckNameAvailabilityContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CheckNameAvailabilityContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CheckNameAvailabilityContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CheckNameAvailabilityContent IJsonModel<CheckNameAvailabilityContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/CheckNameAvailabilityResponse.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/CheckNameAvailabilityResponse.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<CheckNameAvailabilityResponse>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CheckNameAvailabilityResponse>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CheckNameAvailabilityResponse)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(NameAvailable))
             {
                 writer.WritePropertyName("nameAvailable"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CheckNameAvailabilityResponse IJsonModel<CheckNameAvailabilityResponse>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/DetailedInformation.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/DetailedInformation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<DetailedInformation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DetailedInformation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DetailedInformation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ApiName))
             {
                 writer.WritePropertyName("apiName"u8);
@@ -81,7 +89,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DetailedInformation IJsonModel<DetailedInformation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/ErrorResponse.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/ErrorResponse.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<ErrorResponse>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ErrorResponse>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ErrorResponse)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Error))
             {
                 writer.WritePropertyName("error"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ErrorResponse IJsonModel<ErrorResponse>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/ExtensionListResponse.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/ExtensionListResponse.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<ExtensionListResponse>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExtensionListResponse>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExtensionListResponse)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExtensionListResponse IJsonModel<ExtensionListResponse>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/FarmBeatPatch.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/FarmBeatPatch.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<FarmBeatPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FarmBeatPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FarmBeatPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Location))
             {
                 writer.WritePropertyName("location"u8);
@@ -68,7 +76,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FarmBeatPatch IJsonModel<FarmBeatPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/FarmBeatsExtensionListResponse.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/FarmBeatsExtensionListResponse.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<FarmBeatsExtensionListResponse>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FarmBeatsExtensionListResponse>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FarmBeatsExtensionListResponse)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FarmBeatsExtensionListResponse IJsonModel<FarmBeatsExtensionListResponse>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/FarmBeatsListResponse.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/FarmBeatsListResponse.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<FarmBeatsListResponse>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FarmBeatsListResponse>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FarmBeatsListResponse)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FarmBeatsListResponse IJsonModel<FarmBeatsListResponse>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/FarmBeatsUpdateProperties.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/FarmBeatsUpdateProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<FarmBeatsUpdateProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FarmBeatsUpdateProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FarmBeatsUpdateProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(SensorIntegration))
             {
                 writer.WritePropertyName("sensorIntegration"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FarmBeatsUpdateProperties IJsonModel<FarmBeatsUpdateProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/SensorIntegration.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/SensorIntegration.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<SensorIntegration>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<SensorIntegration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(SensorIntegration)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Enabled))
             {
                 writer.WritePropertyName("enabled"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         SensorIntegration IJsonModel<SensorIntegration>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/UnitSystemsInfo.Serialization.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/Generated/Models/UnitSystemsInfo.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 
         void IJsonModel<UnitSystemsInfo>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<UnitSystemsInfo>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(UnitSystemsInfo)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("key"u8);
             writer.WriteStringValue(Key);
             writer.WritePropertyName("values"u8);
@@ -50,7 +58,6 @@ namespace Azure.ResourceManager.AgFoodPlatform.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         UnitSystemsInfo IJsonModel<UnitSystemsInfo>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/autorest.md
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/src/autorest.md
@@ -18,7 +18,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
-
+use-write-core: true
 
 
 format-by-name-rules:


### PR DESCRIPTION
We need to enable WriteCore feature to agrifood. Therefore add `use-write-core: true` and do a regen.