### PR TITLE
[Service Bus] Enhance logging for session timeouts

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -204,6 +204,9 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         internal const int PurgeMessagesCompleteEvent = 120;
         internal const int PurgeMessagesExceptionEvent = 121;
 
+        internal const int ReceiverAcceptSessionTimeoutEvent = 122;
+        internal const int ReceiverAcceptSessionCanceledEvent = 123;
+
         #endregion
         // add new event numbers here incrementing from previous
 
@@ -345,6 +348,27 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(ReceiveDeferredMessageExceptionEvent, identifier, exception);
+            }
+        }
+
+        [Event(ReceiverAcceptSessionCanceledEvent, Level = EventLevel.Verbose, Message = "An accept session operation was for a receiver. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
+        public void ReceiverAcceptSessionCanceled(string fullyQualifiedNamespace, string entityPath, string exception)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ReceiverAcceptSessionCanceledEvent, fullyQualifiedNamespace, entityPath, exception);
+            }
+        }
+
+        [Event(ReceiverAcceptSessionTimeoutEvent, Level = EventLevel.Verbose, Message = "The receiver accept session call timed out. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
+        public virtual void ReceiverAcceptSessionTimeout(
+            string fullyQualifiedNamespace,
+            string entityPath,
+            string exception)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ReceiverAcceptSessionTimeoutEvent, fullyQualifiedNamespace, entityPath, exception);
             }
         }
         #endregion

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -351,7 +351,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(ReceiverAcceptSessionCanceledEvent, Level = EventLevel.Verbose, Message = "An accept session operation was for a receiver. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
+        [Event(ReceiverAcceptSessionCanceledEvent, Level = EventLevel.Verbose, Message = "An accept session operation for a receiver was canceled. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
         public void ReceiverAcceptSessionCanceled(string fullyQualifiedNamespace, string entityPath, string exception)
         {
             if (IsEnabled())

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -82,17 +82,34 @@ namespace Azure.Messaging.ServiceBus
                 return receiver;
             }
             catch (ServiceBusException e)
-                when (e.Reason == ServiceBusFailureReason.ServiceTimeout && isProcessor)
+                when (e.Reason == ServiceBusFailureReason.ServiceTimeout)
             {
                 await receiver.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-                receiver.Logger.ProcessorAcceptSessionTimeout(receiver.FullyQualifiedNamespace, entityPath, e.ToString());
+
+                if (isProcessor)
+                {
+                    receiver.Logger.ProcessorAcceptSessionTimeout(receiver.FullyQualifiedNamespace, entityPath, e.ToString());
+                }
+                else
+                {
+                    receiver.Logger.ReceiverAcceptSessionTimeout(receiver.FullyQualifiedNamespace, entityPath, e.ToString());
+                }
+
                 throw;
             }
             catch (TaskCanceledException exception)
-                when (isProcessor)
             {
                 await receiver.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-                receiver.Logger.ProcessorStoppingAcceptSessionCanceled(receiver.FullyQualifiedNamespace, entityPath, exception.ToString());
+
+                if (isProcessor)
+                {
+                    receiver.Logger.ProcessorStoppingAcceptSessionCanceled(receiver.FullyQualifiedNamespace, entityPath, exception.ToString());
+                }
+                else
+                {
+                    receiver.Logger.ReceiverAcceptSessionCanceled(receiver.FullyQualifiedNamespace, entityPath, exception.ToString());
+                }
+
                 throw;
             }
             catch (Exception ex)


### PR DESCRIPTION
# Summary

The focus of these changes is to enhance the logs emitted when acquiring a session using the `ServiceBusReceiver` times out or is canceled.  As these are known and expected exception conditions, they should be logged as verbose information rather than an error.

## References and related

- [ServiceBusClient.AcceptNextSessionAsync logs ServiceBusException as "exception" (not as verbose) after ServiceTimeout](https://github.com/Azure/azure-sdk-for-net/issues/46096)