### PR TITLE
Enable WriteCore feature for azurelargeinstance

### DIFF
--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/CHANGELOG.md
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Exposed `JsonModelWriteCore` for model serialization procedure.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/api/Azure.ResourceManager.LargeInstance.netstandard2.0.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/api/Azure.ResourceManager.LargeInstance.netstandard2.0.cs
@@ -30,6 +30,7 @@ namespace Azure.ResourceManager.LargeInstance
         public string ProximityPlacementGroup { get { throw null; } }
         public Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProfile StorageProfile { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.LargeInstanceData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.LargeInstanceData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.LargeInstanceData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.LargeInstanceData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.LargeInstanceData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -102,6 +103,7 @@ namespace Azure.ResourceManager.LargeInstance
         public Azure.Core.AzureLocation Location { get { throw null; } }
         public Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProperties StorageProperties { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.LargeStorageInstanceData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.LargeStorageInstanceData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.LargeStorageInstanceData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.LargeStorageInstanceData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.LargeStorageInstanceData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -181,6 +183,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
         public int? DiskSizeGB { get { throw null; } }
         public int? Lun { get { throw null; } }
         public string Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceDisk System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceDisk>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceDisk>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceDisk System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceDisk>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -209,6 +212,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
     {
         public LargeInstanceForceState() { }
         public Azure.ResourceManager.LargeInstance.Models.LargeInstanceForcePowerState? ForceState { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceForceState System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceForceState>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceForceState>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceForceState System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceForceState>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -220,6 +224,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
         internal LargeInstanceHardwareProfile() { }
         public Azure.ResourceManager.LargeInstance.Models.LargeInstanceSizeName? AzureLargeInstanceSize { get { throw null; } }
         public Azure.ResourceManager.LargeInstance.Models.LargeInstanceHardwareTypeName? HardwareType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceHardwareProfile System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceHardwareProfile>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceHardwareProfile>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceHardwareProfile System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceHardwareProfile>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -249,6 +254,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
     {
         internal LargeInstanceIPAddress() { }
         public string IPAddress { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceIPAddress System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceIPAddress>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceIPAddress>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceIPAddress System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceIPAddress>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -260,6 +266,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
         internal LargeInstanceNetworkProfile() { }
         public string CircuitId { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.LargeInstance.Models.LargeInstanceIPAddress> NetworkInterfaces { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceNetworkProfile System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceNetworkProfile>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceNetworkProfile>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceNetworkProfile System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceNetworkProfile>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -278,6 +285,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
         public Azure.Core.ResourceIdentifier ResourceId { get { throw null; } }
         public System.DateTimeOffset? StartOn { get { throw null; } }
         public string Status { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceOperationStatusResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceOperationStatusResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceOperationStatusResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceOperationStatusResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceOperationStatusResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -291,6 +299,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
         public string OSType { get { throw null; } }
         public string SshPublicKey { get { throw null; } }
         public string Version { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceOSProfile System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceOSProfile>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceOSProfile>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceOSProfile System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceOSProfile>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -301,6 +310,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
     {
         public LargeInstancePatch() { }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstancePatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstancePatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstancePatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstancePatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstancePatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -419,6 +429,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
         internal LargeInstanceStorageBillingProperties() { }
         public string BillingMode { get { throw null; } }
         public string Sku { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageBillingProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageBillingProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageBillingProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageBillingProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageBillingProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -430,6 +441,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
         internal LargeInstanceStorageProfile() { }
         public string NfsIPAddress { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.LargeInstance.Models.LargeInstanceDisk> OSDisks { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProfile System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProfile>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProfile>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProfile System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProfile>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -446,6 +458,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
         public Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageBillingProperties StorageBillingProperties { get { throw null; } }
         public string StorageType { get { throw null; } }
         public string WorkloadType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeInstanceStorageProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -456,6 +469,7 @@ namespace Azure.ResourceManager.LargeInstance.Models
     {
         public LargeStorageInstancePatch() { }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeStorageInstancePatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeStorageInstancePatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.LargeInstance.Models.LargeStorageInstancePatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.LargeInstance.Models.LargeStorageInstancePatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.LargeInstance.Models.LargeStorageInstancePatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/LargeInstanceData.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/LargeInstanceData.Serialization.cs
@@ -21,13 +21,22 @@ namespace Azure.ResourceManager.LargeInstance
 
         void IJsonModel<LargeInstanceData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -41,26 +50,6 @@ namespace Azure.ResourceManager.LargeInstance
             }
             writer.WritePropertyName("location"u8);
             writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(HardwareProfile))
@@ -112,22 +101,6 @@ namespace Azure.ResourceManager.LargeInstance
             {
                 writer.WritePropertyName("provisioningState"u8);
                 writer.WriteStringValue(ProvisioningState.Value.ToString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/LargeStorageInstanceData.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/LargeStorageInstanceData.Serialization.cs
@@ -21,13 +21,22 @@ namespace Azure.ResourceManager.LargeInstance
 
         void IJsonModel<LargeStorageInstanceData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeStorageInstanceData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeStorageInstanceData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -41,26 +50,6 @@ namespace Azure.ResourceManager.LargeInstance
             }
             writer.WritePropertyName("location"u8);
             writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(AzureLargeStorageInstanceUniqueIdentifier))
@@ -72,22 +61,6 @@ namespace Azure.ResourceManager.LargeInstance
             {
                 writer.WritePropertyName("storageProperties"u8);
                 writer.WriteObjectValue(StorageProperties, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/AzureLargeInstanceListResult.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/AzureLargeInstanceListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<AzureLargeInstanceListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AzureLargeInstanceListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AzureLargeInstanceListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("value"u8);
             writer.WriteStartArray();
             foreach (var item in Value)
@@ -53,7 +61,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AzureLargeInstanceListResult IJsonModel<AzureLargeInstanceListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/AzureLargeStorageInstanceListResult.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/AzureLargeStorageInstanceListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<AzureLargeStorageInstanceListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AzureLargeStorageInstanceListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AzureLargeStorageInstanceListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("value"u8);
             writer.WriteStartArray();
             foreach (var item in Value)
@@ -53,7 +61,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AzureLargeStorageInstanceListResult IJsonModel<AzureLargeStorageInstanceListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceDisk.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceDisk.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceDisk>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceDisk>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceDisk)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceDisk IJsonModel<LargeInstanceDisk>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceForceState.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceForceState.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceForceState>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceForceState>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceForceState)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ForceState))
             {
                 writer.WritePropertyName("forceState"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceForceState IJsonModel<LargeInstanceForceState>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceHardwareProfile.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceHardwareProfile.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceHardwareProfile>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceHardwareProfile>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceHardwareProfile)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(HardwareType))
             {
                 writer.WritePropertyName("hardwareType"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceHardwareProfile IJsonModel<LargeInstanceHardwareProfile>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceIPAddress.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceIPAddress.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceIPAddress>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceIPAddress>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceIPAddress)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(IPAddress))
             {
                 writer.WritePropertyName("ipAddress"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceIPAddress IJsonModel<LargeInstanceIPAddress>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceNetworkProfile.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceNetworkProfile.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceNetworkProfile>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceNetworkProfile>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceNetworkProfile)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(NetworkInterfaces))
             {
                 writer.WritePropertyName("networkInterfaces"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceNetworkProfile IJsonModel<LargeInstanceNetworkProfile>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceOSProfile.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceOSProfile.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceOSProfile>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceOSProfile>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceOSProfile)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ComputerName))
             {
                 writer.WritePropertyName("computerName"u8);
@@ -61,7 +69,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceOSProfile IJsonModel<LargeInstanceOSProfile>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceOperationStatusResult.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceOperationStatusResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceOperationStatusResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceOperationStatusResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceOperationStatusResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
@@ -88,7 +96,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceOperationStatusResult IJsonModel<LargeInstanceOperationStatusResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstancePatch.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstancePatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstancePatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstancePatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstancePatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstancePatch IJsonModel<LargeInstancePatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceStorageBillingProperties.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceStorageBillingProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceStorageBillingProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceStorageBillingProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceStorageBillingProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(BillingMode))
             {
                 writer.WritePropertyName("billingMode"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceStorageBillingProperties IJsonModel<LargeInstanceStorageBillingProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceStorageProfile.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceStorageProfile.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceStorageProfile>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceStorageProfile>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceStorageProfile)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(NfsIPAddress))
             {
                 writer.WritePropertyName("nfsIpAddress"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceStorageProfile IJsonModel<LargeInstanceStorageProfile>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceStorageProperties.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeInstanceStorageProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeInstanceStorageProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeInstanceStorageProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeInstanceStorageProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
             {
                 writer.WritePropertyName("provisioningState"u8);
@@ -76,7 +84,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeInstanceStorageProperties IJsonModel<LargeInstanceStorageProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeStorageInstancePatch.Serialization.cs
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/Generated/Models/LargeStorageInstancePatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.LargeInstance.Models
 
         void IJsonModel<LargeStorageInstancePatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LargeStorageInstancePatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LargeStorageInstancePatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.LargeInstance.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LargeStorageInstancePatch IJsonModel<LargeStorageInstancePatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/autorest.md
+++ b/sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance/src/autorest.md
@@ -17,6 +17,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 #mgmt-debug:
 #  show-serialized-names: true


### PR DESCRIPTION
We need to enable WriteCore feature to azurelargeinstance. Therefore add `use-write-core: true` and do a regen.