### PR TITLE
Log troubleshooting headers for AzurePipelinesCredential

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/tests/PopTestClient.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/PopTestClient.cs
@@ -20,8 +20,7 @@ namespace Azure.Identity.Broker.Tests
             var pipelineOptions = new HttpPipelineOptions(options);
             pipelineOptions.PerRetryPolicies.Add(new PopTokenAuthenticationPolicy(credential, "https://graph.microsoft.com/.default"));
             _pipeline = HttpPipelineBuilder.Build(
-                pipelineOptions,
-                new HttpPipelineTransportOptions { ServerCertificateCustomValidationCallback = (_) => true });
+                pipelineOptions);
         }
 
         [ForwardsClientCalls(true)]

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Other Changes
 
+- Improved error logging for `AzurePipelinesCredential`.
+
 ## 1.13.0-beta.2 (2024-09-17)
 
 ### Features Added

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs
@@ -16,7 +16,7 @@ namespace Azure.Identity
     /// </summary>
     public class AzurePipelinesCredential : TokenCredential
     {
-        private const string Troubleshooting = "See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/azurepipelinescredential/troubleshoot";
+        internal const string Troubleshooting = "See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/azurepipelinescredential/troubleshoot";
         internal readonly string[] AdditionallyAllowedTenantIds;
         internal string SystemAccessToken { get; }
         internal string TenantId { get; }
@@ -151,7 +151,10 @@ namespace Azure.Identity
                 string error = $"OIDC token not found in response. " + Troubleshooting;
                 if (message.Response.Status != 200)
                 {
-                    error = error + $"\n\nResponse= {message.Response.Content}";
+                    var is_x_vss_e2eidValueFound = message.Response.Headers.TryGetValue("x-vss-e2eid", out var x_vss_e2eidValue);
+                    var is_x_msedge_refValueFound = message.Response.Headers.TryGetValue("x-msedge-ref", out var x_msedge_refValue);
+
+                    error = error + $"\n\nResponse= {message.Response.Content}\n\nx-vss-e2eid= {(is_x_vss_e2eidValueFound ? x_vss_e2eidValue : "Not Found")}\n\nx-msedge-ref= {(is_x_msedge_refValueFound ? x_msedge_refValue : "Not Found")}";
                 }
                 throw new AuthenticationFailedException(error);
             }

--- a/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePipelinesCredentialTests.cs
@@ -114,10 +114,11 @@ namespace Azure.Identity.Tests
                 var mockTransport = new MockTransport(req => new MockResponse(200).WithContent(
                             $"{{\"token_type\": \"Bearer\",\"expires_in\": 9999,\"ext_expires_in\": 9999,\"access_token\": \"mytoken\" }}"));
 
-                var options = new AzurePipelinesCredentialOptions { Transport = mockTransport };
+                var options = new AzurePipelinesCredentialOptions { Transport = mockTransport, OidcRequestUri = "https://mockCollectionUri" };
                 var cred = new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken, options);
 
-                Assert.ThrowsAsync<AuthenticationFailedException>(async () => await cred.GetTokenAsync(new TokenRequestContext(new[] { "scope" }), CancellationToken.None));
+                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await cred.GetTokenAsync(new TokenRequestContext(new[] { "scope" }), CancellationToken.None));
+                Assert.That(ex.Message, Does.Contain(AzurePipelinesCredential.Troubleshooting));
             }
         }
 
@@ -140,7 +141,10 @@ namespace Azure.Identity.Tests
                 {
                     if (req.Uri.Host == "mockcollectionuri")
                     {
-                        return new MockResponse(responseStatusCode).WithContent($"< not json, but an error >");
+                        return new MockResponse(responseStatusCode)
+                            .WithContent($"< not json, but an error >")
+                            .WithHeader("x-vss-e2eid", "myE2EId")
+                            .WithHeader("x-msedge-ref", "myRef");
                     }
                     return new MockResponse(200).WithContent(
                             $"{{\"token_type\": \"Bearer\",\"expires_in\": 9999,\"ext_expires_in\": 9999,\"access_token\": \"mytoken\" }}");
@@ -158,6 +162,9 @@ namespace Azure.Identity.Tests
                 else
                 {
                     Assert.That(ex.Message, Does.Contain("< not json, but an error >"));
+                    Assert.That(ex.Message, Does.Contain(AzurePipelinesCredential.Troubleshooting));
+                    Assert.That(ex.Message, Does.Contain("myE2EId"));
+                    Assert.That(ex.Message, Does.Contain("myRef"));
                 }
             }
         }


### PR DESCRIPTION
closes [#45993](https://github.com/Azure/azure-sdk-for-net/issues/45993)