### PR TITLE
Enable WriteCore feature for confidentialledger

### DIFF
--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Exposed `JsonModelWriteCore` for model serialization procedure.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/api/Azure.ResourceManager.ConfidentialLedger.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/api/Azure.ResourceManager.ConfidentialLedger.netstandard2.0.cs
@@ -21,6 +21,7 @@ namespace Azure.ResourceManager.ConfidentialLedger
     {
         public ConfidentialLedgerData(Azure.Core.AzureLocation location) { }
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerProperties Properties { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.ConfidentialLedgerData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.ConfidentialLedgerData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.ConfidentialLedgerData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.ConfidentialLedgerData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.ConfidentialLedgerData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -94,6 +95,7 @@ namespace Azure.ResourceManager.ConfidentialLedger
     {
         public ManagedCcfData(Azure.Core.AzureLocation location) { }
         public Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfProperties Properties { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.ManagedCcfData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.ManagedCcfData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.ManagedCcfData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.ManagedCcfData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.ManagedCcfData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -167,6 +169,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRoleName? LedgerRoleName { get { throw null; } set { } }
         public System.Guid? PrincipalId { get { throw null; } set { } }
         public System.Guid? TenantId { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.AadBasedSecurityPrincipal System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.AadBasedSecurityPrincipal>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.AadBasedSecurityPrincipal>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.AadBasedSecurityPrincipal System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.AadBasedSecurityPrincipal>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -192,6 +195,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public CertBasedSecurityPrincipal() { }
         public string Cert { get { throw null; } set { } }
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRoleName? LedgerRoleName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.CertBasedSecurityPrincipal System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.CertBasedSecurityPrincipal>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.CertBasedSecurityPrincipal>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.CertBasedSecurityPrincipal System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.CertBasedSecurityPrincipal>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -203,6 +207,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public ConfidentialLedgerBackupContent(System.Uri uri) { }
         public string RestoreRegion { get { throw null; } set { } }
         public System.Uri Uri { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -213,6 +218,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
     {
         internal ConfidentialLedgerBackupResult() { }
         public string Message { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerBackupResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -224,6 +230,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public ConfidentialLedgerDeploymentType() { }
         public System.Uri AppSourceUri { get { throw null; } set { } }
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerLanguageRuntime? LanguageRuntime { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerDeploymentType System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerDeploymentType>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerDeploymentType>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerDeploymentType System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerDeploymentType>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -254,6 +261,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public string Certificate { get { throw null; } set { } }
         public string Encryptionkey { get { throw null; } set { } }
         public System.BinaryData Tags { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerMemberIdentityCertificate System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerMemberIdentityCertificate>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerMemberIdentityCertificate>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerMemberIdentityCertificate System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerMemberIdentityCertificate>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -265,6 +273,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public ConfidentialLedgerNameAvailabilityContent() { }
         public string Name { get { throw null; } set { } }
         public Azure.Core.ResourceType? ResourceType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -277,6 +286,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public bool? IsNameAvailable { get { throw null; } }
         public string Message { get { throw null; } }
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameUnavailableReason? Reason { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerNameAvailabilityResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -314,6 +324,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public System.Uri LedgerUri { get { throw null; } }
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerProvisioningState? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRunningState? RunningState { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -349,6 +360,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public string FileShareName { get { throw null; } }
         public string RestoreRegion { get { throw null; } }
         public System.Uri Uri { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -359,6 +371,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
     {
         internal ConfidentialLedgerRestoreResult() { }
         public string Message { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRestoreResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -448,6 +461,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public ManagedCcfBackupContent(System.Uri uri) { }
         public string RestoreRegion { get { throw null; } set { } }
         public System.Uri Uri { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -458,6 +472,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
     {
         internal ManagedCcfBackupResult() { }
         public string Message { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfBackupResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -475,6 +490,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public int? NodeCount { get { throw null; } set { } }
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerProvisioningState? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.ConfidentialLedger.Models.ConfidentialLedgerRunningState? RunningState { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -487,6 +503,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
         public string FileShareName { get { throw null; } }
         public string RestoreRegion { get { throw null; } }
         public System.Uri Uri { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -497,6 +514,7 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
     {
         internal ManagedCcfRestoreResult() { }
         public string Message { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ConfidentialLedger.Models.ManagedCcfRestoreResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/assets.json
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/confidentialledger/Azure.ResourceManager.ConfidentialLedger",
-  "Tag": "net/confidentialledger/Azure.ResourceManager.ConfidentialLedger_d2664ec10b"
+  "Tag": "net/confidentialledger/Azure.ResourceManager.ConfidentialLedger_49185270f7"
 }

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/ConfidentialLedgerData.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/ConfidentialLedgerData.Serialization.cs
@@ -21,67 +21,27 @@ namespace Azure.ResourceManager.ConfidentialLedger
 
         void IJsonModel<ConfidentialLedgerData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Properties))
             {
                 writer.WritePropertyName("properties"u8);
                 writer.WriteObjectValue(Properties, options);
             }
-            if (Optional.IsCollectionDefined(Tags))
-            {
-                writer.WritePropertyName("tags"u8);
-                writer.WriteStartObject();
-                foreach (var item in Tags)
-                {
-                    writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
-                }
-                writer.WriteEndObject();
-            }
-            writer.WritePropertyName("location"u8);
-            writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerData IJsonModel<ConfidentialLedgerData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/ManagedCcfData.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/ManagedCcfData.Serialization.cs
@@ -21,67 +21,27 @@ namespace Azure.ResourceManager.ConfidentialLedger
 
         void IJsonModel<ManagedCcfData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedCcfData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedCcfData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Properties))
             {
                 writer.WritePropertyName("properties"u8);
                 writer.WriteObjectValue(Properties, options);
             }
-            if (Optional.IsCollectionDefined(Tags))
-            {
-                writer.WritePropertyName("tags"u8);
-                writer.WriteStartObject();
-                foreach (var item in Tags)
-                {
-                    writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
-                }
-                writer.WriteEndObject();
-            }
-            writer.WritePropertyName("location"u8);
-            writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         ManagedCcfData IJsonModel<ManagedCcfData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/AadBasedSecurityPrincipal.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/AadBasedSecurityPrincipal.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<AadBasedSecurityPrincipal>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AadBasedSecurityPrincipal>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AadBasedSecurityPrincipal)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(PrincipalId))
             {
                 writer.WritePropertyName("principalId"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AadBasedSecurityPrincipal IJsonModel<AadBasedSecurityPrincipal>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/CertBasedSecurityPrincipal.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/CertBasedSecurityPrincipal.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<CertBasedSecurityPrincipal>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CertBasedSecurityPrincipal>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CertBasedSecurityPrincipal)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Cert))
             {
                 writer.WritePropertyName("cert"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CertBasedSecurityPrincipal IJsonModel<CertBasedSecurityPrincipal>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerBackupContent.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerBackupContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerBackupContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerBackupContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerBackupContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(RestoreRegion))
             {
                 writer.WritePropertyName("restoreRegion"u8);
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerBackupContent IJsonModel<ConfidentialLedgerBackupContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerBackupResult.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerBackupResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerBackupResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerBackupResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerBackupResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Message))
             {
                 writer.WritePropertyName("message"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerBackupResult IJsonModel<ConfidentialLedgerBackupResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerDeploymentType.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerDeploymentType.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerDeploymentType>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerDeploymentType>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerDeploymentType)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(LanguageRuntime))
             {
                 writer.WritePropertyName("languageRuntime"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerDeploymentType IJsonModel<ConfidentialLedgerDeploymentType>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerList.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerList.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerList>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerList>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerList)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerList IJsonModel<ConfidentialLedgerList>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerMemberIdentityCertificate.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerMemberIdentityCertificate.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerMemberIdentityCertificate>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerMemberIdentityCertificate>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerMemberIdentityCertificate)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Certificate))
             {
                 writer.WritePropertyName("certificate"u8);
@@ -63,7 +71,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerMemberIdentityCertificate IJsonModel<ConfidentialLedgerMemberIdentityCertificate>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerNameAvailabilityContent.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerNameAvailabilityContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerNameAvailabilityContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerNameAvailabilityContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerNameAvailabilityContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerNameAvailabilityContent IJsonModel<ConfidentialLedgerNameAvailabilityContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerNameAvailabilityResult.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerNameAvailabilityResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerNameAvailabilityResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerNameAvailabilityResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerNameAvailabilityResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(IsNameAvailable))
             {
                 writer.WritePropertyName("nameAvailable"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerNameAvailabilityResult IJsonModel<ConfidentialLedgerNameAvailabilityResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerProperties.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(LedgerName))
             {
                 writer.WritePropertyName("ledgerName"u8);
@@ -101,7 +109,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerProperties IJsonModel<ConfidentialLedgerProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerRestoreContent.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerRestoreContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerRestoreContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerRestoreContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerRestoreContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("fileShareName"u8);
             writer.WriteStringValue(FileShareName);
             writer.WritePropertyName("restoreRegion"u8);
@@ -47,7 +55,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerRestoreContent IJsonModel<ConfidentialLedgerRestoreContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerRestoreResult.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ConfidentialLedgerRestoreResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ConfidentialLedgerRestoreResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConfidentialLedgerRestoreResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConfidentialLedgerRestoreResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Message))
             {
                 writer.WritePropertyName("message"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConfidentialLedgerRestoreResult IJsonModel<ConfidentialLedgerRestoreResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfBackupContent.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfBackupContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ManagedCcfBackupContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedCcfBackupContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedCcfBackupContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(RestoreRegion))
             {
                 writer.WritePropertyName("restoreRegion"u8);
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedCcfBackupContent IJsonModel<ManagedCcfBackupContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfBackupResult.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfBackupResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ManagedCcfBackupResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedCcfBackupResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedCcfBackupResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Message))
             {
                 writer.WritePropertyName("message"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedCcfBackupResult IJsonModel<ManagedCcfBackupResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfList.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfList.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ManagedCcfList>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedCcfList>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedCcfList)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedCcfList IJsonModel<ManagedCcfList>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfProperties.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ManagedCcfProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedCcfProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedCcfProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(AppName))
             {
                 writer.WritePropertyName("appName"u8);
@@ -86,7 +94,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedCcfProperties IJsonModel<ManagedCcfProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfRestoreContent.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfRestoreContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ManagedCcfRestoreContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedCcfRestoreContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedCcfRestoreContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("fileShareName"u8);
             writer.WriteStringValue(FileShareName);
             writer.WritePropertyName("restoreRegion"u8);
@@ -47,7 +55,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedCcfRestoreContent IJsonModel<ManagedCcfRestoreContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfRestoreResult.Serialization.cs
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/Generated/Models/ManagedCcfRestoreResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 
         void IJsonModel<ManagedCcfRestoreResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedCcfRestoreResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedCcfRestoreResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Message))
             {
                 writer.WritePropertyName("message"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.ConfidentialLedger.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedCcfRestoreResult IJsonModel<ManagedCcfRestoreResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/autorest.md
+++ b/sdk/confidentialledger/Azure.ResourceManager.ConfidentialLedger/src/autorest.md
@@ -19,6 +19,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 #mgmt-debug:
 #  show-serialized-names: true


### PR DESCRIPTION
We need to enable WriteCore feature to confidentialledger. Therefore add `use-write-core: true` and do a regen.