### PR TITLE
Fix identity based negotiation result for Socket.IO binding

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.0-beta.3 (2024-09-24)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix the bug that identity based negotiation result is not correct
 
 ## 1.0.0-beta.2 (2024-09-02)
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.csproj
@@ -26,6 +26,7 @@
 		<PackageReference Include="Microsoft.Azure.WebJobs" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" />
 		<PackageReference Include="Microsoft.Extensions.Azure" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Services/WebPubSubForSocketIOService.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Services/WebPubSubForSocketIOService.cs
@@ -37,10 +37,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         }
 
         // For tests.
-        public WebPubSubForSocketIOService(WebPubSubServiceClient client, bool useConnectionString = false)
+        public WebPubSubForSocketIOService(WebPubSubServiceClient client)
         {
             _client = client;
-            _useConnectionStrings = useConnectionString;
         }
 
         public WebPubSubServiceClient Client => _client;

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Services/WebPubSubForSocketIOService.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Services/WebPubSubForSocketIOService.cs
@@ -5,7 +5,10 @@ using Azure;
 using Azure.Core;
 using Azure.Messaging.WebPubSub;
 using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Text;
+using System.Web;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
 {
@@ -34,9 +37,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
         }
 
         // For tests.
-        public WebPubSubForSocketIOService(WebPubSubServiceClient client)
+        public WebPubSubForSocketIOService(WebPubSubServiceClient client, bool useConnectionString = false)
         {
             _client = client;
+            _useConnectionStrings = useConnectionString;
         }
 
         public WebPubSubServiceClient Client => _client;
@@ -52,8 +56,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
             else
             {
                 // For managed identity, the service can handle it.
-                var url = _client.GetClientAccessUri();
-                return new SocketIONegotiationResult(url);
+                // TODO: Currently, there's a bug in `GetClientAccessUri` and we need to get url by ourselves.
+                var url = _client.GetClientAccessUri(userId: userId);
+                var token = HttpUtility.ParseQueryString(url.Query)["access_token"];
+                // The `aud` in token is correct, we use it as the endpoint.
+                var endpoint = new JwtSecurityTokenHandler().ReadJwtToken(token).Claims.First(c => c.Type == "aud").Value.TrimEnd('/'); // Must have
+                return new SocketIONegotiationResult(new Uri($"{endpoint}?access_token={token}"));
             }
         }
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/SocketIOServiceTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/SocketIOServiceTests.cs
@@ -2,9 +2,14 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Azure.Identity;
+using Azure.Messaging.WebPubSub;
 using Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Config;
+using Moq;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using System.Threading;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
 {
@@ -73,6 +78,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
 
             Assert.IsTrue(configs.TryGetKey(host, out var key));
             Assert.Null(key);
+        }
+
+        [Test]
+        public void TestNegotiateResultForAad()
+        {
+            var token = "eyJhbGciOiJIUzI1NiIsImtpZCI6InMtZjZlMTVhZmItNjIxZS00OTc5LTgyZTgtN2FiMGQ4ZmIwMDM1IiwidHlwIjoiSldUIn0.eyJuYmYiOjE3MjcwNzAxODQsImV4cCI6MTcyNzA3MzcyNCwiaWF0IjoxNzI3MDcwMTg0LCJpc3MiOiJodHRwczovL3dlYnB1YnN1Yi5henVyZS5jb20iLCJhdWQiOiJodHRwczovL3Npby01a2tmY2dyMm9icXZtLndlYnB1YnN1Yi5henVyZS5jb20vY2xpZW50cy9zb2NrZXRpby9odWJzL2h1YiJ9.h3QkRTQ4tnI4E9Ee9NODnRO5dGbsscuJimyCnggtiTw";
+            var clientMoc = new Mock<WebPubSubServiceClient>();
+            clientMoc.Setup(c => c.GetClientAccessUri(It.IsAny<TimeSpan>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<WebPubSubClientProtocol>(), It.IsAny<CancellationToken>()))
+                .Returns(new Uri($"https://abc.com?access_token={token}"));
+
+            var service = new WebPubSubForSocketIOService(clientMoc.Object);
+            var result = service.GetNegotiationResult("user");
+
+            Assert.AreEqual("https://sio-5kkfcgr2obqvm.webpubsub.azure.com/", result.Endpoint.AbsoluteUri);
+            Assert.AreEqual("/clients/socketio/hubs/hub", result.Path);
+            Assert.AreEqual(token, result.Token);
         }
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/SocketIOServiceTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/tests/SocketIOServiceTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.Tests
         [Test]
         public void TestNegotiateResultForAad()
         {
-            var token = "eyJhbGciOiJIUzI1NiIsImtpZCI6InMtZjZlMTVhZmItNjIxZS00OTc5LTgyZTgtN2FiMGQ4ZmIwMDM1IiwidHlwIjoiSldUIn0.eyJuYmYiOjE3MjcwNzAxODQsImV4cCI6MTcyNzA3MzcyNCwiaWF0IjoxNzI3MDcwMTg0LCJpc3MiOiJodHRwczovL3dlYnB1YnN1Yi5henVyZS5jb20iLCJhdWQiOiJodHRwczovL3Npby01a2tmY2dyMm9icXZtLndlYnB1YnN1Yi5henVyZS5jb20vY2xpZW50cy9zb2NrZXRpby9odWJzL2h1YiJ9.h3QkRTQ4tnI4E9Ee9NODnRO5dGbsscuJimyCnggtiTw";
+            var token = "eyJhbGciOiJIUzI1NiIsImtpZCI6InMtZjZlMTVhZmItNjIxZS00OTc5LTgyZTgtN2FiMGQ4ZmIwMDM1IiwidHlwIjoiSldUIn0.eyJuYmYiOjE3MjcwNzAxODQsImV4cCI6MTcyNzA3MzcyNCwiaWF0IjoxNzI3MDcwMTg0LCJpc3MiOiJodHRwczovL3dlYnB1YnN1Yi5henVyZS5jb20iLCJhdWQiOiJodHRwczovL3Npby01a2tmY2dyMm9icXZtLndlYnB1YnN1Yi5henVyZS5jb20vY2xpZW50cy9zb2NrZXRpby9odWJzL2h1YiJ9.h3QkRTQ4";
             var clientMoc = new Mock<WebPubSubServiceClient>();
             clientMoc.Setup(c => c.GetClientAccessUri(It.IsAny<TimeSpan>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<WebPubSubClientProtocol>(), It.IsAny<CancellationToken>()))
                 .Returns(new Uri($"https://abc.com?access_token={token}"));


### PR DESCRIPTION
# Contributing to the Azure SDK

Fix identity-based negotiation result for Socket.IO binding

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
