### PR TITLE
Enable WriteCore feature for customer-insights

### DIFF
--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/CHANGELOG.md
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
+- Exposed `JsonModelWriteCore` for model serialization procedure.
 
 ### Breaking Changes
 

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/api/Azure.ResourceManager.CustomerInsights.netstandard2.0.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/api/Azure.ResourceManager.CustomerInsights.netstandard2.0.cs
@@ -24,6 +24,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public string PolicyName { get { throw null; } }
         public string PrimaryKey { get { throw null; } set { } }
         public string SecondaryKey { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.AuthorizationPolicyResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.AuthorizationPolicyResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.AuthorizationPolicyResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.AuthorizationPolicyResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.AuthorizationPolicyResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -86,6 +87,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public string RunId { get { throw null; } }
         public Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingState? State { get { throw null; } }
         public System.Guid? TenantId { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.ConnectorMappingResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.ConnectorMappingResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.ConnectorMappingResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.ConnectorMappingResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.ConnectorMappingResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -142,6 +144,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public System.DateTimeOffset? LastModified { get { throw null; } }
         public Azure.ResourceManager.CustomerInsights.Models.ConnectorState? State { get { throw null; } }
         public System.Guid? TenantId { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.ConnectorResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.ConnectorResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.ConnectorResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.ConnectorResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.ConnectorResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -217,6 +220,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public string ProvisioningState { get { throw null; } }
         public int? TenantFeatures { get { throw null; } set { } }
         public string WebEndpoint { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.HubData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.HubData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.HubData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.HubData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.HubData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -337,6 +341,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public System.Guid? TenantId { get { throw null; } }
         public string TimestampFieldName { get { throw null; } set { } }
         public string TypeName { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.InteractionResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.InteractionResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.InteractionResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.InteractionResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.InteractionResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -401,6 +406,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public System.Guid? TenantId { get { throw null; } }
         public Azure.ResourceManager.CustomerInsights.Models.KpiThresholds ThresHolds { get { throw null; } set { } }
         public string Unit { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.KpiResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.KpiResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.KpiResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.KpiResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.KpiResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -461,6 +467,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public Azure.ResourceManager.CustomerInsights.Models.EntityType? TargetEntityType { get { throw null; } set { } }
         public string TargetEntityTypeName { get { throw null; } set { } }
         public System.Guid? TenantId { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.LinkResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.LinkResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.LinkResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.LinkResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.LinkResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -523,6 +530,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public string ScoreLabel { get { throw null; } set { } }
         public Azure.ResourceManager.CustomerInsights.Models.PredictionSystemGeneratedEntities SystemGeneratedEntities { get { throw null; } }
         public System.Guid? TenantId { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.PredictionResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.PredictionResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.PredictionResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.PredictionResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.PredictionResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -592,6 +600,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public System.Guid? TenantId { get { throw null; } }
         public string TimestampFieldName { get { throw null; } set { } }
         public string TypeName { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.ProfileResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.ProfileResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.ProfileResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.ProfileResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.ProfileResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -650,6 +659,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public string RelationshipGuidId { get { throw null; } }
         public string RelationshipName { get { throw null; } set { } }
         public System.Guid? TenantId { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.RelationshipLinkResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.RelationshipLinkResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.RelationshipLinkResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.RelationshipLinkResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.RelationshipLinkResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -707,6 +717,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public string RelationshipGuidId { get { throw null; } }
         public string RelationshipName { get { throw null; } }
         public System.Guid? TenantId { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.RelationshipResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.RelationshipResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.RelationshipResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.RelationshipResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.RelationshipResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -772,6 +783,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public System.Guid? TenantId { get { throw null; } }
         public Azure.ResourceManager.CustomerInsights.Models.ResourceSetDescription Views { get { throw null; } set { } }
         public Azure.ResourceManager.CustomerInsights.Models.ResourceSetDescription WidgetTypes { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.RoleAssignmentResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.RoleAssignmentResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.RoleAssignmentResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.RoleAssignmentResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.RoleAssignmentResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -821,6 +833,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public System.Guid? TenantId { get { throw null; } }
         public string UserId { get { throw null; } set { } }
         public string ViewName { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.ViewResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.ViewResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.ViewResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.ViewResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.ViewResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -873,6 +886,7 @@ namespace Azure.ResourceManager.CustomerInsights
         public System.Guid? TenantId { get { throw null; } }
         public string WidgetTypeName { get { throw null; } }
         public string WidgetVersion { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.WidgetTypeResourceFormatData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.WidgetTypeResourceFormatData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.WidgetTypeResourceFormatData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.WidgetTypeResourceFormatData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.WidgetTypeResourceFormatData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -972,6 +986,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public string PrincipalId { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> PrincipalMetadata { get { throw null; } }
         public string PrincipalType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.AssignmentPrincipal System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.AssignmentPrincipal>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.AssignmentPrincipal>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.AssignmentPrincipal System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.AssignmentPrincipal>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -985,6 +1000,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public string PolicyName { get { throw null; } }
         public string PrimaryKey { get { throw null; } }
         public string SecondaryKey { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.AuthorizationPolicy System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.AuthorizationPolicy>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.AuthorizationPolicy>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.AuthorizationPolicy System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.AuthorizationPolicy>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1004,6 +1020,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         internal CanonicalProfileDefinition() { }
         public int? CanonicalProfileId { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinitionPropertiesItem> Properties { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1018,6 +1035,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public int? Rank { get { throw null; } }
         public string Value { get { throw null; } }
         public Azure.ResourceManager.CustomerInsights.Models.CanonicalPropertyValueType? ValueType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinitionPropertiesItem System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinitionPropertiesItem>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinitionPropertiesItem>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinitionPropertiesItem System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.CanonicalProfileDefinitionPropertiesItem>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1061,6 +1079,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public ConnectorMappingAvailability(int interval) { }
         public Azure.ResourceManager.CustomerInsights.Models.FrequencyType? Frequency { get { throw null; } set { } }
         public int Interval { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingAvailability System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingAvailability>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingAvailability>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingAvailability System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingAvailability>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1072,6 +1091,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public ConnectorMappingCompleteOperation() { }
         public Azure.ResourceManager.CustomerInsights.Models.CompletionOperationType? CompletionOperationType { get { throw null; } set { } }
         public string DestinationFolder { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingCompleteOperation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingCompleteOperation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingCompleteOperation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingCompleteOperation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingCompleteOperation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1083,6 +1103,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public ConnectorMappingErrorManagement(Azure.ResourceManager.CustomerInsights.Models.ErrorManagementType errorManagementType) { }
         public int? ErrorLimit { get { throw null; } set { } }
         public Azure.ResourceManager.CustomerInsights.Models.ErrorManagementType ErrorManagementType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingErrorManagement System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingErrorManagement>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingErrorManagement>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingErrorManagement System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingErrorManagement>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1098,6 +1119,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public Azure.ResourceManager.CustomerInsights.Models.FormatType FormatType { get { throw null; } }
         public string QuoteCharacter { get { throw null; } set { } }
         public string QuoteEscapeCharacter { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingFormat System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingFormat>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingFormat>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingFormat System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingFormat>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1115,6 +1137,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingFormat Format { get { throw null; } set { } }
         public bool? HasHeader { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingStructure> Structure { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1138,6 +1161,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public string CustomFormatSpecifier { get { throw null; } set { } }
         public bool? IsEncrypted { get { throw null; } set { } }
         public string PropertyName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingStructure System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingStructure>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingStructure>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingStructure System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ConnectorMappingStructure>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1184,6 +1208,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public string Name { get { throw null; } }
         public int? Precedence { get { throw null; } }
         public Azure.ResourceManager.CustomerInsights.Models.Status? Status { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.DataSourcePrecedence System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.DataSourcePrecedence>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.DataSourcePrecedence>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.DataSourcePrecedence System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.DataSourcePrecedence>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1253,6 +1278,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public string EntityType { get { throw null; } set { } }
         public string EntityTypeName { get { throw null; } set { } }
         public string RelativePath { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.GetImageUploadUrlInput System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.GetImageUploadUrlInput>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.GetImageUploadUrlInput>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.GetImageUploadUrlInput System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.GetImageUploadUrlInput>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1265,6 +1291,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public int? MaxUnits { get { throw null; } set { } }
         public int? MinUnits { get { throw null; } set { } }
         public string SkuName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.HubBillingInfoFormat System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.HubBillingInfoFormat>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.HubBillingInfoFormat>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.HubBillingInfoFormat System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.HubBillingInfoFormat>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1277,6 +1304,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public System.Uri ContentUri { get { throw null; } }
         public bool? ImageExists { get { throw null; } }
         public string RelativePath { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ImageDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ImageDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ImageDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ImageDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ImageDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1293,6 +1321,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public KpiAlias(string aliasName, string expression) { }
         public string AliasName { get { throw null; } set { } }
         public string Expression { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiAlias System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiAlias>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiAlias>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiAlias System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.KpiAlias>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1321,6 +1350,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public System.Guid? TenantId { get { throw null; } }
         public Azure.ResourceManager.CustomerInsights.Models.KpiThresholds ThresHolds { get { throw null; } }
         public string Unit { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.KpiDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1332,6 +1362,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public KpiExtract(string extractName, string expression) { }
         public string Expression { get { throw null; } set { } }
         public string ExtractName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiExtract System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiExtract>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiExtract>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiExtract System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.KpiExtract>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1355,6 +1386,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public System.Collections.Generic.IReadOnlyDictionary<string, string> DisplayName { get { throw null; } }
         public string FieldName { get { throw null; } }
         public string FieldType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiGroupByMetadata System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiGroupByMetadata>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiGroupByMetadata>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiGroupByMetadata System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.KpiGroupByMetadata>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1365,6 +1397,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
     {
         internal KpiParticipantProfilesMetadata() { }
         public string TypeName { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiParticipantProfilesMetadata System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiParticipantProfilesMetadata>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiParticipantProfilesMetadata>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiParticipantProfilesMetadata System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.KpiParticipantProfilesMetadata>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1377,6 +1410,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public bool IncreasingKpi { get { throw null; } set { } }
         public decimal LowerLimit { get { throw null; } set { } }
         public decimal UpperLimit { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiThresholds System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiThresholds>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.KpiThresholds>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.KpiThresholds System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.KpiThresholds>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1397,6 +1431,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public System.Collections.Generic.IList<Azure.ResourceManager.CustomerInsights.Models.ParticipantPropertyReference> ParticipantPropertyReferences { get { throw null; } }
         public string ProfileTypeName { get { throw null; } set { } }
         public string Role { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.Participant System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.Participant>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.Participant>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.Participant System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.Participant>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1408,6 +1443,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public ParticipantProfilePropertyReference(string interactionPropertyName, string profilePropertyName) { }
         public string InteractionPropertyName { get { throw null; } set { } }
         public string ProfilePropertyName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ParticipantProfilePropertyReference System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ParticipantProfilePropertyReference>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ParticipantProfilePropertyReference>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ParticipantProfilePropertyReference System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ParticipantProfilePropertyReference>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1419,6 +1455,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public ParticipantPropertyReference(string sourcePropertyName, string targetPropertyName) { }
         public string SourcePropertyName { get { throw null; } set { } }
         public string TargetPropertyName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ParticipantPropertyReference System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ParticipantPropertyReference>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ParticipantPropertyReference>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ParticipantPropertyReference System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ParticipantPropertyReference>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1437,6 +1474,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinitionDistributionsItem> Distributions { get { throw null; } }
         public long? TotalNegatives { get { throw null; } }
         public long? TotalPositives { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1451,6 +1489,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public long? Positives { get { throw null; } }
         public long? PositivesAboveThreshold { get { throw null; } }
         public int? ScoreThreshold { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinitionDistributionsItem System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinitionDistributionsItem>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinitionDistributionsItem>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinitionDistributionsItem System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.PredictionDistributionDefinitionDistributionsItem>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1463,6 +1502,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public string GradeName { get { throw null; } set { } }
         public int? MaxScoreThreshold { get { throw null; } set { } }
         public int? MinScoreThreshold { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionGradesItem System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionGradesItem>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionGradesItem>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionGradesItem System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.PredictionGradesItem>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1475,6 +1515,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public string Grade { get { throw null; } set { } }
         public string Reason { get { throw null; } set { } }
         public string Score { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionMappings System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionMappings>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionMappings>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionMappings System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.PredictionMappings>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1529,6 +1570,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public decimal? TrainingAccuracy { get { throw null; } }
         public int? TrainingSetCount { get { throw null; } }
         public int? ValidationSetCount { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionModelStatus System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionModelStatus>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionModelStatus>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionModelStatus System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.PredictionModelStatus>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1541,6 +1583,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public System.Collections.Generic.IReadOnlyList<string> GeneratedInteractionTypes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> GeneratedKpis { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<string> GeneratedLinks { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionSystemGeneratedEntities System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionSystemGeneratedEntities>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionSystemGeneratedEntities>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionSystemGeneratedEntities System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.PredictionSystemGeneratedEntities>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1555,6 +1598,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public long? PrimaryProfileInstanceCount { get { throw null; } }
         public string ScoreName { get { throw null; } }
         public System.Guid? TenantId { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionTrainingResults System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionTrainingResults>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PredictionTrainingResults>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PredictionTrainingResults System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.PredictionTrainingResults>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1566,6 +1610,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public ProfileEnumValidValuesFormat() { }
         public System.Collections.Generic.IDictionary<string, string> LocalizedValueNames { get { throw null; } }
         public int? Value { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ProfileEnumValidValuesFormat System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ProfileEnumValidValuesFormat>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ProfileEnumValidValuesFormat>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ProfileEnumValidValuesFormat System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ProfileEnumValidValuesFormat>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1591,6 +1636,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public int? MaxLength { get { throw null; } set { } }
         public string PropertyId { get { throw null; } set { } }
         public string SchemaItemPropLink { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PropertyDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PropertyDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.PropertyDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.PropertyDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.PropertyDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1625,6 +1671,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public string InteractionFieldName { get { throw null; } set { } }
         public Azure.ResourceManager.CustomerInsights.Models.LinkType? LinkType { get { throw null; } set { } }
         public string RelationshipFieldName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RelationshipLinkFieldMapping System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipLinkFieldMapping>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipLinkFieldMapping>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RelationshipLinkFieldMapping System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipLinkFieldMapping>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1639,6 +1686,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.CustomerInsights.Models.ParticipantProfilePropertyReference> ProfilePropertyReferences { get { throw null; } }
         public string RelatedProfileName { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.CustomerInsights.Models.ParticipantProfilePropertyReference> RelatedProfilePropertyReferences { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RelationshipsLookup System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipsLookup>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipsLookup>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RelationshipsLookup System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipsLookup>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1650,6 +1698,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public RelationshipTypeFieldMapping(string profileFieldName, string relatedProfileKeyProperty) { }
         public string ProfileFieldName { get { throw null; } set { } }
         public string RelatedProfileKeyProperty { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeFieldMapping System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeFieldMapping>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeFieldMapping>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeFieldMapping System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeFieldMapping>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1660,6 +1709,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
     {
         public RelationshipTypeMapping(System.Collections.Generic.IEnumerable<Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeFieldMapping> fieldMappings) { }
         public System.Collections.Generic.IList<Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeFieldMapping> FieldMappings { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeMapping System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeMapping>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeMapping>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeMapping System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.RelationshipTypeMapping>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1671,6 +1721,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public ResourceSetDescription() { }
         public System.Collections.Generic.IList<string> Elements { get { throw null; } }
         public System.Collections.Generic.IList<string> Exceptions { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ResourceSetDescription System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ResourceSetDescription>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.ResourceSetDescription>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.ResourceSetDescription System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.ResourceSetDescription>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1682,6 +1733,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public RoleResourceFormat() { }
         public string Description { get { throw null; } set { } }
         public string RoleName { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RoleResourceFormat System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RoleResourceFormat>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.RoleResourceFormat>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.RoleResourceFormat System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.RoleResourceFormat>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1723,6 +1775,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public System.Collections.Generic.IDictionary<string, string> DisplayName { get { throw null; } }
         public System.Collections.Generic.IList<string> KeyPropertyNames { get { throw null; } }
         public string StrongIdName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.StrongId System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.StrongId>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.StrongId>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.StrongId System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.StrongId>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1734,6 +1787,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         internal SuggestRelationshipLinksResponse() { }
         public string InteractionName { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.CustomerInsights.Models.RelationshipsLookup> SuggestedRelationships { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.SuggestRelationshipLinksResponse System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.SuggestRelationshipLinksResponse>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.SuggestRelationshipLinksResponse>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.SuggestRelationshipLinksResponse System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.SuggestRelationshipLinksResponse>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -1746,6 +1800,7 @@ namespace Azure.ResourceManager.CustomerInsights.Models
         public Azure.ResourceManager.CustomerInsights.Models.LinkType? LinkType { get { throw null; } set { } }
         public string SourcePropertyName { get { throw null; } set { } }
         public string TargetPropertyName { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.TypePropertiesMapping System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.TypePropertiesMapping>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.CustomerInsights.Models.TypePropertiesMapping>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.CustomerInsights.Models.TypePropertiesMapping System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.CustomerInsights.Models.TypePropertiesMapping>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/AuthorizationPolicyResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/AuthorizationPolicyResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<AuthorizationPolicyResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AuthorizationPolicyResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AuthorizationPolicyResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(PolicyName))
@@ -74,22 +63,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("secondaryKey"u8);
                 writer.WriteStringValue(SecondaryKey);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/ConnectorMappingResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/ConnectorMappingResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<ConnectorMappingResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorMappingResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorMappingResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ConnectorName))
@@ -124,22 +113,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("tenantId"u8);
                 writer.WriteStringValue(TenantId.Value);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/ConnectorResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/ConnectorResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<ConnectorResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ConnectorId))
@@ -122,22 +111,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("isInternal"u8);
                 writer.WriteBooleanValue(IsInternal.Value);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/HubData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/HubData.Serialization.cs
@@ -21,46 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<HubData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<HubData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(HubData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (Optional.IsCollectionDefined(Tags))
-            {
-                writer.WritePropertyName("tags"u8);
-                writer.WriteStartObject();
-                foreach (var item in Tags)
-                {
-                    writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
-                }
-                writer.WriteEndObject();
-            }
-            writer.WritePropertyName("location"u8);
-            writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ApiEndpoint))
@@ -87,22 +63,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("hubBillingInfo"u8);
                 writer.WriteObjectValue(HubBillingInfo, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/InteractionResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/InteractionResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<InteractionResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<InteractionResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(InteractionResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Attributes))
@@ -253,22 +242,6 @@ namespace Azure.ResourceManager.CustomerInsights
                 writer.WriteStringValue(DataSourceReferenceId);
             }
             writer.WriteEndObject();
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
             writer.WriteEndObject();
         }
 

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/KpiResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/KpiResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<KpiResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<KpiResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(KpiResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(EntityType))
@@ -181,22 +170,6 @@ namespace Azure.ResourceManager.CustomerInsights
                     writer.WriteObjectValue(item, options);
                 }
                 writer.WriteEndArray();
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/LinkResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/LinkResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<LinkResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LinkResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LinkResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(TenantId))
@@ -136,22 +125,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("operationType"u8);
                 writer.WriteStringValue(OperationType.Value.ToSerialString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/AssignmentPrincipal.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/AssignmentPrincipal.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<AssignmentPrincipal>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AssignmentPrincipal>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AssignmentPrincipal)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("principalId"u8);
             writer.WriteStringValue(PrincipalId);
             writer.WritePropertyName("principalType"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AssignmentPrincipal IJsonModel<AssignmentPrincipal>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/AuthorizationPolicy.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/AuthorizationPolicy.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<AuthorizationPolicy>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AuthorizationPolicy>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AuthorizationPolicy)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(PolicyName))
             {
                 writer.WritePropertyName("policyName"u8);
@@ -63,7 +71,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AuthorizationPolicy IJsonModel<AuthorizationPolicy>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/AuthorizationPolicyListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/AuthorizationPolicyListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<AuthorizationPolicyListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<AuthorizationPolicyListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(AuthorizationPolicyListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         AuthorizationPolicyListResult IJsonModel<AuthorizationPolicyListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/CanonicalProfileDefinition.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/CanonicalProfileDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<CanonicalProfileDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CanonicalProfileDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CanonicalProfileDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(CanonicalProfileId))
             {
                 writer.WritePropertyName("canonicalProfileId"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CanonicalProfileDefinition IJsonModel<CanonicalProfileDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/CanonicalProfileDefinitionPropertiesItem.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/CanonicalProfileDefinitionPropertiesItem.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<CanonicalProfileDefinitionPropertiesItem>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CanonicalProfileDefinitionPropertiesItem>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CanonicalProfileDefinitionPropertiesItem)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ProfileName))
             {
                 writer.WritePropertyName("profileName"u8);
@@ -66,7 +74,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CanonicalProfileDefinitionPropertiesItem IJsonModel<CanonicalProfileDefinitionPropertiesItem>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ConnectorListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectorListResult IJsonModel<ConnectorListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingAvailability.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingAvailability.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ConnectorMappingAvailability>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorMappingAvailability>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorMappingAvailability)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Frequency))
             {
                 writer.WritePropertyName("frequency"u8);
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectorMappingAvailability IJsonModel<ConnectorMappingAvailability>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingCompleteOperation.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingCompleteOperation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ConnectorMappingCompleteOperation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorMappingCompleteOperation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorMappingCompleteOperation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(CompletionOperationType))
             {
                 writer.WritePropertyName("completionOperationType"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectorMappingCompleteOperation IJsonModel<ConnectorMappingCompleteOperation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingErrorManagement.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingErrorManagement.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ConnectorMappingErrorManagement>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorMappingErrorManagement>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorMappingErrorManagement)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("errorManagementType"u8);
             writer.WriteStringValue(ErrorManagementType.ToSerialString());
             if (Optional.IsDefined(ErrorLimit))
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectorMappingErrorManagement IJsonModel<ConnectorMappingErrorManagement>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingFormat.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingFormat.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ConnectorMappingFormat>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorMappingFormat>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorMappingFormat)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("formatType"u8);
             writer.WriteStringValue(FormatType.ToString());
             if (Optional.IsDefined(ColumnDelimiter))
@@ -68,7 +76,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectorMappingFormat IJsonModel<ConnectorMappingFormat>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ConnectorMappingListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorMappingListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorMappingListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectorMappingListResult IJsonModel<ConnectorMappingListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingProperties.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ConnectorMappingProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorMappingProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorMappingProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(FolderPath))
             {
                 writer.WritePropertyName("folderPath"u8);
@@ -71,7 +79,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectorMappingProperties IJsonModel<ConnectorMappingProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingStructure.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ConnectorMappingStructure.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ConnectorMappingStructure>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectorMappingStructure>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectorMappingStructure)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("propertyName"u8);
             writer.WriteStringValue(PropertyName);
             writer.WritePropertyName("columnName"u8);
@@ -55,7 +63,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectorMappingStructure IJsonModel<ConnectorMappingStructure>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/DataSourcePrecedence.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/DataSourcePrecedence.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<DataSourcePrecedence>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataSourcePrecedence>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataSourcePrecedence)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Precedence))
             {
                 writer.WritePropertyName("precedence"u8);
@@ -74,7 +82,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataSourcePrecedence IJsonModel<DataSourcePrecedence>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/GetImageUploadUrlInput.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/GetImageUploadUrlInput.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<GetImageUploadUrlInput>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<GetImageUploadUrlInput>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(GetImageUploadUrlInput)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(EntityType))
             {
                 writer.WritePropertyName("entityType"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         GetImageUploadUrlInput IJsonModel<GetImageUploadUrlInput>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/HubBillingInfoFormat.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/HubBillingInfoFormat.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<HubBillingInfoFormat>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<HubBillingInfoFormat>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(HubBillingInfoFormat)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(SkuName))
             {
                 writer.WritePropertyName("skuName"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         HubBillingInfoFormat IJsonModel<HubBillingInfoFormat>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/HubListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/HubListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<HubListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<HubListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(HubListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         HubListResult IJsonModel<HubListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ImageDefinition.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ImageDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ImageDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ImageDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ImageDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ImageExists))
             {
                 writer.WritePropertyName("imageExists"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ImageDefinition IJsonModel<ImageDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/InteractionListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/InteractionListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<InteractionListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<InteractionListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(InteractionListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         InteractionListResult IJsonModel<InteractionListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiAlias.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiAlias.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<KpiAlias>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<KpiAlias>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(KpiAlias)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("aliasName"u8);
             writer.WriteStringValue(AliasName);
             writer.WritePropertyName("expression"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         KpiAlias IJsonModel<KpiAlias>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiDefinition.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<KpiDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<KpiDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(KpiDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("entityType"u8);
             writer.WriteStringValue(EntityType.ToSerialString());
             writer.WritePropertyName("entityTypeName"u8);
@@ -158,7 +166,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         KpiDefinition IJsonModel<KpiDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiExtract.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiExtract.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<KpiExtract>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<KpiExtract>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(KpiExtract)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("extractName"u8);
             writer.WriteStringValue(ExtractName);
             writer.WritePropertyName("expression"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         KpiExtract IJsonModel<KpiExtract>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiGroupByMetadata.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiGroupByMetadata.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<KpiGroupByMetadata>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<KpiGroupByMetadata>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(KpiGroupByMetadata)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(DisplayName))
             {
                 writer.WritePropertyName("displayName"u8);
@@ -62,7 +70,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         KpiGroupByMetadata IJsonModel<KpiGroupByMetadata>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<KpiListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<KpiListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(KpiListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         KpiListResult IJsonModel<KpiListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiParticipantProfilesMetadata.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiParticipantProfilesMetadata.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<KpiParticipantProfilesMetadata>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<KpiParticipantProfilesMetadata>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(KpiParticipantProfilesMetadata)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("typeName"u8);
             writer.WriteStringValue(TypeName);
             if (options.Format != "W" && _serializedAdditionalRawData != null)
@@ -43,7 +51,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         KpiParticipantProfilesMetadata IJsonModel<KpiParticipantProfilesMetadata>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiThresholds.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/KpiThresholds.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<KpiThresholds>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<KpiThresholds>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(KpiThresholds)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("lowerLimit"u8);
             writer.WriteNumberValue(LowerLimit);
             writer.WritePropertyName("upperLimit"u8);
@@ -47,7 +55,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         KpiThresholds IJsonModel<KpiThresholds>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/LinkListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/LinkListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<LinkListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<LinkListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(LinkListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         LinkListResult IJsonModel<LinkListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/Participant.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/Participant.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<Participant>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<Participant>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(Participant)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("profileTypeName"u8);
             writer.WriteStringValue(ProfileTypeName);
             writer.WritePropertyName("participantPropertyReferences"u8);
@@ -79,7 +87,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         Participant IJsonModel<Participant>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ParticipantProfilePropertyReference.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ParticipantProfilePropertyReference.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ParticipantProfilePropertyReference>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ParticipantProfilePropertyReference>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ParticipantProfilePropertyReference)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("interactionPropertyName"u8);
             writer.WriteStringValue(InteractionPropertyName);
             writer.WritePropertyName("profilePropertyName"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ParticipantProfilePropertyReference IJsonModel<ParticipantProfilePropertyReference>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ParticipantPropertyReference.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ParticipantPropertyReference.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ParticipantPropertyReference>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ParticipantPropertyReference>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ParticipantPropertyReference)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("sourcePropertyName"u8);
             writer.WriteStringValue(SourcePropertyName);
             writer.WritePropertyName("targetPropertyName"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ParticipantPropertyReference IJsonModel<ParticipantPropertyReference>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionDistributionDefinition.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionDistributionDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PredictionDistributionDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionDistributionDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionDistributionDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(TotalPositives))
             {
                 writer.WritePropertyName("totalPositives"u8);
@@ -61,7 +69,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PredictionDistributionDefinition IJsonModel<PredictionDistributionDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionDistributionDefinitionDistributionsItem.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionDistributionDefinitionDistributionsItem.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PredictionDistributionDefinitionDistributionsItem>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionDistributionDefinitionDistributionsItem>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionDistributionDefinitionDistributionsItem)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ScoreThreshold))
             {
                 writer.WritePropertyName("scoreThreshold"u8);
@@ -66,7 +74,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PredictionDistributionDefinitionDistributionsItem IJsonModel<PredictionDistributionDefinitionDistributionsItem>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionGradesItem.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionGradesItem.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PredictionGradesItem>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionGradesItem>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionGradesItem)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(GradeName))
             {
                 writer.WritePropertyName("gradeName"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PredictionGradesItem IJsonModel<PredictionGradesItem>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PredictionListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PredictionListResult IJsonModel<PredictionListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionMappings.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionMappings.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PredictionMappings>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionMappings>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionMappings)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("score"u8);
             writer.WriteStringValue(Score);
             writer.WritePropertyName("grade"u8);
@@ -47,7 +55,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PredictionMappings IJsonModel<PredictionMappings>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionModelStatus.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionModelStatus.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PredictionModelStatus>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionModelStatus>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionModelStatus)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(TenantId))
             {
                 writer.WritePropertyName("tenantId"u8);
@@ -93,7 +101,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PredictionModelStatus IJsonModel<PredictionModelStatus>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionSystemGeneratedEntities.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionSystemGeneratedEntities.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PredictionSystemGeneratedEntities>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionSystemGeneratedEntities>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionSystemGeneratedEntities)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(GeneratedInteractionTypes))
             {
                 writer.WritePropertyName("generatedInteractionTypes"u8);
@@ -72,7 +80,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PredictionSystemGeneratedEntities IJsonModel<PredictionSystemGeneratedEntities>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionTrainingResults.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PredictionTrainingResults.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PredictionTrainingResults>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionTrainingResults>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionTrainingResults)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(TenantId))
             {
                 writer.WritePropertyName("tenantId"u8);
@@ -71,7 +79,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PredictionTrainingResults IJsonModel<PredictionTrainingResults>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ProfileEnumValidValuesFormat.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ProfileEnumValidValuesFormat.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ProfileEnumValidValuesFormat>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ProfileEnumValidValuesFormat>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ProfileEnumValidValuesFormat)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -57,7 +65,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ProfileEnumValidValuesFormat IJsonModel<ProfileEnumValidValuesFormat>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ProfileListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ProfileListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ProfileListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ProfileListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ProfileListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ProfileListResult IJsonModel<ProfileListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PropertyDefinition.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/PropertyDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<PropertyDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PropertyDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PropertyDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ArrayValueSeparator))
             {
                 writer.WritePropertyName("arrayValueSeparator"u8);
@@ -125,7 +133,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PropertyDefinition IJsonModel<PropertyDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipLinkFieldMapping.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipLinkFieldMapping.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RelationshipLinkFieldMapping>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RelationshipLinkFieldMapping>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RelationshipLinkFieldMapping)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("interactionFieldName"u8);
             writer.WriteStringValue(InteractionFieldName);
             if (Optional.IsDefined(LinkType))
@@ -50,7 +58,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RelationshipLinkFieldMapping IJsonModel<RelationshipLinkFieldMapping>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipLinkListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipLinkListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RelationshipLinkListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RelationshipLinkListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RelationshipLinkListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RelationshipLinkListResult IJsonModel<RelationshipLinkListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RelationshipListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RelationshipListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RelationshipListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RelationshipListResult IJsonModel<RelationshipListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipTypeFieldMapping.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipTypeFieldMapping.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RelationshipTypeFieldMapping>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RelationshipTypeFieldMapping>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RelationshipTypeFieldMapping)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("profileFieldName"u8);
             writer.WriteStringValue(ProfileFieldName);
             writer.WritePropertyName("relatedProfileKeyProperty"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RelationshipTypeFieldMapping IJsonModel<RelationshipTypeFieldMapping>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipTypeMapping.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipTypeMapping.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RelationshipTypeMapping>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RelationshipTypeMapping>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RelationshipTypeMapping)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("fieldMappings"u8);
             writer.WriteStartArray();
             foreach (var item in FieldMappings)
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RelationshipTypeMapping IJsonModel<RelationshipTypeMapping>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipsLookup.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RelationshipsLookup.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RelationshipsLookup>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RelationshipsLookup>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RelationshipsLookup)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProfileName))
             {
                 writer.WritePropertyName("profileName"u8);
@@ -76,7 +84,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RelationshipsLookup IJsonModel<RelationshipsLookup>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ResourceSetDescription.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ResourceSetDescription.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ResourceSetDescription>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ResourceSetDescription>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ResourceSetDescription)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Elements))
             {
                 writer.WritePropertyName("elements"u8);
@@ -61,7 +69,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ResourceSetDescription IJsonModel<ResourceSetDescription>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RoleAssignmentListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RoleAssignmentListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RoleAssignmentListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RoleAssignmentListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RoleAssignmentListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RoleAssignmentListResult IJsonModel<RoleAssignmentListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RoleListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RoleListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RoleListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RoleListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RoleListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         RoleListResult IJsonModel<RoleListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RoleResourceFormat.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/RoleResourceFormat.Serialization.cs
@@ -20,33 +20,22 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<RoleResourceFormat>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RoleResourceFormat>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RoleResourceFormat)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(RoleName))
@@ -58,22 +47,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
             {
                 writer.WritePropertyName("description"u8);
                 writer.WriteStringValue(Description);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/StrongId.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/StrongId.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<StrongId>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<StrongId>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(StrongId)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("keyPropertyNames"u8);
             writer.WriteStartArray();
             foreach (var item in KeyPropertyNames)
@@ -72,7 +80,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         StrongId IJsonModel<StrongId>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/SuggestRelationshipLinksResponse.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/SuggestRelationshipLinksResponse.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<SuggestRelationshipLinksResponse>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<SuggestRelationshipLinksResponse>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(SuggestRelationshipLinksResponse)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(InteractionName))
             {
                 writer.WritePropertyName("interactionName"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         SuggestRelationshipLinksResponse IJsonModel<SuggestRelationshipLinksResponse>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/TypePropertiesMapping.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/TypePropertiesMapping.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<TypePropertiesMapping>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<TypePropertiesMapping>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(TypePropertiesMapping)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("sourcePropertyName"u8);
             writer.WriteStringValue(SourcePropertyName);
             writer.WritePropertyName("targetPropertyName"u8);
@@ -50,7 +58,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         TypePropertiesMapping IJsonModel<TypePropertiesMapping>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ViewListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/ViewListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<ViewListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ViewListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ViewListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ViewListResult IJsonModel<ViewListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/WidgetTypeListResult.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/Models/WidgetTypeListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 
         void IJsonModel<WidgetTypeListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<WidgetTypeListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(WidgetTypeListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.CustomerInsights.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         WidgetTypeListResult IJsonModel<WidgetTypeListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/PredictionResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/PredictionResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<PredictionResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PredictionResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PredictionResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Description))
@@ -166,22 +155,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("systemGeneratedEntities"u8);
                 writer.WriteObjectValue(SystemGeneratedEntities, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/ProfileResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/ProfileResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<ProfileResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ProfileResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ProfileResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Attributes))
@@ -194,22 +183,6 @@ namespace Azure.ResourceManager.CustomerInsights
                     writer.WriteObjectValue(item, options);
                 }
                 writer.WriteEndArray();
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/RelationshipLinkResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/RelationshipLinkResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<RelationshipLinkResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RelationshipLinkResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RelationshipLinkResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsCollectionDefined(DisplayName))
@@ -131,22 +120,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("tenantId"u8);
                 writer.WriteStringValue(TenantId.Value);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/RelationshipResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/RelationshipResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<RelationshipResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RelationshipResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RelationshipResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(Cardinality))
@@ -131,22 +120,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("tenantId"u8);
                 writer.WriteStringValue(TenantId.Value);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/RoleAssignmentResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/RoleAssignmentResourceFormatData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<RoleAssignmentResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<RoleAssignmentResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(RoleAssignmentResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(TenantId))
@@ -166,22 +155,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("segments"u8);
                 writer.WriteObjectValue(Segments, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/ViewResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/ViewResourceFormatData.Serialization.cs
@@ -20,33 +20,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<ViewResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ViewResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ViewResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ViewName))
@@ -89,22 +78,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("created"u8);
                 writer.WriteStringValue(Created.Value, "O");
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/WidgetTypeResourceFormatData.Serialization.cs
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/Generated/WidgetTypeResourceFormatData.Serialization.cs
@@ -20,33 +20,22 @@ namespace Azure.ResourceManager.CustomerInsights
 
         void IJsonModel<WidgetTypeResourceFormatData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<WidgetTypeResourceFormatData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(WidgetTypeResourceFormatData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(WidgetTypeName))
@@ -99,22 +88,6 @@ namespace Azure.ResourceManager.CustomerInsights
             {
                 writer.WritePropertyName("created"u8);
                 writer.WriteStringValue(Created.Value, "O");
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/autorest.md
+++ b/sdk/customer-insights/Azure.ResourceManager.CustomerInsights/src/autorest.md
@@ -18,6 +18,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 format-by-name-rules:
   'tenantId': 'uuid'


### PR DESCRIPTION
We need to enable WriteCore feature to customer-insights. Therefore add `use-write-core: true` and do a regen.