### PR TITLE
Enable WriteCore feature for managednetwork

### DIFF
--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/CHANGELOG.md
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
+- Exposed `JsonModelWriteCore` for model serialization procedure.
 
 ### Breaking Changes
 

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/api/Azure.ResourceManager.ManagedNetwork.netstandard2.0.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/api/Azure.ResourceManager.ManagedNetwork.netstandard2.0.cs
@@ -24,6 +24,7 @@ namespace Azure.ResourceManager.ManagedNetwork
         public Azure.ETag? ETag { get { throw null; } }
         public Azure.ResourceManager.ManagedNetwork.Models.ProvisioningState? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.ManagedNetwork.Models.Scope Scope { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.ManagedNetworkData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.ManagedNetworkData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -73,6 +74,7 @@ namespace Azure.ResourceManager.ManagedNetwork
         public System.Collections.Generic.IList<Azure.ResourceManager.Resources.Models.WritableSubResource> Subnets { get { throw null; } }
         public System.Collections.Generic.IList<Azure.ResourceManager.Resources.Models.WritableSubResource> Subscriptions { get { throw null; } }
         public System.Collections.Generic.IList<Azure.ResourceManager.Resources.Models.WritableSubResource> VirtualNetworks { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.ManagedNetworkGroupData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkGroupData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkGroupData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.ManagedNetworkGroupData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkGroupData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -120,6 +122,7 @@ namespace Azure.ResourceManager.ManagedNetwork
         public ManagedNetworkPeeringPolicyData() { }
         public Azure.Core.AzureLocation? Location { get { throw null; } set { } }
         public Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPeeringPolicyProperties Properties { get { throw null; } set { } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.ManagedNetworkPeeringPolicyData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkPeeringPolicyData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkPeeringPolicyData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.ManagedNetworkPeeringPolicyData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.ManagedNetworkPeeringPolicyData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -200,6 +203,7 @@ namespace Azure.ResourceManager.ManagedNetwork
         public Azure.ETag? ETag { get { throw null; } }
         public Azure.Core.AzureLocation? Location { get { throw null; } set { } }
         public Azure.ResourceManager.ManagedNetwork.Models.ProvisioningState? ProvisioningState { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.ScopeAssignmentData System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.ScopeAssignmentData>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.ScopeAssignmentData>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.ScopeAssignmentData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.ScopeAssignmentData>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -270,6 +274,7 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
         internal ConnectivityCollection() { }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.ManagedNetwork.ManagedNetworkGroupData> Groups { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.ManagedNetwork.ManagedNetworkPeeringPolicyData> Peerings { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.ConnectivityCollection System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.ConnectivityCollection>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.ConnectivityCollection>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.ConnectivityCollection System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.Models.ConnectivityCollection>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -315,6 +320,7 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
     {
         public ManagedNetworkPatch() { }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPatch System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPatch>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPatch>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPatch System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPatch>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -328,6 +334,7 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
         public Azure.Core.ResourceIdentifier HubId { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.ResourceManager.Resources.Models.WritableSubResource> Mesh { get { throw null; } }
         public System.Collections.Generic.IList<Azure.ResourceManager.Resources.Models.WritableSubResource> Spokes { get { throw null; } }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPeeringPolicyProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPeeringPolicyProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPeeringPolicyProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPeeringPolicyProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.Models.ManagedNetworkPeeringPolicyProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -359,6 +366,7 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
         public ResourceProperties() { }
         public Azure.ETag? ETag { get { throw null; } }
         public Azure.ResourceManager.ManagedNetwork.Models.ProvisioningState? ProvisioningState { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.ResourceProperties System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.ResourceProperties>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.ResourceProperties>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.ResourceProperties System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.Models.ResourceProperties>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
@@ -372,6 +380,7 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
         public System.Collections.Generic.IList<Azure.ResourceManager.Resources.Models.WritableSubResource> Subnets { get { throw null; } }
         public System.Collections.Generic.IList<Azure.ResourceManager.Resources.Models.WritableSubResource> Subscriptions { get { throw null; } }
         public System.Collections.Generic.IList<Azure.ResourceManager.Resources.Models.WritableSubResource> VirtualNetworks { get { throw null; } }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.Scope System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.Scope>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         void System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.ManagedNetwork.Models.Scope>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.ManagedNetwork.Models.Scope System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.ManagedNetwork.Models.Scope>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/ManagedNetworkData.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/ManagedNetworkData.Serialization.cs
@@ -21,46 +21,22 @@ namespace Azure.ResourceManager.ManagedNetwork
 
         void IJsonModel<ManagedNetworkData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedNetworkData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedNetworkData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
-            if (Optional.IsCollectionDefined(Tags))
-            {
-                writer.WritePropertyName("tags"u8);
-                writer.WriteStartObject();
-                foreach (var item in Tags)
-                {
-                    writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
-                }
-                writer.WriteEndObject();
-            }
-            writer.WritePropertyName("location"u8);
-            writer.WriteStringValue(Location);
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
@@ -82,22 +58,6 @@ namespace Azure.ResourceManager.ManagedNetwork
             {
                 writer.WritePropertyName("connectivity"u8);
                 writer.WriteObjectValue(Connectivity, options);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/ManagedNetworkGroupData.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/ManagedNetworkGroupData.Serialization.cs
@@ -22,13 +22,22 @@ namespace Azure.ResourceManager.ManagedNetwork
 
         void IJsonModel<ManagedNetworkGroupData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedNetworkGroupData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedNetworkGroupData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Kind))
             {
                 writer.WritePropertyName("kind"u8);
@@ -38,26 +47,6 @@ namespace Azure.ResourceManager.ManagedNetwork
             {
                 writer.WritePropertyName("location"u8);
                 writer.WriteStringValue(Location.Value);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -110,22 +99,6 @@ namespace Azure.ResourceManager.ManagedNetwork
                     JsonSerializer.Serialize(writer, item);
                 }
                 writer.WriteEndArray();
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/ManagedNetworkPeeringPolicyData.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/ManagedNetworkPeeringPolicyData.Serialization.cs
@@ -21,13 +21,22 @@ namespace Azure.ResourceManager.ManagedNetwork
 
         void IJsonModel<ManagedNetworkPeeringPolicyData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedNetworkPeeringPolicyData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedNetworkPeeringPolicyData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Properties))
             {
                 writer.WritePropertyName("properties"u8);
@@ -38,42 +47,6 @@ namespace Azure.ResourceManager.ManagedNetwork
                 writer.WritePropertyName("location"u8);
                 writer.WriteStringValue(Location.Value);
             }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         ManagedNetworkPeeringPolicyData IJsonModel<ManagedNetworkPeeringPolicyData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ConnectivityCollection.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ConnectivityCollection.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<ConnectivityCollection>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ConnectivityCollection>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ConnectivityCollection)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsCollectionDefined(Groups))
             {
                 writer.WritePropertyName("groups"u8);
@@ -61,7 +69,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ConnectivityCollection IJsonModel<ConnectivityCollection>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkGroupListResult.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkGroupListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<ManagedNetworkGroupListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedNetworkGroupListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedNetworkGroupListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedNetworkGroupListResult IJsonModel<ManagedNetworkGroupListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkListResult.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<ManagedNetworkListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedNetworkListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedNetworkListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedNetworkListResult IJsonModel<ManagedNetworkListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkPatch.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkPatch.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<ManagedNetworkPatch>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedNetworkPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedNetworkPatch)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Tags))
             {
                 writer.WritePropertyName("tags"u8);
@@ -52,7 +60,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedNetworkPatch IJsonModel<ManagedNetworkPatch>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkPeeringPolicyListResult.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkPeeringPolicyListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<ManagedNetworkPeeringPolicyListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedNetworkPeeringPolicyListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedNetworkPeeringPolicyListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ManagedNetworkPeeringPolicyListResult IJsonModel<ManagedNetworkPeeringPolicyListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkPeeringPolicyProperties.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ManagedNetworkPeeringPolicyProperties.Serialization.cs
@@ -20,13 +20,22 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<ManagedNetworkPeeringPolicyProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ManagedNetworkPeeringPolicyProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ManagedNetworkPeeringPolicyProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             writer.WritePropertyName("type"u8);
             writer.WriteStringValue(ConnectivityType.ToString());
             if (Optional.IsDefined(Hub))
@@ -54,32 +63,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
                 }
                 writer.WriteEndArray();
             }
-            if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
-            {
-                writer.WritePropertyName("provisioningState"u8);
-                writer.WriteStringValue(ProvisioningState.Value.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(ETag))
-            {
-                writer.WritePropertyName("etag"u8);
-                writer.WriteStringValue(ETag.Value.ToString());
-            }
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
         }
 
         ManagedNetworkPeeringPolicyProperties IJsonModel<ManagedNetworkPeeringPolicyProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ResourceProperties.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ResourceProperties.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<ResourceProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ResourceProperties>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ResourceProperties)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (options.Format != "W" && Optional.IsDefined(ProvisioningState))
             {
                 writer.WritePropertyName("provisioningState"u8);
@@ -51,7 +59,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ResourceProperties IJsonModel<ResourceProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/Scope.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/Scope.Serialization.cs
@@ -20,13 +20,21 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<Scope>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<Scope>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(Scope)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(ManagementGroups))
             {
                 writer.WritePropertyName("managementGroups"u8);
@@ -82,7 +90,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         Scope IJsonModel<Scope>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ScopeAssignmentListResult.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/Models/ScopeAssignmentListResult.Serialization.cs
@@ -19,13 +19,21 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 
         void IJsonModel<ScopeAssignmentListResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ScopeAssignmentListResult>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ScopeAssignmentListResult)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
             if (Optional.IsCollectionDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -56,7 +64,6 @@ namespace Azure.ResourceManager.ManagedNetwork.Models
 #endif
                 }
             }
-            writer.WriteEndObject();
         }
 
         ScopeAssignmentListResult IJsonModel<ScopeAssignmentListResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/ScopeAssignmentData.Serialization.cs
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/Generated/ScopeAssignmentData.Serialization.cs
@@ -21,37 +21,26 @@ namespace Azure.ResourceManager.ManagedNetwork
 
         void IJsonModel<ScopeAssignmentData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
             var format = options.Format == "W" ? ((IPersistableModel<ScopeAssignmentData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
                 throw new FormatException($"The model {nameof(ScopeAssignmentData)} does not support writing '{format}' format.");
             }
 
-            writer.WriteStartObject();
+            base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Location))
             {
                 writer.WritePropertyName("location"u8);
                 writer.WriteStringValue(Location.Value);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("id"u8);
-                writer.WriteStringValue(Id);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name);
-            }
-            if (options.Format != "W")
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(ResourceType);
-            }
-            if (options.Format != "W" && Optional.IsDefined(SystemData))
-            {
-                writer.WritePropertyName("systemData"u8);
-                JsonSerializer.Serialize(writer, SystemData);
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
@@ -69,22 +58,6 @@ namespace Azure.ResourceManager.ManagedNetwork
             {
                 writer.WritePropertyName("assignedManagedNetwork"u8);
                 writer.WriteStringValue(AssignedManagedNetwork);
-            }
-            writer.WriteEndObject();
-            if (options.Format != "W" && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
             }
             writer.WriteEndObject();
         }

--- a/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/autorest.md
+++ b/sdk/managednetwork/Azure.ResourceManager.ManagedNetwork/src/autorest.md
@@ -19,6 +19,7 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 use-model-reader-writer: true
+use-write-core: true
 
 format-by-name-rules:
   'tenantId': 'uuid'


### PR DESCRIPTION
We need to enable WriteCore feature to managednetwork. Therefore add `use-write-core: true` and do a regen.