### PR TITLE
[Storage] Fix Storage base package perf pipelines

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/perf-tests.yml
+++ b/sdk/storage/Azure.Storage.Blobs/perf-tests.yml
@@ -3,7 +3,7 @@ Service: storage-blob
 Project: sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj
 
 PackageVersions:
-- Azure.Storage.Blobs: 12.14.1
+- Azure.Storage.Blobs: 12.22.1
 - Azure.Storage.Blobs: source
 
 Tests:

--- a/sdk/storage/Azure.Storage.Blobs/perf.yml
+++ b/sdk/storage/Azure.Storage.Blobs/perf.yml
@@ -1,8 +1,8 @@
 parameters:
 - name: LanguageVersion
-  displayName: LanguageVersion (6, 7)
+  displayName: LanguageVersion (6, 8)
   type: string
-  default: '7'
+  default: '8'
 - name: PackageVersions
   displayName: PackageVersions (regex of package versions to run)
   type: string

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf-tests.yml
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf-tests.yml
@@ -3,7 +3,7 @@ Service: storage-file-datalake
 Project: sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Azure.Storage.Files.DataLake.Perf.csproj
 
 PackageVersions:
-- Azure.Storage.Files.DataLake: 12.12.1
+- Azure.Storage.Files.DataLake: 12.20.0
 - Azure.Storage.Files.DataLake: source
 
 Tests:

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf.yml
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf.yml
@@ -1,8 +1,8 @@
 parameters:
 - name: LanguageVersion
-  displayName: LanguageVersion (6, 7)
+  displayName: LanguageVersion (6, 8)
   type: string
-  default: '7'
+  default: '8'
 - name: packageVersions
   displayName: PackageVersions (regex of package versions to run)
   type: string

--- a/sdk/storage/Azure.Storage.Files.Shares/perf-tests.yml
+++ b/sdk/storage/Azure.Storage.Files.Shares/perf-tests.yml
@@ -3,7 +3,7 @@ Service: storage-file-share
 Project: sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj
 
 PackageVersions:
-- Azure.Storage.Files.Shares: 12.12.1
+- Azure.Storage.Files.Shares: 12.20.0
 - Azure.Storage.Files.Shares: source
 
 Tests:

--- a/sdk/storage/Azure.Storage.Files.Shares/perf.yml
+++ b/sdk/storage/Azure.Storage.Files.Shares/perf.yml
@@ -1,8 +1,8 @@
 parameters:
 - name: LanguageVersion
-  displayName: LanguageVersion (6, 7)
+  displayName: LanguageVersion (6, 8)
   type: string
-  default: '7'
+  default: '8'
 - name: PackageVersions
   displayName: PackageVersions (regex of package versions to run)
   type: string


### PR DESCRIPTION
The Storage perf pipelines have been broken since the update to .NET 8 as they default to targeting .NET 7 and our packages now target .NET 8. This just bumps the default version for these pipelines as well as updates the tested version to the most recent release for each package.

[Small example run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4181041&view=results)