### PR TITLE
Use simpler delegate when constructing AzureEventSourceListener

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Improved the efficiency of `AzureEventSourceLogForwarder` by eliminating message formatting. ([#46202](https://github.com/Azure/azure-sdk-for-net/pull/46202))
+
 ## 1.7.5 (2024-08-15)
 
 ### Other Changes

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/AzureEventSourceLogForwarder.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/AzureEventSourceLogForwarder.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Azure
         /// </summary>
         public void Start()
         {
-            _listener ??= new AzureEventSourceListener((e, s) => LogEvent(e), EventLevel.Verbose);
+            _listener ??= new AzureEventSourceListener(LogEvent, EventLevel.Verbose);
         }
 
         private void LogEvent(EventWrittenEventArgs eventData)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -32,6 +32,8 @@
   .NET](https://learn.microsoft.com/dotnet/azure/sdk/logging).
   ([#45649](https://github.com/Azure/azure-sdk-for-net/pull/45649))
 
+* Improved the efficiency of `AzureEventSourceLogForwarder` by eliminating message formatting. ([#46202](https://github.com/Azure/azure-sdk-for-net/pull/46202))
+
 ## 1.3.0-beta.1 (2024-07-12)
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/AzureSdkCompat/AzureEventSourceLogForwarder.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/AzureSdkCompat/AzureEventSourceLogForwarder.cs
@@ -79,7 +79,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.AzureSdkCompat
             {
                 // Setting even a single custom filter for Azure SDK logs will reset the default warning level and switch to listening at the verbose level.
                 // This gives the customer full control over the log levels for all Azure SDK components.
-                _listener ??= new AzureEventSourceListener((e, s) => LogEvent(e), _hasAzureLoggerFilterOptionsRules ? EventLevel.Verbose : EventLevel.Warning);
+                _listener ??= new AzureEventSourceListener(LogEvent, _hasAzureLoggerFilterOptionsRules ? EventLevel.Verbose : EventLevel.Warning);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
Following the completion of #45191 and the publishing of an Azure.Core version with that change, this PR makes use of the new constructor in the Extensions Monitor.OpenTelemetry projects.