### PR TITLE
Enable WriteCore feature for costmanagement

### DIFF
--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/CHANGELOG.md
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
+- Exposed `JsonModelWriteCore` for model serialization procedure.
 
 ### Breaking Changes
 

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/api/Azure.ResourceManager.CostManagement.netstandard2.0.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/api/Azure.ResourceManager.CostManagement.netstandard2.0.cs
@@ -30,6 +30,7 @@ namespace Azure.ResourceManager.CostManagement
         public Azure.ResourceManager.CostManagement.Models.CostManagementAlertStatus? Status { get { throw null; } set { } }
         public string StatusModificationUserName { get { throw null; } set { } }
         public System.DateTimeOffset? StatusModifiedOn { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.CostManagementAlertData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.CostManagementAlertData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.CostManagementAlertData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.CostManagementAlertData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.CostManagementAlertData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -81,6 +82,7 @@ namespace Azure.ResourceManager.CostManagement
         public bool? PartitionData { get { throw null; } set { } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.CostManagement.Models.ExportRun> RunHistoryValue { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.ExportSchedule Schedule { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.CostManagementExportData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.CostManagementExportData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.CostManagementExportData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.CostManagementExportData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.CostManagementExportData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -205,6 +207,7 @@ namespace Azure.ResourceManager.CostManagement
         public Azure.ResourceManager.CostManagement.Models.ReportTimeframeType? Timeframe { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ReportConfigTimePeriod TimePeriod { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ViewReportType? TypePropertiesQueryType { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.CostManagementViewData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.CostManagementViewData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.CostManagementViewData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.CostManagementViewData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.CostManagementViewData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -277,6 +280,7 @@ namespace Azure.ResourceManager.CostManagement
         public Azure.Core.ResourceIdentifier Scope { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ScheduledActionStatus? Status { get { throw null; } set { } }
         public Azure.Core.ResourceIdentifier ViewId { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.ScheduledActionData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.ScheduledActionData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.ScheduledActionData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.ScheduledActionData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.ScheduledActionData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -508,6 +512,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.CostManagementAlertType? AlertType { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.CostManagementAlertCategory? Category { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.AlertCriterion? Criteria { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AlertPropertiesDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AlertPropertiesDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AlertPropertiesDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AlertPropertiesDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.AlertPropertiesDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -539,6 +544,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.AlertTimeGrainType? TimeGrainType { get { throw null; } set { } }
         public string TriggeredBy { get { throw null; } set { } }
         public string Unit { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AlertPropertiesDetails System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AlertPropertiesDetails>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AlertPropertiesDetails>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AlertPropertiesDetails System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.AlertPropertiesDetails>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -580,6 +586,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public decimal? SavingsPercentage { get { throw null; } }
         public decimal? TotalCost { get { throw null; } }
         public decimal? WastageCost { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AllSavingsBenefitDetails System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AllSavingsBenefitDetails>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AllSavingsBenefitDetails>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AllSavingsBenefitDetails System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.AllSavingsBenefitDetails>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -591,6 +598,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         internal AllSavingsList() { }
         public System.Uri NextLink { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.CostManagement.Models.AllSavingsBenefitDetails> Value { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AllSavingsList System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AllSavingsList>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AllSavingsList>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AllSavingsList System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.AllSavingsList>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -635,6 +643,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummaryReportSchema? ReportUri { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummaryReportSchema? SecondaryReportUri { get { throw null; } }
         public System.DateTimeOffset? ValidUntil { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AsyncOperationStatusProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AsyncOperationStatusProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.AsyncOperationStatusProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.AsyncOperationStatusProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.AsyncOperationStatusProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -646,6 +655,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public BenefitRecommendationModel() { }
         public Azure.ResourceManager.CostManagement.Models.BillingAccountBenefitKind? Kind { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.BenefitRecommendationProperties Properties { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitRecommendationModel System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitRecommendationModel>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitRecommendationModel>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitRecommendationModel System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.BenefitRecommendationModel>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -685,6 +695,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.BenefitRecommendationPeriodTerm? Term { get { throw null; } set { } }
         public int? TotalHours { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.RecommendationUsageDetails Usage { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitRecommendationProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitRecommendationProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitRecommendationProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitRecommendationProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.BenefitRecommendationProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -721,6 +732,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.BenefitRecommendationUsageGrain Grain { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.BillingAccountBenefitKind? Kind { get { throw null; } set { } }
         public System.DateTimeOffset StartOn { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -733,6 +745,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesContent Input { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.AsyncOperationStatusProperties Properties { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.OperationStatusType? Status { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesOperationStatus System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesOperationStatus>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesOperationStatus>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesOperationStatus System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummariesOperationStatus>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -742,6 +755,7 @@ namespace Azure.ResourceManager.CostManagement.Models
     public partial class BenefitUtilizationSummary : Azure.ResourceManager.Models.ResourceData, System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummary>, System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummary>
     {
         public BenefitUtilizationSummary() { }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummary System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummary>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummary>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummary System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.BenefitUtilizationSummary>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -801,6 +815,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public System.DateTimeOffset? NextRunTimeEstimate { get { throw null; } }
         public bool? PartitionData { get { throw null; } set { } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.CostManagement.Models.ExportRun> RunHistoryValue { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CommonExportProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CommonExportProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CommonExportProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CommonExportProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.CommonExportProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -881,6 +896,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.CostManagementAlertStatus? Status { get { throw null; } set { } }
         public string StatusModificationUserName { get { throw null; } set { } }
         public System.DateTimeOffset? StatusModifiedOn { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CostManagementAlertPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CostManagementAlertPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CostManagementAlertPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CostManagementAlertPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.CostManagementAlertPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -965,6 +981,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public int? Total { get { throw null; } }
         public System.DateTimeOffset? UsageEnd { get { throw null; } }
         public System.DateTimeOffset? UsageStart { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CostManagementDimension System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CostManagementDimension>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CostManagementDimension>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CostManagementDimension System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.CostManagementDimension>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -976,6 +993,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public CostManagementNameAvailabilityContent() { }
         public string Name { get { throw null; } set { } }
         public string ResourceType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -988,6 +1006,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public string Message { get { throw null; } }
         public bool? NameAvailable { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.CostManagementUnavailabilityReason? Reason { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.CostManagementNameAvailabilityResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1018,6 +1037,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public System.Uri DownloadUri { get { throw null; } }
         public System.DateTimeOffset? ExpiryOn { get { throw null; } }
         public System.DateTimeOffset? ValidTill { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.DownloadURL System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.DownloadURL>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.DownloadURL>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.DownloadURL System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.DownloadURL>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1029,6 +1049,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ExportDataset() { }
         public System.Collections.Generic.IList<string> Columns { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.GranularityType? Granularity { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportDataset System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportDataset>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportDataset>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportDataset System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportDataset>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1042,6 +1063,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.ExportType ExportType { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.TimeframeType Timeframe { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ExportTimePeriod TimePeriod { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1056,6 +1078,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public string RootFolderPath { get { throw null; } set { } }
         public string SasToken { get { throw null; } set { } }
         public string StorageAccount { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportDeliveryDestination System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportDeliveryDestination>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportDeliveryDestination>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportDeliveryDestination System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportDeliveryDestination>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1066,6 +1089,7 @@ namespace Azure.ResourceManager.CostManagement.Models
     {
         public ExportDeliveryInfo(Azure.ResourceManager.CostManagement.Models.ExportDeliveryDestination destination) { }
         public Azure.ResourceManager.CostManagement.Models.ExportDeliveryDestination Destination { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportDeliveryInfo System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportDeliveryInfo>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportDeliveryInfo>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportDeliveryInfo System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportDeliveryInfo>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1094,6 +1118,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ExportRecurrencePeriod(System.DateTimeOffset from) { }
         public System.DateTimeOffset From { get { throw null; } set { } }
         public System.DateTimeOffset? To { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportRecurrencePeriod System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportRecurrencePeriod>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportRecurrencePeriod>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportRecurrencePeriod System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportRecurrencePeriod>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1113,6 +1138,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.ExportRunExecutionStatus? Status { get { throw null; } set { } }
         public string SubmittedBy { get { throw null; } set { } }
         public System.DateTimeOffset? SubmittedOn { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportRun System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportRun>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportRun>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportRun System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportRun>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1124,6 +1150,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ExportRunErrorDetails() { }
         public string Code { get { throw null; } }
         public string Message { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportRunErrorDetails System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportRunErrorDetails>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportRunErrorDetails>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportRunErrorDetails System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportRunErrorDetails>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1177,6 +1204,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.ExportScheduleRecurrenceType? Recurrence { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ExportRecurrencePeriod RecurrencePeriod { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ExportScheduleStatusType? Status { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportSchedule System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportSchedule>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportSchedule>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportSchedule System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportSchedule>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1226,6 +1254,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ExportTimePeriod(System.DateTimeOffset from, System.DateTimeOffset to) { }
         public System.DateTimeOffset From { get { throw null; } set { } }
         public System.DateTimeOffset To { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportTimePeriod System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportTimePeriod>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ExportTimePeriod>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ExportTimePeriod System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ExportTimePeriod>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1274,6 +1303,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ForecastAggregation(Azure.ResourceManager.CostManagement.Models.FunctionName name, Azure.ResourceManager.CostManagement.Models.FunctionType function) { }
         public Azure.ResourceManager.CostManagement.Models.FunctionType Function { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.FunctionName Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastAggregation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastAggregation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastAggregation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastAggregation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ForecastAggregation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1285,6 +1315,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         internal ForecastColumn() { }
         public string ForecastColumnType { get { throw null; } }
         public string Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastColumn System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastColumn>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastColumn>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastColumn System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ForecastColumn>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1297,6 +1328,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public string Name { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.ForecastOperatorType Operator { get { throw null; } }
         public System.Collections.Generic.IList<string> Values { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastComparisonExpression System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastComparisonExpression>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastComparisonExpression>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastComparisonExpression System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ForecastComparisonExpression>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1310,6 +1342,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public System.Collections.Generic.IList<string> Columns { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.ForecastFilter Filter { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.GranularityType? Granularity { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastDataset System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastDataset>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastDataset>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastDataset System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ForecastDataset>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1325,6 +1358,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public bool? IncludeFreshPartialCost { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ForecastTimeframe Timeframe { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.ForecastTimePeriod TimePeriod { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ForecastDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1338,6 +1372,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.ForecastComparisonExpression Dimensions { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.CostManagement.Models.ForecastFilter> Or { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.ForecastComparisonExpression Tags { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastFilter System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastFilter>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastFilter>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastFilter System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ForecastFilter>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1371,6 +1406,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IList<System.BinaryData>> Rows { get { throw null; } }
         public string Sku { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ForecastResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1399,6 +1435,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ForecastTimePeriod(System.DateTimeOffset from, System.DateTimeOffset to) { }
         public System.DateTimeOffset From { get { throw null; } }
         public System.DateTimeOffset To { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastTimePeriod System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastTimePeriod>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ForecastTimePeriod>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ForecastTimePeriod System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ForecastTimePeriod>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1506,6 +1543,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.BillingAccountBenefitKind? BenefitType { get { throw null; } set { } }
         public System.DateTimeOffset? UsageOn { get { throw null; } }
         public decimal? UtilizationPercentage { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.IncludedQuantityUtilizationSummary System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.IncludedQuantityUtilizationSummary>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.IncludedQuantityUtilizationSummary>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.IncludedQuantityUtilizationSummary System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.IncludedQuantityUtilizationSummary>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1539,6 +1577,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public string RegionalFormat { get { throw null; } set { } }
         public string Subject { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> To { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.NotificationProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.NotificationProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.NotificationProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.NotificationProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.NotificationProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1551,6 +1590,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.ReservationReportSchema? ReportUri { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.OperationStatusType? Status { get { throw null; } }
         public System.DateTimeOffset? ValidUntil { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.OperationStatus System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.OperationStatus>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.OperationStatus>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.OperationStatus System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.OperationStatus>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1582,6 +1622,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public QueryAggregation(string name, Azure.ResourceManager.CostManagement.Models.FunctionType function) { }
         public Azure.ResourceManager.CostManagement.Models.FunctionType Function { get { throw null; } }
         public string Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryAggregation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryAggregation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryAggregation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryAggregation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryAggregation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1593,6 +1634,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         internal QueryColumn() { }
         public string Name { get { throw null; } }
         public string QueryColumnType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryColumn System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryColumn>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryColumn>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryColumn System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryColumn>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1623,6 +1665,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public string Name { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.QueryOperatorType Operator { get { throw null; } }
         public System.Collections.Generic.IList<string> Values { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryComparisonExpression System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryComparisonExpression>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryComparisonExpression>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryComparisonExpression System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryComparisonExpression>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1637,6 +1680,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.QueryFilter Filter { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.GranularityType? Granularity { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.CostManagement.Models.QueryGrouping> Grouping { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryDataset System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryDataset>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryDataset>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryDataset System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryDataset>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1650,6 +1694,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.ExportType ExportType { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.TimeframeType Timeframe { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.QueryTimePeriod TimePeriod { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1663,6 +1708,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.QueryComparisonExpression Dimensions { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.CostManagement.Models.QueryFilter> Or { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.QueryComparisonExpression Tags { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryFilter System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryFilter>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryFilter>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryFilter System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryFilter>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1674,6 +1720,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public QueryGrouping(Azure.ResourceManager.CostManagement.Models.QueryColumnType columnType, string name) { }
         public Azure.ResourceManager.CostManagement.Models.QueryColumnType ColumnType { get { throw null; } }
         public string Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryGrouping System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryGrouping>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryGrouping>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryGrouping System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryGrouping>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1707,6 +1754,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IList<System.BinaryData>> Rows { get { throw null; } }
         public string Sku { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1718,6 +1766,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public QueryTimePeriod(System.DateTimeOffset from, System.DateTimeOffset to) { }
         public System.DateTimeOffset From { get { throw null; } }
         public System.DateTimeOffset To { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryTimePeriod System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryTimePeriod>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.QueryTimePeriod>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.QueryTimePeriod System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.QueryTimePeriod>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1729,6 +1778,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public RecommendationUsageDetails() { }
         public System.Collections.Generic.IReadOnlyList<decimal> Charges { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.BenefitRecommendationUsageGrain? UsageGrain { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.RecommendationUsageDetails System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.RecommendationUsageDetails>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.RecommendationUsageDetails>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.RecommendationUsageDetails System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.RecommendationUsageDetails>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1740,6 +1790,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ReportConfigAggregation(string name, Azure.ResourceManager.CostManagement.Models.FunctionType function) { }
         public Azure.ResourceManager.CostManagement.Models.FunctionType Function { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigAggregation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigAggregation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigAggregation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigAggregation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ReportConfigAggregation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1752,6 +1803,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public string Name { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ComparisonOperatorType Operator { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> Values { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigComparisonExpression System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigComparisonExpression>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigComparisonExpression>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigComparisonExpression System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ReportConfigComparisonExpression>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1767,6 +1819,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.ReportGranularityType? Granularity { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.CostManagement.Models.ReportConfigGrouping> Grouping { get { throw null; } }
         public System.Collections.Generic.IList<Azure.ResourceManager.CostManagement.Models.ReportConfigSorting> Sorting { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigDataset System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigDataset>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigDataset>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigDataset System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ReportConfigDataset>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1780,6 +1833,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.ResourceManager.CostManagement.Models.ReportConfigComparisonExpression Dimensions { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.CostManagement.Models.ReportConfigFilter> Or { get { throw null; } }
         public Azure.ResourceManager.CostManagement.Models.ReportConfigComparisonExpression Tags { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigFilter System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigFilter>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigFilter>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigFilter System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ReportConfigFilter>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1791,6 +1845,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ReportConfigGrouping(Azure.ResourceManager.CostManagement.Models.QueryColumnType queryColumnType, string name) { }
         public string Name { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.QueryColumnType QueryColumnType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigGrouping System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigGrouping>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigGrouping>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigGrouping System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ReportConfigGrouping>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1802,6 +1857,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ReportConfigSorting(string name) { }
         public Azure.ResourceManager.CostManagement.Models.ReportConfigSortingType? Direction { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigSorting System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigSorting>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigSorting>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigSorting System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ReportConfigSorting>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1831,6 +1887,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ReportConfigTimePeriod(System.DateTimeOffset from, System.DateTimeOffset to) { }
         public System.DateTimeOffset From { get { throw null; } set { } }
         public System.DateTimeOffset To { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigTimePeriod System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigTimePeriod>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ReportConfigTimePeriod>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ReportConfigTimePeriod System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ReportConfigTimePeriod>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1913,6 +1970,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public decimal? MaxUtilizationPercentage { get { throw null; } }
         public decimal? MinUtilizationPercentage { get { throw null; } }
         public System.DateTimeOffset? UsageOn { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.SavingsPlanUtilizationSummary System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.SavingsPlanUtilizationSummary>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.SavingsPlanUtilizationSummary>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.SavingsPlanUtilizationSummary System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.SavingsPlanUtilizationSummary>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -2046,6 +2104,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public int? HourOfDay { get { throw null; } set { } }
         public System.DateTimeOffset StartOn { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.CostManagement.Models.ScheduledActionWeeksOfMonth> WeeksOfMonth { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ScheduleProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ScheduleProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ScheduleProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ScheduleProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ScheduleProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -2055,6 +2114,7 @@ namespace Azure.ResourceManager.CostManagement.Models
     public partial class SharedScopeBenefitRecommendationProperties : Azure.ResourceManager.CostManagement.Models.BenefitRecommendationProperties, System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.SharedScopeBenefitRecommendationProperties>, System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.SharedScopeBenefitRecommendationProperties>
     {
         public SharedScopeBenefitRecommendationProperties() { }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.SharedScopeBenefitRecommendationProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.SharedScopeBenefitRecommendationProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.SharedScopeBenefitRecommendationProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.SharedScopeBenefitRecommendationProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.SharedScopeBenefitRecommendationProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -2066,6 +2126,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public SingleScopeBenefitRecommendationProperties() { }
         public string ResourceGroup { get { throw null; } }
         public string SubscriptionId { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.SingleScopeBenefitRecommendationProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.SingleScopeBenefitRecommendationProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.SingleScopeBenefitRecommendationProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.SingleScopeBenefitRecommendationProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.SingleScopeBenefitRecommendationProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -2131,6 +2192,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public Azure.Core.ResourceIdentifier Id { get { throw null; } set { } }
         public bool? IsEnabled { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ViewKpiType? KpiType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ViewKpiProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ViewKpiProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ViewKpiProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ViewKpiProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ViewKpiProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -2179,6 +2241,7 @@ namespace Azure.ResourceManager.CostManagement.Models
         public ViewPivotProperties() { }
         public string Name { get { throw null; } set { } }
         public Azure.ResourceManager.CostManagement.Models.ViewPivotType? PivotType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ViewPivotProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ViewPivotProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CostManagement.Models.ViewPivotProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CostManagement.Models.ViewPivotProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CostManagement.Models.ViewPivotProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/CostManagementAlertData.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/CostManagementAlertData.Serialization.cs
@@ -21,37 +21,26 @@ namespace Azure.ResourceManager.CostManagement
 
         void IJsonModel<CostManagementAlertData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementAlertData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementAlertData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(ETag))
             {
                 writer.WritePropertyName("eTag"u8);
                 writer.WriteStringValue(ETag.Value.ToString());
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -109,22 +98,6 @@ namespace Azure.ResourceManager.CostManagement
             {
                 writer.WritePropertyName("statusModificationTime"u8);
                 writer.WriteStringValue(StatusModifiedOn.Value, "O");
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/CostManagementExportData.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/CostManagementExportData.Serialization.cs
@@ -21,37 +21,26 @@ namespace Azure.ResourceManager.CostManagement
 
         void IJsonModel<CostManagementExportData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementExportData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementExportData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(ETag))
             {
                 writer.WritePropertyName("eTag"u8);
                 writer.WriteStringValue(ETag.Value.ToString());
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -89,22 +78,6 @@ namespace Azure.ResourceManager.CostManagement
             {
                 writer.WritePropertyName("schedule"u8);
                 writer.WriteObjectValue(Schedule, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/CostManagementViewData.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/CostManagementViewData.Serialization.cs
@@ -21,37 +21,26 @@ namespace Azure.ResourceManager.CostManagement
 
         void IJsonModel<CostManagementViewData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementViewData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementViewData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(ETag))
             {
                 writer.WritePropertyName("eTag"u8);
                 writer.WriteStringValue(ETag.Value.ToString());
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -148,22 +137,6 @@ namespace Azure.ResourceManager.CostManagement
                 writer.WriteBooleanValue(IncludeMonetaryCommitment.Value);
             }
             writer.WriteEndObject();
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
             writer.WriteEndObject();
         }
 

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AlertPropertiesDefinition.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AlertPropertiesDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<AlertPropertiesDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AlertPropertiesDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AlertPropertiesDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(AlertType))
             {
                 writer.WritePropertyName("type"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AlertPropertiesDefinition IJsonModel<AlertPropertiesDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AlertPropertiesDetails.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AlertPropertiesDetails.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<AlertPropertiesDetails>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AlertPropertiesDetails>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AlertPropertiesDetails)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(TimeGrainType))
             {
                 writer.WritePropertyName("timeGrainType"u8);
@@ -224,7 +232,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AlertPropertiesDetails IJsonModel<AlertPropertiesDetails>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AllSavingsBenefitDetails.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AllSavingsBenefitDetails.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<AllSavingsBenefitDetails>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AllSavingsBenefitDetails>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AllSavingsBenefitDetails)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(OverageCost))
             {
                 writer.WritePropertyName("overageCost"u8);
@@ -86,7 +94,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AllSavingsBenefitDetails IJsonModel<AllSavingsBenefitDetails>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AllSavingsList.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AllSavingsList.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<AllSavingsList>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AllSavingsList>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AllSavingsList)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AllSavingsList IJsonModel<AllSavingsList>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AsyncOperationStatusProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/AsyncOperationStatusProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<AsyncOperationStatusProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AsyncOperationStatusProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AsyncOperationStatusProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ReportUri))
             {
                 writer.WritePropertyName("reportUrl"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AsyncOperationStatusProperties IJsonModel<AsyncOperationStatusProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitRecommendationModel.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitRecommendationModel.Serialization.cs
@@ -20,13 +20,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitRecommendationModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitRecommendationModel>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitRecommendationModel)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Properties))
             {
                 writer.WritePropertyName("properties"u8);
@@ -37,42 +46,6 @@ namespace Azure.ResourceManager.CostManagement.Models
                 writer.WritePropertyName("kind"u8);
                 writer.WriteStringValue(Kind.Value.ToString());
             }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         BenefitRecommendationModel IJsonModel<BenefitRecommendationModel>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitRecommendationProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitRecommendationProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitRecommendationProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitRecommendationProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitRecommendationProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(FirstConsumptionOn))
             {
                 writer.WritePropertyName("firstConsumptionDate"u8);
@@ -103,7 +111,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         BenefitRecommendationProperties IJsonModel<BenefitRecommendationProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitRecommendationsListResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitRecommendationsListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitRecommendationsListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitRecommendationsListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitRecommendationsListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         BenefitRecommendationsListResult IJsonModel<BenefitRecommendationsListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitUtilizationSummariesContent.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitUtilizationSummariesContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitUtilizationSummariesContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitUtilizationSummariesContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitUtilizationSummariesContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(BillingAccountId))
             {
                 writer.WritePropertyName("billingAccountId"u8);
@@ -72,7 +80,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         BenefitUtilizationSummariesContent IJsonModel<BenefitUtilizationSummariesContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitUtilizationSummariesListResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitUtilizationSummariesListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitUtilizationSummariesListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitUtilizationSummariesListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitUtilizationSummariesListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         BenefitUtilizationSummariesListResult IJsonModel<BenefitUtilizationSummariesListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitUtilizationSummariesOperationStatus.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitUtilizationSummariesOperationStatus.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitUtilizationSummariesOperationStatus>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitUtilizationSummariesOperationStatus>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitUtilizationSummariesOperationStatus)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Input))
             {
                 writer.WritePropertyName("input"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         BenefitUtilizationSummariesOperationStatus IJsonModel<BenefitUtilizationSummariesOperationStatus>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitUtilizationSummary.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/BenefitUtilizationSummary.Serialization.cs
@@ -18,51 +18,24 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitUtilizationSummary>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitUtilizationSummary>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitUtilizationSummary)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("kind"u8);
             writer.WriteStringValue(Kind.ToString());
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         BenefitUtilizationSummary IJsonModel<BenefitUtilizationSummary>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CommonExportProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CommonExportProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<CommonExportProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CommonExportProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CommonExportProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Format))
             {
                 writer.WritePropertyName("format"u8);
@@ -65,7 +73,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CommonExportProperties IJsonModel<CommonExportProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementAlertPatch.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementAlertPatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<CostManagementAlertPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementAlertPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementAlertPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(Definition))
@@ -99,7 +107,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CostManagementAlertPatch IJsonModel<CostManagementAlertPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementAlertsResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementAlertsResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<CostManagementAlertsResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementAlertsResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementAlertsResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CostManagementAlertsResult IJsonModel<CostManagementAlertsResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementDimension.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementDimension.Serialization.cs
@@ -20,13 +20,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<CostManagementDimension>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementDimension>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementDimension)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(Location))
             {
                 writer.WritePropertyName("location"u8);
@@ -52,26 +61,6 @@ namespace Azure.ResourceManager.CostManagement.Models
                     writer.WriteStringValue(item.Value);
                 }
                 writer.WriteEndObject();
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -124,22 +113,6 @@ namespace Azure.ResourceManager.CostManagement.Models
             {
                 writer.WritePropertyName("nextLink"u8);
                 writer.WriteStringValue(NextLink);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementDimensionsListResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementDimensionsListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<CostManagementDimensionsListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementDimensionsListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementDimensionsListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CostManagementDimensionsListResult IJsonModel<CostManagementDimensionsListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementNameAvailabilityContent.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementNameAvailabilityContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<CostManagementNameAvailabilityContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementNameAvailabilityContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementNameAvailabilityContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CostManagementNameAvailabilityContent IJsonModel<CostManagementNameAvailabilityContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementNameAvailabilityResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/CostManagementNameAvailabilityResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<CostManagementNameAvailabilityResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CostManagementNameAvailabilityResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CostManagementNameAvailabilityResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(NameAvailable))
             {
                 writer.WritePropertyName("nameAvailable"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CostManagementNameAvailabilityResult IJsonModel<CostManagementNameAvailabilityResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/DownloadURL.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/DownloadURL.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<DownloadURL>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DownloadURL>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DownloadURL)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ExpiryOn))
             {
                 writer.WritePropertyName("expiryTime"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DownloadURL IJsonModel<DownloadURL>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDataset.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDataset.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportDataset>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportDataset>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportDataset)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Granularity))
             {
                 writer.WritePropertyName("granularity"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportDataset IJsonModel<ExportDataset>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDatasetConfiguration.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDatasetConfiguration.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportDatasetConfiguration>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportDatasetConfiguration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportDatasetConfiguration)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Columns))
             {
                 writer.WritePropertyName("columns"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportDatasetConfiguration IJsonModel<ExportDatasetConfiguration>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDefinition.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("type"u8);
             writer.WriteStringValue(ExportType.ToString());
             writer.WritePropertyName("timeframe"u8);
@@ -55,7 +63,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportDefinition IJsonModel<ExportDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDeliveryDestination.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDeliveryDestination.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportDeliveryDestination>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportDeliveryDestination>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportDeliveryDestination)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ResourceId))
             {
                 writer.WritePropertyName("resourceId"u8);
@@ -63,7 +71,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportDeliveryDestination IJsonModel<ExportDeliveryDestination>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDeliveryInfo.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportDeliveryInfo.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportDeliveryInfo>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportDeliveryInfo>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportDeliveryInfo)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("destination"u8);
             writer.WriteObjectValue(Destination, options);
             if (options.Format != "W" && _serializedAdditionalRawData != null)
@@ -43,7 +51,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportDeliveryInfo IJsonModel<ExportDeliveryInfo>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportExecutionListResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportExecutionListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportExecutionListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportExecutionListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportExecutionListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportExecutionListResult IJsonModel<ExportExecutionListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportListResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportListResult IJsonModel<ExportListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportRecurrencePeriod.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportRecurrencePeriod.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportRecurrencePeriod>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportRecurrencePeriod>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportRecurrencePeriod)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("from"u8);
             writer.WriteStringValue(From, "O");
             if (Optional.IsDefined(To))
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportRecurrencePeriod IJsonModel<ExportRecurrencePeriod>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportRun.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportRun.Serialization.cs
@@ -20,37 +20,26 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportRun>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportRun>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportRun)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(ETag))
             {
                 writer.WritePropertyName("eTag"u8);
                 writer.WriteStringValue(ETag.Value.ToString());
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -98,22 +87,6 @@ namespace Azure.ResourceManager.CostManagement.Models
             {
                 writer.WritePropertyName("error"u8);
                 writer.WriteObjectValue(Error, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportRunErrorDetails.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportRunErrorDetails.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportRunErrorDetails>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportRunErrorDetails>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportRunErrorDetails)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Code))
             {
                 writer.WritePropertyName("code"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportRunErrorDetails IJsonModel<ExportRunErrorDetails>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportSchedule.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportSchedule.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportSchedule>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportSchedule>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportSchedule)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Status))
             {
                 writer.WritePropertyName("status"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportSchedule IJsonModel<ExportSchedule>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportTimePeriod.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ExportTimePeriod.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ExportTimePeriod>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExportTimePeriod>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExportTimePeriod)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("from"u8);
             writer.WriteStringValue(From, "O");
             writer.WritePropertyName("to"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExportTimePeriod IJsonModel<ExportTimePeriod>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/FileDestination.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/FileDestination.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<FileDestination>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FileDestination>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FileDestination)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(FileFormats))
             {
                 writer.WritePropertyName("fileFormats"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FileDestination IJsonModel<FileDestination>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastAggregation.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastAggregation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastAggregation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastAggregation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastAggregation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name.ToString());
             writer.WritePropertyName("function"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ForecastAggregation IJsonModel<ForecastAggregation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastColumn.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastColumn.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastColumn>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastColumn>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastColumn)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ForecastColumn IJsonModel<ForecastColumn>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastComparisonExpression.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastComparisonExpression.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastComparisonExpression>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastComparisonExpression>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastComparisonExpression)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("operator"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ForecastComparisonExpression IJsonModel<ForecastComparisonExpression>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastDataset.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastDataset.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastDataset>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastDataset>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastDataset)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Granularity))
             {
                 writer.WritePropertyName("granularity"u8);
@@ -64,7 +72,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ForecastDataset IJsonModel<ForecastDataset>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastDatasetConfiguration.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastDatasetConfiguration.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastDatasetConfiguration>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastDatasetConfiguration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastDatasetConfiguration)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Columns))
             {
                 writer.WritePropertyName("columns"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ForecastDatasetConfiguration IJsonModel<ForecastDatasetConfiguration>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastDefinition.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("type"u8);
             writer.WriteStringValue(ForecastType.ToString());
             writer.WritePropertyName("timeframe"u8);
@@ -62,7 +70,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ForecastDefinition IJsonModel<ForecastDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastFilter.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastFilter.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastFilter>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastFilter>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastFilter)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(And))
             {
                 writer.WritePropertyName("and"u8);
@@ -71,7 +79,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ForecastFilter IJsonModel<ForecastFilter>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastResult.Serialization.cs
@@ -20,13 +20,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(Location))
             {
                 writer.WritePropertyName("location"u8);
@@ -52,26 +61,6 @@ namespace Azure.ResourceManager.CostManagement.Models
                     writer.WriteStringValue(item.Value);
                 }
                 writer.WriteEndObject();
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -121,22 +110,6 @@ namespace Azure.ResourceManager.CostManagement.Models
                     writer.WriteEndArray();
                 }
                 writer.WriteEndArray();
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastTimePeriod.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ForecastTimePeriod.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ForecastTimePeriod>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ForecastTimePeriod>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ForecastTimePeriod)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("from"u8);
             writer.WriteStringValue(From, "O");
             writer.WritePropertyName("to"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ForecastTimePeriod IJsonModel<ForecastTimePeriod>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/IncludedQuantityUtilizationSummary.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/IncludedQuantityUtilizationSummary.Serialization.cs
@@ -20,35 +20,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<IncludedQuantityUtilizationSummary>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<IncludedQuantityUtilizationSummary>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(IncludedQuantityUtilizationSummary)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToString());
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ArmSkuName))
@@ -80,22 +67,6 @@ namespace Azure.ResourceManager.CostManagement.Models
             {
                 writer.WritePropertyName("utilizationPercentage"u8);
                 writer.WriteNumberValue(UtilizationPercentage.Value);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/NotificationProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/NotificationProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<NotificationProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<NotificationProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(NotificationProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("to"u8);
             writer.WriteStartArray();
             foreach (var item in To)
@@ -65,7 +73,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         NotificationProperties IJsonModel<NotificationProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/OperationStatus.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/OperationStatus.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<OperationStatus>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<OperationStatus>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(OperationStatus)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Status))
             {
                 writer.WritePropertyName("status"u8);
@@ -59,7 +67,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         OperationStatus IJsonModel<OperationStatus>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryAggregation.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryAggregation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryAggregation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryAggregation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryAggregation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("function"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryAggregation IJsonModel<QueryAggregation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryColumn.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryColumn.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryColumn>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryColumn>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryColumn)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryColumn IJsonModel<QueryColumn>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryComparisonExpression.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryComparisonExpression.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryComparisonExpression>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryComparisonExpression>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryComparisonExpression)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("operator"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryComparisonExpression IJsonModel<QueryComparisonExpression>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryDataset.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryDataset.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryDataset>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryDataset>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryDataset)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Granularity))
             {
                 writer.WritePropertyName("granularity"u8);
@@ -77,7 +85,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryDataset IJsonModel<QueryDataset>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryDatasetConfiguration.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryDatasetConfiguration.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryDatasetConfiguration>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryDatasetConfiguration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryDatasetConfiguration)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Columns))
             {
                 writer.WritePropertyName("columns"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryDatasetConfiguration IJsonModel<QueryDatasetConfiguration>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryDefinition.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("type"u8);
             writer.WriteStringValue(ExportType.ToString());
             writer.WritePropertyName("timeframe"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryDefinition IJsonModel<QueryDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryFilter.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryFilter.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryFilter>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryFilter>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryFilter)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(And))
             {
                 writer.WritePropertyName("and"u8);
@@ -71,7 +79,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryFilter IJsonModel<QueryFilter>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryGrouping.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryGrouping.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryGrouping>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryGrouping>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryGrouping)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("type"u8);
             writer.WriteStringValue(ColumnType.ToString());
             writer.WritePropertyName("name"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryGrouping IJsonModel<QueryGrouping>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryResult.Serialization.cs
@@ -20,13 +20,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(Location))
             {
                 writer.WritePropertyName("location"u8);
@@ -52,26 +61,6 @@ namespace Azure.ResourceManager.CostManagement.Models
                     writer.WriteStringValue(item.Value);
                 }
                 writer.WriteEndObject();
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -121,22 +110,6 @@ namespace Azure.ResourceManager.CostManagement.Models
                     writer.WriteEndArray();
                 }
                 writer.WriteEndArray();
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryTimePeriod.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/QueryTimePeriod.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<QueryTimePeriod>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<QueryTimePeriod>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(QueryTimePeriod)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("from"u8);
             writer.WriteStringValue(From, "O");
             writer.WritePropertyName("to"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         QueryTimePeriod IJsonModel<QueryTimePeriod>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/RecommendationUsageDetails.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/RecommendationUsageDetails.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<RecommendationUsageDetails>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RecommendationUsageDetails>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RecommendationUsageDetails)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(UsageGrain))
             {
                 writer.WritePropertyName("usageGrain"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RecommendationUsageDetails IJsonModel<RecommendationUsageDetails>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigAggregation.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigAggregation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ReportConfigAggregation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ReportConfigAggregation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ReportConfigAggregation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("function"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ReportConfigAggregation IJsonModel<ReportConfigAggregation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigComparisonExpression.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigComparisonExpression.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ReportConfigComparisonExpression>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ReportConfigComparisonExpression>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ReportConfigComparisonExpression)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("operator"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ReportConfigComparisonExpression IJsonModel<ReportConfigComparisonExpression>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigDataset.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigDataset.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ReportConfigDataset>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ReportConfigDataset>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ReportConfigDataset)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Granularity))
             {
                 writer.WritePropertyName("granularity"u8);
@@ -87,7 +95,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ReportConfigDataset IJsonModel<ReportConfigDataset>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigDatasetConfiguration.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigDatasetConfiguration.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ReportConfigDatasetConfiguration>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ReportConfigDatasetConfiguration>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ReportConfigDatasetConfiguration)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Columns))
             {
                 writer.WritePropertyName("columns"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ReportConfigDatasetConfiguration IJsonModel<ReportConfigDatasetConfiguration>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigFilter.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigFilter.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ReportConfigFilter>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ReportConfigFilter>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ReportConfigFilter)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(And))
             {
                 writer.WritePropertyName("and"u8);
@@ -71,7 +79,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ReportConfigFilter IJsonModel<ReportConfigFilter>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigGrouping.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigGrouping.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ReportConfigGrouping>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ReportConfigGrouping>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ReportConfigGrouping)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("type"u8);
             writer.WriteStringValue(QueryColumnType.ToString());
             writer.WritePropertyName("name"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ReportConfigGrouping IJsonModel<ReportConfigGrouping>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigSorting.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigSorting.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ReportConfigSorting>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ReportConfigSorting>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ReportConfigSorting)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Direction))
             {
                 writer.WritePropertyName("direction"u8);
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ReportConfigSorting IJsonModel<ReportConfigSorting>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigTimePeriod.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ReportConfigTimePeriod.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ReportConfigTimePeriod>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ReportConfigTimePeriod>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ReportConfigTimePeriod)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("from"u8);
             writer.WriteStringValue(From, "O");
             writer.WritePropertyName("to"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ReportConfigTimePeriod IJsonModel<ReportConfigTimePeriod>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/SavingsPlanUtilizationSummary.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/SavingsPlanUtilizationSummary.Serialization.cs
@@ -20,35 +20,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<SavingsPlanUtilizationSummary>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<SavingsPlanUtilizationSummary>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(SavingsPlanUtilizationSummary)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToString());
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ArmSkuName))
@@ -90,22 +77,6 @@ namespace Azure.ResourceManager.CostManagement.Models
             {
                 writer.WritePropertyName("maxUtilizationPercentage"u8);
                 writer.WriteNumberValue(MaxUtilizationPercentage.Value);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ScheduleProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ScheduleProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ScheduleProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ScheduleProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ScheduleProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("frequency"u8);
             writer.WriteStringValue(Frequency.ToString());
             if (Optional.IsDefined(HourOfDay))
@@ -77,7 +85,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ScheduleProperties IJsonModel<ScheduleProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ScheduledActionListResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ScheduledActionListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ScheduledActionListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ScheduledActionListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ScheduledActionListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ScheduledActionListResult IJsonModel<ScheduledActionListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/SharedScopeBenefitRecommendationProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/SharedScopeBenefitRecommendationProperties.Serialization.cs
@@ -19,91 +19,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<SharedScopeBenefitRecommendationProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<SharedScopeBenefitRecommendationProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(SharedScopeBenefitRecommendationProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W" && Optional.IsDefined(FirstConsumptionOn))
-            {
-                writer.WritePropertyName("firstConsumptionDate"u8);
-                writer.WriteStringValue(FirstConsumptionOn.Value, "O");
-            }
-            if (options.Format != "W" && Optional.IsDefined(LastConsumptionOn))
-            {
-                writer.WritePropertyName("lastConsumptionDate"u8);
-                writer.WriteStringValue(LastConsumptionOn.Value, "O");
-            }
-            if (Optional.IsDefined(LookBackPeriod))
-            {
-                writer.WritePropertyName("lookBackPeriod"u8);
-                writer.WriteStringValue(LookBackPeriod.Value.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(TotalHours))
-            {
-                writer.WritePropertyName("totalHours"u8);
-                writer.WriteNumberValue(TotalHours.Value);
-            }
-            if (Optional.IsDefined(Usage))
-            {
-                writer.WritePropertyName("usage"u8);
-                writer.WriteObjectValue(Usage, options);
-            }
-            if (options.Format != "W" && Optional.IsDefined(ArmSkuName))
-            {
-                writer.WritePropertyName("armSkuName"u8);
-                writer.WriteStringValue(ArmSkuName);
-            }
-            if (Optional.IsDefined(Term))
-            {
-                writer.WritePropertyName("term"u8);
-                writer.WriteStringValue(Term.Value.ToString());
-            }
-            if (Optional.IsDefined(CommitmentGranularity))
-            {
-                writer.WritePropertyName("commitmentGranularity"u8);
-                writer.WriteStringValue(CommitmentGranularity.Value.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(CurrencyCode))
-            {
-                writer.WritePropertyName("currencyCode"u8);
-                writer.WriteStringValue(CurrencyCode);
-            }
-            if (options.Format != "W" && Optional.IsDefined(CostWithoutBenefit))
-            {
-                writer.WritePropertyName("costWithoutBenefit"u8);
-                writer.WriteNumberValue(CostWithoutBenefit.Value);
-            }
-            if (Optional.IsDefined(RecommendationDetails))
-            {
-                writer.WritePropertyName("recommendationDetails"u8);
-                writer.WriteObjectValue(RecommendationDetails, options);
-            }
-            if (options.Format != "W" && Optional.IsDefined(AllRecommendationDetails))
-            {
-                writer.WritePropertyName("allRecommendationDetails"u8);
-                writer.WriteObjectValue(AllRecommendationDetails, options);
-            }
-            writer.WritePropertyName("scope"u8);
-            writer.WriteStringValue(Scope.ToString());
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
+            base.JsonModelWriteCore(writer, options);
         }
 
         SharedScopeBenefitRecommendationProperties IJsonModel<SharedScopeBenefitRecommendationProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/SingleScopeBenefitRecommendationProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/SingleScopeBenefitRecommendationProperties.Serialization.cs
@@ -19,13 +19,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<SingleScopeBenefitRecommendationProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<SingleScopeBenefitRecommendationProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(SingleScopeBenefitRecommendationProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(SubscriptionId))
             {
                 writer.WritePropertyName("subscriptionId"u8);
@@ -36,84 +45,6 @@ namespace Azure.ResourceManager.CostManagement.Models
                 writer.WritePropertyName("resourceGroup"u8);
                 writer.WriteStringValue(ResourceGroup);
             }
-            if (options.Format != "W" && Optional.IsDefined(FirstConsumptionOn))
-            {
-                writer.WritePropertyName("firstConsumptionDate"u8);
-                writer.WriteStringValue(FirstConsumptionOn.Value, "O");
-            }
-            if (options.Format != "W" && Optional.IsDefined(LastConsumptionOn))
-            {
-                writer.WritePropertyName("lastConsumptionDate"u8);
-                writer.WriteStringValue(LastConsumptionOn.Value, "O");
-            }
-            if (Optional.IsDefined(LookBackPeriod))
-            {
-                writer.WritePropertyName("lookBackPeriod"u8);
-                writer.WriteStringValue(LookBackPeriod.Value.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(TotalHours))
-            {
-                writer.WritePropertyName("totalHours"u8);
-                writer.WriteNumberValue(TotalHours.Value);
-            }
-            if (Optional.IsDefined(Usage))
-            {
-                writer.WritePropertyName("usage"u8);
-                writer.WriteObjectValue(Usage, options);
-            }
-            if (options.Format != "W" && Optional.IsDefined(ArmSkuName))
-            {
-                writer.WritePropertyName("armSkuName"u8);
-                writer.WriteStringValue(ArmSkuName);
-            }
-            if (Optional.IsDefined(Term))
-            {
-                writer.WritePropertyName("term"u8);
-                writer.WriteStringValue(Term.Value.ToString());
-            }
-            if (Optional.IsDefined(CommitmentGranularity))
-            {
-                writer.WritePropertyName("commitmentGranularity"u8);
-                writer.WriteStringValue(CommitmentGranularity.Value.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(CurrencyCode))
-            {
-                writer.WritePropertyName("currencyCode"u8);
-                writer.WriteStringValue(CurrencyCode);
-            }
-            if (options.Format != "W" && Optional.IsDefined(CostWithoutBenefit))
-            {
-                writer.WritePropertyName("costWithoutBenefit"u8);
-                writer.WriteNumberValue(CostWithoutBenefit.Value);
-            }
-            if (Optional.IsDefined(RecommendationDetails))
-            {
-                writer.WritePropertyName("recommendationDetails"u8);
-                writer.WriteObjectValue(RecommendationDetails, options);
-            }
-            if (options.Format != "W" && Optional.IsDefined(AllRecommendationDetails))
-            {
-                writer.WritePropertyName("allRecommendationDetails"u8);
-                writer.WriteObjectValue(AllRecommendationDetails, options);
-            }
-            writer.WritePropertyName("scope"u8);
-            writer.WriteStringValue(Scope.ToString());
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         SingleScopeBenefitRecommendationProperties IJsonModel<SingleScopeBenefitRecommendationProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/UnknownBenefitRecommendationProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/UnknownBenefitRecommendationProperties.Serialization.cs
@@ -19,91 +19,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitRecommendationProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitRecommendationProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitRecommendationProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W" && Optional.IsDefined(FirstConsumptionOn))
-            {
-                writer.WritePropertyName("firstConsumptionDate"u8);
-                writer.WriteStringValue(FirstConsumptionOn.Value, "O");
-            }
-            if (options.Format != "W" && Optional.IsDefined(LastConsumptionOn))
-            {
-                writer.WritePropertyName("lastConsumptionDate"u8);
-                writer.WriteStringValue(LastConsumptionOn.Value, "O");
-            }
-            if (Optional.IsDefined(LookBackPeriod))
-            {
-                writer.WritePropertyName("lookBackPeriod"u8);
-                writer.WriteStringValue(LookBackPeriod.Value.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(TotalHours))
-            {
-                writer.WritePropertyName("totalHours"u8);
-                writer.WriteNumberValue(TotalHours.Value);
-            }
-            if (Optional.IsDefined(Usage))
-            {
-                writer.WritePropertyName("usage"u8);
-                writer.WriteObjectValue(Usage, options);
-            }
-            if (options.Format != "W" && Optional.IsDefined(ArmSkuName))
-            {
-                writer.WritePropertyName("armSkuName"u8);
-                writer.WriteStringValue(ArmSkuName);
-            }
-            if (Optional.IsDefined(Term))
-            {
-                writer.WritePropertyName("term"u8);
-                writer.WriteStringValue(Term.Value.ToString());
-            }
-            if (Optional.IsDefined(CommitmentGranularity))
-            {
-                writer.WritePropertyName("commitmentGranularity"u8);
-                writer.WriteStringValue(CommitmentGranularity.Value.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(CurrencyCode))
-            {
-                writer.WritePropertyName("currencyCode"u8);
-                writer.WriteStringValue(CurrencyCode);
-            }
-            if (options.Format != "W" && Optional.IsDefined(CostWithoutBenefit))
-            {
-                writer.WritePropertyName("costWithoutBenefit"u8);
-                writer.WriteNumberValue(CostWithoutBenefit.Value);
-            }
-            if (Optional.IsDefined(RecommendationDetails))
-            {
-                writer.WritePropertyName("recommendationDetails"u8);
-                writer.WriteObjectValue(RecommendationDetails, options);
-            }
-            if (options.Format != "W" && Optional.IsDefined(AllRecommendationDetails))
-            {
-                writer.WritePropertyName("allRecommendationDetails"u8);
-                writer.WriteObjectValue(AllRecommendationDetails, options);
-            }
-            writer.WritePropertyName("scope"u8);
-            writer.WriteStringValue(Scope.ToString());
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
+            base.JsonModelWriteCore(writer, options);
         }
 
         BenefitRecommendationProperties IJsonModel<BenefitRecommendationProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/UnknownBenefitUtilizationSummary.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/UnknownBenefitUtilizationSummary.Serialization.cs
@@ -20,51 +20,22 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<BenefitUtilizationSummary>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<BenefitUtilizationSummary>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(BenefitUtilizationSummary)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToString());
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
+            base.JsonModelWriteCore(writer, options);
         }
 
         BenefitUtilizationSummary IJsonModel<BenefitUtilizationSummary>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ViewKpiProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ViewKpiProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ViewKpiProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ViewKpiProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ViewKpiProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(KpiType))
             {
                 writer.WritePropertyName("type"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ViewKpiProperties IJsonModel<ViewKpiProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ViewListResult.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ViewListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ViewListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ViewListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ViewListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ViewListResult IJsonModel<ViewListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ViewPivotProperties.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Models/ViewPivotProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CostManagement.Models
 
         void IJsonModel<ViewPivotProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ViewPivotProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ViewPivotProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(PivotType))
             {
                 writer.WritePropertyName("type"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CostManagement.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ViewPivotProperties IJsonModel<ViewPivotProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/ScheduledActionData.Serialization.cs
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/ScheduledActionData.Serialization.cs
@@ -21,13 +21,22 @@ namespace Azure.ResourceManager.CostManagement
 
         void IJsonModel<ScheduledActionData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ScheduledActionData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ScheduledActionData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(ETag))
             {
                 writer.WritePropertyName("eTag"u8);
@@ -37,26 +46,6 @@ namespace Azure.ResourceManager.CostManagement
             {
                 writer.WritePropertyName("kind"u8);
                 writer.WriteStringValue(Kind.Value.ToString());
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -99,22 +88,6 @@ namespace Azure.ResourceManager.CostManagement
             {
                 writer.WritePropertyName("viewId"u8);
                 writer.WriteStringValue(ViewId);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/autorest.md
+++ b/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/autorest.md
@@ -23,6 +23,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 # mgmt-debug:
 #   show-serialized-names: true


### PR DESCRIPTION
We need to enable WriteCore feature to costmanagement. Therefore add `use-write-core: true` and do a regen.