### PR TITLE
[Storage] [DataMovement] [API-Change] Changed BlobsStorageResourceProvider.FromBlob() & BlobsStorageResourceProvider.FromContainer() to take a Uri over string

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -26,6 +26,8 @@
     - `BlobStorageResourceOptions.CacheControl`
     - `BlobStorageResourceOptions.Metadata`
 - Changed `BlobStorageResourceContainerOptions.BlobType` from `Azure.Storage.Blobs.Models.BlobType` to `DataTransferProperty<Azure.Storage.Blobs.Models.BlobType>`
+- Changed `FromContainer(string containerUri, BlobStorageResourceContainerOptions options = default)` to `FromContainer(Uri containerUri, BlobStorageResourceContainerOptions options = default)`
+- Changed `FromBlob(string blobUri, BlobStorageResourceOptions options = default)` to `FromBlob(Uri blobUri, BlobStorageResourceOptions options = default)`
 
 ## 12.0.0-beta.4 (2023-12-05)
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 ### Breaking Changes
+- Changed `FromContainer(string containerUri, BlobStorageResourceContainerOptions options = default)` to `FromContainer(Uri containerUri, BlobStorageResourceContainerOptions options = default)`
+- Changed `FromBlob(string blobUri, BlobStorageResourceOptions options = default)` to `FromBlob(Uri blobUri, BlobStorageResourceOptions options = default)`
 
 ### Bugs Fixed
 - Fixed bug where using OAuth would not preserve source properties to destination properties.
@@ -26,8 +28,6 @@
     - `BlobStorageResourceOptions.CacheControl`
     - `BlobStorageResourceOptions.Metadata`
 - Changed `BlobStorageResourceContainerOptions.BlobType` from `Azure.Storage.Blobs.Models.BlobType` to `DataTransferProperty<Azure.Storage.Blobs.Models.BlobType>`
-- Changed `FromContainer(string containerUri, BlobStorageResourceContainerOptions options = default)` to `FromContainer(Uri containerUri, BlobStorageResourceContainerOptions options = default)`
-- Changed `FromBlob(string blobUri, BlobStorageResourceOptions options = default)` to `FromBlob(Uri blobUri, BlobStorageResourceOptions options = default)`
 
 ## 12.0.0-beta.4 (2023-12-05)
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/README.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/README.md
@@ -161,17 +161,17 @@ To create a blob `StorageResource`, use the methods `FromBlob` or `FromContainer
 
 ```C# Snippet:ResourceConstruction_Blobs
 StorageResource container = blobs.FromContainer(
-    "http://myaccount.blob.core.windows.net/container");
+    new Uri("http://myaccount.blob.core.windows.net/container"));
 
 // Block blobs are the default if no options are specified
 StorageResource blockBlob = blobs.FromBlob(
-    "http://myaccount.blob.core.windows.net/container/sample-blob-block",
+    new Uri("http://myaccount.blob.core.windows.net/container/sample-blob-block"),
     new BlockBlobStorageResourceOptions());
 StorageResource pageBlob = blobs.FromBlob(
-    "http://myaccount.blob.core.windows.net/container/sample-blob-page",
+    new Uri("http://myaccount.blob.core.windows.net/container/sample-blob-page"),
     new PageBlobStorageResourceOptions());
 StorageResource appendBlob = blobs.FromBlob(
-    "http://myaccount.blob.core.windows.net/container/sample-blob-append",
+    new Uri("http://myaccount.blob.core.windows.net/container/sample-blob-append"),
     new AppendBlobStorageResourceOptions());
 ```
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net6.0.cs
@@ -32,12 +32,12 @@ namespace Azure.Storage.DataMovement.Blobs
         public BlobsStorageResourceProvider(Azure.Storage.DataMovement.Blobs.BlobsStorageResourceProvider.GetTokenCredential getTokenCredentialAsync) { }
         public BlobsStorageResourceProvider(Azure.Storage.StorageSharedKeyCredential credential) { }
         protected override string ProviderId { get { throw null; } }
-        public Azure.Storage.DataMovement.StorageResource FromBlob(string blobUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions options = null) { throw null; }
+        public Azure.Storage.DataMovement.StorageResource FromBlob(System.Uri blobUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Blobs.BlobContainerClient client, Azure.Storage.DataMovement.Blobs.BlobStorageResourceContainerOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Blobs.Specialized.AppendBlobClient client, Azure.Storage.DataMovement.Blobs.AppendBlobStorageResourceOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Blobs.Specialized.BlockBlobClient client, Azure.Storage.DataMovement.Blobs.BlockBlobStorageResourceOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Blobs.Specialized.PageBlobClient client, Azure.Storage.DataMovement.Blobs.PageBlobStorageResourceOptions options = null) { throw null; }
-        public Azure.Storage.DataMovement.StorageResource FromContainer(string containerUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceContainerOptions options = null) { throw null; }
+        public Azure.Storage.DataMovement.StorageResource FromContainer(System.Uri containerUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceContainerOptions options = null) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromDestinationAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromSourceAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
         public delegate Azure.AzureSasCredential GetAzureSasCredential(System.Uri uri, bool readOnly);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.0.cs
@@ -32,12 +32,12 @@ namespace Azure.Storage.DataMovement.Blobs
         public BlobsStorageResourceProvider(Azure.Storage.DataMovement.Blobs.BlobsStorageResourceProvider.GetTokenCredential getTokenCredentialAsync) { }
         public BlobsStorageResourceProvider(Azure.Storage.StorageSharedKeyCredential credential) { }
         protected override string ProviderId { get { throw null; } }
-        public Azure.Storage.DataMovement.StorageResource FromBlob(string blobUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions options = null) { throw null; }
+        public Azure.Storage.DataMovement.StorageResource FromBlob(System.Uri blobUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Blobs.BlobContainerClient client, Azure.Storage.DataMovement.Blobs.BlobStorageResourceContainerOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Blobs.Specialized.AppendBlobClient client, Azure.Storage.DataMovement.Blobs.AppendBlobStorageResourceOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Blobs.Specialized.BlockBlobClient client, Azure.Storage.DataMovement.Blobs.BlockBlobStorageResourceOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Blobs.Specialized.PageBlobClient client, Azure.Storage.DataMovement.Blobs.PageBlobStorageResourceOptions options = null) { throw null; }
-        public Azure.Storage.DataMovement.StorageResource FromContainer(string containerUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceContainerOptions options = null) { throw null; }
+        public Azure.Storage.DataMovement.StorageResource FromContainer(System.Uri containerUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceContainerOptions options = null) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromDestinationAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromSourceAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
         public delegate Azure.AzureSasCredential GetAzureSasCredential(System.Uri uri, bool readOnly);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/samples/Sample01b_HelloWorldAsync.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/samples/Sample01b_HelloWorldAsync.cs
@@ -58,17 +58,17 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                     // Construct simple blob resources for data movement
                     #region Snippet:ResourceConstruction_Blobs
                     StorageResource container = blobs.FromContainer(
-                        "http://myaccount.blob.core.windows.net/container");
+                        new Uri("http://myaccount.blob.core.windows.net/container"));
 
                     // Block blobs are the default if no options are specified
                     StorageResource blockBlob = blobs.FromBlob(
-                        "http://myaccount.blob.core.windows.net/container/sample-blob-block",
+                        new Uri("http://myaccount.blob.core.windows.net/container/sample-blob-block"),
                         new BlockBlobStorageResourceOptions());
                     StorageResource pageBlob = blobs.FromBlob(
-                        "http://myaccount.blob.core.windows.net/container/sample-blob-page",
+                        new Uri("http://myaccount.blob.core.windows.net/container/sample-blob-page"),
                         new PageBlobStorageResourceOptions());
                     StorageResource appendBlob = blobs.FromBlob(
-                        "http://myaccount.blob.core.windows.net/container/sample-blob-append",
+                        new Uri("http://myaccount.blob.core.windows.net/container/sample-blob-append"),
                         new AppendBlobStorageResourceOptions());
                     #endregion
                 }
@@ -198,7 +198,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 LocalFilesStorageResourceProvider files = new();
 
                 // Get a reference to a destination blobs
-                string destinationBlobUri = container.GetBlockBlobClient("sample-blob").Uri.ToString();
+                Uri destinationBlobUri = container.GetBlockBlobClient("sample-blob").Uri;
                 TransferManager transferManager = new TransferManager(new TransferManagerOptions());
 
                 // Create simple transfer single blob upload job
@@ -255,7 +255,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
             {
                 // Get a reference to a source blobs and upload sample content to download
                 BlockBlobClient sourceBlobClient = container.GetBlockBlobClient("sample-blob");
-                string sourceBlobUri = sourceBlobClient.Uri.ToString();
+                Uri sourceBlobUri = sourceBlobClient.Uri;
                 BlockBlobClient sourceBlob2 = container.GetBlockBlobClient("sample-blob2");
 
                 using (FileStream stream = File.Open(originalPath, FileMode.Open))
@@ -352,7 +352,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
 
             // Make a service request to verify we've successfully authenticated
             await blobContainerClient.CreateIfNotExistsAsync();
-            string blobContainerUri = blobContainerClient.Uri.ToString();
+            Uri blobContainerUri = blobContainerClient.Uri;
 
             // Prepare for upload
             try
@@ -615,7 +615,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
 
             // Create a client that can authenticate with a connection string
             BlobContainerClient blobContainerClient = service.GetBlobContainerClient(containerName);
-            string blobContainerUri = blobContainerClient.Uri.ToString();
+            Uri blobContainerUri = blobContainerClient.Uri;
 
             // Make a service request to verify we've successfully authenticated
             await blobContainerClient.CreateIfNotExistsAsync();
@@ -710,7 +710,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
             {
                 // Get a reference to a destination blobs
                 BlockBlobClient sourceBlockBlobClient = container.GetBlockBlobClient("sample-blob");
-                string sourceBlobUri = sourceBlockBlobClient.Uri.ToString();
+                Uri sourceBlobUri = sourceBlockBlobClient.Uri;
 
                 using (FileStream stream = File.Open(originalPath, FileMode.Open))
                 {
@@ -719,7 +719,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 }
 
                 AppendBlobClient destinationAppendBlobClient = container.GetAppendBlobClient("sample-blob2");
-                string destinationBlobUri = destinationAppendBlobClient.Uri.ToString();
+                Uri destinationBlobUri = destinationAppendBlobClient.Uri;
 
                 // Upload file data
                 TransferManager transferManager = new TransferManager(default);
@@ -777,8 +777,8 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
             // Create a client that can authenticate with a connection string
             BlobServiceClient service = new BlobServiceClient(serviceUri, credential);
             BlobContainerClient container = service.GetBlobContainerClient(containerName);
-            string sourceContainerUri = container.Uri.ToString();
-            string destinationContainerUri = container.Uri.ToString();
+            Uri sourceContainerUri = container.Uri;
+            Uri destinationContainerUri = container.Uri;
 
             // Make a service request to verify we've successfully authenticated
             await container.CreateIfNotExistsAsync();

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobsStorageResourceProvider.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobsStorageResourceProvider.cs
@@ -311,14 +311,14 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <returns>
         /// The configured storage resource.
         /// </returns>
-        public StorageResource FromContainer(string containerUri, BlobStorageResourceContainerOptions options = default)
+        public StorageResource FromContainer(Uri containerUri, BlobStorageResourceContainerOptions options = default)
         {
             BlobContainerClient client = _credentialType switch
             {
-                CredentialType.None => new BlobContainerClient(new Uri(containerUri)),
-                CredentialType.SharedKey => new BlobContainerClient(new Uri(containerUri), _getStorageSharedKeyCredential(new Uri(containerUri), false)),
-                CredentialType.Token => new BlobContainerClient(new Uri(containerUri), _getTokenCredential(new Uri(containerUri), false)),
-                CredentialType.Sas => new BlobContainerClient(new Uri(containerUri), _getAzureSasCredential(new Uri(containerUri), false)),
+                CredentialType.None => new BlobContainerClient(containerUri),
+                CredentialType.SharedKey => new BlobContainerClient(containerUri, _getStorageSharedKeyCredential(containerUri, false)),
+                CredentialType.Token => new BlobContainerClient(containerUri, _getTokenCredential(containerUri, false)),
+                CredentialType.Sas => new BlobContainerClient(containerUri, _getAzureSasCredential(containerUri, false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };
             return new BlobStorageResourceContainer(client, options);
@@ -347,16 +347,16 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <returns>
         /// The configured storage resource.
         /// </returns>
-        public StorageResource FromBlob(string blobUri, BlobStorageResourceOptions options = default)
+        public StorageResource FromBlob(Uri blobUri, BlobStorageResourceOptions options = default)
         {
             if (options is BlockBlobStorageResourceOptions)
             {
                 BlockBlobClient blockClient = _credentialType switch
                 {
-                    CredentialType.None => new BlockBlobClient(new Uri(blobUri)),
-                    CredentialType.SharedKey => new BlockBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(new Uri(blobUri), false)),
-                    CredentialType.Token => new BlockBlobClient(new Uri(blobUri), _getTokenCredential(new Uri(blobUri), false)),
-                    CredentialType.Sas => new BlockBlobClient(new Uri(blobUri), _getAzureSasCredential(new Uri(blobUri), false)),
+                    CredentialType.None => new BlockBlobClient(blobUri),
+                    CredentialType.SharedKey => new BlockBlobClient(blobUri, _getStorageSharedKeyCredential(blobUri, false)),
+                    CredentialType.Token => new BlockBlobClient(blobUri, _getTokenCredential(blobUri, false)),
+                    CredentialType.Sas => new BlockBlobClient(blobUri, _getAzureSasCredential(blobUri, false)),
                     _ => throw BadCredentialTypeException(_credentialType),
                 };
                 return new BlockBlobStorageResource(blockClient, options as BlockBlobStorageResourceOptions);
@@ -365,10 +365,10 @@ namespace Azure.Storage.DataMovement.Blobs
             {
                 PageBlobClient pageClient = _credentialType switch
                 {
-                    CredentialType.None => new PageBlobClient(new Uri(blobUri)),
-                    CredentialType.SharedKey => new PageBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(new Uri(blobUri), false)),
-                    CredentialType.Token => new PageBlobClient(new Uri(blobUri), _getTokenCredential(new Uri(blobUri), false)),
-                    CredentialType.Sas => new PageBlobClient(new Uri(blobUri), _getAzureSasCredential(new Uri(blobUri), false)),
+                    CredentialType.None => new PageBlobClient(blobUri),
+                    CredentialType.SharedKey => new PageBlobClient(blobUri, _getStorageSharedKeyCredential(blobUri, false)),
+                    CredentialType.Token => new PageBlobClient(blobUri, _getTokenCredential(blobUri, false)),
+                    CredentialType.Sas => new PageBlobClient(blobUri, _getAzureSasCredential(blobUri, false)),
                     _ => throw BadCredentialTypeException(_credentialType),
                 };
                 return new PageBlobStorageResource(pageClient, options as PageBlobStorageResourceOptions);
@@ -377,20 +377,20 @@ namespace Azure.Storage.DataMovement.Blobs
             {
                 AppendBlobClient appendClient = _credentialType switch
                 {
-                    CredentialType.None => new AppendBlobClient(new Uri(blobUri)),
-                    CredentialType.SharedKey => new AppendBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(new Uri(blobUri), false)),
-                    CredentialType.Token => new AppendBlobClient(new Uri(blobUri), _getTokenCredential(new Uri(blobUri), false)),
-                    CredentialType.Sas => new AppendBlobClient(new Uri(blobUri), _getAzureSasCredential(new Uri(blobUri), false)),
+                    CredentialType.None => new AppendBlobClient(blobUri),
+                    CredentialType.SharedKey => new AppendBlobClient(blobUri, _getStorageSharedKeyCredential(blobUri, false)),
+                    CredentialType.Token => new AppendBlobClient(blobUri, _getTokenCredential(blobUri, false)),
+                    CredentialType.Sas => new AppendBlobClient(blobUri, _getAzureSasCredential(blobUri, false)),
                     _ => throw BadCredentialTypeException(_credentialType),
                 };
                 return new AppendBlobStorageResource(appendClient, options as AppendBlobStorageResourceOptions);
             }
             BlockBlobClient client = _credentialType switch
             {
-                CredentialType.None => new BlockBlobClient(new Uri(blobUri)),
-                CredentialType.SharedKey => new BlockBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(new Uri(blobUri), false)),
-                CredentialType.Token => new BlockBlobClient(new Uri(blobUri), _getTokenCredential(new Uri(blobUri), false)),
-                CredentialType.Sas => new BlockBlobClient(new Uri(blobUri), _getAzureSasCredential(new Uri(blobUri), false)),
+                CredentialType.None => new BlockBlobClient(blobUri),
+                CredentialType.SharedKey => new BlockBlobClient(blobUri, _getStorageSharedKeyCredential(blobUri, false)),
+                CredentialType.Token => new BlockBlobClient(blobUri, _getTokenCredential(blobUri, false)),
+                CredentialType.Sas => new BlockBlobClient(blobUri, _getAzureSasCredential(blobUri, false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };
             return new BlockBlobStorageResource(client, options as BlockBlobStorageResourceOptions);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobStorageResourceProviderTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobStorageResourceProviderTests.cs
@@ -110,7 +110,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
         {
             const string containerName = "mycontainer";
             const string prefix = "my/prefix";
-            string uri = $"https://myaccount.blob.core.windows.net/{containerName}" + (withPrefix ? $"/{prefix}" : "");
+            Uri uri = new Uri($"https://myaccount.blob.core.windows.net/{containerName}" + (withPrefix ? $"/{prefix}" : ""));
             (Mock<StorageSharedKeyCredential> SharedKey, Mock<TokenCredential> Token, Mock<AzureSasCredential> Sas) mockCreds = GetMockCreds();
 
             BlobsStorageResourceProvider provider = credType switch
@@ -124,8 +124,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             BlobStorageResourceContainer resource = provider.FromContainer(uri) as BlobStorageResourceContainer;
 
             Assert.IsNotNull(resource);
-            Assert.AreEqual(uri, resource.Uri.ToString());
-            Assert.AreEqual(uri, resource.BlobContainerClient.Uri.ToString());
+            Assert.AreEqual(uri, resource.Uri);
+            Assert.AreEqual(uri, resource.BlobContainerClient.Uri);
             AssertCredPresent(resource.BlobContainerClient.ClientConfiguration, credType);
         }
 
@@ -137,7 +137,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
         {
             const string containerName = "mycontainer";
             const string blobName = "my/blob.txt";
-            string uri = $"https://myaccount.blob.core.windows.net/{containerName}/{blobName}";
+            Uri uri = new Uri($"https://myaccount.blob.core.windows.net/{containerName}/{blobName}");
             (Mock<StorageSharedKeyCredential> SharedKey, Mock<TokenCredential> Token, Mock<AzureSasCredential> Sas) mockCreds = GetMockCreds();
 
             BlobsStorageResourceProvider provider = credType switch
@@ -160,8 +160,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
 
             Assert.IsNotNull(resource);
             AssertBlobStorageResourceType(resource, blobType, out BlobBaseClient underlyingClient);
-            Assert.AreEqual(uri, resource.Uri.ToString());
-            Assert.AreEqual(uri, underlyingClient.Uri.ToString());
+            Assert.AreEqual(uri, resource.Uri);
+            Assert.AreEqual(uri, underlyingClient.Uri);
             AssertCredPresent(underlyingClient.ClientConfiguration, credType);
         }
     }


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net-pr/issues/2135
