### PR TITLE
[Search] Fix nightly test failures

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/SearchIndexClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchIndexClientTests.cs
@@ -109,6 +109,7 @@ namespace Azure.Search.Documents.Tests
         }
 
         [Test]
+        [ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2024_09_01_Preview)]
         public async Task GetServiceStatistics()
         {
             await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
@@ -145,6 +146,7 @@ namespace Azure.Search.Documents.Tests
         }
 
         [Test]
+        [ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2024_09_01_Preview)]
         public async Task CreateIndex()
         {
             await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);
@@ -179,6 +181,7 @@ namespace Azure.Search.Documents.Tests
         }
 
         [Test]
+        [ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2024_09_01_Preview)]
         public async Task UpdateIndex()
         {
             await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);


### PR DESCRIPTION
Some tests are failing in the nightly pipeline because certain features have not been released as GA. To address this, I added the `[ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2024_09_01_Preview)]` attribute to ensure the tests run correctly in the nightly pipeline.

For more details, see the failure here:  
[Azure DevOps build log](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4183099&view=logs&j=af9f8b59-5011-5b85-14f9-cc1dc691e60a&t=8e2c0714-7ac9-5b0a-6b15-228ada1d6b14&l=2058)