### PR TITLE
[Storage] Cleanup after WebJobs Release

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/src/Microsoft.Azure.WebJobs.Extensions.Storage.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/src/Microsoft.Azure.WebJobs.Extensions.Storage.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -15,9 +15,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs\src\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj" />
-		<!-- Remove pointing to the released package of Microsoft.Azure.WebJobs.Extensions.Storage.Queues and reenable pointing to the unreleased version after
-		release the common package. https://github.com/Azure/azure-sdk-for-net/issues/38145 -->
-    <!--<ProjectReference Include="..\..\Microsoft.Azure.WebJobs.Extensions.Storage.Queues\src\Microsoft.Azure.WebJobs.Extensions.Storage.Queues.csproj" /> -->
-		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" VersionOverride="5.1.3" />
+    <ProjectReference Include="..\..\Microsoft.Azure.WebJobs.Extensions.Storage.Queues\src\Microsoft.Azure.WebJobs.Extensions.Storage.Queues.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/38145

Added this line during the webjobs release to be able to release individual packages at once. No longer necessary since the release is finished.