### PR TITLE
[Storage][DataMovement] Use try/finally for locks in `LocalTransferCheckpointer`

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
@@ -153,19 +153,22 @@ namespace Azure.Storage.DataMovement
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
             if (_transferStates.TryGetValue(transferId, out JobPlanFile jobPlanFile))
             {
-                // Lock MMF
                 await jobPlanFile.WriteLock.WaitAsync().ConfigureAwait(false);
-
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath))
-                using (MemoryMappedViewStream mmfStream = mmf.CreateViewStream(offset, length, MemoryMappedFileAccess.Read))
+                try
                 {
-                    await mmfStream.CopyToAsync(copiedStream).ConfigureAwait(false);
-                }
+                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath))
+                    using (MemoryMappedViewStream mmfStream = mmf.CreateViewStream(offset, length, MemoryMappedFileAccess.Read))
+                    {
+                        await mmfStream.CopyToAsync(copiedStream).ConfigureAwait(false);
+                    }
 
-                // Release MMF
-                jobPlanFile.WriteLock.Release();
-                copiedStream.Position = 0;
-                return copiedStream;
+                    copiedStream.Position = 0;
+                    return copiedStream;
+                }
+                finally
+                {
+                    jobPlanFile.WriteLock.Release();
+                }
             }
             else
             {
@@ -187,20 +190,22 @@ namespace Azure.Storage.DataMovement
                     int maxArraySize = length > 0 ? length : DataMovementConstants.DefaultArrayPoolArraySize;
                     Stream copiedStream = new PooledMemoryStream(ArrayPool<byte>.Shared, maxArraySize);
 
-                    // MMF lock
                     await jobPartPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-                    // Open up MemoryMappedFile
-                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPartPlanFile.FilePath))
-                    using (MemoryMappedViewStream mmfStream = mmf.CreateViewStream(offset, length, MemoryMappedFileAccess.Read))
+                    try
                     {
-                        await mmfStream.CopyToAsync(copiedStream).ConfigureAwait(false);
-                    }
+                        using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPartPlanFile.FilePath))
+                        using (MemoryMappedViewStream mmfStream = mmf.CreateViewStream(offset, length, MemoryMappedFileAccess.Read))
+                        {
+                            await mmfStream.CopyToAsync(copiedStream).ConfigureAwait(false);
+                        }
 
-                    // MMF release
-                    jobPartPlanFile.WriteLock.Release();
-                    copiedStream.Position = 0;
-                    return copiedStream;
+                        copiedStream.Position = 0;
+                        return copiedStream;
+                    }
+                    finally
+                    {
+                        jobPartPlanFile.WriteLock.Release();
+                    }
                 }
                 else
                 {
@@ -224,18 +229,20 @@ namespace Azure.Storage.DataMovement
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
             if (_transferStates.TryGetValue(transferId, out JobPlanFile jobPlanFile))
             {
-                // Lock MMF
                 await jobPlanFile.WriteLock.WaitAsync().ConfigureAwait(false);
-
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath, FileMode.Open))
-                using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(fileOffset, length, MemoryMappedFileAccess.Write))
+                try
                 {
-                    accessor.WriteArray(0, buffer, bufferOffset, length);
-                    accessor.Flush();
+                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath, FileMode.Open))
+                    using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(fileOffset, length, MemoryMappedFileAccess.Write))
+                    {
+                        accessor.WriteArray(0, buffer, bufferOffset, length);
+                        accessor.Flush();
+                    }
                 }
-
-                // Release MMF
-                jobPlanFile.WriteLock.Release();
+                finally
+                {
+                    jobPlanFile.WriteLock.Release();
+                }
             }
             else
             {
@@ -306,18 +313,20 @@ namespace Azure.Storage.DataMovement
 
             if (_transferStates.TryGetValue(transferId, out JobPlanFile jobPlanFile))
             {
-                // Lock MMF
                 await jobPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath, FileMode.Open))
-                using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(offset, length))
+                try
                 {
-                    accessor.Write(0, (int)status.ToJobPlanStatus());
-                    accessor.Flush();
+                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath, FileMode.Open))
+                    using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(offset, length))
+                    {
+                        accessor.Write(0, (int)status.ToJobPlanStatus());
+                        accessor.Flush();
+                    }
                 }
-
-                // Release MMF
-                jobPlanFile.WriteLock.Release();
+                finally
+                {
+                    jobPlanFile.WriteLock.Release();
+                }
             }
             else
             {
@@ -340,18 +349,20 @@ namespace Azure.Storage.DataMovement
             {
                 if (jobPlanFile.JobParts.TryGetValue(partNumber, out JobPartPlanFile file))
                 {
-                    // Lock MMF
                     await file.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.FilePath, FileMode.Open))
-                    using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(offset, length))
+                    try
                     {
-                        accessor.Write(0, (int)status.ToJobPlanStatus());
-                        accessor.Flush();
+                        using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.FilePath, FileMode.Open))
+                        using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(offset, length))
+                        {
+                            accessor.Write(0, (int)status.ToJobPlanStatus());
+                            accessor.Flush();
+                        }
                     }
-
-                    // Release MMF
-                    file.WriteLock.Release();
+                    finally
+                    {
+                        file.WriteLock.Release();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Resolves #37253

Simply adds try/finally statements for all usages of the Semaphore used to lock access to the memory mapped file to guarantee the lock is released even if an exception occurs.