### PR TITLE
[AzureMonidorDistro] sync vendored code

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 ### Other Changes
 
+* Updated the code of vendored resource detector library `OpenTelemetry.Resources.Azure` from the OpenTelemetry .NET contrib repository.
+  Code has been updated to [1.0.0-beta.8](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/Resources.Azure-1.0.0-beta.9/src/OpenTelemetry.Resources.Azure).
+  ([#46207](https://github.com/Azure/azure-sdk-for-net/pull/46207))
+
 * Updated field mappings for telemetry sent to LiveMetrics.
   ([#45103](https://github.com/Azure/azure-sdk-for-net/pull/45103))
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Other Changes
 
 * Updated the code of vendored resource detector library `OpenTelemetry.Resources.Azure` from the OpenTelemetry .NET contrib repository.
-  Code has been updated to [1.0.0-beta.8](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/Resources.Azure-1.0.0-beta.9/src/OpenTelemetry.Resources.Azure).
+  Code has been updated to [1.0.0-beta.9](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/Resources.Azure-1.0.0-beta.9/src/OpenTelemetry.Resources.Azure).
   ([#46207](https://github.com/Azure/azure-sdk-for-net/pull/46207))
 
 * Updated field mappings for telemetry sent to LiveMetrics.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections.Generic;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Resources.Azure;
@@ -66,7 +64,7 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
         string? websiteResourceGroup = Environment.GetEnvironmentVariable(ResourceAttributeConstants.AppServiceResourceGroupEnvVar);
         string websiteOwnerName = Environment.GetEnvironmentVariable(ResourceAttributeConstants.AppServiceOwnerNameEnvVar) ?? string.Empty;
 
-#if NET6_0_OR_GREATER
+#if NET
         int idx = websiteOwnerName.IndexOf('+', StringComparison.Ordinal);
 #else
         int idx = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/AzureResourceBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/AzureResourceBuilderExtensions.cs
@@ -14,8 +14,8 @@ internal static class AzureResourceBuilderExtensions
     /// <summary>
     /// Enables Azure App Service resource detector.
     /// </summary>
-    /// <param name="builder"><see cref="ResourceBuilder" /> being configured.</param>
-    /// <returns>The instance of <see cref="ResourceBuilder" /> being configured.</returns>
+    /// <param name="builder">The <see cref="ResourceBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="ResourceBuilder"/> being configured.</returns>
     public static ResourceBuilder AddAzureAppServiceDetector(this ResourceBuilder builder)
     {
         Guard.ThrowIfNull(builder);
@@ -25,8 +25,8 @@ internal static class AzureResourceBuilderExtensions
     /// <summary>
     /// Enables Azure VM resource detector.
     /// </summary>
-    /// <param name="builder"><see cref="ResourceBuilder" /> being configured.</param>
-    /// <returns>The instance of <see cref="ResourceBuilder" /> being configured.</returns>
+    /// <param name="builder">The <see cref="ResourceBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="ResourceBuilder"/> being configured.</returns>
     public static ResourceBuilder AddAzureVMDetector(this ResourceBuilder builder)
     {
         Guard.ThrowIfNull(builder);
@@ -36,8 +36,8 @@ internal static class AzureResourceBuilderExtensions
     /// <summary>
     /// Enables Azure Container Apps resource detector.
     /// </summary>
-    /// <param name="builder"><see cref="ResourceBuilder" /> being configured.</param>
-    /// <returns>The instance of <see cref="ResourceBuilder" /> being configured.</returns>
+    /// <param name="builder">The <see cref="ResourceBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="ResourceBuilder"/> being configured.</returns>
     public static ResourceBuilder AddAzureContainerAppsDetector(this ResourceBuilder builder)
     {
         Guard.ThrowIfNull(builder);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Generic;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Resources.Azure;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/AzureVmMetaDataRequestor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/AzureVmMetaDataRequestor.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Net.Http;
 using System.Text.Json;
 
 namespace OpenTelemetry.Resources.Azure;
@@ -26,7 +24,7 @@ internal static class AzureVmMetaDataRequestor
 
         if (res != null)
         {
-#if NET6_0_OR_GREATER
+#if NET
             return JsonSerializer.Deserialize(res, SourceGenerationContext.Default.AzureVmMetadataResponse);
 #else
             return JsonSerializer.Deserialize<AzureVmMetadataResponse>(res);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/ResourceAttributeConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/ResourceAttributeConstants.cs
@@ -27,6 +27,10 @@ internal sealed class ResourceAttributeConstants
     internal const string AzureContainerAppsReplicaNameEnvVar = "CONTAINER_APP_REPLICA_NAME";
     internal const string AzureContainerAppsRevisionEnvVar = "CONTAINER_APP_REVISION";
 
+    // Azure Container Apps Jobs environment variables
+    internal const string AzureContainerAppJobNameEnvVar = "CONTAINER_APP_JOB_NAME";
+    internal const string AzureContainerAppJobExecutionNameEnvVar = "CONTAINER_APP_JOB_EXECUTION_NAME";
+
     // Azure resource attributes constant values
     internal const string AzureAppServicePlatformValue = "azure_app_service";
     internal const string AzureCloudProviderValue = "azure";

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/SourceGenerationContext.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/OpenTelemetry.Resources.Azure/SourceGenerationContext.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET6_0_OR_GREATER
+#if NET
 using System.Text.Json.Serialization;
 
 namespace OpenTelemetry.Resources.Azure;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/AssemblyVersionExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/AssemblyVersionExtensions.cs
@@ -3,11 +3,8 @@
 
 #nullable enable
 
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-using System;
 using System.Diagnostics;
 using System.Reflection;
-#pragma warning restore IDE0005 // Using directive is unnecessary.
 
 namespace OpenTelemetry.Internal;
 
@@ -26,7 +23,7 @@ internal static class AssemblyVersionExtensions
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
         Debug.Assert(!string.IsNullOrEmpty(informationalVersion), "AssemblyInformationalVersionAttribute was not found in assembly");
 
-#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NET || NETSTANDARD2_1_OR_GREATER
         var indexOfPlusSign = informationalVersion!.IndexOf('+', StringComparison.Ordinal);
 #else
         var indexOfPlusSign = informationalVersion!.IndexOf('+');

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceListener.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceListener.cs
@@ -3,12 +3,8 @@
 
 #nullable enable
 
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using OpenTelemetry.Internal;
-#pragma warning restore IDE0005 // Using directive is unnecessary.
 
 namespace OpenTelemetry.Instrumentation;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceSubscriber.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/DiagnosticSourceSubscriber.cs
@@ -3,13 +3,8 @@
 
 #nullable enable
 
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using OpenTelemetry.Internal;
-#pragma warning restore IDE0005 // Using directive is unnecessary.
 
 namespace OpenTelemetry.Instrumentation;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/ExceptionExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/ExceptionExtensions.cs
@@ -3,11 +3,7 @@
 
 #nullable enable
 
-#pragma warning disable IDE0005 // Using directive is unnecessary. <- Projects with ImplicitUsings enabled don't need System or System.Threading
-using System;
 using System.Globalization;
-using System.Threading;
-#pragma warning restore IDE0005 // Using directive is unnecessary.
 
 namespace OpenTelemetry.Internal;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/Guard.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/Guard.cs
@@ -3,25 +3,19 @@
 
 #nullable enable
 
-// Note: When implicit usings are enabled in a project this file will generate
-// warnings/errors without this suppression.
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-
 // Note: For some targets this file will contain more than one type/namespace.
 #pragma warning disable IDE0161 // Convert to file-scoped namespace
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1403 // File may only contain a single namespace
 #pragma warning disable SA1649 // File name should match first type name
 
-#if !NET6_0_OR_GREATER
+#if !NET
 namespace System.Runtime.CompilerServices
 {
     /// <summary>Allows capturing of the expressions passed to a method.</summary>
@@ -38,7 +32,7 @@ namespace System.Runtime.CompilerServices
 }
 #endif
 
-#if !NET6_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
+#if !NET && !NETSTANDARD2_1_OR_GREATER
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>Specifies that an output is not <see langword="null"/> even if

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/PropertyFetcher.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/PropertyFetcher.cs
@@ -3,11 +3,7 @@
 
 #nullable disable
 
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-using System;
-using System.Linq;
 using System.Reflection;
-#pragma warning restore IDE0005 // Using directive is unnecessary.
 
 namespace OpenTelemetry.Instrumentation;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Vendoring/Shared/SemanticConventions.cs
@@ -58,6 +58,11 @@ internal static class SemanticConventions
     public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
     public const string AttributeDbMongoDbCollection = "db.mongodb.collection";
 
+    public const string AttributeRpcSystem = "rpc.system";
+    public const string AttributeRpcService = "rpc.service";
+    public const string AttributeRpcMethod = "rpc.method";
+    public const string AttributeRpcGrpcStatusCode = "rpc.grpc.status_code";
+
     public const string AttributeMessageType = "message.type";
     public const string AttributeMessageId = "message.id";
     public const string AttributeMessageCompressedSize = "message.compressed_size";
@@ -111,5 +116,25 @@ internal static class SemanticConventions
     public const string AttributeServerAddress = "server.address"; // replaces: "net.host.name" (AttributeNetHostName)
     public const string AttributeServerPort = "server.port"; // replaces: "net.host.port" (AttributeNetHostPort)
     public const string AttributeUserAgentOriginal = "user_agent.original"; // replaces: http.user_agent (AttributeHttpUserAgent)
+
+    // v1.24.0 Messaging spans
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-spans.md
+    public const string AttributeMessagingClientId = "messaging.client_id";
+    public const string AttributeMessagingDestinationName = "messaging.destination.name";
+
+    // v1.24.0 Messaging metrics
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-metrics.md
+    public const string MetricMessagingPublishDuration = "messaging.publish.duration";
+    public const string MetricMessagingPublishMessages = "messaging.publish.messages";
+    public const string MetricMessagingReceiveDuration = "messaging.receive.duration";
+    public const string MetricMessagingReceiveMessages = "messaging.receive.messages";
+
+    // v1.24.0 Messaging (Kafka)
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/kafka.md
+    public const string AttributeMessagingKafkaConsumerGroup = "messaging.kafka.consumer.group";
+    public const string AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition";
+    public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
+    public const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
+
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }


### PR DESCRIPTION
This PR updates the OpenTelemetry.Resources.Azure library to 1.0.0-beta.9 which was released earlier today.
- https://www.nuget.org/packages/OpenTelemetry.Resources.Azure/1.0.0-beta.9
- https://github.com/open-telemetry/opentelemetry-dotnet-contrib/releases/tag/Resources.Azure-1.0.0-beta.9

## Steps followed to Sync Vendored code

1. Create a New Branch in azure-sdk-for-net repo. This is where changes will be committed. 
2. Sync OpenTelemetry.NET Contrib Repository
    2a. Clone the OpenTelemetry.NET Contrib Repository
    ```bash
    git clone https://github.com/open-telemetry/opentelemetry-dotnet-contrib.git
    ```
    2b. Fetch the tags
    ```bash
    git fetch --tags
    ```
3. Sync `OpenTelemetry.Resources.Azure`
    3a. Checkout the most recent release
    ```bash
    git checkout tags/Resources.Azure-1.0.0-beta.9
    ```
    3b. Copy the following folders into the `Azure.Monitor.OpenTelemetry.AspNetCore`'s `Vendoring` directory:
    - `OpenTelemetry.Resources.Azure`
        - Remove the following files:
            - *.csproj
            - README.md
            - CHANGELOG.MD
            - AssemblyInfo.cs
    - `Shared`
        - Must do a file comparison to confirm there are no missing changes or conflicts.
4. Additional Changes
    - Modified all instrumentation public APIs to internal.
    - Added `#pragma warning disable` `AZC0102` and `AZC0104` to `Azure.VmMetaDataRequestor.cs`. These are code standards that only exist in this Azure SDK reop.
    