### PR TITLE
Azure OpenAI: set header in order to avoid adding multiple Authorization headers on retries

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureTokenAuthenticationPolicy.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureTokenAuthenticationPolicy.cs
@@ -34,7 +34,7 @@ internal partial class AzureTokenAuthenticationPolicy : PipelinePolicy
                 TokenRequestContext tokenRequestContext = CreateRequestContext(message.Request);
                 _currentToken = _credential.GetToken(tokenRequestContext, cancellationToken: default);
             }
-            message?.Request?.Headers?.Add("Authorization", $"Bearer {_currentToken.Value.Token}");
+            message?.Request?.Headers?.Set("Authorization", $"Bearer {_currentToken.Value.Token}");
         }
         ProcessNext(message, pipeline, currentIndex);
         if (message?.Response?.Status == (int)HttpStatusCode.Unauthorized)
@@ -53,7 +53,7 @@ internal partial class AzureTokenAuthenticationPolicy : PipelinePolicy
                 _currentToken
                     = await _credential.GetTokenAsync(tokenRequestContext, cancellationToken: default).ConfigureAwait(false);
             }
-            message?.Request?.Headers?.Add("Authorization", $"Bearer {_currentToken.Value.Token}");
+            message?.Request?.Headers?.Set("Authorization", $"Bearer {_currentToken.Value.Token}");
         }
         await ProcessNextAsync(message, pipeline, currentIndex).ConfigureAwait(false);
         if (message?.Response?.Status == (int)HttpStatusCode.Unauthorized)


### PR DESCRIPTION
Fix https://github.com/Azure/azure-sdk-for-net/issues/46109

Thanks @mikeharder  for https://github.com/Azure/azure-sdk-for-net/issues/46109#issuecomment-2389642980!