### PR TITLE
Enable WriteCore feature for changeanalysis

### DIFF
--- a/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/CHANGELOG.md
+++ b/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
+- Exposed `JsonModelWriteCore` for model serialization procedure.
 
 ### Breaking Changes
 

--- a/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/api/Azure.ResourceManager.ChangeAnalysis.netstandard2.0.cs
+++ b/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/api/Azure.ResourceManager.ChangeAnalysis.netstandard2.0.cs
@@ -52,6 +52,7 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
         public System.Collections.Generic.IReadOnlyList<string> InitiatedByList { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.ChangeAnalysis.Models.PropertyChange> PropertyChanges { get { throw null; } }
         public Azure.Core.ResourceIdentifier ResourceId { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ChangeAnalysis.Models.ChangeProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ChangeAnalysis.Models.ChangeProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ChangeAnalysis.Models.ChangeProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ChangeAnalysis.Models.ChangeProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ChangeAnalysis.Models.ChangeProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -81,6 +82,7 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
     {
         internal DetectedChangeData() { }
         public Azure.ResourceManager.ChangeAnalysis.Models.ChangeProperties Properties { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ChangeAnalysis.Models.DetectedChangeData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ChangeAnalysis.Models.DetectedChangeData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ChangeAnalysis.Models.DetectedChangeData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ChangeAnalysis.Models.DetectedChangeData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ChangeAnalysis.Models.DetectedChangeData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -99,6 +101,7 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
         public Azure.ResourceManager.ChangeAnalysis.Models.PropertyChangeLevel? Level { get { throw null; } }
         public string NewValue { get { throw null; } }
         public string OldValue { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ChangeAnalysis.Models.PropertyChange System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ChangeAnalysis.Models.PropertyChange>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ChangeAnalysis.Models.PropertyChange>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ChangeAnalysis.Models.PropertyChange System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ChangeAnalysis.Models.PropertyChange>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/Generated/Models/ChangeList.Serialization.cs
+++ b/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/Generated/Models/ChangeList.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
 
         void IJsonModel<ChangeList>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ChangeList>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ChangeList)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ChangeList IJsonModel<ChangeList>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/Generated/Models/ChangeProperties.Serialization.cs
+++ b/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/Generated/Models/ChangeProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
 
         void IJsonModel<ChangeProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ChangeProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ChangeProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ResourceId))
             {
                 writer.WritePropertyName("resourceId"u8);
@@ -76,7 +84,6 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ChangeProperties IJsonModel<ChangeProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/Generated/Models/DetectedChangeData.Serialization.cs
+++ b/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/Generated/Models/DetectedChangeData.Serialization.cs
@@ -20,54 +20,27 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
 
         void IJsonModel<DetectedChangeData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DetectedChangeData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DetectedChangeData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Properties))
             {
                 writer.WritePropertyName("properties"u8);
                 writer.WriteObjectValue(Properties, options);
             }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         DetectedChangeData IJsonModel<DetectedChangeData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/Generated/Models/PropertyChange.Serialization.cs
+++ b/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/Generated/Models/PropertyChange.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
 
         void IJsonModel<PropertyChange>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PropertyChange>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PropertyChange)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ChangeType))
             {
                 writer.WritePropertyName("changeType"u8);
@@ -86,7 +94,6 @@ namespace Azure.ResourceManager.ChangeAnalysis.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PropertyChange IJsonModel<PropertyChange>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/autorest.md
+++ b/sdk/changeanalysis/Azure.ResourceManager.ChangeAnalysis/src/autorest.md
@@ -15,6 +15,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 override-operation-name:
   Changes_ListChangesByResourceGroup: GetChangesByResourceGroup


### PR DESCRIPTION
We need to enable WriteCore feature to changeanalysis. Therefore add `use-write-core: true` and do a regen.