### PR TITLE
Enable WriteCore feature for defendereasm

### DIFF
--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/CHANGELOG.md
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
+- Exposed `JsonModelWriteCore` for model serialization procedure.
 
 ### Breaking Changes
 

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/api/Azure.ResourceManager.DefenderEasm.netstandard2.0.cs
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/api/Azure.ResourceManager.DefenderEasm.netstandard2.0.cs
@@ -33,6 +33,7 @@ namespace Azure.ResourceManager.DefenderEasm
         public string Color { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public Azure.ResourceManager.DefenderEasm.Models.EasmResourceProvisioningState? ProvisioningState { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.EasmLabelData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.EasmLabelData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.EasmLabelData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.EasmLabelData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DefenderEasm.EasmLabelData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -80,6 +81,7 @@ namespace Azure.ResourceManager.DefenderEasm
         public EasmWorkspaceData(Azure.Core.AzureLocation location) { }
         public string DataPlaneEndpoint { get { throw null; } }
         public Azure.ResourceManager.DefenderEasm.Models.EasmResourceProvisioningState? ProvisioningState { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.EasmWorkspaceData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.EasmWorkspaceData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.EasmWorkspaceData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.EasmWorkspaceData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DefenderEasm.EasmWorkspaceData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -155,6 +157,7 @@ namespace Azure.ResourceManager.DefenderEasm.Models
         public string Color { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public Azure.ResourceManager.DefenderEasm.Models.EasmResourceProvisioningState? ProvisioningState { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.Models.EasmLabelPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.Models.EasmLabelPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.Models.EasmLabelPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.Models.EasmLabelPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DefenderEasm.Models.EasmLabelPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -201,6 +204,7 @@ namespace Azure.ResourceManager.DefenderEasm.Models
         public string Reason { get { throw null; } set { } }
         public string StartedAt { get { throw null; } set { } }
         public string State { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.Models.EasmTask System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.Models.EasmTask>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.Models.EasmTask>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.Models.EasmTask System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DefenderEasm.Models.EasmTask>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -212,6 +216,7 @@ namespace Azure.ResourceManager.DefenderEasm.Models
         public EasmWorkspacePatch() { }
         public Azure.ResourceManager.Models.SystemData SystemData { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.Models.EasmWorkspacePatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.Models.EasmWorkspacePatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DefenderEasm.Models.EasmWorkspacePatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DefenderEasm.Models.EasmWorkspacePatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DefenderEasm.Models.EasmWorkspacePatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/assets.json
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/assets.json
@@ -2,5 +2,5 @@
     "AssetsRepo": "Azure/azure-sdk-assets",
     "AssetsRepoPrefixPath": "net",
     "TagPrefix": "net/defendereasm/Azure.ResourceManager.DefenderEasm",
-    "Tag": "net/defendereasm/Azure.ResourceManager.DefenderEasm_8d690bc5f1"
+    "Tag": "net/defendereasm/Azure.ResourceManager.DefenderEasm_5116c9e1f1"
 }

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/EasmLabelData.Serialization.cs
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/EasmLabelData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.DefenderEasm
 
         void IJsonModel<EasmLabelData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<EasmLabelData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(EasmLabelData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
@@ -64,22 +53,6 @@ namespace Azure.ResourceManager.DefenderEasm
             {
                 writer.WritePropertyName("color"u8);
                 writer.WriteStringValue(Color);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/EasmWorkspaceData.Serialization.cs
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/EasmWorkspaceData.Serialization.cs
@@ -21,46 +21,22 @@ namespace Azure.ResourceManager.DefenderEasm
 
         void IJsonModel<EasmWorkspaceData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<EasmWorkspaceData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(EasmWorkspaceData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (Optional.IsCollectionDefined(Tags))
-            {
-                writer.WritePropertyName("tags"u8);
-                writer.WriteStartObject();
-                foreach (var item in Tags)
-                {
-                    writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
-                }
-                writer.WriteEndObject();
-            }
-            writer.WritePropertyName("location"u8);
-            writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
@@ -72,22 +48,6 @@ namespace Azure.ResourceManager.DefenderEasm
             {
                 writer.WritePropertyName("dataPlaneEndpoint"u8);
                 writer.WriteStringValue(DataPlaneEndpoint);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmLabelListResult.Serialization.cs
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmLabelListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DefenderEasm.Models
 
         void IJsonModel<EasmLabelListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<EasmLabelListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(EasmLabelListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DefenderEasm.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         EasmLabelListResult IJsonModel<EasmLabelListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmLabelPatch.Serialization.cs
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmLabelPatch.Serialization.cs
@@ -20,33 +20,22 @@ namespace Azure.ResourceManager.DefenderEasm.Models
 
         void IJsonModel<EasmLabelPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<EasmLabelPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(EasmLabelPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
@@ -63,22 +52,6 @@ namespace Azure.ResourceManager.DefenderEasm.Models
             {
                 writer.WritePropertyName("color"u8);
                 writer.WriteStringValue(Color);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmTask.Serialization.cs
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmTask.Serialization.cs
@@ -20,33 +20,22 @@ namespace Azure.ResourceManager.DefenderEasm.Models
 
         void IJsonModel<EasmTask>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<EasmTask>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(EasmTask)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
@@ -95,22 +84,6 @@ namespace Azure.ResourceManager.DefenderEasm.Models
                     JsonSerializer.Serialize(writer, document.RootElement);
                 }
 #endif
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmWorkspaceListResult.Serialization.cs
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmWorkspaceListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DefenderEasm.Models
 
         void IJsonModel<EasmWorkspaceListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<EasmWorkspaceListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(EasmWorkspaceListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(NextLink))
             {
                 writer.WritePropertyName("nextLink"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DefenderEasm.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         EasmWorkspaceListResult IJsonModel<EasmWorkspaceListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmWorkspacePatch.Serialization.cs
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/Generated/Models/EasmWorkspacePatch.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DefenderEasm.Models
 
         void IJsonModel<EasmWorkspacePatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<EasmWorkspacePatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(EasmWorkspacePatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -58,7 +66,6 @@ namespace Azure.ResourceManager.DefenderEasm.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         EasmWorkspacePatch IJsonModel<EasmWorkspacePatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/autorest.md
+++ b/sdk/defendereasm/Azure.ResourceManager.DefenderEasm/src/autorest.md
@@ -18,6 +18,7 @@ skip-csproj: true
 modelerfour:
     flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 #mgmt-debug:
 #  show-serialized-names: true


### PR DESCRIPTION
We need to enable WriteCore feature to defendereasm. Therefore add `use-write-core: true` and do a regen.