### PR TITLE
Annotate return value handling property for SignalR trigger

### DIFF
--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 1.15.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.15.0 (2024-10-14)
 
 ### Bugs Fixed
-
-### Other Changes
+* Fixed the issue that the function return value from isolated-worker process is not handled correctly.
 
 ## 1.14.0 (2024-05-24)
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net6.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net6.0.cs
@@ -1,0 +1,302 @@
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    public static partial class Category
+    {
+        public const string Connections = "connections";
+        public const string Messages = "messages";
+    }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    public static partial class Event
+    {
+        public const string Connected = "connected";
+        public const string Disconnected = "disconnected";
+    }
+    [Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public enum GroupAction
+    {
+        [System.Runtime.Serialization.EnumMemberAttribute(Value="add")]
+        Add = 0,
+        [System.Runtime.Serialization.EnumMemberAttribute(Value="remove")]
+        Remove = 1,
+        [System.Runtime.Serialization.EnumMemberAttribute(Value="removeAll")]
+        RemoveAll = 2,
+    }
+    public partial class InvocationContext
+    {
+        public InvocationContext() { }
+        public object[] Arguments { get { throw null; } set { } }
+        public string Category { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Claims { get { throw null; } set { } }
+        public string ConnectionId { get { throw null; } set { } }
+        public string Error { get { throw null; } set { } }
+        public string Event { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get { throw null; } set { } }
+        public string Hub { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Query { get { throw null; } set { } }
+        public string UserId { get { throw null; } set { } }
+    }
+    public static partial class InvocationContextExtensions
+    {
+        public static Microsoft.Azure.SignalR.Management.ClientManager GetClientManager(this Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext) { throw null; }
+        public static System.Threading.Tasks.Task<Microsoft.AspNetCore.SignalR.IHubClients> GetClientsAsync(this Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext) { throw null; }
+        public static System.Threading.Tasks.Task<Microsoft.AspNetCore.SignalR.IGroupManager> GetGroupsAsync(this Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext) { throw null; }
+        public static System.Threading.Tasks.Task<Microsoft.Azure.SignalR.Management.IUserGroupManager> GetUserGroupManagerAsync(this Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext) { throw null; }
+    }
+    public partial interface ISecurityTokenValidator
+    {
+        Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult ValidateToken(Microsoft.AspNetCore.Http.HttpRequest request);
+    }
+    public partial interface IServiceHubContextStore
+    {
+        Microsoft.Azure.SignalR.Management.IServiceManager ServiceManager { get; }
+        System.Threading.Tasks.ValueTask<Microsoft.Azure.SignalR.Management.IServiceHubContext> GetAsync(string hubName);
+    }
+    public partial interface ISignalRConnectionInfoConfigurer
+    {
+        System.Func<Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult, Microsoft.AspNetCore.Http.HttpRequest, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail> Configure { get; set; }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public abstract partial class NegotiationBaseAttribute : System.Attribute
+    {
+        protected NegotiationBaseAttribute() { }
+        public string[] ClaimTypeList { get { throw null; } set { } }
+        public string ConnectionStringSetting { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string HubName { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string IdToken { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string UserId { get { throw null; } set { } }
+    }
+    public sealed partial class SecurityTokenResult
+    {
+        internal SecurityTokenResult() { }
+        [Newtonsoft.Json.JsonPropertyAttribute("exception")]
+        public System.Exception Exception { get { throw null; } }
+        public System.Security.Claims.ClaimsPrincipal Principal { get { throw null; } }
+        [Newtonsoft.Json.JsonPropertyAttribute("status")]
+        public Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenStatus Status { get { throw null; } }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Empty() { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Error(System.Exception ex) { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal) { throw null; }
+    }
+    public enum SecurityTokenStatus
+    {
+        Valid = 0,
+        Error = 1,
+        Empty = 2,
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SecurityTokenValidationAttribute : System.Attribute
+    {
+        public SecurityTokenValidationAttribute() { }
+    }
+    public abstract partial class ServerlessHub : System.IDisposable
+    {
+        protected ServerlessHub(Microsoft.Azure.SignalR.Management.IServiceHubContext hubContext = null, Microsoft.Azure.SignalR.Management.IServiceManager serviceManager = null) { }
+        public Microsoft.Azure.SignalR.Management.ClientManager ClientManager { get { throw null; } }
+        public Microsoft.AspNetCore.SignalR.IHubClients Clients { get { throw null; } }
+        public Microsoft.AspNetCore.SignalR.IGroupManager Groups { get { throw null; } }
+        public string HubName { get { throw null; } }
+        public Microsoft.Azure.SignalR.Management.IUserGroupManager UserGroups { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        protected System.Collections.Generic.IList<System.Security.Claims.Claim> GetClaims(string jwt) { throw null; }
+        protected Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionInfo Negotiate(string userId = null, System.Collections.Generic.IList<System.Security.Claims.Claim> claims = null, System.TimeSpan? lifetime = default(System.TimeSpan?)) { throw null; }
+        protected System.Threading.Tasks.Task<Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionInfo> NegotiateAsync(Microsoft.Azure.SignalR.Management.NegotiationOptions options) { throw null; }
+        [System.AttributeUsageAttribute(System.AttributeTargets.Class)]
+        protected internal partial class SignalRConnectionAttribute : System.Attribute, Microsoft.Azure.WebJobs.IConnectionProvider
+        {
+            public SignalRConnectionAttribute(string connectionStringSetting) { }
+            public string Connection { get { throw null; } set { } }
+        }
+    }
+    public abstract partial class ServerlessHub<T> where T : class
+    {
+        protected ServerlessHub() { }
+        protected ServerlessHub(Microsoft.Azure.SignalR.Management.ServiceHubContext<T> serviceHubContext) { }
+        public Microsoft.Azure.SignalR.Management.ClientManager ClientManager { get { throw null; } }
+        public Microsoft.AspNetCore.SignalR.IHubClients<T> Clients { get { throw null; } }
+        public Microsoft.Azure.SignalR.Management.GroupManager Groups { get { throw null; } }
+        public string HubName { get { throw null; } }
+        public Microsoft.Azure.SignalR.Management.UserGroupManager UserGroups { get { throw null; } }
+        protected System.Collections.Generic.IList<System.Security.Claims.Claim> GetClaims(string jwt) { throw null; }
+        protected System.Threading.Tasks.Task<Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionInfo> NegotiateAsync(Microsoft.Azure.SignalR.Management.NegotiationOptions options) { throw null; }
+    }
+    public partial class SignalRAsyncCollector<T> : Microsoft.Azure.WebJobs.IAsyncCollector<T>
+    {
+        internal SignalRAsyncCollector() { }
+        public System.Threading.Tasks.Task AddAsync(T item, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SignalRAttribute : System.Attribute
+    {
+        public SignalRAttribute() { }
+        public string ConnectionStringSetting { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string HubName { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class)]
+    public partial class SignalRConnectionAttribute : System.Attribute, Microsoft.Azure.WebJobs.IConnectionProvider
+    {
+        public SignalRConnectionAttribute(string connection) { }
+        public string Connection { get { throw null; } set { } }
+    }
+    public partial class SignalRConnectionDetail
+    {
+        public SignalRConnectionDetail() { }
+        public System.Collections.Generic.IList<System.Security.Claims.Claim> Claims { get { throw null; } set { } }
+        public string UserId { get { throw null; } set { } }
+    }
+    public partial class SignalRConnectionInfo
+    {
+        public SignalRConnectionInfo() { }
+        [Newtonsoft.Json.JsonPropertyAttribute("accessToken")]
+        public string AccessToken { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("url")]
+        public string Url { get { throw null; } set { } }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
+    {
+        public SignalRConnectionInfoAttribute() { }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalREndpointsAttribute : System.Attribute
+    {
+        public SignalREndpointsAttribute() { }
+        public string ConnectionStringSetting { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string HubName { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, AllowMultiple=true, Inherited=true)]
+    public abstract partial class SignalRFilterAttribute : Microsoft.Azure.WebJobs.Host.FunctionInvocationFilterAttribute
+    {
+        protected SignalRFilterAttribute() { }
+        public abstract System.Threading.Tasks.Task FilterAsync(Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext, System.Threading.CancellationToken cancellationToken);
+        public override System.Threading.Tasks.Task OnExecutingAsync(Microsoft.Azure.WebJobs.Host.FunctionExecutingContext executingContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public static partial class SignalRFunctionsHostBuilderExtensions
+    {
+        public static Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder AddDefaultAuth(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder builder, System.Action<Microsoft.IdentityModel.Tokens.TokenValidationParameters> configureTokenValidationParameters, System.Func<Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult, Microsoft.AspNetCore.Http.HttpRequest, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail> configurer = null) { throw null; }
+    }
+    [Newtonsoft.Json.JsonObjectAttribute]
+    public partial class SignalRGroupAction
+    {
+        public SignalRGroupAction() { }
+        [Newtonsoft.Json.JsonPropertyAttribute("action")]
+        [Newtonsoft.Json.JsonRequiredAttribute]
+        public Microsoft.Azure.WebJobs.Extensions.SignalRService.GroupAction Action { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("connectionId")]
+        public string ConnectionId { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("endpoints")]
+        public Microsoft.Azure.SignalR.ServiceEndpoint[] Endpoints { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("groupName")]
+        public string GroupName { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("userId")]
+        public string UserId { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalRIgnoreAttribute : System.Attribute
+    {
+        public SignalRIgnoreAttribute() { }
+    }
+    [Newtonsoft.Json.JsonObjectAttribute]
+    public partial class SignalRMessage
+    {
+        public SignalRMessage() { }
+        [Newtonsoft.Json.JsonPropertyAttribute("arguments")]
+        [Newtonsoft.Json.JsonRequiredAttribute]
+        public object[] Arguments { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("connectionId")]
+        public string ConnectionId { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("endpoints")]
+        public Microsoft.Azure.SignalR.ServiceEndpoint[] Endpoints { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("groupName")]
+        public string GroupName { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("target")]
+        [Newtonsoft.Json.JsonRequiredAttribute]
+        public string Target { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("userId")]
+        public string UserId { get { throw null; } set { } }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalRNegotiationAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
+    {
+        public SignalRNegotiationAttribute() { }
+    }
+    public partial class SignalROptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
+    {
+        public SignalROptions() { }
+        public System.TimeSpan? HttpClientTimeout { get { throw null; } set { } }
+        public Azure.Core.Serialization.ObjectSerializer? JsonObjectSerializer { get { throw null; } set { } }
+        public Microsoft.AspNetCore.SignalR.Protocol.IHubProtocol? MessagePackHubProtocol { get { throw null; } set { } }
+        public Microsoft.Azure.SignalR.Management.ServiceManagerRetryOptions? RetryOptions { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Microsoft.Azure.SignalR.ServiceEndpoint> ServiceEndpoints { get { throw null; } }
+        public Microsoft.Azure.SignalR.Management.ServiceTransportType ServiceTransportType { get { throw null; } set { } }
+        string Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter.Format() { throw null; }
+    }
+    public partial class SignalROutputConverter
+    {
+        public SignalROutputConverter() { }
+        public object ConvertToSignalROutput(object input) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalRParameterAttribute : System.Attribute
+    {
+        public SignalRParameterAttribute() { }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute(TriggerHandlesReturnValue=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalRTriggerAttribute : System.Attribute
+    {
+        public SignalRTriggerAttribute() { }
+        public SignalRTriggerAttribute(string hubName, string category, string @event) { }
+        public SignalRTriggerAttribute(string hubName, string category, string @event, params string[] parameterNames) { }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string Category { get { throw null; } }
+        public string ConnectionStringSetting { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string Event { get { throw null; } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string HubName { get { throw null; } }
+        public string[] ParameterNames { get { throw null; } }
+    }
+    public static partial class SignalRTriggerCategories
+    {
+        public const string Connections = "connections";
+        public const string Messages = "messages";
+    }
+    public static partial class SignalRTriggerEvents
+    {
+        public const string Connected = "connected";
+        public const string Disconnected = "disconnected";
+    }
+    public partial class SignalRTriggerException : System.Exception
+    {
+        public SignalRTriggerException() { }
+        public SignalRTriggerException(string message) { }
+        public SignalRTriggerException(string message, System.Exception innerException) { }
+    }
+    public static partial class SignalRWebJobsBuilderExtensions
+    {
+        public static Microsoft.Azure.WebJobs.IWebJobsBuilder AddSignalR(this Microsoft.Azure.WebJobs.IWebJobsBuilder builder) { throw null; }
+    }
+    public partial class SignalRWebJobsStartup : Microsoft.Azure.WebJobs.Hosting.IWebJobsStartup
+    {
+        public SignalRWebJobsStartup() { }
+        public void Configure(Microsoft.Azure.WebJobs.IWebJobsBuilder builder) { }
+    }
+    public static partial class StaticServiceHubContextStore
+    {
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.IServiceHubContextStore Get(string connectionStringSetting = "AzureSignalRConnectionString") { throw null; }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net8.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net8.0.cs
@@ -1,0 +1,302 @@
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    public static partial class Category
+    {
+        public const string Connections = "connections";
+        public const string Messages = "messages";
+    }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    public static partial class Event
+    {
+        public const string Connected = "connected";
+        public const string Disconnected = "disconnected";
+    }
+    [Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public enum GroupAction
+    {
+        [System.Runtime.Serialization.EnumMemberAttribute(Value="add")]
+        Add = 0,
+        [System.Runtime.Serialization.EnumMemberAttribute(Value="remove")]
+        Remove = 1,
+        [System.Runtime.Serialization.EnumMemberAttribute(Value="removeAll")]
+        RemoveAll = 2,
+    }
+    public partial class InvocationContext
+    {
+        public InvocationContext() { }
+        public object[] Arguments { get { throw null; } set { } }
+        public string Category { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Claims { get { throw null; } set { } }
+        public string ConnectionId { get { throw null; } set { } }
+        public string Error { get { throw null; } set { } }
+        public string Event { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get { throw null; } set { } }
+        public string Hub { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Query { get { throw null; } set { } }
+        public string UserId { get { throw null; } set { } }
+    }
+    public static partial class InvocationContextExtensions
+    {
+        public static Microsoft.Azure.SignalR.Management.ClientManager GetClientManager(this Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext) { throw null; }
+        public static System.Threading.Tasks.Task<Microsoft.AspNetCore.SignalR.IHubClients> GetClientsAsync(this Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext) { throw null; }
+        public static System.Threading.Tasks.Task<Microsoft.AspNetCore.SignalR.IGroupManager> GetGroupsAsync(this Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext) { throw null; }
+        public static System.Threading.Tasks.Task<Microsoft.Azure.SignalR.Management.IUserGroupManager> GetUserGroupManagerAsync(this Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext) { throw null; }
+    }
+    public partial interface ISecurityTokenValidator
+    {
+        Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult ValidateToken(Microsoft.AspNetCore.Http.HttpRequest request);
+    }
+    public partial interface IServiceHubContextStore
+    {
+        Microsoft.Azure.SignalR.Management.IServiceManager ServiceManager { get; }
+        System.Threading.Tasks.ValueTask<Microsoft.Azure.SignalR.Management.IServiceHubContext> GetAsync(string hubName);
+    }
+    public partial interface ISignalRConnectionInfoConfigurer
+    {
+        System.Func<Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult, Microsoft.AspNetCore.Http.HttpRequest, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail> Configure { get; set; }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public abstract partial class NegotiationBaseAttribute : System.Attribute
+    {
+        protected NegotiationBaseAttribute() { }
+        public string[] ClaimTypeList { get { throw null; } set { } }
+        public string ConnectionStringSetting { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string HubName { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string IdToken { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string UserId { get { throw null; } set { } }
+    }
+    public sealed partial class SecurityTokenResult
+    {
+        internal SecurityTokenResult() { }
+        [Newtonsoft.Json.JsonPropertyAttribute("exception")]
+        public System.Exception Exception { get { throw null; } }
+        public System.Security.Claims.ClaimsPrincipal Principal { get { throw null; } }
+        [Newtonsoft.Json.JsonPropertyAttribute("status")]
+        public Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenStatus Status { get { throw null; } }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Empty() { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Error(System.Exception ex) { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal) { throw null; }
+    }
+    public enum SecurityTokenStatus
+    {
+        Valid = 0,
+        Error = 1,
+        Empty = 2,
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SecurityTokenValidationAttribute : System.Attribute
+    {
+        public SecurityTokenValidationAttribute() { }
+    }
+    public abstract partial class ServerlessHub : System.IDisposable
+    {
+        protected ServerlessHub(Microsoft.Azure.SignalR.Management.IServiceHubContext hubContext = null, Microsoft.Azure.SignalR.Management.IServiceManager serviceManager = null) { }
+        public Microsoft.Azure.SignalR.Management.ClientManager ClientManager { get { throw null; } }
+        public Microsoft.AspNetCore.SignalR.IHubClients Clients { get { throw null; } }
+        public Microsoft.AspNetCore.SignalR.IGroupManager Groups { get { throw null; } }
+        public string HubName { get { throw null; } }
+        public Microsoft.Azure.SignalR.Management.IUserGroupManager UserGroups { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        protected System.Collections.Generic.IList<System.Security.Claims.Claim> GetClaims(string jwt) { throw null; }
+        protected Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionInfo Negotiate(string userId = null, System.Collections.Generic.IList<System.Security.Claims.Claim> claims = null, System.TimeSpan? lifetime = default(System.TimeSpan?)) { throw null; }
+        protected System.Threading.Tasks.Task<Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionInfo> NegotiateAsync(Microsoft.Azure.SignalR.Management.NegotiationOptions options) { throw null; }
+        [System.AttributeUsageAttribute(System.AttributeTargets.Class)]
+        protected internal partial class SignalRConnectionAttribute : System.Attribute, Microsoft.Azure.WebJobs.IConnectionProvider
+        {
+            public SignalRConnectionAttribute(string connectionStringSetting) { }
+            public string Connection { get { throw null; } set { } }
+        }
+    }
+    public abstract partial class ServerlessHub<T> where T : class
+    {
+        protected ServerlessHub() { }
+        protected ServerlessHub(Microsoft.Azure.SignalR.Management.ServiceHubContext<T> serviceHubContext) { }
+        public Microsoft.Azure.SignalR.Management.ClientManager ClientManager { get { throw null; } }
+        public Microsoft.AspNetCore.SignalR.IHubClients<T> Clients { get { throw null; } }
+        public Microsoft.Azure.SignalR.Management.GroupManager Groups { get { throw null; } }
+        public string HubName { get { throw null; } }
+        public Microsoft.Azure.SignalR.Management.UserGroupManager UserGroups { get { throw null; } }
+        protected System.Collections.Generic.IList<System.Security.Claims.Claim> GetClaims(string jwt) { throw null; }
+        protected System.Threading.Tasks.Task<Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionInfo> NegotiateAsync(Microsoft.Azure.SignalR.Management.NegotiationOptions options) { throw null; }
+    }
+    public partial class SignalRAsyncCollector<T> : Microsoft.Azure.WebJobs.IAsyncCollector<T>
+    {
+        internal SignalRAsyncCollector() { }
+        public System.Threading.Tasks.Task AddAsync(T item, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SignalRAttribute : System.Attribute
+    {
+        public SignalRAttribute() { }
+        public string ConnectionStringSetting { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string HubName { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class)]
+    public partial class SignalRConnectionAttribute : System.Attribute, Microsoft.Azure.WebJobs.IConnectionProvider
+    {
+        public SignalRConnectionAttribute(string connection) { }
+        public string Connection { get { throw null; } set { } }
+    }
+    public partial class SignalRConnectionDetail
+    {
+        public SignalRConnectionDetail() { }
+        public System.Collections.Generic.IList<System.Security.Claims.Claim> Claims { get { throw null; } set { } }
+        public string UserId { get { throw null; } set { } }
+    }
+    public partial class SignalRConnectionInfo
+    {
+        public SignalRConnectionInfo() { }
+        [Newtonsoft.Json.JsonPropertyAttribute("accessToken")]
+        public string AccessToken { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("url")]
+        public string Url { get { throw null; } set { } }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
+    {
+        public SignalRConnectionInfoAttribute() { }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalREndpointsAttribute : System.Attribute
+    {
+        public SignalREndpointsAttribute() { }
+        public string ConnectionStringSetting { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string HubName { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, AllowMultiple=true, Inherited=true)]
+    public abstract partial class SignalRFilterAttribute : Microsoft.Azure.WebJobs.Host.FunctionInvocationFilterAttribute
+    {
+        protected SignalRFilterAttribute() { }
+        public abstract System.Threading.Tasks.Task FilterAsync(Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext invocationContext, System.Threading.CancellationToken cancellationToken);
+        public override System.Threading.Tasks.Task OnExecutingAsync(Microsoft.Azure.WebJobs.Host.FunctionExecutingContext executingContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public static partial class SignalRFunctionsHostBuilderExtensions
+    {
+        public static Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder AddDefaultAuth(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder builder, System.Action<Microsoft.IdentityModel.Tokens.TokenValidationParameters> configureTokenValidationParameters, System.Func<Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult, Microsoft.AspNetCore.Http.HttpRequest, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail> configurer = null) { throw null; }
+    }
+    [Newtonsoft.Json.JsonObjectAttribute]
+    public partial class SignalRGroupAction
+    {
+        public SignalRGroupAction() { }
+        [Newtonsoft.Json.JsonPropertyAttribute("action")]
+        [Newtonsoft.Json.JsonRequiredAttribute]
+        public Microsoft.Azure.WebJobs.Extensions.SignalRService.GroupAction Action { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("connectionId")]
+        public string ConnectionId { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("endpoints")]
+        public Microsoft.Azure.SignalR.ServiceEndpoint[] Endpoints { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("groupName")]
+        public string GroupName { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("userId")]
+        public string UserId { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalRIgnoreAttribute : System.Attribute
+    {
+        public SignalRIgnoreAttribute() { }
+    }
+    [Newtonsoft.Json.JsonObjectAttribute]
+    public partial class SignalRMessage
+    {
+        public SignalRMessage() { }
+        [Newtonsoft.Json.JsonPropertyAttribute("arguments")]
+        [Newtonsoft.Json.JsonRequiredAttribute]
+        public object[] Arguments { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("connectionId")]
+        public string ConnectionId { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("endpoints")]
+        public Microsoft.Azure.SignalR.ServiceEndpoint[] Endpoints { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("groupName")]
+        public string GroupName { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("target")]
+        [Newtonsoft.Json.JsonRequiredAttribute]
+        public string Target { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("userId")]
+        public string UserId { get { throw null; } set { } }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalRNegotiationAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
+    {
+        public SignalRNegotiationAttribute() { }
+    }
+    public partial class SignalROptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
+    {
+        public SignalROptions() { }
+        public System.TimeSpan? HttpClientTimeout { get { throw null; } set { } }
+        public Azure.Core.Serialization.ObjectSerializer? JsonObjectSerializer { get { throw null; } set { } }
+        public Microsoft.AspNetCore.SignalR.Protocol.IHubProtocol? MessagePackHubProtocol { get { throw null; } set { } }
+        public Microsoft.Azure.SignalR.Management.ServiceManagerRetryOptions? RetryOptions { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Microsoft.Azure.SignalR.ServiceEndpoint> ServiceEndpoints { get { throw null; } }
+        public Microsoft.Azure.SignalR.Management.ServiceTransportType ServiceTransportType { get { throw null; } set { } }
+        string Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter.Format() { throw null; }
+    }
+    public partial class SignalROutputConverter
+    {
+        public SignalROutputConverter() { }
+        public object ConvertToSignalROutput(object input) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalRParameterAttribute : System.Attribute
+    {
+        public SignalRParameterAttribute() { }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute(TriggerHandlesReturnValue=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
+    public partial class SignalRTriggerAttribute : System.Attribute
+    {
+        public SignalRTriggerAttribute() { }
+        public SignalRTriggerAttribute(string hubName, string category, string @event) { }
+        public SignalRTriggerAttribute(string hubName, string category, string @event, params string[] parameterNames) { }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string Category { get { throw null; } }
+        public string ConnectionStringSetting { get { throw null; } set { } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string Event { get { throw null; } }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string HubName { get { throw null; } }
+        public string[] ParameterNames { get { throw null; } }
+    }
+    public static partial class SignalRTriggerCategories
+    {
+        public const string Connections = "connections";
+        public const string Messages = "messages";
+    }
+    public static partial class SignalRTriggerEvents
+    {
+        public const string Connected = "connected";
+        public const string Disconnected = "disconnected";
+    }
+    public partial class SignalRTriggerException : System.Exception
+    {
+        public SignalRTriggerException() { }
+        public SignalRTriggerException(string message) { }
+        public SignalRTriggerException(string message, System.Exception innerException) { }
+    }
+    public static partial class SignalRWebJobsBuilderExtensions
+    {
+        public static Microsoft.Azure.WebJobs.IWebJobsBuilder AddSignalR(this Microsoft.Azure.WebJobs.IWebJobsBuilder builder) { throw null; }
+    }
+    public partial class SignalRWebJobsStartup : Microsoft.Azure.WebJobs.Hosting.IWebJobsStartup
+    {
+        public SignalRWebJobsStartup() { }
+        public void Configure(Microsoft.Azure.WebJobs.IWebJobsBuilder builder) { }
+    }
+    public static partial class StaticServiceHubContextStore
+    {
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.IServiceHubContextStore Get(string connectionStringSetting = "AzureSignalRConnectionString") { throw null; }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
@@ -254,8 +254,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         public SignalRParameterAttribute() { }
     }
-    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
-    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute(TriggerHandlesReturnValue=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
     public partial class SignalRTriggerAttribute : System.Attribute
     {
         public SignalRTriggerAttribute() { }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRConfigProvider.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRConfigProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             // Trigger binding rule
             var triggerBindingRule = context.AddBindingRule<SignalRTriggerAttribute>();
             triggerBindingRule.AddConverter<InvocationContext, JObject>(JObject.FromObject);
-            triggerBindingRule.BindToTrigger<InvocationContext>(new SignalRTriggerBindingProvider(_dispatcher, _nameResolver, _serviceManagerStore, webhookException));
+            triggerBindingRule.BindToTrigger(new SignalRTriggerBindingProvider(_dispatcher, _nameResolver, _serviceManagerStore, webhookException));
 
             // Non-trigger binding rule
             var signalRConnectionInfoAttributeRule = context.AddBindingRule<SignalRConnectionInfoAttribute>();

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks);net8.0</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
     <Version>1.15.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net8.0</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
     <Version>1.15.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
-    <Version>1.15.0-beta.1</Version>
+    <Version>1.15.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <SignAssembly>true</SignAssembly>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -5,7 +5,6 @@
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
     <Version>1.15.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.14.0</ApiCompatVersion>
     <SignAssembly>true</SignAssembly>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
     <NoWarn>$(NoWarn);CS1591;AZC0107;</NoWarn>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRTriggerAttribute.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRTriggerAttribute.cs
@@ -10,8 +10,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     /// <summary>
     /// Attribute used to mark a function that should be triggered by messages sent from SignalR clients.
     /// </summary>
-    [AttributeUsage(AttributeTargets.ReturnValue | AttributeTargets.Parameter)]
-    [Binding]
+    [AttributeUsage(AttributeTargets.Parameter)]
+#pragma warning disable CS0618 // Type or member is obsolete
+    [Binding(TriggerHandlesReturnValue = true)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class SignalRTriggerAttribute : Attribute
     {
         /// <summary>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRTriggerBinding.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRTriggerBinding.cs
@@ -17,6 +17,7 @@ using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
@@ -201,6 +202,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 {
                     return Task.FromResult<object>(JObject.FromObject(_value));
                 }
+                // Isolated worker model
+                else if (_parameter.ParameterType == typeof(string))
+                {
+                    return Task.FromResult(JsonConvert.SerializeObject(_value) as object);
+                }
 
                 return Task.FromResult<object>(null);
             }
@@ -210,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 return _value.ToString();
             }
 
-            public Type Type => _parameter.GetType();
+            public Type Type => _parameter.ParameterType;
 
             // No use here
             public Task SetValueAsync(object value, CancellationToken cancellationToken)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Utils/JTokenWrapper.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Utils/JTokenWrapper.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR.Protocol;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService;
+
+/// <summary>
+/// Helps to make the <see cref="JToken"/> object correctly seralized in <see cref="JsonHubProtocol"/> that using System.Text.Json internally.
+/// <para>Since .Net Core 3.0, the <see cref="JsonHubProtocol"/> uses System.Text.Json library for JSON (de)serialization, which cannot handle <see cref="JToken"/> correctly. However, in isolated worker model, if a SignalR trigger function returns an object, then the SignalR extensions in host process gets a <see cref="JToken"/> object. We need to make sure the <see cref="JToken"/> object serialized correctly in the <see cref="CompletionMessage"/>.</para>
+/// </summary>
+
+[System.Text.Json.Serialization.JsonConverter(typeof(JTokenWrapperJsonConverter))]
+internal class JTokenWrapper
+{
+    public JTokenWrapper(JToken value)
+    {
+        Value = value;
+    }
+
+    public JToken Value { get; }
+}
+
+internal class JTokenWrapperJsonConverter : System.Text.Json.Serialization.JsonConverter<JTokenWrapper>
+{
+    public override JTokenWrapper Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, JTokenWrapper value, JsonSerializerOptions options)
+    {
+#if NET6_0_OR_GREATER
+        var jsonString = JsonConvert.SerializeObject(value.Value);
+        writer.WriteRawValue(jsonString);
+#elif NETSTANDARD2_0
+        // No need to implement.
+        // First of all, the SignalR extensions for host process always run on .NET 6 or greater runtime when this class is first written.
+        // Even if somehow the extensions run on .NET Framework, the JsonHubProtocol would use Newtonsoft.Json for serialization and this class would not be used.
+        throw new NotImplementedException("Serializing Newtonsoft.Json.JsonToken with System.Text.Json is not implemented. ");
+#endif
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
         {
             var ctx = new DefaultHttpContext();
             var req = ctx.Request;
-            req.Headers.Add("Authorization", new StringValues(tokenString));
+            req.Headers.Append("Authorization", new StringValues(tokenString));
 
             Action<TokenValidationParameters> configureTokenValidationParameters = parameters =>
             {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Utils/TestHelpers.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Utils/TestHelpers.cs
@@ -68,13 +68,13 @@ namespace SignalRServiceExtension.Tests.Utils
             var context = new DefaultHttpContext();
             context.Request.ContentType = contentType;
             context.Request.Method = "Post";
-            context.Request.Headers.Add(Constants.AsrsHubNameHeader, hub);
-            context.Request.Headers.Add(Constants.AsrsCategory, category);
-            context.Request.Headers.Add(Constants.AsrsEvent, @event);
-            context.Request.Headers.Add(Constants.AsrsConnectionIdHeader, connectionId);
+            context.Request.Headers.Append(Constants.AsrsHubNameHeader, hub);
+            context.Request.Headers.Append(Constants.AsrsCategory, category);
+            context.Request.Headers.Append(Constants.AsrsEvent, @event);
+            context.Request.Headers.Append(Constants.AsrsConnectionIdHeader, connectionId);
             if (signatures != null)
             {
-                context.Request.Headers.Add(Constants.AsrsSignature, string.Join(",", signatures));
+                context.Request.Headers.Append(Constants.AsrsSignature, string.Join(",", signatures));
             }
             context.Request.Body = content == null ? Stream.Null : new MemoryStream(content);
 


### PR DESCRIPTION
Support handling function return value from worker process 
Fix https://github.com/Azure/azure-functions-dotnet-worker/issues/1496

The reason to add .NET 6 and .NET 8 as TFM:
The worker function return value is a Newtonsoft JObject if it's an object in the worker. Since .NET Core Frameworks, the default SignalR JSON protocol uses System.Text.Json library and can't serialize Newtonsoft JObject. Therefore, we need to wrap the JObject to a System.Text.Json serializable object with a customized JSON converter. The customized JSON converter first converts the Newtonsoft JObject to JSON with Newtonsoft library, then writes the raw JSON object with System.Text.Json writer. For .NET Standard 2.0, it's not possible to write a raw JSON with System.Text.Json writer, therefore, we need to add .NET 6 and .NET 8 as TFM to write the raw JSON.
