### PR TITLE
Enable WriteCore feature for datalake-store

### DIFF
--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/CHANGELOG.md
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
+- Exposed `JsonModelWriteCore` for model serialization procedure.
 
 ### Breaking Changes
 

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/api/Azure.ResourceManager.DataLakeStore.netstandard2.0.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/api/Azure.ResourceManager.DataLakeStore.netstandard2.0.cs
@@ -43,6 +43,7 @@ namespace Azure.ResourceManager.DataLakeStore
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.DataLakeStore.DataLakeStoreTrustedIdProviderData> TrustedIdProviders { get { throw null; } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderState? TrustedIdProviderState { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.DataLakeStore.DataLakeStoreVirtualNetworkRuleData> VirtualNetworkRules { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.DataLakeStoreAccountData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreAccountData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreAccountData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.DataLakeStoreAccountData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreAccountData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -121,6 +122,7 @@ namespace Azure.ResourceManager.DataLakeStore
         internal DataLakeStoreFirewallRuleData() { }
         public System.Net.IPAddress EndIPAddress { get { throw null; } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.DataLakeStoreFirewallRuleData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreFirewallRuleData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreFirewallRuleData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.DataLakeStoreFirewallRuleData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreFirewallRuleData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -167,6 +169,7 @@ namespace Azure.ResourceManager.DataLakeStore
     {
         internal DataLakeStoreTrustedIdProviderData() { }
         public System.Uri IdProvider { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.DataLakeStoreTrustedIdProviderData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreTrustedIdProviderData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreTrustedIdProviderData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.DataLakeStoreTrustedIdProviderData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreTrustedIdProviderData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -213,6 +216,7 @@ namespace Azure.ResourceManager.DataLakeStore
     {
         internal DataLakeStoreVirtualNetworkRuleData() { }
         public Azure.Core.ResourceIdentifier SubnetId { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.DataLakeStoreVirtualNetworkRuleData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreVirtualNetworkRuleData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreVirtualNetworkRuleData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.DataLakeStoreVirtualNetworkRuleData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.DataLakeStoreVirtualNetworkRuleData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -300,6 +304,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountStatus? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountState? State { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountBasicData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountBasicData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountBasicData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountBasicData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountBasicData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -332,6 +337,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public System.Collections.Generic.IList<Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent> TrustedIdProviders { get { throw null; } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderState? TrustedIdProviderState { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent> VirtualNetworkRules { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -343,6 +349,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public DataLakeStoreAccountEncryptionConfig(Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountEncryptionConfigType configType) { }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountEncryptionConfigType ConfigType { get { throw null; } set { } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountKeyVaultMetaInfo KeyVaultMetaInfo { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountEncryptionConfig System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountEncryptionConfig>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountEncryptionConfig>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountEncryptionConfig System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountEncryptionConfig>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -360,6 +367,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public string EncryptionKeyName { get { throw null; } set { } }
         public string EncryptionKeyVersion { get { throw null; } set { } }
         public string KeyVaultResourceId { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountKeyVaultMetaInfo System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountKeyVaultMetaInfo>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountKeyVaultMetaInfo>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountKeyVaultMetaInfo System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountKeyVaultMetaInfo>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -371,6 +379,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public DataLakeStoreAccountNameAvailabilityContent(string name, Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreResourceType resourceType) { }
         public string Name { get { throw null; } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreResourceType ResourceType { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -383,6 +392,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public bool? IsNameAvailable { get { throw null; } }
         public string Message { get { throw null; } }
         public string Reason { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountNameAvailabilityResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -402,6 +412,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public System.Collections.Generic.IList<Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountUpdateContent> TrustedIdProviders { get { throw null; } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderState? TrustedIdProviderState { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountUpdateContent> VirtualNetworkRules { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreAccountPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -435,6 +446,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public int? MaxAccountCount { get { throw null; } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreSubscriptionState? State { get { throw null; } }
         public System.Guid? SubscriptionId { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreCapabilityInformation System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreCapabilityInformation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreCapabilityInformation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreCapabilityInformation System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreCapabilityInformation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -471,6 +483,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public DataLakeStoreFirewallRuleCreateOrUpdateContent(System.Net.IPAddress startIPAddress, System.Net.IPAddress endIPAddress) { }
         public System.Net.IPAddress EndIPAddress { get { throw null; } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRuleCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRuleCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRuleCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRuleCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRuleCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -482,6 +495,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public DataLakeStoreFirewallRulePatch() { }
         public System.Net.IPAddress EndIPAddress { get { throw null; } set { } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRulePatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRulePatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRulePatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRulePatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreFirewallRulePatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -535,6 +549,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
     {
         public DataLakeStoreTrustedIdProviderCreateOrUpdateContent(System.Uri idProvider) { }
         public System.Uri IdProvider { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -545,6 +560,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
     {
         public DataLakeStoreTrustedIdProviderPatch() { }
         public System.Uri IdProvider { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreTrustedIdProviderPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -564,6 +580,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public int? Limit { get { throw null; } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsageName Name { get { throw null; } }
         public Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsageUnit? Unit { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsage System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsage>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsage>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsage System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsage>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -575,6 +592,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         internal DataLakeStoreUsageName() { }
         public string LocalizedValue { get { throw null; } }
         public string Value { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsageName System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsageName>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsageName>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsageName System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreUsageName>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -594,6 +612,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
     {
         public DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent(Azure.Core.ResourceIdentifier subnetId) { }
         public Azure.Core.ResourceIdentifier SubnetId { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -604,6 +623,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
     {
         public DataLakeStoreVirtualNetworkRulePatch() { }
         public Azure.Core.ResourceIdentifier SubnetId { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRulePatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRulePatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRulePatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRulePatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.DataLakeStoreVirtualNetworkRulePatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -616,6 +636,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public System.Net.IPAddress EndIPAddress { get { throw null; } }
         public string Name { get { throw null; } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -628,6 +649,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public System.Net.IPAddress EndIPAddress { get { throw null; } set { } }
         public string Name { get { throw null; } }
         public System.Net.IPAddress StartIPAddress { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.FirewallRuleForDataLakeStoreAccountUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -649,6 +671,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent(string name, System.Uri idProvider) { }
         public System.Uri IdProvider { get { throw null; } }
         public string Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -660,6 +683,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public TrustedIdProviderForDataLakeStoreAccountUpdateContent(string name) { }
         public System.Uri IdProvider { get { throw null; } set { } }
         public string Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.TrustedIdProviderForDataLakeStoreAccountUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -671,6 +695,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent(string name, Azure.Core.ResourceIdentifier subnetId) { }
         public string Name { get { throw null; } }
         public Azure.Core.ResourceIdentifier SubnetId { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -682,6 +707,7 @@ namespace Azure.ResourceManager.DataLakeStore.Models
         public VirtualNetworkRuleForDataLakeStoreAccountUpdateContent(string name) { }
         public string Name { get { throw null; } }
         public Azure.Core.ResourceIdentifier SubnetId { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountUpdateContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountUpdateContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountUpdateContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountUpdateContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DataLakeStore.Models.VirtualNetworkRuleForDataLakeStoreAccountUpdateContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/DataLakeStoreAccountData.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/DataLakeStoreAccountData.Serialization.cs
@@ -21,13 +21,22 @@ namespace Azure.ResourceManager.DataLakeStore
 
         void IJsonModel<DataLakeStoreAccountData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(Identity))
             {
                 writer.WritePropertyName("identity"u8);
@@ -48,26 +57,6 @@ namespace Azure.ResourceManager.DataLakeStore
                     writer.WriteStringValue(item.Value);
                 }
                 writer.WriteEndObject();
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -175,22 +164,6 @@ namespace Azure.ResourceManager.DataLakeStore
             {
                 writer.WritePropertyName("currentTier"u8);
                 writer.WriteStringValue(CurrentTier.Value.ToSerialString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/DataLakeStoreFirewallRuleData.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/DataLakeStoreFirewallRuleData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.DataLakeStore
 
         void IJsonModel<DataLakeStoreFirewallRuleData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreFirewallRuleData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreFirewallRuleData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(StartIPAddress))
@@ -59,22 +48,6 @@ namespace Azure.ResourceManager.DataLakeStore
             {
                 writer.WritePropertyName("endIpAddress"u8);
                 writer.WriteStringValue(EndIPAddress.ToString());
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/DataLakeStoreTrustedIdProviderData.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/DataLakeStoreTrustedIdProviderData.Serialization.cs
@@ -20,55 +20,28 @@ namespace Azure.ResourceManager.DataLakeStore
 
         void IJsonModel<DataLakeStoreTrustedIdProviderData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreTrustedIdProviderData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreTrustedIdProviderData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(IdProvider))
             {
                 writer.WritePropertyName("idProvider"u8);
                 writer.WriteStringValue(IdProvider.AbsoluteUri);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/DataLakeStoreVirtualNetworkRuleData.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/DataLakeStoreVirtualNetworkRuleData.Serialization.cs
@@ -20,55 +20,28 @@ namespace Azure.ResourceManager.DataLakeStore
 
         void IJsonModel<DataLakeStoreVirtualNetworkRuleData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreVirtualNetworkRuleData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreVirtualNetworkRuleData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(SubnetId))
             {
                 writer.WritePropertyName("subnetId"u8);
                 writer.WriteStringValue(SubnetId);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountBasicData.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountBasicData.Serialization.cs
@@ -20,13 +20,22 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreAccountBasicData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountBasicData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountBasicData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(Location))
             {
                 writer.WritePropertyName("location"u8);
@@ -42,26 +51,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
                     writer.WriteStringValue(item.Value);
                 }
                 writer.WriteEndObject();
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -94,22 +83,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
             {
                 writer.WritePropertyName("endpoint"u8);
                 writer.WriteStringValue(Endpoint);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountCreateOrUpdateContent.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("location"u8);
             writer.WriteStringValue(Location);
             if (Optional.IsCollectionDefined(Tags))
@@ -128,7 +136,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountCreateOrUpdateContent IJsonModel<DataLakeStoreAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountEncryptionConfig.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountEncryptionConfig.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreAccountEncryptionConfig>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountEncryptionConfig>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountEncryptionConfig)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("type"u8);
             writer.WriteStringValue(ConfigType.ToSerialString());
             if (Optional.IsDefined(KeyVaultMetaInfo))
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountEncryptionConfig IJsonModel<DataLakeStoreAccountEncryptionConfig>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountKeyVaultMetaInfo.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountKeyVaultMetaInfo.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreAccountKeyVaultMetaInfo>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountKeyVaultMetaInfo>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountKeyVaultMetaInfo)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("keyVaultResourceId"u8);
             writer.WriteStringValue(KeyVaultResourceId);
             writer.WritePropertyName("encryptionKeyName"u8);
@@ -47,7 +55,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountKeyVaultMetaInfo IJsonModel<DataLakeStoreAccountKeyVaultMetaInfo>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountListResult.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreAccountListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountListResult IJsonModel<DataLakeStoreAccountListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountNameAvailabilityContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountNameAvailabilityContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreAccountNameAvailabilityContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountNameAvailabilityContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountNameAvailabilityContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("type"u8);
@@ -45,7 +53,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountNameAvailabilityContent IJsonModel<DataLakeStoreAccountNameAvailabilityContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountNameAvailabilityResult.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountNameAvailabilityResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreAccountNameAvailabilityResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountNameAvailabilityResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountNameAvailabilityResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(IsNameAvailable))
             {
                 writer.WritePropertyName("nameAvailable"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountNameAvailabilityResult IJsonModel<DataLakeStoreAccountNameAvailabilityResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountPatch.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreAccountPatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreAccountPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreAccountPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreAccountPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -115,7 +123,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreAccountPatch IJsonModel<DataLakeStoreAccountPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreCapabilityInformation.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreCapabilityInformation.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreCapabilityInformation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreCapabilityInformation>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreCapabilityInformation)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(SubscriptionId))
             {
                 writer.WritePropertyName("subscriptionId"u8);
@@ -66,7 +74,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreCapabilityInformation IJsonModel<DataLakeStoreCapabilityInformation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreFirewallRuleCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreFirewallRuleCreateOrUpdateContent.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreFirewallRuleCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreFirewallRuleCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreFirewallRuleCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             writer.WritePropertyName("startIpAddress"u8);
@@ -49,7 +57,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreFirewallRuleCreateOrUpdateContent IJsonModel<DataLakeStoreFirewallRuleCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreFirewallRuleListResult.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreFirewallRuleListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreFirewallRuleListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreFirewallRuleListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreFirewallRuleListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreFirewallRuleListResult IJsonModel<DataLakeStoreFirewallRuleListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreFirewallRulePatch.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreFirewallRulePatch.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreFirewallRulePatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreFirewallRulePatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreFirewallRulePatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(StartIPAddress))
@@ -55,7 +63,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreFirewallRulePatch IJsonModel<DataLakeStoreFirewallRulePatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreTrustedIdProviderCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreTrustedIdProviderCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreTrustedIdProviderCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreTrustedIdProviderCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreTrustedIdProviderCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             writer.WritePropertyName("idProvider"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreTrustedIdProviderCreateOrUpdateContent IJsonModel<DataLakeStoreTrustedIdProviderCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreTrustedIdProviderListResult.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreTrustedIdProviderListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreTrustedIdProviderListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreTrustedIdProviderListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreTrustedIdProviderListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreTrustedIdProviderListResult IJsonModel<DataLakeStoreTrustedIdProviderListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreTrustedIdProviderPatch.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreTrustedIdProviderPatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreTrustedIdProviderPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreTrustedIdProviderPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreTrustedIdProviderPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(IdProvider))
@@ -49,7 +57,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreTrustedIdProviderPatch IJsonModel<DataLakeStoreTrustedIdProviderPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreUsage.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreUsage.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreUsage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreUsage>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreUsage)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Unit))
             {
                 writer.WritePropertyName("unit"u8);
@@ -66,7 +74,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreUsage IJsonModel<DataLakeStoreUsage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreUsageListResult.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreUsageListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreUsageListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreUsageListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreUsageListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreUsageListResult IJsonModel<DataLakeStoreUsageListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreUsageName.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreUsageName.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreUsageName>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreUsageName>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreUsageName)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreUsageName IJsonModel<DataLakeStoreUsageName>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             writer.WritePropertyName("subnetId"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent IJsonModel<DataLakeStoreVirtualNetworkRuleCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreVirtualNetworkRuleListResult.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreVirtualNetworkRuleListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreVirtualNetworkRuleListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreVirtualNetworkRuleListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreVirtualNetworkRuleListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreVirtualNetworkRuleListResult IJsonModel<DataLakeStoreVirtualNetworkRuleListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreVirtualNetworkRulePatch.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/DataLakeStoreVirtualNetworkRulePatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<DataLakeStoreVirtualNetworkRulePatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DataLakeStoreVirtualNetworkRulePatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DataLakeStoreVirtualNetworkRulePatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (Optional.IsDefined(SubnetId))
@@ -49,7 +57,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DataLakeStoreVirtualNetworkRulePatch IJsonModel<DataLakeStoreVirtualNetworkRulePatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent IJsonModel<FirewallRuleForDataLakeStoreAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/FirewallRuleForDataLakeStoreAccountUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/FirewallRuleForDataLakeStoreAccountUpdateContent.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<FirewallRuleForDataLakeStoreAccountUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<FirewallRuleForDataLakeStoreAccountUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(FirewallRuleForDataLakeStoreAccountUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -57,7 +65,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         FirewallRuleForDataLakeStoreAccountUpdateContent IJsonModel<FirewallRuleForDataLakeStoreAccountUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent IJsonModel<TrustedIdProviderForDataLakeStoreAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/TrustedIdProviderForDataLakeStoreAccountUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/TrustedIdProviderForDataLakeStoreAccountUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<TrustedIdProviderForDataLakeStoreAccountUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<TrustedIdProviderForDataLakeStoreAccountUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(TrustedIdProviderForDataLakeStoreAccountUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         TrustedIdProviderForDataLakeStoreAccountUpdateContent IJsonModel<TrustedIdProviderForDataLakeStoreAccountUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/UpdateEncryptionConfig.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/UpdateEncryptionConfig.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<UpdateEncryptionConfig>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<UpdateEncryptionConfig>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(UpdateEncryptionConfig)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(KeyVaultMetaInfo))
             {
                 writer.WritePropertyName("keyVaultMetaInfo"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         UpdateEncryptionConfig IJsonModel<UpdateEncryptionConfig>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/UpdateKeyVaultMetaInfo.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/UpdateKeyVaultMetaInfo.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<UpdateKeyVaultMetaInfo>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<UpdateKeyVaultMetaInfo>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(UpdateKeyVaultMetaInfo)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(EncryptionKeyVersion))
             {
                 writer.WritePropertyName("encryptionKeyVersion"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         UpdateKeyVaultMetaInfo IJsonModel<UpdateKeyVaultMetaInfo>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -48,7 +56,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent IJsonModel<VirtualNetworkRuleForDataLakeStoreAccountCreateOrUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/VirtualNetworkRuleForDataLakeStoreAccountUpdateContent.Serialization.cs
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/Generated/Models/VirtualNetworkRuleForDataLakeStoreAccountUpdateContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 
         void IJsonModel<VirtualNetworkRuleForDataLakeStoreAccountUpdateContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<VirtualNetworkRuleForDataLakeStoreAccountUpdateContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(VirtualNetworkRuleForDataLakeStoreAccountUpdateContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             writer.WritePropertyName("properties"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DataLakeStore.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         VirtualNetworkRuleForDataLakeStoreAccountUpdateContent IJsonModel<VirtualNetworkRuleForDataLakeStoreAccountUpdateContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/autorest.md
+++ b/sdk/datalake-store/Azure.ResourceManager.DataLakeStore/src/autorest.md
@@ -16,6 +16,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 request-path-to-parent:
   /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}


### PR DESCRIPTION
We need to enable WriteCore feature to datalake-store. Therefore add `use-write-core: true` and do a regen.