### PR TITLE
[AzureMonitorExporter] update variable names used in Readme

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
@@ -117,10 +117,10 @@ Azure Active Directory (AAD) authentication is an optional feature that can be u
 
 ```C#
 // Call UseAzureMonitor and set Credential to authenticate through Active Directory.
-builder.Services.AddOpenTelemetry().UseAzureMonitor(o =>
+builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
 {
-    o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
-    o.Credential = new DefaultAzureCredential();
+    options.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+    options.Credential = new DefaultAzureCredential();
 });
 ```
 
@@ -135,9 +135,9 @@ Note that the `Credential` property is optional. If it is not set, Azure Monitor
 When using the Azure Monitor Distro, the sampling percentage for telemetry data is set to 100% (1.0F) by default. For example, let's say you want to set the sampling percentage to 50%. You can achieve this by modifying the code as follows:
 
 ``` C#
-builder.Services.AddOpenTelemetry().UseAzureMonitor(o =>
+builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
 {
-    o.SamplingRatio = 0.5F;
+    options.SamplingRatio = 0.5F;
 });
 ```
 
@@ -256,9 +256,9 @@ dotnet add package --prerelease OpenTelemetry.Instrumentation.SqlClient
 ```
 
 ```C#
-builder.Services.AddOpenTelemetry().UseAzureMonitor().WithTracing(builder =>
+builder.Services.AddOpenTelemetry().UseAzureMonitor().WithTracing(tracing =>
 {
-    builder.AddSqlClientInstrumentation(options =>
+    tracing.AddSqlClientInstrumentation(options =>
     {
         options.SetDbStatementForStoredProcedure = false;
     });
@@ -273,10 +273,10 @@ To disable Live Metrics, you can set the `EnableLiveMetrics` property to `false`
 
 ```C#
 // Disable Live Metrics by setting EnableLiveMetrics to false in the UseAzureMonitor configuration.
-builder.Services.AddOpenTelemetry().UseAzureMonitor(o =>
+builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
 {
-    o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
-    o.EnableLiveMetrics = false;
+    options.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+    options.EnableLiveMetrics = false;
 });
 ```
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -37,8 +37,8 @@ The following examples demonstrate how to add the `AzureMonitorExporter` to your
 
 - Traces
     ```csharp
-    Sdk.CreateTracerProviderBuilder()
-        .AddAzureMonitorTraceExporter(o => o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000")
+    var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        .AddAzureMonitorTraceExporter(options => options.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000")
         .Build();
     ```
 
@@ -46,8 +46,8 @@ The following examples demonstrate how to add the `AzureMonitorExporter` to your
 
 - Metrics
     ```csharp
-    Sdk.CreateMeterProviderBuilder()
-        .AddAzureMonitorMetricExporter(o => o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000")
+    var meterProvider = Sdk.CreateMeterProviderBuilder()
+        .AddAzureMonitorMetricExporter(options => options.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000")
         .Build();
     ```
 
@@ -55,11 +55,11 @@ The following examples demonstrate how to add the `AzureMonitorExporter` to your
 
 - Logs
     ```csharp
-    LoggerFactory.Create(builder =>
+    var loggerFactory = LoggerFactory.Create(builder =>
     {
-        builder.AddOpenTelemetry(options =>
+        builder.AddOpenTelemetry(logging =>
         {
-            options.AddAzureMonitorLogExporter(o => o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000");
+            logging.AddAzureMonitorLogExporter(options => options.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000");
         });
     });
     ```
@@ -78,11 +78,11 @@ There are two options to enable AAD authentication. Note that if both have been 
     ```csharp
     var credential = new DefaultAzureCredential();
 
-    Sdk.CreateTracerProviderBuilder()
-        .AddAzureMonitorTraceExporter(o =>
+    var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        .AddAzureMonitorTraceExporter(options =>
         {
-            o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
-            o.Credential = credential;
+            options.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+            options.Credential = credential;
         })
         .Build();
     ```
@@ -92,8 +92,8 @@ There are two options to enable AAD authentication. Note that if both have been 
     ```csharp
     var credential = new DefaultAzureCredential();
 
-    Sdk.CreateTracerProviderBuilder()
-        .AddAzureMonitorTraceExporter(o => o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000", credential)
+    var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        .AddAzureMonitorTraceExporter(options => options.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000", credential)
         .Build();
     ```
 
@@ -151,10 +151,10 @@ To include the scope with your logs, set `OpenTelemetryLoggerOptions.IncludeScop
 ```csharp
 var loggerFactory = LoggerFactory.Create(builder =>
 {
-    builder.AddOpenTelemetry(options =>
+    builder.AddOpenTelemetry(logging =>
     {
-        options.AddAzureMonitorLogExporter(o => o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000");
-        options.IncludeScopes = true;
+        logging.AddAzureMonitorLogExporter(options => options.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000");
+        logging.IncludeScopes = true;
     });
 });
 ```

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -35,6 +35,9 @@ These are provided without support and are not intended for production workloads
 
 The following examples demonstrate how to add the `AzureMonitorExporter` to your OpenTelemetry configuration.
 
+It's important to keep the `TracerProvider`, `MeterProvider`, and `LoggerFactory` instances active throughout the process lifetime. These must be properly disposed when your application is shutting down to flush any remaining telemetry items.
+
+
 - Traces
     ```csharp
     var tracerProvider = Sdk.CreateTracerProviderBuilder()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -37,7 +37,6 @@ The following examples demonstrate how to add the `AzureMonitorExporter` to your
 
 It's important to keep the `TracerProvider`, `MeterProvider`, and `LoggerFactory` instances active throughout the process lifetime. These must be properly disposed when your application is shutting down to flush any remaining telemetry items.
 
-
 - Traces
     ```csharp
     var tracerProvider = Sdk.CreateTracerProviderBuilder()


### PR DESCRIPTION
fixes #42634 

This PR updates our Readme examples. Variable names now match those shown in the docs in the OpenTelemetry repo.