### PR TITLE
[Storage] [DataMovement] Param assertion in CreateJobPartAsync to differentiate APIs

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage.Common;
 
 namespace Azure.Storage.DataMovement
 {
@@ -140,6 +141,9 @@ namespace Azure.Storage.DataMovement
             StorageResourceItem destinationResource,
             long? length = default)
         {
+            Argument.AssertNotNull(sourceResource, nameof(sourceResource));
+            Argument.AssertNotNull(destinationResource, nameof(destinationResource));
+
             // Create Job Part file as we're initializing the job part
             ServiceToServiceJobPart part = new ServiceToServiceJobPart(
                 job: job,

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Buffers;
 using Azure.Storage.Shared;
 using Azure.Core;
+using Azure.Storage.Common;
 
 namespace Azure.Storage.DataMovement
 {
@@ -140,6 +141,9 @@ namespace Azure.Storage.DataMovement
             StorageResourceItem destinationResource,
             long? length = default)
         {
+            Argument.AssertNotNull(sourceResource, nameof(sourceResource));
+            Argument.AssertNotNull(destinationResource, nameof(destinationResource));
+
             // Create Job Part file as we're initializing the job part
             StreamToUriJobPart part = new StreamToUriJobPart(
                 job: job,

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.IO;
 using System.Threading;
 using Azure.Core;
+using Azure.Storage.Common;
 
 namespace Azure.Storage.DataMovement
 {
@@ -142,6 +143,9 @@ namespace Azure.Storage.DataMovement
             StorageResourceItem destinationResource,
             long? length = default)
         {
+            Argument.AssertNotNull(sourceResource, nameof(sourceResource));
+            Argument.AssertNotNull(destinationResource, nameof(destinationResource));
+
             // Create Job Part file as we're initializing the job part
             UriToStreamJobPart part = new UriToStreamJobPart(
                 job: job,


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/35359
