### PR TITLE
Fix cref to Azure.Core.Pipeline.RetryPolicy

### DIFF
--- a/sdk/core/Azure.Core/src/ClientOptions.cs
+++ b/sdk/core/Azure.Core/src/ClientOptions.cs
@@ -93,7 +93,7 @@ namespace Azure.Core
 
         /// <summary>
         /// Gets or sets the policy to use for retries. If a policy is specified, it will be used in place of the <see cref="Retry"/> property.
-        /// The <see cref="RetryPolicy"/> type can be derived from to modify the default behavior without needing to fully implement the retry logic.
+        /// The <see cref="Pipeline.RetryPolicy"/> type can be derived from to modify the default behavior without needing to fully implement the retry logic.
         /// If <see cref="RetryPolicy.Process"/> is overridden or a custom <see cref="HttpPipelinePolicy"/> is specified,
         /// it is the implementer's responsibility to update the <see cref="HttpMessage.ProcessingContext"/> values.
         /// </summary>


### PR DESCRIPTION
It looks like the docs for [`ClientOptions.RetryPolicy`](https://learn.microsoft.com/en-us/dotnet/api/azure.core.clientoptions.retrypolicy?view=azure-dotnet#azure-core-clientoptions-retrypolicy) are referring to property `Azure.Core.ClientOptions.RetryPolicy` when what was probably intended was type [`Azure.Core.Pipeline.RetryPolicy`](https://learn.microsoft.com/en-us/dotnet/api/azure.core.pipeline.retrypolicy?view=azure-dotnet).

Before, the cref was just to simple name `RetryPolicy`, and since the property was in a nearer scope than the type, the property was picked. Now, we use name `Pipeline.RetryPolicy`, and since we are within declaration of namespace `Azure.Core`, `Pipeline` binds to the namespace we want and we get the type we want.
