### PR TITLE
[BUG] GetProcessorCount for webjobs service bus extension does not override processor count for flex consumption (Fixes #45970)

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-[BUG] GetProcessorCount for webjobs service bus extension does not override processor count for flex consumption #45970
+GetProcessorCount for webjobs service bus extension does not override processor count for flex consumption. (#45970)
 
 ### Other Changes
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+[BUG] GetProcessorCount for webjobs service bus extension does not override processor count for flex consumption #45970
 
 ### Other Changes
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Constants.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Constants.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public const string DefaultConnectionStringName = "ServiceBus";
         public const string DefaultConnectionSettingStringName = "AzureWebJobsServiceBus";
         public const string DynamicSku = "Dynamic";
+        public const string FlexConsumptionSku = "FlexConsumption";
         public const string AzureWebsiteSku = "WEBSITE_SKU";
         public const string ProcessMessagesActivityName = "ServiceBusListener.ProcessMessages";
         public const string ProcessSessionMessagesActivityName = "ServiceBusListener.ProcessSessionMessages";

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Utility.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Utility.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public static int GetProcessorCount()
         {
             string skuValue = Environment.GetEnvironmentVariable(Constants.AzureWebsiteSku);
-            return string.Equals(skuValue, Constants.DynamicSku, StringComparison.OrdinalIgnoreCase) || string.Equals(skuValue, Constants.DynamicSku, StringComparison.OrdinalIgnoreCase)
+            return string.Equals(skuValue, Constants.DynamicSku, StringComparison.OrdinalIgnoreCase) || string.Equals(skuValue, Constants.FlexConsumptionSku, StringComparison.OrdinalIgnoreCase)
                 ? 1 : Environment.ProcessorCount;
         }
     }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Utility.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Utility.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public static int GetProcessorCount()
         {
             string skuValue = Environment.GetEnvironmentVariable(Constants.AzureWebsiteSku);
-            return string.Equals(skuValue, Constants.DynamicSku, StringComparison.OrdinalIgnoreCase) ? 1 : Environment.ProcessorCount;
+            return string.Equals(skuValue, Constants.DynamicSku, StringComparison.OrdinalIgnoreCase) || string.Equals(skuValue, Constants.DynamicSku, StringComparison.OrdinalIgnoreCase)
+                ? 1 : Environment.ProcessorCount;
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/UtilityTest.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/UtilityTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
+{
+    internal class UtilityTest
+    {
+        [Test]
+        public void GetProcessorCount_ReturnsOneForDynamicAndFlexSkus()
+        {
+            Environment.SetEnvironmentVariable(Constants.AzureWebsiteSku, Constants.DynamicSku);
+            Assert.AreEqual(1, Utility.GetProcessorCount());
+
+            Environment.SetEnvironmentVariable(Constants.AzureWebsiteSku, Constants.FlexConsumptionSku);
+            Assert.AreEqual(1, Utility.GetProcessorCount());
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/45970
