### PR TITLE
Log exceptions in EventHubMetricsProvider, Handle SystemOutOfBounds array exception thrown in GetValidWorkerCount

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             }
             catch (Exception e)
             {
-                _logger.LogWarning($"Encountered an exception while checking EventHub '{_client.EventHubName}'. Error: {e.Message}");
+                _logger.LogWarning($"Encountered an exception while getting checkpoints for EventHub '{_client.EventHubName}' used for scaling. Error: {e.Message}");
             }
 
             return CreateTriggerMetrics(partitionPropertiesTasks.Select(t => t.Result).ToList(), checkpoints);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             }
             catch (Exception e)
             {
-                _logger.LogWarning($"Encountered an exception while getting checkpoints for EventHub '{_client.EventHubName}' used for scaling. Error: {e.Message}");
+                _logger.LogWarning($"Encountered an exception while getting checkpoints for Event Hub '{_client.EventHubName}' used for scaling. Error: {e.Message}");
             }
 
             return CreateTriggerMetrics(partitionPropertiesTasks.Select(t => t.Result).ToList(), checkpoints);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             }
             catch (Exception e)
             {
-                _logger.LogWarning($"Encountered an exception while checking EventHub '{_client.EventHubName}'. Error: {e.Message}");
+                _logger.LogWarning($"Encountered an exception while checking Event Hub '{_client.EventHubName}'. Error: {e.Message}");
                 return metrics;
             }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -78,9 +78,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             {
                 checkpoints = await Task.WhenAll(checkpointTasks).ConfigureAwait(false);
             }
-            catch
+            catch (Exception e)
             {
-                // GetCheckpointsAsync would log
+                _logger.LogWarning($"Encountered an exception while checking EventHub '{_client.EventHubName}'. Error: {e.Message}");
             }
 
             return CreateTriggerMetrics(partitionPropertiesTasks.Select(t => t.Result).ToList(), checkpoints);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs
@@ -178,6 +178,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
         /// <returns></returns>
         internal static int GetValidWorkerCount(int workerCount, int[] sortedValidWorkerCountList)
         {
+            if (sortedValidWorkerCountList.Length == 0)
+            {
+                return 0;
+            }
+
             int i = Array.BinarySearch(sortedValidWorkerCountList, workerCount);
             if (i >= 0)
             {

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsTargetScalerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsTargetScalerTests.cs
@@ -129,6 +129,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [TestCase(21, new[] { 1, 4, 10, 20 }, 20)]
         [TestCase(0, new[] { 1, 4, 10, 20 }, 1)]
         [TestCase(10, new[] { 1, 4, 10, 20 }, 10)]
+        [TestCase(10, new int[0], 0)]
         public void GetSortedValidWorkerCountsForPartitionCount_ReturnsExpected(int workerCount, int[] sortedWorkerCountList, int expectedValidWorkerCount)
         {
             int actualValidWorkerCount = EventHubsTargetScaler.GetValidWorkerCount(workerCount, sortedWorkerCountList);


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

Index out of bounds error:
All("ScaleControllerEvents")
| where PreciseTimeStamp > ago(4h)
| where Level == 2
| where * contains "bounds" and * contains "eventhub"
| take 1
| project Details

```
System.IndexOutOfRangeException : Index was outside the bounds of the array.
   at Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners.EventHubsTargetScaler.GetScaleResultInternal(TargetScalerContext context,Int64 eventCount,Int32 partitionCount)
   at async Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners.EventHubsTargetScaler.GetScaleResultAsync(TargetScalerContext context)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Host.Scale.ScaleManager.GetTargetScalersResultAsync(ScaleStatusContext context,IEnumerable`1 targetScalersToProcess) at D:\a\_work\1\s\src\Microsoft.Azure.WebJobs.Host\Scale\ScaleManager.cs : 167
```



















