### PR TITLE
Enable WriteCore feature for edgezones

### DIFF
--- a/sdk/edgezones/Azure.ResourceManager.EdgeZones/CHANGELOG.md
+++ b/sdk/edgezones/Azure.ResourceManager.EdgeZones/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Exposed `JsonModelWriteCore` for model serialization procedure.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/edgezones/Azure.ResourceManager.EdgeZones/api/Azure.ResourceManager.EdgeZones.netstandard2.0.cs
+++ b/sdk/edgezones/Azure.ResourceManager.EdgeZones/api/Azure.ResourceManager.EdgeZones.netstandard2.0.cs
@@ -36,6 +36,7 @@ namespace Azure.ResourceManager.EdgeZones
         public string RegionCategory { get { throw null; } }
         public string RegionType { get { throw null; } }
         public Azure.ResourceManager.EdgeZones.Models.EdgeZonesRegistrationState? RegistrationState { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.EdgeZones.ExtendedZoneData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.EdgeZones.ExtendedZoneData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.EdgeZones.ExtendedZoneData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.EdgeZones.ExtendedZoneData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.EdgeZones.ExtendedZoneData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/edgezones/Azure.ResourceManager.EdgeZones/src/Generated/ExtendedZoneData.Serialization.cs
+++ b/sdk/edgezones/Azure.ResourceManager.EdgeZones/src/Generated/ExtendedZoneData.Serialization.cs
@@ -21,33 +21,22 @@ namespace Azure.ResourceManager.EdgeZones
 
         void IJsonModel<ExtendedZoneData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExtendedZoneData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExtendedZoneData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
@@ -104,22 +93,6 @@ namespace Azure.ResourceManager.EdgeZones
             {
                 writer.WritePropertyName("homeLocation"u8);
                 writer.WriteStringValue(HomeLocation);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/edgezones/Azure.ResourceManager.EdgeZones/src/Generated/Models/ExtendedZoneListResult.Serialization.cs
+++ b/sdk/edgezones/Azure.ResourceManager.EdgeZones/src/Generated/Models/ExtendedZoneListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.EdgeZones.Models
 
         void IJsonModel<ExtendedZoneListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ExtendedZoneListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ExtendedZoneListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             writer.WritePropertyName("value"u8);
             writer.WriteStartArray();
             foreach (var item in Value)
@@ -53,7 +61,6 @@ namespace Azure.ResourceManager.EdgeZones.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ExtendedZoneListResult IJsonModel<ExtendedZoneListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/edgezones/Azure.ResourceManager.EdgeZones/src/autorest.md
+++ b/sdk/edgezones/Azure.ResourceManager.EdgeZones/src/autorest.md
@@ -17,6 +17,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 #mgmt-debug:
 #  show-serialized-names: true


### PR DESCRIPTION
We need to enable WriteCore feature to edgezones. Therefore add `use-write-core: true` and do a regen.