### PR TITLE
[Schema Registry] SchemaFormat alignment and release prep

### DIFF
--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/CHANGELOG.md
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/CHANGELOG.md
@@ -1,14 +1,8 @@
 # Release History
 
-## 1.4.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+## 1.4.0 (2024-09-17)
+- General availability of JSON and Custom schema formats.
+- General availability of `SchemRegistrySerializer`
 
 ## 1.4.0-beta.2 (2023-08-08)
 

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/CHANGELOG.md
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
 ## 1.4.0 (2024-09-17)
+
+### Features Added
+
 - General availability of JSON and Custom schema formats.
 - General availability of `SchemRegistrySerializer`
 

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/assets.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/schemaregistry/Azure.Data.SchemaRegistry",
-  "Tag": "net/schemaregistry/Azure.Data.SchemaRegistry_9445b56920"
+  "Tag": "net/schemaregistry/Azure.Data.SchemaRegistry_a754283886"
 }

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/assets.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/schemaregistry/Azure.Data.SchemaRegistry",
-  "Tag": "net/schemaregistry/Azure.Data.SchemaRegistry_4b3f12dd0e"
+  "Tag": "net/schemaregistry/Azure.Data.SchemaRegistry_9445b56920"
 }

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/Azure.Data.SchemaRegistry.csproj
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/Azure.Data.SchemaRegistry.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Azure Schema Registry SDK</Description>
     <AssemblyTitle>Azure Schema Registry SDK</AssemblyTitle>
-    <Version>1.4.0-beta.3</Version>
+    <Version>1.4.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageTags>Azure;Schema Registry;SchemaRegistry;.NET;Data;$(PackageCommonTags)</PackageTags>

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaFormat.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaFormat.cs
@@ -33,8 +33,7 @@ namespace Azure.Data.SchemaRegistry
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         /// <remarks>
         /// If using a schema format that is unsupported by this client, upgrade to a
-        /// version that supports the schema format. Otherwise, the content MIME type
-        /// string will be returned as the `format` value in the `properties` of the returned Schema.
+        /// version that supports the schema format.
         /// </remarks>
         public SchemaFormat(string value)
         {

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaFormat.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaFormat.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Xml.Schema;
 using Azure.Core;
 
 namespace Azure.Data.SchemaRegistry
@@ -30,19 +31,31 @@ namespace Azure.Data.SchemaRegistry
 
         /// <summary> Initializes a new instance of <see cref="SchemaFormat"/>. </summary>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
+        /// <remarks>
+        /// If using a schema format that is unsupported by this client, upgrade to a
+        /// version that supports the schema format. Otherwise, the content MIME type
+        /// string will be returned as the `format` value in the `properties` of the returned Schema.
+        /// </remarks>
         public SchemaFormat(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
+            ContentType = _value == CustomValue ? CustomContentType : $"application/json; serialization={value}";
+        }
+
+        private SchemaFormat(string value, string contentType)
+        {
+            _value = value;
+            ContentType = contentType;
         }
 
         /// <summary> Avro Serialization schema type. </summary>
-        public static SchemaFormat Avro { get; } = new SchemaFormat(AvroValue);
+        public static SchemaFormat Avro { get; } = new SchemaFormat(AvroValue, AvroContentType);
 
         /// <summary> JSON Serialization schema type. </summary>
-        public static SchemaFormat Json { get; } = new SchemaFormat(JsonValue);
+        public static SchemaFormat Json { get; } = new SchemaFormat(JsonValue, JsonContentType);
 
         /// <summary> Custom Serialization schema type. </summary>
-        public static SchemaFormat Custom { get; } = new SchemaFormat(CustomValue);
+        public static SchemaFormat Custom { get; } = new SchemaFormat(CustomValue, CustomContentType);
 
         ///// <summary> Protobuf Serialization schema type. </summary>
         //public static SchemaFormat Protobuf { get; } = new SchemaFormat(ProtobufValue);
@@ -66,20 +79,7 @@ namespace Azure.Data.SchemaRegistry
         /// <inheritdoc />
         public override string ToString() => _value;
 
-        internal ContentType ToContentType()
-        {
-            switch (_value)
-            {
-                case AvroValue:
-                    return new ContentType(AvroContentType);
-                case JsonValue:
-                    return new ContentType(JsonContentType);
-                //case ProtobufValue:
-                //    return new ContentType(ProtobufContentType);
-                default:
-                    return new ContentType(CustomContentType);
-            }
-        }
+        internal string ContentType { get; }
 
         internal static SchemaFormat FromContentType(string contentTypeValue)
         {

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaRegistryClient.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaRegistryClient.cs
@@ -109,6 +109,12 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="format">The serialization format of the schema.</param>
         /// <param name="cancellationToken">The cancellation token for the operation.</param>
         /// <returns>The properties of the schema.</returns>
+        /// <remarks>
+        /// If using a schema format that is unsupported by this client, upgrade to a
+        /// version that supports the schema format. Otherwise, the content MIME type
+        /// string will be returned as the value of the <see cref="SchemaProperties.Format"/>
+        /// for the returned Schema.
+        /// </remarks>
         public virtual Response<SchemaProperties> RegisterSchema(
             string groupName,
             string schemaName,
@@ -165,6 +171,12 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="format">The serialization format of the schema.</param>
         /// <param name="cancellationToken">The cancellation token for the operation.</param>
         /// <returns>The properties of the schema, including the schema ID provided by the service.</returns>
+        /// <remarks>
+        /// If using a schema format that is unsupported by this client, upgrade to a
+        /// version that supports the schema format. Otherwise, the content MIME type
+        /// string will be returned as the value of the <see cref="SchemaProperties.Format"/>
+        /// for the returned Schema.
+        /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual async Task<Response<SchemaProperties>> GetSchemaPropertiesAsync(
             string groupName,
@@ -185,6 +197,12 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="format">The serialization format of the schema.</param>
         /// <param name="cancellationToken">The cancellation token for the operation.</param>
         /// <returns>The properties of the schema, including the schema ID provided by the service.</returns>
+        /// <remarks>
+        /// If using a schema format that is unsupported by this client, upgrade to a
+        /// version that supports the schema format. Otherwise, the content MIME type
+        /// string will be returned as the value of the <see cref="SchemaProperties.Format"/>
+        /// for the returned Schema.
+        /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual Response<SchemaProperties> GetSchemaProperties(
             string groupName,
@@ -239,6 +257,12 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="schemaId">The schema ID of the the schema from the SchemaRegistry.</param>
         /// <param name="cancellationToken">The cancellation token for the operation.</param>
         /// <returns>The properties of the schema, including the schema content provided by the service.</returns>
+        /// <remarks>
+        /// If using a schema format that is unsupported by this client, upgrade to a
+        /// version that supports the schema format. Otherwise, the content MIME type
+        /// string will be returned as the value of the <see cref="SchemaProperties.Format"/>
+        /// for the returned <see cref="SchemaRegistrySchema.Properties"/>.
+        /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual async Task<Response<SchemaRegistrySchema>> GetSchemaAsync(string schemaId, CancellationToken cancellationToken = default) =>
 #pragma warning restore AZC0015 // Unexpected client method return type.
@@ -252,6 +276,12 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="schemaVersion"> Version number of specific schema. </param>
         /// <param name="cancellationToken">The cancellation token for the operation.</param>
         /// <returns>The properties of the schema, including the schema content provided by the service.</returns>
+        /// <remarks>
+        /// If using a schema format that is unsupported by this client, upgrade to a
+        /// version that supports the schema format. Otherwise, the content MIME type
+        /// string will be returned as the value of the <see cref="SchemaProperties.Format"/>
+        /// for the returned <see cref="SchemaRegistrySchema.Properties"/>.
+        /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual async Task<Response<SchemaRegistrySchema>> GetSchemaAsync(string groupName, string schemaName, int schemaVersion, CancellationToken cancellationToken = default) =>
 #pragma warning restore AZC0015 // Unexpected client method return type.
@@ -263,6 +293,12 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="schemaId">The schema ID of the the schema from the SchemaRegistry.</param>
         /// <param name="cancellationToken">The cancellation token for the operation.</param>
         /// <returns>The properties of the schema, including the schema content provided by the service.</returns>
+        /// <remarks>
+        /// If using a schema format that is unsupported by this client, upgrade to a
+        /// version that supports the schema format. Otherwise, the content MIME type
+        /// string will be returned as the value of the <see cref="SchemaProperties.Format"/>
+        /// for the returned <see cref="SchemaRegistrySchema.Properties"/>.
+        /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual Response<SchemaRegistrySchema> GetSchema(string schemaId, CancellationToken cancellationToken = default) =>
 #pragma warning restore AZC0015 // Unexpected client method return type.
@@ -276,6 +312,12 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="schemaVersion"> Version number of specific schema. </param>
         /// <param name="cancellationToken">The cancellation token for the operation.</param>
         /// <returns>The properties of the schema, including the schema content provided by the service.</returns>
+        /// <remarks>
+        /// If using a schema format that is unsupported by this client, upgrade to a
+        /// version that supports the schema format. Otherwise, the content MIME type
+        /// string will be returned as the value of the <see cref="SchemaProperties.Format"/>
+        /// for the returned <see cref="SchemaRegistrySchema.Properties"/>.
+        /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual Response<SchemaRegistrySchema> GetSchema(string groupName, string schemaName, int schemaVersion, CancellationToken cancellationToken = default) =>
 #pragma warning restore AZC0015 // Unexpected client method return type.

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaRegistryClient.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaRegistryClient.cs
@@ -133,11 +133,11 @@ namespace Azure.Data.SchemaRegistry
                 Response response;
                 if (async)
                 {
-                    response = await RegisterSchemaAsync(groupName, schemaName, new BinaryData(schemaDefinition), format.ToContentType(), cancellationToken).ConfigureAwait(false);
+                    response = await RegisterSchemaAsync(groupName, schemaName, new BinaryData(schemaDefinition), format.ContentType, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    response = RegisterSchema(groupName, schemaName, new BinaryData(schemaDefinition), format.ToContentType(), cancellationToken);
+                    response = RegisterSchema(groupName, schemaName, new BinaryData(schemaDefinition), format.ContentType, cancellationToken);
                 }
 
                 var schemaIdHeader = response.Headers.TryGetValue("Schema-Id", out string idHeader) ? idHeader : null;
@@ -210,11 +210,11 @@ namespace Azure.Data.SchemaRegistry
                 Response response;
                 if (async)
                 {
-                    response = await GetSchemaPropertiesByContentAsync(groupName, schemaName, new BinaryData(schemaDefinition), format.ToContentType().ToString(), cancellationToken).ConfigureAwait(false);
+                    response = await GetSchemaPropertiesByContentAsync(groupName, schemaName, new BinaryData(schemaDefinition), format.ContentType, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    response = GetSchemaPropertiesByContent(groupName, schemaName, new BinaryData(schemaDefinition), format.ToContentType(), cancellationToken);
+                    response = GetSchemaPropertiesByContent(groupName, schemaName, new BinaryData(schemaDefinition), format.ContentType, cancellationToken);
                 }
 
                 var schemaIdHeader = response.Headers.TryGetValue("Schema-Id", out string idHeader) ? idHeader : null;
@@ -290,11 +290,13 @@ namespace Azure.Data.SchemaRegistry
                 Response<BinaryData> response;
                 if (async)
                 {
-                    response = await GetSchemaByVersionAsync(groupName, schemaName, version, SchemaFormat.Avro.ToContentType().ToString(), cancellationToken).ConfigureAwait(false);
+                    // The generated client expects an "accept" header, which should be the Avro content type
+                    response = await GetSchemaByVersionAsync(groupName, schemaName, version, SchemaFormat.Avro.ContentType, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    response = GetSchemaByVersion(groupName, schemaName, version, SchemaFormat.Avro.ToContentType().ToString(), cancellationToken);
+                    // The generated client expects an "accept" header, which should be the Avro content type
+                    response = GetSchemaByVersion(groupName, schemaName, version, SchemaFormat.Avro.ContentType, cancellationToken);
                 }
 
                 var schemaIdHeader = response.GetRawResponse().Headers.TryGetValue("Schema-Id", out string idHeader) ? idHeader : null;
@@ -324,11 +326,11 @@ namespace Azure.Data.SchemaRegistry
                 Response<BinaryData> response;
                 if (async)
                 {
-                    response = await GetSchemaByIdAsync(schemaId, SchemaFormat.Avro.ToContentType().ToString(), cancellationToken).ConfigureAwait(false);
+                    response = await GetSchemaByIdAsync(schemaId, SchemaFormat.Avro.ContentType, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    response = GetSchemaById(schemaId, SchemaFormat.Avro.ToContentType().ToString(), cancellationToken);
+                    response = GetSchemaById(schemaId, SchemaFormat.Avro.ContentType, cancellationToken);
                 }
 
                 var schemaIdHeader = response.GetRawResponse().Headers.TryGetValue("Schema-Id", out string idHeader) ? idHeader : null;

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SchemaFormatTests.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SchemaFormatTests.cs
@@ -46,25 +46,25 @@ namespace Azure.Data.SchemaRegistry.Tests
         [Test]
         public void VerifyAvroToContentType()
         {
-            Assert.AreEqual(AvroContentType, SchemaFormat.Avro.ToContentType());
+            Assert.AreEqual(AvroContentType, SchemaFormat.Avro.ContentType);
         }
 
         [Test]
         public void VerifyJsonToContentType()
         {
-            Assert.AreEqual(JsonContentType, SchemaFormat.Json.ToContentType());
+            Assert.AreEqual(JsonContentType, SchemaFormat.Json.ContentType);
         }
 
         [Test]
         public void VerifyCustomToContentType()
         {
-            Assert.AreEqual(CustomContentType, SchemaFormat.Custom.ToContentType());
+            Assert.AreEqual(CustomContentType, SchemaFormat.Custom.ContentType);
         }
 
         [Test]
         public void VerifyDefaultToContentType()
         {
-            Assert.AreEqual(CustomContentType, (new SchemaFormat("MyValue")).ToContentType());
+            Assert.AreEqual("application/json; serialization=MyValue", (new SchemaFormat("MyValue")).ContentType);
         }
 
         //[Test]

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SchemaRegistryClientLiveTests.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SchemaRegistryClientLiveTests.cs
@@ -229,8 +229,8 @@ namespace Azure.Data.SchemaRegistry.Tests
             var format = new SchemaFormat("UnknownType");
             Assert.That(
                 async () => await client.GetSchemaPropertiesAsync(groupName, schemaName, "Hello", format),
-                Throws.InstanceOf<RequestFailedException>().And.Property(nameof(RequestFailedException.Status)).EqualTo(404)
-                    .And.Property(nameof(RequestFailedException.ErrorCode)).EqualTo("ItemNotFound"));
+                Throws.InstanceOf<RequestFailedException>().And.Property(nameof(RequestFailedException.Status)).EqualTo(415)
+                    .And.Property(nameof(RequestFailedException.ErrorCode)).EqualTo("InvalidSchemaType"));
         }
 
         [RecordedTest]


### PR DESCRIPTION
Adjusts Content-Type header to align with both other languages and previous GA releases. An unknown format will now map to a Content-Type header of $"application/json; serialization={value}" on a request, value being the string value passed into the SchemaFormat ctor. This aligns with the 1.3.0 release of Azure.Data.SchemaRegistry, as well as the implementations in Python and JS. If an unknown schema format is returned by the service, the value of the Content-Type header is used as the SchemaFormat value.

Also added docs to clarify behavior when a schema is returned from the service with an unknown schema content type.