### PR TITLE
Core `TransferManager` tests

### DIFF
--- a/sdk/storage/Azure.Storage.Common/tests/Shared/MockExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/MockExtensions.cs
@@ -62,5 +62,17 @@ namespace Azure.Storage
                     .Throws<NotSupportedException>();
             }
         }
+
+        public static void VerifyDisposal<T>(this Mock<T> mock)
+            where T : class, IDisposable
+        {
+            mock.Verify(m => m.Dispose(), Times.Once);
+        }
+
+        public static void VerifyAsyncDisposal<T>(this Mock<T> mock)
+            where T : class, IAsyncDisposable
+        {
+            mock.Verify(m => m.DisposeAsync(), Times.Once);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/ChannelProcessing.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ChannelProcessing.cs
@@ -7,9 +7,10 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Azure.Storage.Common;
-using static Azure.Storage.DataMovement.ChannelProcessing;
 
 namespace Azure.Storage.DataMovement;
+
+internal delegate Task ProcessAsync<T>(T item, CancellationToken cancellationToken);
 
 internal interface IProcessor<TItem> : IDisposable
 {
@@ -19,8 +20,6 @@ internal interface IProcessor<TItem> : IDisposable
 
 internal static class ChannelProcessing
 {
-    public delegate Task ProcessAsync<T>(T item, CancellationToken cancellationToken);
-
     public static IProcessor<T> NewProcessor<T>(int parallelism)
     {
         Argument.AssertInRange(parallelism, 1, int.MaxValue, nameof(parallelism));

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobBuilder.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobBuilder.cs
@@ -11,7 +11,7 @@ namespace Azure.Storage.DataMovement;
 
 internal class JobBuilder
 {
-    internal readonly ArrayPool<byte> _arrayPool;
+    private readonly ArrayPool<byte> _arrayPool;
 
     /// <summary>
     /// Defines the error handling method to follow when an error is seen. Defaults to
@@ -19,9 +19,15 @@ internal class JobBuilder
     ///
     /// See <see cref="DataTransferErrorMode"/>.
     /// </summary>
-    internal readonly DataTransferErrorMode _errorHandling;
+    private readonly DataTransferErrorMode _errorHandling;
 
-    internal ClientDiagnostics ClientDiagnostics { get; }
+    private ClientDiagnostics ClientDiagnostics { get; }
+
+    /// <summary>
+    /// Mocking constructor.
+    /// </summary>
+    protected JobBuilder()
+    { }
 
     internal JobBuilder(
         ArrayPool<byte> arrayPool,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Azure.Storage.DataMovement.Tests.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Azure.Storage.DataMovement.Tests.csproj
@@ -31,8 +31,8 @@
     <Compile Include="$(AzureStorageSharedTestSources)\**\*.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobsClientTestFixtureAttribute.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\DisposingContainer.cs" LinkBase="Shared\Storage" />
-    <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteFixture.cs"/>
-    <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteNUnitFixture.cs"/>
+    <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteFixture.cs" />
+    <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteNUnitFixture.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\ClientSideEncryptionTestExtensions.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\StorageTestBase.SasVersion.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\TransferValidationTestBase.cs" />

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Models/StepProcessor.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Models/StepProcessor.cs
@@ -3,10 +3,9 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
-namespace Azure.Storage.DataMovement.Tests.Models
+namespace Azure.Storage.DataMovement.Tests
 {
     /// <summary>
     /// Processor that only processes items one by one from

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Models/StepProcessor.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Models/StepProcessor.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.DataMovement.Tests.Models
+{
+    /// <summary>
+    /// Processor that only processes items one by one from
+    /// its queue only when invoked for each item.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class StepProcessor<T> : IProcessor<T>
+    {
+        private readonly Queue<T> _queue = new();
+
+        public int ItemsInQueue => _queue.Count;
+
+        /// <inheritdoc/>
+        public ProcessAsync<T> Process { get; set; }
+
+        /// <inheritdoc/>
+        public ValueTask QueueAsync(T item, CancellationToken cancellationToken = default)
+        {
+            _queue.Enqueue(item);
+            return new(Task.CompletedTask);
+        }
+
+        /// <summary>
+        /// Attmpts to read an item from internal queue, then completes
+        /// a call to <see cref="Process"/> on it.
+        /// </summary>
+        /// <returns>
+        /// Whether or not an item was successfully read from the queue.
+        /// </returns>
+        public async ValueTask<bool> TryStepAsync(CancellationToken cancellationToken = default)
+        {
+            if (_queue.Count > 0)
+            {
+                await Process?.Invoke(_queue.Dequeue(), cancellationToken);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public async ValueTask<int> StepMany(int maxSteps, CancellationToken cancellationToken = default)
+        {
+            int steps = 0;
+            while (steps < maxSteps && await TryStepAsync(cancellationToken))
+            {
+                steps++;
+            }
+            return steps;
+        }
+
+        public async ValueTask<int> StepAll(CancellationToken cancellationToken = default)
+        {
+            int steps = 0;
+            while (await TryStepAsync(cancellationToken))
+            {
+                steps++;
+            }
+            return steps;
+        }
+
+        public void Dispose()
+        { }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -12,10 +12,8 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.DataMovement.Tests.Models;
-using Castle.Core.Resource;
 using Moq;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 
 namespace Azure.Storage.DataMovement.Tests;
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -2,10 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Storage.DataMovement.Tests.Models;
 using Moq;
 using NUnit.Framework;
 
@@ -14,24 +19,250 @@ namespace Azure.Storage.DataMovement.Tests;
 internal class TransferManagerTests
 {
     [Test]
-    public void CtorConfiguresProcessors()
+    public async Task BasicProcessorLifetime()
     {
         Mock<IProcessor<TransferJobInternal>> jobsProcessor = new();
         Mock<IProcessor<JobPartInternal>> partsProcessor = new();
         Mock<IProcessor<Func<Task>>> chunksProcessor = new();
 
-        TransferManager _ = new(
+        await using (TransferManager _ = new(
             jobsProcessor.Object,
             partsProcessor.Object,
             chunksProcessor.Object,
-            default, default, default);
+            default, default, default))
+        {
+            jobsProcessor.VerifyTransferManagerCtorInvocations();
+            partsProcessor.VerifyTransferManagerCtorInvocations();
+            chunksProcessor.VerifyTransferManagerCtorInvocations();
 
-        jobsProcessor.VerifySet(p => p.Process = It.IsNotNull<ChannelProcessing.ProcessAsync<TransferJobInternal>>(), Times.Once());
-        partsProcessor.VerifySet(p => p.Process = It.IsNotNull<ChannelProcessing.ProcessAsync<JobPartInternal>>(), Times.Once());
-        chunksProcessor.VerifySet(p => p.Process = It.IsNotNull<ChannelProcessing.ProcessAsync<Func<Task>>>(), Times.Once());
+            jobsProcessor.VerifyNoOtherCalls();
+            partsProcessor.VerifyNoOtherCalls();
+            chunksProcessor.VerifyNoOtherCalls();
+        }
+        jobsProcessor.VerifyDisposal();
+        partsProcessor.VerifyDisposal();
+        chunksProcessor.VerifyDisposal();
 
         jobsProcessor.VerifyNoOtherCalls();
         partsProcessor.VerifyNoOtherCalls();
         chunksProcessor.VerifyNoOtherCalls();
     }
+
+    [Test]
+    [Combinatorial]
+    public async Task BasicItemTransfer(
+        [Values(1, 5)] int items,
+        [Values(333, 500, 1024)] int itemSize,
+        [Values(333, 1024)] int chunkSize)
+    {
+        int chunksPerPart = (int)Math.Ceiling((float)itemSize / chunkSize);
+        // TODO: below should be only `items * chunksPerPart` but can't in some cases due to
+        //       a bug in how work items are processed on multipart uploads.
+        int expectedChunksInQueue = Math.Max(chunksPerPart-1, 1) * items;
+
+        Uri srcUri = new("file:///foo/bar");
+        Uri dstUri = new("https://example.com/fizz/buzz");
+
+        StepProcessor<TransferJobInternal> jobsProcessor = new();
+        StepProcessor<JobPartInternal> partsProcessor = new();
+        StepProcessor<Func<Task>> chunksProcessor = new();
+        Mock<JobBuilder> jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
+        Mock<TransferCheckpointer> checkpointer = new();
+
+        var resources = Enumerable.Range(0, items)
+            .Select(_ =>
+            {
+                Mock<StorageResourceItem> srcResource = new(MockBehavior.Strict);
+                Mock<StorageResourceItem> dstResource = new(MockBehavior.Strict);
+
+                srcResource.Setup(r => r.Uri).Returns(srcUri);
+                dstResource.Setup(r => r.Uri).Returns(dstUri);
+
+                srcResource.SetupGet(r => r.ResourceId).Returns("Mock");
+                dstResource.SetupGet(r => r.ResourceId).Returns("Mock");
+
+                dstResource.SetupGet(r => r.TransferType).Returns(default(DataTransferOrder));
+                dstResource.SetupGet(r => r.MaxSupportedChunkSize).Returns(Constants.GB);
+
+                srcResource.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new StorageResourceItemProperties(resourceLength: itemSize, default, default, default)));
+
+                srcResource.Setup(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+                    .Returns<long, long?, CancellationToken>((position, length, cancellation)
+                        => Task.FromResult(new StorageResourceReadStreamResult(
+                            new Mock<Stream>().Object,
+                            new HttpRange(position, length),
+                            new(itemSize, default, default, new()))));
+                dstResource.Setup(r => r.CopyFromStreamAsync(
+                    It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<long>(),
+                    It.IsAny<StorageResourceWriteToOffsetOptions>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                dstResource.Setup(r => r.CompleteTransferAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<StorageResourceCompleteTransferOptions>(),
+                    It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+
+                return (Source: srcResource, Destination: dstResource);
+            }).ToList();
+
+        await using TransferManager transferManager = new(
+            jobsProcessor,
+            partsProcessor,
+            chunksProcessor,
+            jobBuilder.Object,
+            checkpointer.Object,
+            default);
+
+        List<DataTransfer> transfers = new();
+
+        // queue jobs
+        foreach ((Mock<StorageResourceItem> srcResource, Mock<StorageResourceItem> dstResource) in resources)
+        {
+            DataTransfer transfer = await transferManager.StartTransferAsync(
+                srcResource.Object,
+                dstResource.Object,
+                new()
+                {
+                    InitialTransferSize = chunkSize,
+                    MaximumTransferChunkSize = chunkSize,
+                });
+            Assert.That(transfer.HasCompleted, Is.False);
+            transfers.Add(transfer);
+
+            srcResource.VerifySourceResourceOnQueue();
+            dstResource.VerifyDestinationResourceOnQueue();
+            srcResource.VerifyNoOtherCalls();
+            dstResource.VerifyNoOtherCalls();
+        }
+        Assert.That(jobsProcessor.ItemsInQueue, Is.EqualTo(items), "Error during initial Job queueing.");
+
+        // process jobs
+        Assert.That(await jobsProcessor.StepAll(), Is.EqualTo(items));
+        Assert.That(jobsProcessor.ItemsInQueue, Is.EqualTo(0));
+        Assert.That(partsProcessor.ItemsInQueue, Is.EqualTo(items), "Error during Job => Part processing.");
+        foreach ((Mock<StorageResourceItem> srcResource, Mock<StorageResourceItem> dstResource) in resources)
+        {
+            srcResource.VerifySourceResourceOnJobProcess();
+            dstResource.VerifyDestinationResourceOnJobProcess();
+            srcResource.VerifyNoOtherCalls();
+            dstResource.VerifyNoOtherCalls();
+        }
+
+        // process parts
+        Assert.That(await partsProcessor.StepAll(), Is.EqualTo(items));
+        Assert.That(partsProcessor.ItemsInQueue, Is.EqualTo(0));
+        Assert.That(chunksProcessor.ItemsInQueue, Is.EqualTo(expectedChunksInQueue), "Error during Part => Chunk processing.");
+        foreach ((Mock<StorageResourceItem> srcResource, Mock<StorageResourceItem> dstResource) in resources)
+        {
+            srcResource.VerifySourceResourceOnPartProcess();
+            dstResource.VerifyDestinationResourceOnPartProcess();
+            srcResource.VerifyNoOtherCalls();
+            dstResource.VerifyNoOtherCalls();
+        }
+
+        // process chunks
+        Assert.That(await chunksProcessor.StepAll(), Is.EqualTo(expectedChunksInQueue));
+        Assert.That(chunksProcessor.ItemsInQueue, Is.EqualTo(0));
+        foreach ((Mock<StorageResourceItem> srcResource, Mock<StorageResourceItem> dstResource) in resources)
+        {
+            srcResource.VerifySourceResourceOnChunkProcess();
+            dstResource.VerifyDestinationResourceOnChunkProcess();
+            srcResource.VerifyNoOtherCalls();
+            dstResource.VerifyNoOtherCalls();
+        }
+
+        await Task.Delay(10); // TODO flaky that we need this; a random one will often fail without
+
+        foreach (DataTransfer transfer in transfers)
+        {
+            Assert.That(transfer.HasCompleted);
+        }
+    }
+
+    [Test]
+    public void StartContainerTransafer()
+    {
+        Assert.Fail();
+    }
+}
+
+internal static partial class MockExtensions
+{
+    public static void SetupQueueAsync<T>(this Mock<IProcessor<T>> processor, Action<T, CancellationToken> onQueue = default)
+    {
+        var setup = processor.Setup(p => p.QueueAsync(It.IsNotNull<T>(), It.IsNotNull<CancellationToken>()))
+            .Returns(new ValueTask(Task.CompletedTask));
+        if (onQueue != default)
+        {
+            setup.Callback(onQueue);
+        }
+    }
+
+    public static void VerifyTransferManagerCtorInvocations<T>(this Mock<IProcessor<T>> processor)
+    {
+        processor.VerifySet(p => p.Process = It.IsNotNull<ProcessAsync<T>>(), Times.Once());
+    }
+
+    #region StorageResource calls TransferManager processing stages
+    public static void VerifySourceResourceOnQueue(this Mock<StorageResourceItem> srcResource)
+    {
+        srcResource.VerifyGet(r => r.Uri);
+    }
+
+    public static void VerifyDestinationResourceOnQueue(this Mock<StorageResourceItem> dstResource)
+    {
+        dstResource.VerifyGet(r => r.Uri);
+    }
+
+    public static void VerifySourceResourceOnJobProcess(this Mock<StorageResourceItem> srcResource)
+    {
+        srcResource.VerifyGet(r => r.Uri);
+        srcResource.VerifyGet(r => r.ResourceId);
+    }
+
+    public static void VerifyDestinationResourceOnJobProcess(this Mock<StorageResourceItem> dstResource)
+    {
+        dstResource.VerifyGet(r => r.Uri);
+        dstResource.VerifyGet(r => r.ResourceId);
+        dstResource.VerifyGet(r => r.MaxSupportedChunkSize);
+    }
+
+    public static void VerifySourceResourceOnPartProcess(this Mock<StorageResourceItem> srcResource)
+    {
+        srcResource.Verify(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        // TODO: a bug in multipart uploading can result in the first chunk being uploaded at part process
+        // verify at most once to ensure there are no more than this bug.
+        srcResource.Verify(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()), Times.AtMostOnce);
+    }
+
+    public static void VerifyDestinationResourceOnPartProcess(this Mock<StorageResourceItem> dstResource)
+    {
+        dstResource.VerifyGet(r => r.TransferType, Times.AtMost(9999));
+        // TODO: a bug in multipart uploading can result in the first chunk being uploaded at part process
+        // verify at most once to ensure there are no more than this bug.
+        dstResource.Verify(r => r.CopyFromStreamAsync(
+            It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<long>(),
+            It.IsAny<StorageResourceWriteToOffsetOptions>(), It.IsAny<CancellationToken>()),
+            Times.AtMostOnce);
+    }
+
+    public static void VerifySourceResourceOnChunkProcess(this Mock<StorageResourceItem> srcResource)
+    {
+        srcResource.Verify(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    public static void VerifyDestinationResourceOnChunkProcess(this Mock<StorageResourceItem> dstResource)
+    {
+        dstResource.Verify(r => r.CopyFromStreamAsync(
+            It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<long>(),
+            It.IsAny<StorageResourceWriteToOffsetOptions>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+        dstResource.Verify(r => r.CompleteTransferAsync(
+            It.IsAny<bool>(),
+            It.IsAny<StorageResourceCompleteTransferOptions>(),
+            It.IsAny<CancellationToken>()),
+            Times.AtMostOnce); // TODO why don't we complete single part transfers?
+    }
+    #endregion
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -17,7 +17,7 @@ using NUnit.Framework;
 
 namespace Azure.Storage.DataMovement.Tests;
 
-internal class TransferManagerTests
+public class TransferManagerTests
 {
     [Test]
     public async Task BasicProcessorLifetime()

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -6,13 +6,16 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.DataMovement.Tests.Models;
+using Castle.Core.Resource;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace Azure.Storage.DataMovement.Tests;
 
@@ -69,42 +72,15 @@ internal class TransferManagerTests
         Mock<JobBuilder> jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
         Mock<TransferCheckpointer> checkpointer = new();
 
-        var resources = Enumerable.Range(0, items)
-            .Select(_ =>
-            {
-                Mock<StorageResourceItem> srcResource = new(MockBehavior.Strict);
-                Mock<StorageResourceItem> dstResource = new(MockBehavior.Strict);
+        var resources = Enumerable.Range(0, items).Select(_ =>
+        {
+            Mock<StorageResourceItem> srcResource = new(MockBehavior.Strict);
+            Mock<StorageResourceItem> dstResource = new(MockBehavior.Strict);
 
-                srcResource.Setup(r => r.Uri).Returns(srcUri);
-                dstResource.Setup(r => r.Uri).Returns(dstUri);
+            (srcResource, dstResource).BasicSetup(srcUri, dstUri, itemSize);
 
-                srcResource.SetupGet(r => r.ResourceId).Returns("Mock");
-                dstResource.SetupGet(r => r.ResourceId).Returns("Mock");
-
-                dstResource.SetupGet(r => r.TransferType).Returns(default(DataTransferOrder));
-                dstResource.SetupGet(r => r.MaxSupportedChunkSize).Returns(Constants.GB);
-
-                srcResource.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(new StorageResourceItemProperties(resourceLength: itemSize, default, default, default)));
-
-                srcResource.Setup(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
-                    .Returns<long, long?, CancellationToken>((position, length, cancellation)
-                        => Task.FromResult(new StorageResourceReadStreamResult(
-                            new Mock<Stream>().Object,
-                            new HttpRange(position, length),
-                            new(itemSize, default, default, new()))));
-                dstResource.Setup(r => r.CopyFromStreamAsync(
-                    It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<long>(),
-                    It.IsAny<StorageResourceWriteToOffsetOptions>(), It.IsAny<CancellationToken>()))
-                    .Returns(Task.CompletedTask);
-                dstResource.Setup(r => r.CompleteTransferAsync(
-                    It.IsAny<bool>(),
-                    It.IsAny<StorageResourceCompleteTransferOptions>(),
-                    It.IsAny<CancellationToken>()))
-                    .Returns(Task.CompletedTask);
-
-                return (Source: srcResource, Destination: dstResource);
-            }).ToList();
+            return (Source: srcResource, Destination: dstResource);
+        }).ToList();
 
         await using TransferManager transferManager = new(
             jobsProcessor,
@@ -172,7 +148,7 @@ internal class TransferManagerTests
             dstResource.VerifyNoOtherCalls();
         }
 
-        await Task.Delay(10); // TODO flaky that we need this; a random one will often fail without
+        await Task.Delay(20); // TODO flaky that we need this; a random one will often fail without
 
         foreach (DataTransfer transfer in transfers)
         {
@@ -181,9 +157,105 @@ internal class TransferManagerTests
     }
 
     [Test]
-    public void StartContainerTransafer()
+    [Combinatorial]
+    public async Task StartContainerTransafer(
+        [Values(1, 5)] int numJobs,
+        [Values(333, 500, 1024)] int itemSize,
+        [Values(333, 1024)] int chunkSize)
     {
-        Assert.Fail();
+        static int GetItemCountFromContainerIndex(int i) => i*i + 1;
+
+        int numJobParts = Enumerable.Range(1, numJobs).Select(GetItemCountFromContainerIndex).Sum();
+        int chunksPerPart = (int)Math.Ceiling((float)itemSize / chunkSize);
+        // TODO: below should be only `items * chunksPerPart` but can't in some cases due to
+        //       a bug in how work items are processed on multipart uploads.
+        int numChunks = Math.Max(chunksPerPart - 1, 1) * numJobParts;
+
+        Uri srcUri = new("file:///foo/bar");
+        Uri dstUri = new("https://example.com/fizz/buzz");
+
+        StepProcessor<TransferJobInternal> jobsProcessor = new();
+        StepProcessor<JobPartInternal> partsProcessor = new();
+        StepProcessor<Func<Task>> chunksProcessor = new();
+        Mock<JobBuilder> jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
+        Mock<TransferCheckpointer> checkpointer = new();
+
+        var resources = Enumerable.Range(1, numJobs).Select(i =>
+        {
+            Mock<StorageResourceContainer> srcResource = new(MockBehavior.Strict);
+            Mock<StorageResourceContainer> dstResource = new(MockBehavior.Strict);
+            (srcResource, dstResource).BasicSetup(srcUri, dstUri, GetItemCountFromContainerIndex(i), itemSize);
+            return (Source: srcResource, Destination: dstResource);
+        }).ToList();
+
+        await using TransferManager transferManager = new(
+            jobsProcessor,
+            partsProcessor,
+            chunksProcessor,
+            jobBuilder.Object,
+            checkpointer.Object,
+            default);
+
+        List<DataTransfer> transfers = new();
+
+        // queue jobs
+        foreach ((Mock<StorageResourceContainer> srcResource, Mock<StorageResourceContainer> dstResource) in resources)
+        {
+            DataTransfer transfer = await transferManager.StartTransferAsync(
+                srcResource.Object,
+                dstResource.Object,
+                new()
+                {
+                    InitialTransferSize = chunkSize,
+                    MaximumTransferChunkSize = chunkSize,
+                });
+            Assert.That(transfer.HasCompleted, Is.False);
+            transfers.Add(transfer);
+
+            srcResource.VerifySourceResourceOnQueue();
+            dstResource.VerifyDestinationResourceOnQueue();
+            srcResource.VerifyNoOtherCalls();
+            dstResource.VerifyNoOtherCalls();
+        }
+        Assert.That(jobsProcessor.ItemsInQueue, Is.EqualTo(numJobs), "Error during initial Job queueing.");
+
+        // process jobs
+        Assert.That(await jobsProcessor.StepAll(), Is.EqualTo(numJobs));
+        Assert.That(jobsProcessor.ItemsInQueue, Is.EqualTo(0));
+        Assert.That(partsProcessor.ItemsInQueue, Is.EqualTo(numJobParts), "Error during Job => Part processing.");
+        foreach ((Mock<StorageResourceContainer> srcResource, Mock<StorageResourceContainer> dstResource) in resources)
+        {
+            srcResource.VerifySourceResourceOnJobProcess();
+            dstResource.VerifyDestinationResourceOnJobProcess();
+            srcResource.VerifyNoOtherCalls();
+            dstResource.VerifyNoOtherCalls();
+        }
+
+        // process parts
+        Assert.That(await partsProcessor.StepAll(), Is.EqualTo(numJobParts));
+        Assert.That(partsProcessor.ItemsInQueue, Is.EqualTo(0));
+        Assert.That(chunksProcessor.ItemsInQueue, Is.EqualTo(numChunks), "Error during Part => Chunk processing.");
+        foreach ((Mock<StorageResourceContainer> srcResource, Mock<StorageResourceContainer> dstResource) in resources)
+        {
+            srcResource.VerifyNoOtherCalls();
+            dstResource.VerifyNoOtherCalls();
+        }
+
+        // process chunks
+        Assert.That(await chunksProcessor.StepAll(), Is.EqualTo(numChunks));
+        Assert.That(chunksProcessor.ItemsInQueue, Is.EqualTo(0));
+        foreach ((Mock<StorageResourceContainer> srcResource, Mock<StorageResourceContainer> dstResource) in resources)
+        {
+            srcResource.VerifyNoOtherCalls();
+            dstResource.VerifyNoOtherCalls();
+        }
+
+        await Task.Delay(10); // TODO flaky that we need this; a random one will often fail without
+
+        foreach (DataTransfer transfer in transfers)
+        {
+            Assert.That(transfer.HasCompleted);
+        }
     }
 }
 
@@ -197,6 +269,84 @@ internal static partial class MockExtensions
         {
             setup.Callback(onQueue);
         }
+    }
+
+    public static void BasicSetup(
+        this (Mock<StorageResourceItem> Source, Mock<StorageResourceItem> Destination) items,
+        Uri srcUri,
+        Uri dstUri,
+        int itemSize = Constants.KB
+        )
+    {
+        items.Source.Setup(r => r.Uri).Returns(srcUri);
+        items.Destination.Setup(r => r.Uri).Returns(dstUri);
+
+        items.Source.SetupGet(r => r.ResourceId).Returns("Mock");
+        items.Destination.SetupGet(r => r.ResourceId).Returns("Mock");
+
+        items.Destination.SetupGet(r => r.TransferType).Returns(default(DataTransferOrder));
+        items.Destination.SetupGet(r => r.MaxSupportedChunkSize).Returns(Constants.GB);
+
+        items.Source.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new StorageResourceItemProperties(resourceLength: itemSize, default, default, default)));
+
+        items.Source.Setup(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+            .Returns<long, long?, CancellationToken>((position, length, cancellation)
+                => Task.FromResult(new StorageResourceReadStreamResult(
+                    new Mock<Stream>().Object,
+                    new HttpRange(position, length),
+                    new(itemSize, default, default, new()))));
+        items.Destination.Setup(r => r.CopyFromStreamAsync(
+            It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<long>(),
+            It.IsAny<StorageResourceWriteToOffsetOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        items.Destination.Setup(r => r.CompleteTransferAsync(
+            It.IsAny<bool>(),
+            It.IsAny<StorageResourceCompleteTransferOptions>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    public static void BasicSetup(
+        this (Mock<StorageResourceContainer> Source, Mock<StorageResourceContainer> Destination) containers,
+        Uri srcUri,
+        Uri dstUri,
+        int numItems = 5,
+        int itemSize = Constants.KB
+        )
+    {
+        var subResources = Enumerable.Range(0, numItems).Select(_ =>
+        {
+            string name = "/" + Guid.NewGuid().ToString();
+            var items = (
+                Source: new Mock<StorageResourceItem>(MockBehavior.Strict),
+                Destination: new Mock<StorageResourceItem>(MockBehavior.Strict));
+            items.BasicSetup(new Uri(srcUri.ToString() + name), new Uri(dstUri.ToString() + name), itemSize);
+            items.Source.SetupGet(r => r.IsContainer).Returns(false);
+            return items;
+        }).ToList();
+
+        async IAsyncEnumerable<StorageResource> SubResourcesAsAsyncEnumerable(
+            StorageResourceContainer src,
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            foreach (int i in Enumerable.Range(0, numItems))
+            {
+                yield return await Task.FromResult(subResources[i].Source.Object);
+            }
+        }
+
+        containers.Source.SetupGet(r => r.Uri).Returns(srcUri);
+        containers.Destination.SetupGet(r => r.Uri).Returns(dstUri);
+
+        containers.Source.Setup(r => r.GetStorageResourcesAsync(It.IsAny<StorageResourceContainer>(), It.IsAny<CancellationToken>()))
+            .Returns(SubResourcesAsAsyncEnumerable);
+
+        containers.Destination.Setup(r => r.GetStorageResourceReference(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns<string, string>((path, resId) => subResources
+                .Where(pair => pair.Source.Object.Uri.AbsolutePath.Contains(path))
+                .FirstOrDefault().Destination?.Object
+            );
     }
 
     public static void VerifyTransferManagerCtorInvocations<T>(this Mock<IProcessor<T>> processor)
@@ -215,6 +365,16 @@ internal static partial class MockExtensions
         dstResource.VerifyGet(r => r.Uri);
     }
 
+    public static void VerifySourceResourceOnQueue(this Mock<StorageResourceContainer> srcResource)
+    {
+        srcResource.VerifyGet(r => r.Uri);
+    }
+
+    public static void VerifyDestinationResourceOnQueue(this Mock<StorageResourceContainer> dstResource)
+    {
+        dstResource.VerifyGet(r => r.Uri);
+    }
+
     public static void VerifySourceResourceOnJobProcess(this Mock<StorageResourceItem> srcResource)
     {
         srcResource.VerifyGet(r => r.Uri);
@@ -226,6 +386,21 @@ internal static partial class MockExtensions
         dstResource.VerifyGet(r => r.Uri);
         dstResource.VerifyGet(r => r.ResourceId);
         dstResource.VerifyGet(r => r.MaxSupportedChunkSize);
+    }
+
+    public static void VerifySourceResourceOnJobProcess(this Mock<StorageResourceContainer> srcResource)
+    {
+        srcResource.Verify(
+            r => r.GetStorageResourcesAsync(It.IsAny<StorageResourceContainer>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        srcResource.VerifyGet(r => r.Uri, Times.AtLeastOnce());
+    }
+
+    public static void VerifyDestinationResourceOnJobProcess(this Mock<StorageResourceContainer> dstResource)
+    {
+        dstResource.Verify(
+            r => r.GetStorageResourceReference(It.IsAny<string>(), It.IsAny<string>()),
+            Times.AtLeastOnce());
     }
 
     public static void VerifySourceResourceOnPartProcess(this Mock<StorageResourceItem> srcResource)

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Storage.DataMovement.Tests.Models;
 using Moq;
 using NUnit.Framework;
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -156,7 +156,7 @@ internal class TransferManagerTests
 
     [Test]
     [Combinatorial]
-    public async Task StartContainerTransafer(
+    public async Task BasicContainerTransfer(
         [Values(1, 5)] int numJobs,
         [Values(333, 500, 1024)] int itemSize,
         [Values(333, 1024)] int chunkSize)

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Storage.DataMovement.Tests;
+
+internal class TransferManagerTests
+{
+    [Test]
+    public void CtorConfiguresProcessors()
+    {
+        Mock<IProcessor<TransferJobInternal>> jobsProcessor = new();
+        Mock<IProcessor<JobPartInternal>> partsProcessor = new();
+        Mock<IProcessor<Func<Task>>> chunksProcessor = new();
+
+        TransferManager _ = new(
+            jobsProcessor.Object,
+            partsProcessor.Object,
+            chunksProcessor.Object,
+            default, default, default);
+
+        jobsProcessor.VerifySet(p => p.Process = It.IsNotNull<ChannelProcessing.ProcessAsync<TransferJobInternal>>(), Times.Once());
+        partsProcessor.VerifySet(p => p.Process = It.IsNotNull<ChannelProcessing.ProcessAsync<JobPartInternal>>(), Times.Once());
+        chunksProcessor.VerifySet(p => p.Process = It.IsNotNull<ChannelProcessing.ProcessAsync<Func<Task>>>(), Times.Once());
+
+        jobsProcessor.VerifyNoOtherCalls();
+        partsProcessor.VerifyNoOtherCalls();
+        chunksProcessor.VerifyNoOtherCalls();
+    }
+}


### PR DESCRIPTION
Add some happy path tests for the `TransferManager` with fully mocked out dependencies. More to come.

New `StepProcessor` to be injected into `TransferManager` during tests instead of the standard looping `ChannelProcessor`. Job, part, and chunk queues can be processed piece by piece, manually, in any order desired, allowing for deterministic and explicit flow of events during testing.

Misc changes
- Field privatization
- Constructor management for cleanliness and mocking
- Moved delegate for cleaner typing