### PR TITLE
Investigate behavior of AzurePipelinesCredential with invalid system access token

### DIFF
--- a/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialLiveTests.cs
@@ -69,9 +69,8 @@ namespace Azure.Identity.Tests
 
             var cred = new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken);
 
-            AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new[] { "https://management.azure.com//.default" }), CancellationToken.None);
-
-            Assert.IsNotNull(token.Token);
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await cred.GetTokenAsync(new TokenRequestContext(new[] { "https://management.azure.com//.default" }), CancellationToken.None));
+            Assert.That(ex.Message, Does.Contain("302 (Found)"));
         }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialLiveTests.cs
@@ -44,5 +44,34 @@ namespace Azure.Identity.Tests
 
             Assert.IsNotNull(token.Token);
         }
+
+        [Test]
+        [LiveOnly]
+        public async Task AzurePipelineCredentialLiveTest_GetToken_InvalidToken()
+        {
+            string systemAccessToken = "invalidSystemAccessToken";
+            var tenantId = Environment.GetEnvironmentVariable("AZURE_SERVICE_CONNECTION_TENANT_ID");
+            var clientId = Environment.GetEnvironmentVariable("AZURE_SERVICE_CONNECTION_CLIENT_ID");
+            var serviceConnectionId = Environment.GetEnvironmentVariable("AZURE_SERVICE_CONNECTION_ID");
+
+            if (string.IsNullOrEmpty(tenantId) || string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(serviceConnectionId))
+            {
+                var envVars = Environment.GetEnvironmentVariables();
+                StringBuilder sb = new StringBuilder();
+                foreach (var key in envVars.Keys)
+                {
+                    sb.AppendLine($"{key}: {envVars[key]}");
+                }
+                Console.WriteLine(sb);
+                Assert.Fail($"{sb} SYSTEM_ACCESSTOKEN: {systemAccessToken}, AZURE_SERVICE_CONNECTION_TENANT_ID: {tenantId}, AZURE_SERVICE_CONNECTION_CLIENT_ID: {clientId}, AZURE_SERVICE_CONNECTION_ID: {serviceConnectionId}");
+                Assert.Ignore("AzurePipelinesCredentialLiveTests disabled because required environment variables are not set");
+            }
+
+            var cred = new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken);
+
+            AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new[] { "https://management.azure.com//.default" }), CancellationToken.None);
+
+            Assert.IsNotNull(token.Token);
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialLiveTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Identity.Tests
 
         [Test]
         [LiveOnly]
-        public async Task AzurePipelineCredentialLiveTest_GetToken_InvalidToken()
+        public void AzurePipelineCredentialLiveTest_GetToken_InvalidToken()
         {
             string systemAccessToken = "invalidSystemAccessToken";
             var tenantId = Environment.GetEnvironmentVariable("AZURE_SERVICE_CONNECTION_TENANT_ID");


### PR DESCRIPTION
Adding a test similar to https://github.com/Azure/azure-sdk-for-cpp/pull/5875