### PR TITLE
[DocumentIntelligence] Renaming and fixing the behavior of TrainingOperation

### DIFF
--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/CHANGELOG.md
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed a bug where calling `Operation.Id` would sometimes return an `InvalidOperationException` with message "The operation ID was not present in the service response.".
 
 ### Other Changes
 

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/assets.json
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/documentintelligence/Azure.AI.DocumentIntelligence",
-  "Tag": "net/documentintelligence/Azure.AI.DocumentIntelligence_900de40cad"
+  "Tag": "net/documentintelligence/Azure.AI.DocumentIntelligence_0e2741b29e"
 }

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/src/DocumentIntelligenceAdministrationClient.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/src/DocumentIntelligenceAdministrationClient.cs
@@ -11,7 +11,7 @@ namespace Azure.AI.DocumentIntelligence
     public partial class DocumentIntelligenceAdministrationClient
     {
         // CUSTOM CODE NOTE: we're overwriting the behavior of the BuildDocumentModel, ComposeModel,
-        // CopyModelTo, BuildClassifier, and CopyClassifierTo APIs to return an instance of TrainingOperation.
+        // CopyModelTo, BuildClassifier, and CopyClassifierTo APIs to return an instance of OperationWithId.
         // This is a workaround since Operation.Id is not supported by our generator yet (it throws a
         // NotSupportedException), but this ID is needed for the GetOperation API.
 
@@ -47,7 +47,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateBuildDocumentModelRequest(content, context);
                 var internalOperation = await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.BuildDocumentModel", OperationFinalStateVia.OperationLocation, context, waitUntil).ConfigureAwait(false);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -88,7 +88,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateBuildDocumentModelRequest(content, context);
                 var internalOperation = ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.BuildDocumentModel", OperationFinalStateVia.OperationLocation, context, waitUntil);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -129,7 +129,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateComposeModelRequest(content, context);
                 var internalOperation = await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.ComposeModel", OperationFinalStateVia.OperationLocation, context, waitUntil).ConfigureAwait(false);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -170,7 +170,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateComposeModelRequest(content, context);
                 var internalOperation = ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.ComposeModel", OperationFinalStateVia.OperationLocation, context, waitUntil);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -214,7 +214,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateCopyModelToRequest(modelId, content, context);
                 var internalOperation = await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.CopyModelTo", OperationFinalStateVia.OperationLocation, context, waitUntil).ConfigureAwait(false);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -258,7 +258,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateCopyModelToRequest(modelId, content, context);
                 var internalOperation = ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.CopyModelTo", OperationFinalStateVia.OperationLocation, context, waitUntil);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -299,7 +299,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateBuildClassifierRequest(content, context);
                 var internalOperation = await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.BuildClassifier", OperationFinalStateVia.OperationLocation, context, waitUntil).ConfigureAwait(false);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -340,7 +340,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateBuildClassifierRequest(content, context);
                 var internalOperation = ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.BuildClassifier", OperationFinalStateVia.OperationLocation, context, waitUntil);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -384,7 +384,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateCopyClassifierToRequest(classifierId, content, context);
                 var internalOperation = await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.CopyClassifierTo", OperationFinalStateVia.OperationLocation, context, waitUntil).ConfigureAwait(false);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {
@@ -428,7 +428,7 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateCopyClassifierToRequest(classifierId, content, context);
                 var internalOperation = ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceAdministrationClient.CopyClassifierTo", OperationFinalStateVia.OperationLocation, context, waitUntil);
-                return new TrainingOperation(internalOperation);
+                return new OperationWithId(internalOperation);
             }
             catch (Exception e)
             {

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/src/DocumentIntelligenceClient.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/src/DocumentIntelligenceClient.cs
@@ -14,7 +14,7 @@ namespace Azure.AI.DocumentIntelligence
     public partial class DocumentIntelligenceClient
     {
         // CUSTOM CODE NOTE: we're overwriting the behavior of the AnalyzeDocument API to
-        // return an instance of TrainingOperation. This is a workaround since Operation.Id
+        // return an instance of OperationWithId. This is a workaround since Operation.Id
         // is not supported by our generator yet (it throws a NotSupportedException), but
         // this ID is needed for the GetAnalyzeResultPdf and the GetAnalyzeResultImage APIs.
 
@@ -62,18 +62,18 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateAnalyzeDocumentRequest(modelId, content, pages, locale, stringIndexType, features, queryFields, outputContentFormat, output, context);
                 var internalOperation = await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceClient.AnalyzeDocument", OperationFinalStateVia.OperationLocation, context, WaitUntil.Started).ConfigureAwait(false);
-                var trainingOperation = new TrainingOperation(internalOperation);
+                var operationWithId = new OperationWithId(internalOperation);
 
                 // Workaround to obtain the operation ID. The operation-location header is only returned after
                 // the first request that starts the LRO. Because of this we're setting waitUntil to 'Started'
-                // above so we have time to extract the operation ID in the TrainingOperation constructor.
+                // above so we have time to extract the operation ID in the OperationWithId constructor.
 
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    await trainingOperation.WaitForCompletionAsync(context?.CancellationToken ?? default).ConfigureAwait(false);
+                    await operationWithId.WaitForCompletionAsync(context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
 
-                return trainingOperation;
+                return operationWithId;
             }
             catch (Exception e)
             {
@@ -126,18 +126,18 @@ namespace Azure.AI.DocumentIntelligence
             {
                 using HttpMessage message = CreateAnalyzeDocumentRequest(modelId, content, pages, locale, stringIndexType, features, queryFields, outputContentFormat, output, context);
                 var internalOperation = ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DocumentIntelligenceClient.AnalyzeDocument", OperationFinalStateVia.OperationLocation, context, WaitUntil.Started);
-                var trainingOperation = new TrainingOperation(internalOperation);
+                var operationWithId = new OperationWithId(internalOperation);
 
                 // Workaround to obtain the operation ID. The operation-location header is only returned after
                 // the first request that starts the LRO. Because of this we're setting waitUntil to 'Started'
-                // above so we have time to extract the operation ID in the TrainingOperation constructor.
+                // above so we have time to extract the operation ID in the OperationWithId constructor.
 
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    trainingOperation.WaitForCompletion(context?.CancellationToken ?? default);
+                    operationWithId.WaitForCompletion(context?.CancellationToken ?? default);
                 }
 
-                return trainingOperation;
+                return operationWithId;
             }
             catch (Exception e)
             {

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/OperationWithIdLiveTests.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/OperationWithIdLiveTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace Azure.AI.DocumentIntelligence.Tests
 {
-    public class TrainingOperationLiveTests : DocumentIntelligenceLiveTestBase
+    public class OperationWithIdLiveTests : DocumentIntelligenceLiveTestBase
     {
         // Example: 3eb2e5b5-b9d3-4b5a-ac31-90d945f4b4e4
         private const string AnalysisOperationIdPattern = @"^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$";
@@ -18,7 +18,7 @@ namespace Azure.AI.DocumentIntelligence.Tests
         // Example: 31466498286_3eb2e5b5-b9d3-4b5a-ac31-90d945f4b4e4
         private const string TrainingOperationIdPattern = @"^[0-9]+_[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$";
 
-        public TrainingOperationLiveTests(bool isAsync)
+        public OperationWithIdLiveTests(bool isAsync)
             : base(isAsync)
         {
         }


### PR DESCRIPTION
- Renaming our `TrainingOperation` internal helper class to `OperationWithId` since it's not used only by training operations anymore. Analysis operations also make use of it.
- Bringing back the code to extract the operation ID from the response body if the `operation-location` header is not present. Some scenarios still require this approach.
- Updating tests and recordings accordingly.