### PR TITLE
Enable WriteCore feature for datalake-analytics

### DIFF
--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/CHANGELOG.md
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
+- Exposed `JsonModelWriteCore` for model serialization procedure.
 
 ### Breaking Changes
 

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/api/Azure.ResourceManager.DataLakeAnalytics.netstandard2.0.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/api/Azure.ResourceManager.DataLakeAnalytics.netstandard2.0.cs
@@ -53,6 +53,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics
         public int? SystemMaxJobCount { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsVirtualNetworkRule> VirtualNetworkRules { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsAccountData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsAccountData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsAccountData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsAccountData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsAccountData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -114,6 +115,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics
         public int? MinPriorityPerJob { get { throw null; } }
         public System.Guid? ObjectId { get { throw null; } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.AadObjectIdentifierType? ObjectType { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsComputePolicyData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsComputePolicyData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsComputePolicyData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsComputePolicyData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsComputePolicyData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -181,6 +183,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics
         internal DataLakeAnalyticsFirewallRuleData() { }
         public System.Net.IPAddress EndIPAddress { get { throw null; } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsFirewallRuleData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsFirewallRuleData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsFirewallRuleData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsFirewallRuleData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsFirewallRuleData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -229,6 +232,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics
     {
         internal DataLakeAnalyticsStorageAccountInformationData() { }
         public string Suffix { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageAccountInformationData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageAccountInformationData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageAccountInformationData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageAccountInformationData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageAccountInformationData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -276,6 +280,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics
     {
         internal DataLakeAnalyticsStorageContainerData() { }
         public System.DateTimeOffset? LastModifiedOn { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageContainerData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageContainerData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageContainerData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageContainerData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeAnalyticsStorageContainerData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -322,6 +327,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics
     {
         internal DataLakeStoreAccountInformationData() { }
         public string Suffix { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeStoreAccountInformationData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeStoreAccountInformationData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeStoreAccountInformationData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.DataLakeStoreAccountInformationData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.DataLakeStoreAccountInformationData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -434,6 +440,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public string Name { get { throw null; } }
         public System.Guid ObjectId { get { throw null; } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.AadObjectIdentifierType ObjectType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -448,6 +455,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public string Name { get { throw null; } }
         public System.Guid? ObjectId { get { throw null; } set { } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.AadObjectIdentifierType? ObjectType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.ComputePolicyForDataLakeAnalyticsAccountUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -465,6 +473,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountStatus? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountState? State { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountBasic System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountBasic>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountBasic>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountBasic System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountBasic>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -499,6 +508,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public int? QueryStoreRetention { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent> StorageAccounts { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -510,6 +520,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public DataLakeAnalyticsAccountNameAvailabilityContent(string name, Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsResourceType resourceType) { }
         public string Name { get { throw null; } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsResourceType ResourceType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -522,6 +533,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public bool? IsNameAvailable { get { throw null; } }
         public string Message { get { throw null; } }
         public string Reason { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountNameAvailabilityResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -544,6 +556,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public int? QueryStoreRetention { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountUpdateContent> StorageAccounts { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsAccountPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -577,6 +590,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public int? MaxAccountCount { get { throw null; } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsSubscriptionState? State { get { throw null; } }
         public System.Guid? SubscriptionId { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsCapabilityInformation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsCapabilityInformation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsCapabilityInformation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsCapabilityInformation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsCapabilityInformation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -602,6 +616,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public int? MinPriorityPerJob { get { throw null; } set { } }
         public System.Guid ObjectId { get { throw null; } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.AadObjectIdentifierType ObjectType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -615,6 +630,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public int? MinPriorityPerJob { get { throw null; } set { } }
         public System.Guid? ObjectId { get { throw null; } set { } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.AadObjectIdentifierType? ObjectType { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsComputePolicyPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -631,6 +647,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public DataLakeAnalyticsFirewallRuleCreateOrUpdateContent(System.Net.IPAddress startIPAddress, System.Net.IPAddress endIPAddress) { }
         public System.Net.IPAddress EndIPAddress { get { throw null; } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRuleCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRuleCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRuleCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRuleCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRuleCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -642,6 +659,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public DataLakeAnalyticsFirewallRulePatch() { }
         public System.Net.IPAddress EndIPAddress { get { throw null; } set { } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRulePatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRulePatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRulePatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRulePatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsFirewallRulePatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -662,6 +680,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public string RuntimeVersion { get { throw null; } }
         public System.Uri ServerUri { get { throw null; } }
         public string UserName { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsHiveMetastore System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsHiveMetastore>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsHiveMetastore>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsHiveMetastore System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsHiveMetastore>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -689,6 +708,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
     {
         internal DataLakeAnalyticsSasTokenInformation() { }
         public string AccessToken { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsSasTokenInformation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsSasTokenInformation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsSasTokenInformation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsSasTokenInformation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsSasTokenInformation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -710,6 +730,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent(string accessKey) { }
         public string AccessKey { get { throw null; } }
         public string Suffix { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -721,6 +742,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public DataLakeAnalyticsStorageAccountInformationPatch() { }
         public string AccessKey { get { throw null; } set { } }
         public string Suffix { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsStorageAccountInformationPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -753,6 +775,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         internal DataLakeAnalyticsVirtualNetworkRule() { }
         public Azure.Core.ResourceIdentifier SubnetId { get { throw null; } }
         public Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsVirtualNetworkRuleState? VirtualNetworkRuleState { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsVirtualNetworkRule System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsVirtualNetworkRule>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsVirtualNetworkRule>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsVirtualNetworkRule System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeAnalyticsVirtualNetworkRule>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -779,6 +802,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
     {
         public DataLakeStoreAccountInformationCreateOrUpdateContent() { }
         public string Suffix { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreAccountInformationCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreAccountInformationCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreAccountInformationCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreAccountInformationCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreAccountInformationCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -790,6 +814,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent(string name) { }
         public string Name { get { throw null; } }
         public string Suffix { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -801,6 +826,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public DataLakeStoreForDataLakeAnalyticsAccountUpdateContent(string name) { }
         public string Name { get { throw null; } }
         public string Suffix { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.DataLakeStoreForDataLakeAnalyticsAccountUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -819,6 +845,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public System.Net.IPAddress EndIPAddress { get { throw null; } }
         public string Name { get { throw null; } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -831,6 +858,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public System.Net.IPAddress EndIPAddress { get { throw null; } set { } }
         public string Name { get { throw null; } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.FirewallRuleForDataLakeAnalyticsAccountUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -849,6 +877,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public string AccessKey { get { throw null; } }
         public string Name { get { throw null; } }
         public string Suffix { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -861,6 +890,7 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
         public string AccessKey { get { throw null; } set { } }
         public string Name { get { throw null; } }
         public string Suffix { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeAnalytics.Models.StorageAccountForDataLakeAnalyticsAccountUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsAccountData.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsAccountData.Serialization.cs
@@ -21,13 +21,22 @@ namespace Azure.ResourceManager.DataLakeAnalytics
 
         void IJsonModel<DataLakeAnalyticsAccountData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsAccountData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsAccountData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(Location))
             {
                 writer.WritePropertyName("location"u8);
@@ -43,26 +52,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics
                     writer.WriteStringValue(item.Value);
                 }
                 writer.WriteEndObject();
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -245,22 +234,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics
             {
                 writer.WritePropertyName("debugDataAccessLevel"u8);
                 writer.WriteStringValue(DebugDataAccessLevel.Value.ToSerialString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsComputePolicyData.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsComputePolicyData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.DataLakeAnalytics
 
         void IJsonModel<DataLakeAnalyticsComputePolicyData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsComputePolicyData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsComputePolicyData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ObjectId))
@@ -69,22 +58,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics
             {
                 writer.WritePropertyName("minPriorityPerJob"u8);
                 writer.WriteNumberValue(MinPriorityPerJob.Value);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsFirewallRuleData.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsFirewallRuleData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.DataLakeAnalytics
 
         void IJsonModel<DataLakeAnalyticsFirewallRuleData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsFirewallRuleData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsFirewallRuleData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(StartIPAddress))
@@ -59,22 +48,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics
             {
                 writer.WritePropertyName("endIpAddress"u8);
                 writer.WriteStringValue(EndIPAddress.ToString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsStorageAccountInformationData.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsStorageAccountInformationData.Serialization.cs
@@ -20,55 +20,28 @@ namespace Azure.ResourceManager.DataLakeAnalytics
 
         void IJsonModel<DataLakeAnalyticsStorageAccountInformationData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsStorageAccountInformationData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsStorageAccountInformationData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Suffix))
             {
                 writer.WritePropertyName("suffix"u8);
                 writer.WriteStringValue(Suffix);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsStorageContainerData.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeAnalyticsStorageContainerData.Serialization.cs
@@ -20,55 +20,28 @@ namespace Azure.ResourceManager.DataLakeAnalytics
 
         void IJsonModel<DataLakeAnalyticsStorageContainerData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsStorageContainerData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsStorageContainerData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(LastModifiedOn))
             {
                 writer.WritePropertyName("lastModifiedTime"u8);
                 writer.WriteStringValue(LastModifiedOn.Value, "O");
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeStoreAccountInformationData.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/DataLakeStoreAccountInformationData.Serialization.cs
@@ -20,55 +20,28 @@ namespace Azure.ResourceManager.DataLakeAnalytics
 
         void IJsonModel<DataLakeStoreAccountInformationData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountInformationData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountInformationData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Suffix))
             {
                 writer.WritePropertyName("suffix"u8);
                 writer.WriteStringValue(Suffix);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -60,7 +68,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent IJsonModel<ComputePolicyForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/ComputePolicyForDataLakeAnalyticsAccountUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/ComputePolicyForDataLakeAnalyticsAccountUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<ComputePolicyForDataLakeAnalyticsAccountUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ComputePolicyForDataLakeAnalyticsAccountUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ComputePolicyForDataLakeAnalyticsAccountUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -66,7 +74,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ComputePolicyForDataLakeAnalyticsAccountUpdateContent IJsonModel<ComputePolicyForDataLakeAnalyticsAccountUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountBasic.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountBasic.Serialization.cs
@@ -20,13 +20,22 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsAccountBasic>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsAccountBasic>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsAccountBasic)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(Location))
             {
                 writer.WritePropertyName("location"u8);
@@ -42,26 +51,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
                     writer.WriteStringValue(item.Value);
                 }
                 writer.WriteEndObject();
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -94,22 +83,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
             {
                 writer.WritePropertyName("endpoint"u8);
                 writer.WriteStringValue(Endpoint);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("location"u8);
             writer.WriteStringValue(Location);
             if (Optional.IsCollectionDefined(Tags))
@@ -136,7 +144,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsAccountCreateOrUpdateContent IJsonModel<DataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountListResult.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsAccountListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsAccountListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsAccountListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -61,7 +69,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsAccountListResult IJsonModel<DataLakeAnalyticsAccountListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountNameAvailabilityContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountNameAvailabilityContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsAccountNameAvailabilityContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsAccountNameAvailabilityContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsAccountNameAvailabilityContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("type"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsAccountNameAvailabilityContent IJsonModel<DataLakeAnalyticsAccountNameAvailabilityContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountNameAvailabilityResult.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountNameAvailabilityResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsAccountNameAvailabilityResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsAccountNameAvailabilityResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsAccountNameAvailabilityResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(IsNameAvailable))
             {
                 writer.WritePropertyName("nameAvailable"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsAccountNameAvailabilityResult IJsonModel<DataLakeAnalyticsAccountNameAvailabilityResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountPatch.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsAccountPatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsAccountPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsAccountPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsAccountPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -135,7 +143,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsAccountPatch IJsonModel<DataLakeAnalyticsAccountPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsCapabilityInformation.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsCapabilityInformation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsCapabilityInformation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsCapabilityInformation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsCapabilityInformation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(SubscriptionId))
             {
                 writer.WritePropertyName("subscriptionId"u8);
@@ -66,7 +74,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsCapabilityInformation IJsonModel<DataLakeAnalyticsCapabilityInformation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsComputePolicyCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsComputePolicyCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsComputePolicyCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsComputePolicyCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsComputePolicyCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             writer.WritePropertyName("objectId"u8);
@@ -58,7 +66,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsComputePolicyCreateOrUpdateContent IJsonModel<DataLakeAnalyticsComputePolicyCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsComputePolicyListResult.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsComputePolicyListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsComputePolicyListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsComputePolicyListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsComputePolicyListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsComputePolicyListResult IJsonModel<DataLakeAnalyticsComputePolicyListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsComputePolicyPatch.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsComputePolicyPatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsComputePolicyPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsComputePolicyPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsComputePolicyPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(ObjectId))
@@ -64,7 +72,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsComputePolicyPatch IJsonModel<DataLakeAnalyticsComputePolicyPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsFirewallRuleCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsFirewallRuleCreateOrUpdateContent.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsFirewallRuleCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsFirewallRuleCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsFirewallRuleCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             writer.WritePropertyName("startIpAddress"u8);
@@ -49,7 +57,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsFirewallRuleCreateOrUpdateContent IJsonModel<DataLakeAnalyticsFirewallRuleCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsFirewallRuleListResult.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsFirewallRuleListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsFirewallRuleListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsFirewallRuleListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsFirewallRuleListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsFirewallRuleListResult IJsonModel<DataLakeAnalyticsFirewallRuleListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsFirewallRulePatch.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsFirewallRulePatch.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsFirewallRulePatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsFirewallRulePatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsFirewallRulePatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(StartIPAddress))
@@ -55,7 +63,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsFirewallRulePatch IJsonModel<DataLakeAnalyticsFirewallRulePatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsHiveMetastore.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsHiveMetastore.Serialization.cs
@@ -20,33 +20,22 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsHiveMetastore>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsHiveMetastore>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsHiveMetastore)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ServerUri))
@@ -78,22 +67,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
             {
                 writer.WritePropertyName("nestedResourceProvisioningState"u8);
                 writer.WriteStringValue(NestedResourceProvisioningState.Value.ToSerialString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsSasTokenInformation.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsSasTokenInformation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsSasTokenInformation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsSasTokenInformation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsSasTokenInformation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(AccessToken))
             {
                 writer.WritePropertyName("accessToken"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsSasTokenInformation IJsonModel<DataLakeAnalyticsSasTokenInformation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsSasTokenInformationListResult.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsSasTokenInformationListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsSasTokenInformationListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsSasTokenInformationListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsSasTokenInformationListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsSasTokenInformationListResult IJsonModel<DataLakeAnalyticsSasTokenInformationListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             writer.WritePropertyName("accessKey"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent IJsonModel<DataLakeAnalyticsStorageAccountInformationCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsStorageAccountInformationListResult.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsStorageAccountInformationListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsStorageAccountInformationListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsStorageAccountInformationListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsStorageAccountInformationListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsStorageAccountInformationListResult IJsonModel<DataLakeAnalyticsStorageAccountInformationListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsStorageAccountInformationPatch.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsStorageAccountInformationPatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsStorageAccountInformationPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsStorageAccountInformationPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsStorageAccountInformationPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(AccessKey))
@@ -54,7 +62,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsStorageAccountInformationPatch IJsonModel<DataLakeAnalyticsStorageAccountInformationPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsStorageContainerListResult.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsStorageContainerListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsStorageContainerListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsStorageContainerListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsStorageContainerListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeAnalyticsStorageContainerListResult IJsonModel<DataLakeAnalyticsStorageContainerListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsVirtualNetworkRule.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeAnalyticsVirtualNetworkRule.Serialization.cs
@@ -20,33 +20,22 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeAnalyticsVirtualNetworkRule>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeAnalyticsVirtualNetworkRule>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeAnalyticsVirtualNetworkRule)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(SubnetId))
@@ -58,22 +47,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
             {
                 writer.WritePropertyName("virtualNetworkRuleState"u8);
                 writer.WriteStringValue(VirtualNetworkRuleState.Value.ToSerialString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeStoreAccountInformationCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeStoreAccountInformationCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeStoreAccountInformationCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountInformationCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountInformationCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(Suffix))
@@ -49,7 +57,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountInformationCreateOrUpdateContent IJsonModel<DataLakeStoreAccountInformationCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeStoreAccountInformationListResult.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeStoreAccountInformationListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeStoreAccountInformationListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountInformationListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountInformationListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountInformationListResult IJsonModel<DataLakeStoreAccountInformationListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent IJsonModel<DataLakeStoreForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeStoreForDataLakeAnalyticsAccountUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/DataLakeStoreForDataLakeAnalyticsAccountUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<DataLakeStoreForDataLakeAnalyticsAccountUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreForDataLakeAnalyticsAccountUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreForDataLakeAnalyticsAccountUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreForDataLakeAnalyticsAccountUpdateContent IJsonModel<DataLakeStoreForDataLakeAnalyticsAccountUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent IJsonModel<FirewallRuleForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/FirewallRuleForDataLakeAnalyticsAccountUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/FirewallRuleForDataLakeAnalyticsAccountUpdateContent.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<FirewallRuleForDataLakeAnalyticsAccountUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FirewallRuleForDataLakeAnalyticsAccountUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FirewallRuleForDataLakeAnalyticsAccountUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -57,7 +65,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FirewallRuleForDataLakeAnalyticsAccountUpdateContent IJsonModel<FirewallRuleForDataLakeAnalyticsAccountUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -53,7 +61,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent IJsonModel<StorageAccountForDataLakeAnalyticsAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/StorageAccountForDataLakeAnalyticsAccountUpdateContent.Serialization.cs
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/Generated/Models/StorageAccountForDataLakeAnalyticsAccountUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 
         void IJsonModel<StorageAccountForDataLakeAnalyticsAccountUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<StorageAccountForDataLakeAnalyticsAccountUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(StorageAccountForDataLakeAnalyticsAccountUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeAnalytics.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         StorageAccountForDataLakeAnalyticsAccountUpdateContent IJsonModel<StorageAccountForDataLakeAnalyticsAccountUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/autorest.md
+++ b/sdk/datalake-analytics/Azure.ResourceManager.DataLakeAnalytics/src/autorest.md
@@ -20,6 +20,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 mgmt-debug:
   show-serialized-names: true


### PR DESCRIPTION
We need to enable WriteCore feature to datalake-analytics. Therefore add `use-write-core: true` and do a regen.