### PR TITLE
Enable WriteCore feature for deviceprovisioningservices

### DIFF
--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/CHANGELOG.md
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
+- Exposed `JsonModelWriteCore` for model serialization procedure.
 
 ### Breaking Changes
 

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/api/Azure.ResourceManager.DeviceProvisioningServices.netstandard2.0.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/api/Azure.ResourceManager.DeviceProvisioningServices.netstandard2.0.cs
@@ -23,6 +23,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
         public Azure.ETag? ETag { get { throw null; } set { } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServiceProperties Properties { get { throw null; } set { } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuInfo Sku { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServiceData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServiceData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServiceData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServiceData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServiceData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -91,6 +92,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
         public DeviceProvisioningServicesCertificateData() { }
         public Azure.ETag? ETag { get { throw null; } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesCertificateProperties Properties { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesCertificateData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesCertificateData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesCertificateData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesCertificateData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesCertificateData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -161,6 +163,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
     {
         public DeviceProvisioningServicesPrivateEndpointConnectionData(Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateEndpointConnectionProperties properties) { }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateEndpointConnectionProperties Properties { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateEndpointConnectionData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateEndpointConnectionData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateEndpointConnectionData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateEndpointConnectionData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateEndpointConnectionData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -220,6 +223,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
     {
         internal DeviceProvisioningServicesPrivateLinkResourceData() { }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkResourceProperties Properties { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateLinkResourceData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateLinkResourceData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateLinkResourceData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateLinkResourceData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.DeviceProvisioningServicesPrivateLinkResourceData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -275,6 +279,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
     {
         public CertificateVerificationCodeContent() { }
         public string Certificate { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -292,6 +297,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public System.BinaryData Thumbprint { get { throw null; } }
         public System.DateTimeOffset? UpdatedOn { get { throw null; } }
         public string VerificationCode { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -303,6 +309,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         internal CertificateVerificationCodeResult() { }
         public Azure.ETag? ETag { get { throw null; } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeProperties Properties { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.CertificateVerificationCodeResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -313,6 +320,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
     {
         public DeviceProvisioningServicePatch() { }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicePatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicePatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicePatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicePatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicePatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -334,6 +342,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPublicNetworkAccess? PublicNetworkAccess { get { throw null; } set { } }
         public string ServiceOperationsHostName { get { throw null; } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesState? State { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServiceProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServiceProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServiceProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServiceProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServiceProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -391,6 +400,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public string Subject { get { throw null; } }
         public System.BinaryData Thumbprint { get { throw null; } }
         public System.DateTimeOffset? UpdatedOn { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesCertificateProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesCertificateProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesCertificateProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesCertificateProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesCertificateProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -467,6 +477,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public string FilterName { get { throw null; } set { } }
         public string IPMask { get { throw null; } set { } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesIPFilterTargetType? Target { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesIPFilterRule System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesIPFilterRule>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesIPFilterRule>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesIPFilterRule System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesIPFilterRule>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -483,6 +494,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
     {
         public DeviceProvisioningServicesNameAvailabilityContent(string name) { }
         public string Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityContent System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityContent>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityContent>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityContent System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityContent>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -495,6 +507,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public bool? IsNameAvailable { get { throw null; } }
         public string Message { get { throw null; } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameUnavailableReason? Reason { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityResult System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityResult>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityResult>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityResult System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesNameAvailabilityResult>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -524,6 +537,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public DeviceProvisioningServicesPrivateEndpointConnectionProperties(Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkServiceConnectionState connectionState) { }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkServiceConnectionState ConnectionState { get { throw null; } set { } }
         public Azure.Core.ResourceIdentifier PrivateEndpointId { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateEndpointConnectionProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateEndpointConnectionProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateEndpointConnectionProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateEndpointConnectionProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateEndpointConnectionProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -536,6 +550,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public string GroupId { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<string> RequiredMembers { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<string> RequiredZoneNames { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkResourceProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkResourceProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkResourceProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkResourceProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkResourceProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -548,6 +563,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public string ActionsRequired { get { throw null; } set { } }
         public string Description { get { throw null; } set { } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkServiceConnectionStatus Status { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkServiceConnectionState System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkServiceConnectionState>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkServiceConnectionState>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkServiceConnectionState System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesPrivateLinkServiceConnectionState>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -599,6 +615,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public string PrimaryKey { get { throw null; } set { } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesAccessKeyRight Rights { get { throw null; } set { } }
         public string SecondaryKey { get { throw null; } set { } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSharedAccessKey System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSharedAccessKey>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSharedAccessKey>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSharedAccessKey System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSharedAccessKey>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -626,6 +643,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
     {
         internal DeviceProvisioningServicesSkuDefinition() { }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSku? Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuDefinition System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuDefinition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuDefinition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuDefinition System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuDefinition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -638,6 +656,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public long? Capacity { get { throw null; } set { } }
         public Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSku? Name { get { throw null; } set { } }
         public string Tier { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuInfo System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuInfo>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuInfo>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuInfo System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.DeviceProvisioningServicesSkuInfo>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -680,6 +699,7 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
         public string ConnectionString { get { throw null; } set { } }
         public Azure.Core.AzureLocation Location { get { throw null; } set { } }
         public string Name { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.IotHubDefinitionDescription System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.IotHubDefinitionDescription>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DeviceProvisioningServices.Models.IotHubDefinitionDescription>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DeviceProvisioningServices.Models.IotHubDefinitionDescription System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.DeviceProvisioningServices.Models.IotHubDefinitionDescription>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/assets.json
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices",
-  "Tag": "net/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices_1868df1cee"
+  "Tag": "net/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices_5bcfcb5736"
 }

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/DeviceProvisioningServiceData.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/DeviceProvisioningServiceData.Serialization.cs
@@ -21,13 +21,22 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
 
         void IJsonModel<DeviceProvisioningServiceData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServiceData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServiceData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(ETag))
             {
                 writer.WritePropertyName("etag"u8);
@@ -37,55 +46,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
             writer.WriteObjectValue(Properties, options);
             writer.WritePropertyName("sku"u8);
             writer.WriteObjectValue(Sku, options);
-            if (Optional.IsCollectionDefined(Tags))
-            {
-                writer.WritePropertyName("tags"u8);
-                writer.WriteStartObject();
-                foreach (var item in Tags)
-                {
-                    writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
-                }
-                writer.WriteEndObject();
-            }
-            writer.WritePropertyName("location"u8);
-            writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServiceData IJsonModel<DeviceProvisioningServiceData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/DeviceProvisioningServicesCertificateData.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/DeviceProvisioningServicesCertificateData.Serialization.cs
@@ -21,13 +21,22 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
 
         void IJsonModel<DeviceProvisioningServicesCertificateData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesCertificateData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesCertificateData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Properties))
             {
                 writer.WritePropertyName("properties"u8);
@@ -38,42 +47,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
                 writer.WritePropertyName("etag"u8);
                 writer.WriteStringValue(ETag.Value.ToString());
             }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesCertificateData IJsonModel<DeviceProvisioningServicesCertificateData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/DeviceProvisioningServicesPrivateEndpointConnectionData.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/DeviceProvisioningServicesPrivateEndpointConnectionData.Serialization.cs
@@ -21,51 +21,24 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
 
         void IJsonModel<DeviceProvisioningServicesPrivateEndpointConnectionData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesPrivateEndpointConnectionData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesPrivateEndpointConnectionData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteObjectValue(Properties, options);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesPrivateEndpointConnectionData IJsonModel<DeviceProvisioningServicesPrivateEndpointConnectionData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/DeviceProvisioningServicesPrivateLinkResourceData.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/DeviceProvisioningServicesPrivateLinkResourceData.Serialization.cs
@@ -21,51 +21,24 @@ namespace Azure.ResourceManager.DeviceProvisioningServices
 
         void IJsonModel<DeviceProvisioningServicesPrivateLinkResourceData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesPrivateLinkResourceData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesPrivateLinkResourceData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteObjectValue(Properties, options);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesPrivateLinkResourceData IJsonModel<DeviceProvisioningServicesPrivateLinkResourceData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/CertificateListDescription.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/CertificateListDescription.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<CertificateListDescription>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CertificateListDescription>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CertificateListDescription)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CertificateListDescription IJsonModel<CertificateListDescription>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/CertificateVerificationCodeContent.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/CertificateVerificationCodeContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<CertificateVerificationCodeContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CertificateVerificationCodeContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CertificateVerificationCodeContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Certificate))
             {
                 writer.WritePropertyName("certificate"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CertificateVerificationCodeContent IJsonModel<CertificateVerificationCodeContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/CertificateVerificationCodeProperties.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/CertificateVerificationCodeProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<CertificateVerificationCodeProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CertificateVerificationCodeProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CertificateVerificationCodeProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(VerificationCode))
             {
                 writer.WritePropertyName("verificationCode"u8);
@@ -95,7 +103,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         CertificateVerificationCodeProperties IJsonModel<CertificateVerificationCodeProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/CertificateVerificationCodeResult.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/CertificateVerificationCodeResult.Serialization.cs
@@ -20,13 +20,22 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<CertificateVerificationCodeResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<CertificateVerificationCodeResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(CertificateVerificationCodeResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (options.Format != "W" && Optional.IsDefined(ETag))
             {
                 writer.WritePropertyName("etag"u8);
@@ -37,42 +46,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
                 writer.WritePropertyName("properties"u8);
                 writer.WriteObjectValue(Properties, options);
             }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         CertificateVerificationCodeResult IJsonModel<CertificateVerificationCodeResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicePatch.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicePatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicePatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicePatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicePatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicePatch IJsonModel<DeviceProvisioningServicePatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServiceProperties.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServiceProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServiceProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServiceProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServiceProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(State))
             {
                 writer.WritePropertyName("state"u8);
@@ -121,7 +129,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServiceProperties IJsonModel<DeviceProvisioningServiceProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesCertificateProperties.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesCertificateProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesCertificateProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesCertificateProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesCertificateProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(Subject))
             {
                 writer.WritePropertyName("subject"u8);
@@ -90,7 +98,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesCertificateProperties IJsonModel<DeviceProvisioningServicesCertificateProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesIPFilterRule.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesIPFilterRule.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesIPFilterRule>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesIPFilterRule>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesIPFilterRule)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("filterName"u8);
             writer.WriteStringValue(FilterName);
             writer.WritePropertyName("action"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesIPFilterRule IJsonModel<DeviceProvisioningServicesIPFilterRule>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesNameAvailabilityContent.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesNameAvailabilityContent.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesNameAvailabilityContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesNameAvailabilityContent>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesNameAvailabilityContent)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("name"u8);
             writer.WriteStringValue(Name);
             if (options.Format != "W" && _serializedAdditionalRawData != null)
@@ -43,7 +51,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesNameAvailabilityContent IJsonModel<DeviceProvisioningServicesNameAvailabilityContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesNameAvailabilityResult.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesNameAvailabilityResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesNameAvailabilityResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesNameAvailabilityResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesNameAvailabilityResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(IsNameAvailable))
             {
                 writer.WritePropertyName("nameAvailable"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesNameAvailabilityResult IJsonModel<DeviceProvisioningServicesNameAvailabilityResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesPrivateEndpointConnectionProperties.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesPrivateEndpointConnectionProperties.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesPrivateEndpointConnectionProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesPrivateEndpointConnectionProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesPrivateEndpointConnectionProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(PrivateEndpoint))
             {
                 writer.WritePropertyName("privateEndpoint"u8);
@@ -49,7 +57,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesPrivateEndpointConnectionProperties IJsonModel<DeviceProvisioningServicesPrivateEndpointConnectionProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesPrivateLinkResourceProperties.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesPrivateLinkResourceProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesPrivateLinkResourceProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesPrivateLinkResourceProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesPrivateLinkResourceProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(GroupId))
             {
                 writer.WritePropertyName("groupId"u8);
@@ -66,7 +74,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesPrivateLinkResourceProperties IJsonModel<DeviceProvisioningServicesPrivateLinkResourceProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesPrivateLinkServiceConnectionState.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesPrivateLinkServiceConnectionState.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesPrivateLinkServiceConnectionState>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesPrivateLinkServiceConnectionState>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesPrivateLinkServiceConnectionState)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("status"u8);
             writer.WriteStringValue(Status.ToString());
             writer.WritePropertyName("description"u8);
@@ -50,7 +58,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesPrivateLinkServiceConnectionState IJsonModel<DeviceProvisioningServicesPrivateLinkServiceConnectionState>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesSharedAccessKey.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesSharedAccessKey.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesSharedAccessKey>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesSharedAccessKey>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesSharedAccessKey)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("keyName"u8);
             writer.WriteStringValue(KeyName);
             if (Optional.IsDefined(PrimaryKey))
@@ -55,7 +63,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesSharedAccessKey IJsonModel<DeviceProvisioningServicesSharedAccessKey>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesSkuDefinition.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesSkuDefinition.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesSkuDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesSkuDefinition>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesSkuDefinition)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -46,7 +54,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesSkuDefinition IJsonModel<DeviceProvisioningServicesSkuDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesSkuInfo.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/DeviceProvisioningServicesSkuInfo.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<DeviceProvisioningServicesSkuInfo>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<DeviceProvisioningServicesSkuInfo>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(DeviceProvisioningServicesSkuInfo)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         DeviceProvisioningServicesSkuInfo IJsonModel<DeviceProvisioningServicesSkuInfo>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/IotDpsSkuDefinitionListResult.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/IotDpsSkuDefinitionListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<IotDpsSkuDefinitionListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<IotDpsSkuDefinitionListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(IotDpsSkuDefinitionListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         IotDpsSkuDefinitionListResult IJsonModel<IotDpsSkuDefinitionListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/IotHubDefinitionDescription.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/IotHubDefinitionDescription.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<IotHubDefinitionDescription>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<IotHubDefinitionDescription>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(IotHubDefinitionDescription)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsDefined(ApplyAllocationPolicy))
             {
                 writer.WritePropertyName("applyAllocationPolicy"u8);
@@ -60,7 +68,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         IotHubDefinitionDescription IJsonModel<IotHubDefinitionDescription>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/PrivateLinkResources.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/PrivateLinkResources.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<PrivateLinkResources>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<PrivateLinkResources>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(PrivateLinkResources)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         PrivateLinkResources IJsonModel<PrivateLinkResources>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/ProvisioningServiceDescriptionListResult.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/ProvisioningServiceDescriptionListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<ProvisioningServiceDescriptionListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ProvisioningServiceDescriptionListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ProvisioningServiceDescriptionListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ProvisioningServiceDescriptionListResult IJsonModel<ProvisioningServiceDescriptionListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/SharedAccessSignatureAuthorizationRuleListResult.Serialization.cs
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/Generated/Models/SharedAccessSignatureAuthorizationRuleListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 
         void IJsonModel<SharedAccessSignatureAuthorizationRuleListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<SharedAccessSignatureAuthorizationRuleListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(SharedAccessSignatureAuthorizationRuleListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.DeviceProvisioningServices.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         SharedAccessSignatureAuthorizationRuleListResult IJsonModel<SharedAccessSignatureAuthorizationRuleListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/autorest.md
+++ b/sdk/deviceprovisioningservices/Azure.ResourceManager.DeviceProvisioningServices/src/autorest.md
@@ -18,6 +18,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 
 


### PR DESCRIPTION
We need to enable WriteCore feature to deviceprovisioningservices. Therefore add `use-write-core: true` and do a regen.