### PR TITLE
Azure.Provisioning: rename `ResourceName` to `IdentifierName`

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/api/Azure.Provisioning.AppConfiguration.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/api/Azure.Provisioning.AppConfiguration.netstandard2.0.cs
@@ -32,7 +32,7 @@ namespace Azure.Provisioning.AppConfiguration
     }
     public partial class AppConfigurationKeyValue : Azure.Provisioning.Primitives.Resource
     {
-        public AppConfigurationKeyValue(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppConfigurationKeyValue(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ContentType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -45,7 +45,7 @@ namespace Azure.Provisioning.AppConfiguration
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Value { get { throw null; } set { } }
-        public static Azure.Provisioning.AppConfiguration.AppConfigurationKeyValue FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppConfiguration.AppConfigurationKeyValue FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_05_01;
@@ -61,7 +61,7 @@ namespace Azure.Provisioning.AppConfiguration
     }
     public partial class AppConfigurationPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public AppConfigurationPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppConfigurationPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppConfiguration.AppConfigurationPrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -69,7 +69,7 @@ namespace Azure.Provisioning.AppConfiguration
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppConfiguration.AppConfigurationProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppConfiguration.AppConfigurationPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppConfiguration.AppConfigurationPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_10_01;
@@ -119,7 +119,7 @@ namespace Azure.Provisioning.AppConfiguration
     }
     public partial class AppConfigurationReplica : Azure.Provisioning.Primitives.Resource
     {
-        public AppConfigurationReplica(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppConfigurationReplica(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Endpoint { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -127,7 +127,7 @@ namespace Azure.Provisioning.AppConfiguration
         public Azure.Provisioning.AppConfiguration.AppConfigurationStore? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppConfiguration.AppConfigurationReplicaProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppConfiguration.AppConfigurationReplica FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppConfiguration.AppConfigurationReplica FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -146,7 +146,7 @@ namespace Azure.Provisioning.AppConfiguration
     }
     public partial class AppConfigurationStore : Azure.Provisioning.Primitives.Resource
     {
-        public AppConfigurationStore(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppConfigurationStore(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppConfiguration.AppConfigurationCreateMode> CreateMode { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> DisableLocalAuth { get { throw null; } set { } }
@@ -164,9 +164,9 @@ namespace Azure.Provisioning.AppConfiguration
         public Azure.Provisioning.BicepValue<int> SoftDeleteRetentionInDays { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.AppConfiguration.AppConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.AppConfiguration.AppConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.AppConfiguration.AppConfigurationBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.AppConfiguration.AppConfigurationStore FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppConfiguration.AppConfigurationStore FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppConfiguration.AppConfigurationStoreApiKey> GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationKeyValue.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationKeyValue.cs
@@ -103,10 +103,15 @@ public partial class AppConfigurationKeyValue : Resource
     /// <summary>
     /// Creates a new AppConfigurationKeyValue.
     /// </summary>
-    /// <param name="resourceName">Name of the AppConfigurationKeyValue.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppConfigurationKeyValue resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppConfigurationKeyValue.</param>
-    public AppConfigurationKeyValue(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.AppConfiguration/configurationStores/keyValues", resourceVersion ?? "2024-05-01")
+    public AppConfigurationKeyValue(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.AppConfiguration/configurationStores/keyValues", resourceVersion ?? "2024-05-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _contentType = BicepValue<string>.DefineProperty(this, "ContentType", ["properties", "contentType"]);
@@ -146,9 +151,14 @@ public partial class AppConfigurationKeyValue : Resource
     /// <summary>
     /// Creates a reference to an existing AppConfigurationKeyValue.
     /// </summary>
-    /// <param name="resourceName">Name of the AppConfigurationKeyValue.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppConfigurationKeyValue resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppConfigurationKeyValue.</param>
     /// <returns>The existing AppConfigurationKeyValue resource.</returns>
-    public static AppConfigurationKeyValue FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppConfigurationKeyValue FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationPrivateEndpointConnection.cs
@@ -63,10 +63,16 @@ public partial class AppConfigurationPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new AppConfigurationPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the AppConfigurationPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// AppConfigurationPrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppConfigurationPrivateEndpointConnection.</param>
-    public AppConfigurationPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.AppConfiguration/configurationStores/privateEndpointConnections", resourceVersion ?? "2024-05-01")
+    public AppConfigurationPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.AppConfiguration/configurationStores/privateEndpointConnections", resourceVersion ?? "2024-05-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<AppConfigurationPrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -112,9 +118,15 @@ public partial class AppConfigurationPrivateEndpointConnection : Resource
     /// Creates a reference to an existing
     /// AppConfigurationPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the AppConfigurationPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// AppConfigurationPrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppConfigurationPrivateEndpointConnection.</param>
     /// <returns>The existing AppConfigurationPrivateEndpointConnection resource.</returns>
-    public static AppConfigurationPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppConfigurationPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationReplica.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationReplica.cs
@@ -63,10 +63,15 @@ public partial class AppConfigurationReplica : Resource
     /// <summary>
     /// Creates a new AppConfigurationReplica.
     /// </summary>
-    /// <param name="resourceName">Name of the AppConfigurationReplica.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppConfigurationReplica resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppConfigurationReplica.</param>
-    public AppConfigurationReplica(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.AppConfiguration/configurationStores/replicas", resourceVersion ?? "2024-05-01")
+    public AppConfigurationReplica(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.AppConfiguration/configurationStores/replicas", resourceVersion ?? "2024-05-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"]);
@@ -96,11 +101,16 @@ public partial class AppConfigurationReplica : Resource
     /// <summary>
     /// Creates a reference to an existing AppConfigurationReplica.
     /// </summary>
-    /// <param name="resourceName">Name of the AppConfigurationReplica.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppConfigurationReplica resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppConfigurationReplica.</param>
     /// <returns>The existing AppConfigurationReplica resource.</returns>
-    public static AppConfigurationReplica FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppConfigurationReplica FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this AppConfigurationReplica resource.

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
@@ -131,10 +131,15 @@ public partial class AppConfigurationStore : Resource
     /// <summary>
     /// Creates a new AppConfigurationStore.
     /// </summary>
-    /// <param name="resourceName">Name of the AppConfigurationStore.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppConfigurationStore resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppConfigurationStore.</param>
-    public AppConfigurationStore(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.AppConfiguration/configurationStores", resourceVersion ?? "2024-05-01")
+    public AppConfigurationStore(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.AppConfiguration/configurationStores", resourceVersion ?? "2024-05-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -189,11 +194,16 @@ public partial class AppConfigurationStore : Resource
     /// <summary>
     /// Creates a reference to an existing AppConfigurationStore.
     /// </summary>
-    /// <param name="resourceName">Name of the AppConfigurationStore.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppConfigurationStore resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppConfigurationStore.</param>
     /// <returns>The existing AppConfigurationStore resource.</returns>
-    public static AppConfigurationStore FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppConfigurationStore FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this AppConfigurationStore resource.
@@ -210,7 +220,7 @@ public partial class AppConfigurationStore : Resource
     public BicepList<AppConfigurationStoreApiKey> GetKeys() =>
         BicepList<AppConfigurationStoreApiKey>.FromExpression(
             AppConfigurationStoreApiKey.FromExpression,
-            new MemberExpression(new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")), "keys"));
+            new MemberExpression(new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")), "keys"));
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -220,10 +230,10 @@ public partial class AppConfigurationStore : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(AppConfigurationBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -236,13 +246,13 @@ public partial class AppConfigurationStore : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(AppConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(AppConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{AppConfigurationBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.netstandard2.0.cs
@@ -30,7 +30,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerApp : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerApp(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerApp(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppConfiguration> Configuration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> CustomDomainVerificationId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> EnvironmentId { get { throw null; } set { } }
@@ -51,7 +51,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppTemplate> Template { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WorkloadProfileName { get { throw null; } set { } }
-        public static Azure.Provisioning.AppContainers.ContainerApp FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerApp FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -94,7 +94,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppAuthConfig : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppAuthConfig(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppAuthConfig(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.EncryptionSettings> EncryptionSettings { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppGlobalValidation> GlobalValidation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppHttpSettings> HttpSettings { get { throw null; } set { } }
@@ -105,7 +105,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.AppContainers.ContainerApp? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppAuthPlatform> Platform { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppContainers.ContainerAppAuthConfig FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppAuthConfig FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_03_01;
@@ -209,7 +209,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppConnectedEnvironment : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppConnectedEnvironment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppConnectedEnvironment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppCustomDomainConfiguration> CustomDomainConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DaprAIConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DefaultDomain { get { throw null; } }
@@ -222,7 +222,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepValue<System.Net.IPAddress> StaticIP { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_10_01;
@@ -233,7 +233,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppConnectedEnvironmentCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppConnectedEnvironmentCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppConnectedEnvironmentCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -241,7 +241,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppCertificateProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironmentCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironmentCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_10_01;
@@ -252,7 +252,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppConnectedEnvironmentDaprComponent : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppConnectedEnvironmentDaprComponent(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppConnectedEnvironmentDaprComponent(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ComponentType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IgnoreErrors { get { throw null; } set { } }
@@ -265,7 +265,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepValue<string> SecretStoreComponent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } set { } }
-        public static Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironmentDaprComponent FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironmentDaprComponent FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_10_01;
@@ -287,13 +287,13 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppConnectedEnvironmentStorage : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppConnectedEnvironmentStorage(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppConnectedEnvironmentStorage(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppAzureFileProperties> ConnectedEnvironmentStorageAzureFile { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironment? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironmentStorage FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppConnectedEnvironmentStorage FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_10_01;
@@ -613,7 +613,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppJob : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppJob(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppJob(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppJobConfiguration> Configuration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EnvironmentId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EventStreamEndpoint { get { throw null; } }
@@ -627,7 +627,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppJobTemplate> Template { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WorkloadProfileName { get { throw null; } set { } }
-        public static Azure.Provisioning.AppContainers.ContainerAppJob FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppJob FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2023_05_01;
@@ -720,7 +720,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppManagedCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppManagedCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppManagedCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -728,7 +728,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ManagedCertificateProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.AppContainers.ContainerAppManagedCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppManagedCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2023_05_01;
@@ -738,7 +738,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppManagedEnvironment : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppManagedEnvironment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppManagedEnvironment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppLogsConfiguration> AppLogsConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppCustomDomainConfiguration> CustomDomainConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DaprAIConnectionString { get { throw null; } set { } }
@@ -762,9 +762,9 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppVnetConfiguration> VnetConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppContainers.ContainerAppWorkloadProfile> WorkloadProfiles { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.AppContainers.AppContainersBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.AppContainers.AppContainersBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.AppContainers.AppContainersBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_03_01;
@@ -776,7 +776,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppManagedEnvironmentCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppManagedEnvironmentCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppManagedEnvironmentCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -784,7 +784,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppCertificateProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironmentCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironmentCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_03_01;
@@ -796,7 +796,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppManagedEnvironmentDaprComponent : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppManagedEnvironmentDaprComponent(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppManagedEnvironmentDaprComponent(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ComponentType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IgnoreErrors { get { throw null; } set { } }
@@ -809,7 +809,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.BicepValue<string> SecretStoreComponent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } set { } }
-        public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironmentDaprComponent FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironmentDaprComponent FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_03_01;
@@ -826,13 +826,13 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppManagedEnvironmentStorage : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppManagedEnvironmentStorage(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppManagedEnvironmentStorage(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppAzureFileProperties> ManagedEnvironmentStorageAzureFile { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.AppContainers.ContainerAppManagedEnvironment? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironmentStorage FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppManagedEnvironmentStorage FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_03_01;
@@ -974,7 +974,7 @@ namespace Azure.Provisioning.AppContainers
     }
     public partial class ContainerAppSourceControl : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerAppSourceControl(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerAppSourceControl(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Branch { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppContainers.ContainerAppGitHubActionConfiguration> GitHubActionConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -983,7 +983,7 @@ namespace Azure.Provisioning.AppContainers
         public Azure.Provisioning.AppContainers.ContainerApp? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> RepoUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppContainers.ContainerAppSourceControl FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppContainers.ContainerAppSourceControl FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_03_01;

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerApp.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerApp.cs
@@ -148,10 +148,15 @@ public partial class ContainerApp : Resource
     /// <summary>
     /// Creates a new ContainerApp.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerApp.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerApp resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerApp.</param>
-    public ContainerApp(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/containerApps", resourceVersion ?? "2024-03-01")
+    public ContainerApp(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/containerApps", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -209,11 +214,16 @@ public partial class ContainerApp : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerApp.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerApp.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerApp resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerApp.</param>
     /// <returns>The existing ContainerApp resource.</returns>
-    public static ContainerApp FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerApp FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ContainerApp resource.

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppAuthConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppAuthConfig.cs
@@ -88,10 +88,15 @@ public partial class ContainerAppAuthConfig : Resource
     /// <summary>
     /// Creates a new ContainerAppAuthConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppAuthConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppAuthConfig resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppAuthConfig.</param>
-    public ContainerAppAuthConfig(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/containerApps/authConfigs", resourceVersion ?? "2024-03-01")
+    public ContainerAppAuthConfig(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/containerApps/authConfigs", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _encryptionSettings = BicepValue<EncryptionSettings>.DefineProperty(this, "EncryptionSettings", ["properties", "encryptionSettings"]);
@@ -139,9 +144,14 @@ public partial class ContainerAppAuthConfig : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerAppAuthConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppAuthConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppAuthConfig resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppAuthConfig.</param>
     /// <returns>The existing ContainerAppAuthConfig resource.</returns>
-    public static ContainerAppAuthConfig FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppAuthConfig FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironment.cs
@@ -95,10 +95,15 @@ public partial class ContainerAppConnectedEnvironment : Resource
     /// <summary>
     /// Creates a new ContainerAppConnectedEnvironment.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppConnectedEnvironment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppConnectedEnvironment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironment.</param>
-    public ContainerAppConnectedEnvironment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/connectedEnvironments", resourceVersion ?? "2024-03-01")
+    public ContainerAppConnectedEnvironment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/connectedEnvironments", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -143,9 +148,14 @@ public partial class ContainerAppConnectedEnvironment : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerAppConnectedEnvironment.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppConnectedEnvironment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppConnectedEnvironment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironment.</param>
     /// <returns>The existing ContainerAppConnectedEnvironment resource.</returns>
-    public static ContainerAppConnectedEnvironment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppConnectedEnvironment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentCertificate.cs
@@ -63,10 +63,16 @@ public partial class ContainerAppConnectedEnvironmentCertificate : Resource
     /// <summary>
     /// Creates a new ContainerAppConnectedEnvironmentCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppConnectedEnvironmentCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppConnectedEnvironmentCertificate resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentCertificate.</param>
-    public ContainerAppConnectedEnvironmentCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/connectedEnvironments/certificates", resourceVersion ?? "2024-03-01")
+    public ContainerAppConnectedEnvironmentCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/connectedEnvironments/certificates", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -107,9 +113,15 @@ public partial class ContainerAppConnectedEnvironmentCertificate : Resource
     /// Creates a reference to an existing
     /// ContainerAppConnectedEnvironmentCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppConnectedEnvironmentCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppConnectedEnvironmentCertificate resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentCertificate.</param>
     /// <returns>The existing ContainerAppConnectedEnvironmentCertificate resource.</returns>
-    public static ContainerAppConnectedEnvironmentCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppConnectedEnvironmentCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentDaprComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentDaprComponent.cs
@@ -93,10 +93,16 @@ public partial class ContainerAppConnectedEnvironmentDaprComponent : Resource
     /// <summary>
     /// Creates a new ContainerAppConnectedEnvironmentDaprComponent.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppConnectedEnvironmentDaprComponent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppConnectedEnvironmentDaprComponent resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentDaprComponent.</param>
-    public ContainerAppConnectedEnvironmentDaprComponent(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/connectedEnvironments/daprComponents", resourceVersion ?? "2024-03-01")
+    public ContainerAppConnectedEnvironmentDaprComponent(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/connectedEnvironments/daprComponents", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _componentType = BicepValue<string>.DefineProperty(this, "ComponentType", ["properties", "componentType"]);
@@ -143,9 +149,15 @@ public partial class ContainerAppConnectedEnvironmentDaprComponent : Resource
     /// Creates a reference to an existing
     /// ContainerAppConnectedEnvironmentDaprComponent.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppConnectedEnvironmentDaprComponent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppConnectedEnvironmentDaprComponent resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentDaprComponent.</param>
     /// <returns>The existing ContainerAppConnectedEnvironmentDaprComponent resource.</returns>
-    public static ContainerAppConnectedEnvironmentDaprComponent FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppConnectedEnvironmentDaprComponent FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentStorage.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentStorage.cs
@@ -50,10 +50,15 @@ public partial class ContainerAppConnectedEnvironmentStorage : Resource
     /// <summary>
     /// Creates a new ContainerAppConnectedEnvironmentStorage.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppConnectedEnvironmentStorage.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppConnectedEnvironmentStorage resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentStorage.</param>
-    public ContainerAppConnectedEnvironmentStorage(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/connectedEnvironments/storages", resourceVersion ?? "2024-03-01")
+    public ContainerAppConnectedEnvironmentStorage(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/connectedEnvironments/storages", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectedEnvironmentStorageAzureFile = BicepValue<ContainerAppAzureFileProperties>.DefineProperty(this, "ConnectedEnvironmentStorageAzureFile", ["properties", "azureFile"]);
@@ -92,9 +97,14 @@ public partial class ContainerAppConnectedEnvironmentStorage : Resource
     /// Creates a reference to an existing
     /// ContainerAppConnectedEnvironmentStorage.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppConnectedEnvironmentStorage.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppConnectedEnvironmentStorage resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentStorage.</param>
     /// <returns>The existing ContainerAppConnectedEnvironmentStorage resource.</returns>
-    public static ContainerAppConnectedEnvironmentStorage FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppConnectedEnvironmentStorage FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppJob.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppJob.cs
@@ -100,10 +100,15 @@ public partial class ContainerAppJob : Resource
     /// <summary>
     /// Creates a new ContainerAppJob.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppJob.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppJob resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppJob.</param>
-    public ContainerAppJob(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/jobs", resourceVersion ?? "2024-03-01")
+    public ContainerAppJob(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/jobs", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -144,9 +149,14 @@ public partial class ContainerAppJob : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerAppJob.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppJob.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppJob resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppJob.</param>
     /// <returns>The existing ContainerAppJob resource.</returns>
-    public static ContainerAppJob FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppJob FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedCertificate.cs
@@ -63,10 +63,15 @@ public partial class ContainerAppManagedCertificate : Resource
     /// <summary>
     /// Creates a new ContainerAppManagedCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppManagedCertificate
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedCertificate.</param>
-    public ContainerAppManagedCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/managedEnvironments/managedCertificates", resourceVersion ?? "2024-03-01")
+    public ContainerAppManagedCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/managedEnvironments/managedCertificates", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -101,9 +106,14 @@ public partial class ContainerAppManagedCertificate : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerAppManagedCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppManagedCertificate
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedCertificate.</param>
     /// <returns>The existing ContainerAppManagedCertificate resource.</returns>
-    public static ContainerAppManagedCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppManagedCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
@@ -170,10 +170,15 @@ public partial class ContainerAppManagedEnvironment : Resource
     /// <summary>
     /// Creates a new ContainerAppManagedEnvironment.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedEnvironment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppManagedEnvironment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironment.</param>
-    public ContainerAppManagedEnvironment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/managedEnvironments", resourceVersion ?? "2024-03-01")
+    public ContainerAppManagedEnvironment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/managedEnvironments", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -234,11 +239,16 @@ public partial class ContainerAppManagedEnvironment : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerAppManagedEnvironment.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedEnvironment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppManagedEnvironment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironment.</param>
     /// <returns>The existing ContainerAppManagedEnvironment resource.</returns>
-    public static ContainerAppManagedEnvironment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppManagedEnvironment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -248,10 +258,10 @@ public partial class ContainerAppManagedEnvironment : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(AppContainersBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -264,13 +274,13 @@ public partial class ContainerAppManagedEnvironment : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(AppContainersBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(AppContainersBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{AppContainersBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentCertificate.cs
@@ -63,10 +63,16 @@ public partial class ContainerAppManagedEnvironmentCertificate : Resource
     /// <summary>
     /// Creates a new ContainerAppManagedEnvironmentCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedEnvironmentCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppManagedEnvironmentCertificate resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentCertificate.</param>
-    public ContainerAppManagedEnvironmentCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/managedEnvironments/certificates", resourceVersion ?? "2024-03-01")
+    public ContainerAppManagedEnvironmentCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/managedEnvironments/certificates", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -112,9 +118,15 @@ public partial class ContainerAppManagedEnvironmentCertificate : Resource
     /// Creates a reference to an existing
     /// ContainerAppManagedEnvironmentCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedEnvironmentCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppManagedEnvironmentCertificate resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentCertificate.</param>
     /// <returns>The existing ContainerAppManagedEnvironmentCertificate resource.</returns>
-    public static ContainerAppManagedEnvironmentCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppManagedEnvironmentCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentDaprComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentDaprComponent.cs
@@ -93,10 +93,16 @@ public partial class ContainerAppManagedEnvironmentDaprComponent : Resource
     /// <summary>
     /// Creates a new ContainerAppManagedEnvironmentDaprComponent.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedEnvironmentDaprComponent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppManagedEnvironmentDaprComponent resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentDaprComponent.</param>
-    public ContainerAppManagedEnvironmentDaprComponent(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/managedEnvironments/daprComponents", resourceVersion ?? "2024-03-01")
+    public ContainerAppManagedEnvironmentDaprComponent(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/managedEnvironments/daprComponents", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _componentType = BicepValue<string>.DefineProperty(this, "ComponentType", ["properties", "componentType"]);
@@ -147,9 +153,15 @@ public partial class ContainerAppManagedEnvironmentDaprComponent : Resource
     /// Creates a reference to an existing
     /// ContainerAppManagedEnvironmentDaprComponent.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedEnvironmentDaprComponent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppManagedEnvironmentDaprComponent resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentDaprComponent.</param>
     /// <returns>The existing ContainerAppManagedEnvironmentDaprComponent resource.</returns>
-    public static ContainerAppManagedEnvironmentDaprComponent FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppManagedEnvironmentDaprComponent FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentStorage.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentStorage.cs
@@ -50,10 +50,15 @@ public partial class ContainerAppManagedEnvironmentStorage : Resource
     /// <summary>
     /// Creates a new ContainerAppManagedEnvironmentStorage.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedEnvironmentStorage.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppManagedEnvironmentStorage resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentStorage.</param>
-    public ContainerAppManagedEnvironmentStorage(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/managedEnvironments/storages", resourceVersion ?? "2024-03-01")
+    public ContainerAppManagedEnvironmentStorage(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/managedEnvironments/storages", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _managedEnvironmentStorageAzureFile = BicepValue<ContainerAppAzureFileProperties>.DefineProperty(this, "ManagedEnvironmentStorageAzureFile", ["properties", "azureFile"]);
@@ -97,9 +102,14 @@ public partial class ContainerAppManagedEnvironmentStorage : Resource
     /// Creates a reference to an existing
     /// ContainerAppManagedEnvironmentStorage.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppManagedEnvironmentStorage.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerAppManagedEnvironmentStorage resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentStorage.</param>
     /// <returns>The existing ContainerAppManagedEnvironmentStorage resource.</returns>
-    public static ContainerAppManagedEnvironmentStorage FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppManagedEnvironmentStorage FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppSourceControl.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppSourceControl.cs
@@ -70,10 +70,15 @@ public partial class ContainerAppSourceControl : Resource
     /// <summary>
     /// Creates a new ContainerAppSourceControl.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppSourceControl.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppSourceControl
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppSourceControl.</param>
-    public ContainerAppSourceControl(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.App/containerApps/sourcecontrols", resourceVersion ?? "2024-03-01")
+    public ContainerAppSourceControl(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.App/containerApps/sourcecontrols", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _branch = BicepValue<string>.DefineProperty(this, "Branch", ["properties", "branch"]);
@@ -119,9 +124,14 @@ public partial class ContainerAppSourceControl : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerAppSourceControl.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerAppSourceControl.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerAppSourceControl
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppSourceControl.</param>
     /// <returns>The existing ContainerAppSourceControl resource.</returns>
-    public static ContainerAppSourceControl FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerAppSourceControl FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/api/Azure.Provisioning.AppService.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/api/Azure.Provisioning.AppService.netstandard2.0.cs
@@ -2,7 +2,7 @@ namespace Azure.Provisioning.AppService
 {
     public partial class AppCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public AppCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> CanonicalName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.BinaryData> CerBlob { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DomainValidationMethod { get { throw null; } set { } }
@@ -30,7 +30,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ThumbprintString { get { throw null; } }
-        public static Azure.Provisioning.AppService.AppCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AppCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -143,7 +143,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class AppServiceCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public AppServiceCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppServiceCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> KeyVaultId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> KeyVaultSecretName { get { throw null; } set { } }
@@ -154,7 +154,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.KeyVaultSecretStatus> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.AppServiceCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AppServiceCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_08_01;
@@ -196,7 +196,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class AppServiceCertificateOrder : Azure.Provisioning.Primitives.Resource
     {
-        public AppServiceCertificateOrder(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppServiceCertificateOrder(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.AppServiceCertificateNotRenewableReason> AppServiceCertificateNotRenewableReasons { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<Azure.Provisioning.AppService.AppServiceCertificateProperties> Certificates { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.CertificateOrderContact> Contact { get { throw null; } }
@@ -223,7 +223,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> ValidityInYears { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.AppServiceCertificateOrder FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AppServiceCertificateOrder FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_08_01;
@@ -264,7 +264,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class AppServiceDomain : Azure.Provisioning.Primitives.Resource
     {
-        public AppServiceDomain(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppServiceDomain(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AuthCode { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.DomainPurchaseConsent> Consent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.RegistrationContactInfo> ContactAdmin { get { throw null; } set { } }
@@ -291,7 +291,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceDnsType> TargetDnsType { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.AppServiceDomain FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AppServiceDomain FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_02_01;
@@ -339,7 +339,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class AppServiceEnvironment : Azure.Provisioning.Primitives.Resource
     {
-        public AppServiceEnvironment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppServiceEnvironment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.AppServiceNameValuePair> ClusterSettings { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.CustomDnsSuffixConfigurationData> CustomDnsSuffixConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> DedicatedHostCount { get { throw null; } set { } }
@@ -366,7 +366,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceEnvironmentUpgradePreference> UpgradePreference { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> UserWhitelistedIPRanges { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceVirtualNetworkProfile> VirtualNetwork { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.AppServiceEnvironment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AppServiceEnvironment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -475,7 +475,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class AppServicePlan : Azure.Provisioning.Primitives.Resource
     {
-        public AppServicePlan(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppServicePlan(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ExtendedAzureLocation> ExtendedLocation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> FreeOfferExpireOn { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> GeoRegion { get { throw null; } }
@@ -507,7 +507,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<int> TargetWorkerCount { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> TargetWorkerSizeId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WorkerTierName { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.AppServicePlan FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AppServicePlan FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -550,14 +550,14 @@ namespace Azure.Provisioning.AppService
     }
     public partial class AppServicePlanVirtualNetworkConnectionGateway : Azure.Provisioning.Primitives.Resource
     {
-        public AppServicePlanVirtualNetworkConnectionGateway(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppServicePlanVirtualNetworkConnectionGateway(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> VnetName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> VpnPackageUri { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.AppServicePlanVirtualNetworkConnectionGateway FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AppServicePlanVirtualNetworkConnectionGateway FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public enum AppServiceResourceType
     {
@@ -594,7 +594,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class AppServiceSourceControl : Azure.Provisioning.Primitives.Resource
     {
-        public AppServiceSourceControl(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AppServiceSourceControl(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> ExpireOn { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -603,7 +603,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Token { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> TokenSecret { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.AppServiceSourceControl FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AppServiceSourceControl FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -768,7 +768,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class AseV3NetworkingConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public AseV3NetworkingConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AseV3NetworkingConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> AllowNewPrivateEndpointConnections { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<System.Net.IPAddress> ExternalInboundIPAddresses { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -782,7 +782,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.AppService.AppServiceEnvironment? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<System.Net.IPAddress> WindowsOutboundIPAddresses { get { throw null; } }
-        public static Azure.Provisioning.AppService.AseV3NetworkingConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.AseV3NetworkingConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -959,7 +959,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class CustomDnsSuffixConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public CustomDnsSuffixConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CustomDnsSuffixConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Uri> CertificateUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DnsSuffix { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -970,7 +970,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> ProvisioningDetails { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.CustomDnsSuffixProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.CustomDnsSuffixConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.CustomDnsSuffixConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1049,14 +1049,14 @@ namespace Azure.Provisioning.AppService
     }
     public partial class DomainOwnershipIdentifier : Azure.Provisioning.Primitives.Resource
     {
-        public DomainOwnershipIdentifier(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public DomainOwnershipIdentifier(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> OwnershipId { get { throw null; } set { } }
         public Azure.Provisioning.AppService.AppServiceDomain? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.DomainOwnershipIdentifier FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.DomainOwnershipIdentifier FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_02_01;
@@ -1201,7 +1201,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class HostingEnvironmentMultiRolePool : Azure.Provisioning.Primitives.Resource
     {
-        public HostingEnvironmentMultiRolePool(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public HostingEnvironmentMultiRolePool(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.ComputeModeOption> ComputeMode { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<string> InstanceNames { get { throw null; } }
@@ -1213,7 +1213,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<int> WorkerCount { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WorkerSize { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> WorkerSizeId { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.HostingEnvironmentMultiRolePool FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.HostingEnvironmentMultiRolePool FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1250,7 +1250,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class HostingEnvironmentPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public HostingEnvironmentPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public HostingEnvironmentPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<System.Net.IPAddress> IPAddresses { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -1260,7 +1260,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.PrivateLinkConnectionState> PrivateLinkServiceConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.HostingEnvironmentPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.HostingEnvironmentPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1312,7 +1312,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class HostingEnvironmentWorkerPool : Azure.Provisioning.Primitives.Resource
     {
-        public HostingEnvironmentWorkerPool(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public HostingEnvironmentWorkerPool(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.ComputeModeOption> ComputeMode { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<string> InstanceNames { get { throw null; } }
@@ -1324,7 +1324,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<int> WorkerCount { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WorkerSize { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> WorkerSizeId { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.HostingEnvironmentWorkerPool FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.HostingEnvironmentWorkerPool FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1399,7 +1399,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class KubeEnvironment : Azure.Provisioning.Primitives.Resource
     {
-        public KubeEnvironment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public KubeEnvironment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> AksResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppLogsConfiguration> AppLogsConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.ArcConfiguration> ArcConfiguration { get { throw null; } set { } }
@@ -1417,7 +1417,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> StaticIP { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.KubeEnvironment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.KubeEnvironment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_03_01;
@@ -1459,7 +1459,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class LogsSiteConfig : Azure.Provisioning.Primitives.Resource
     {
-        public LogsSiteConfig(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public LogsSiteConfig(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.ApplicationLogsConfig> ApplicationLogs { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceHttpLogsConfig> HttpLogs { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -1469,7 +1469,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.AppService.WebSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.LogsSiteConfig FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.LogsSiteConfig FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1507,7 +1507,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class LogsSiteSlotConfig : Azure.Provisioning.Primitives.Resource
     {
-        public LogsSiteSlotConfig(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public LogsSiteSlotConfig(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.ApplicationLogsConfig> ApplicationLogs { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceHttpLogsConfig> HttpLogs { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -1517,7 +1517,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.AppService.WebSiteSlot? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.LogsSiteSlotConfig FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.LogsSiteSlotConfig FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1608,7 +1608,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class PublishingUser : Azure.Provisioning.Primitives.Resource
     {
-        public PublishingUser(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PublishingUser(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
@@ -1618,7 +1618,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> PublishingUserName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> ScmUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.PublishingUser FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.PublishingUser FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1728,14 +1728,14 @@ namespace Azure.Provisioning.AppService
     }
     public partial class ScmSiteBasicPublishingCredentialsPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ScmSiteBasicPublishingCredentialsPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ScmSiteBasicPublishingCredentialsPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> Allow { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.AppService.WebSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.ScmSiteBasicPublishingCredentialsPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.ScmSiteBasicPublishingCredentialsPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1773,14 +1773,14 @@ namespace Azure.Provisioning.AppService
     }
     public partial class ScmSiteSlotBasicPublishingCredentialsPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ScmSiteSlotBasicPublishingCredentialsPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ScmSiteSlotBasicPublishingCredentialsPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> Allow { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.AppService.WebSiteSlot? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.ScmSiteSlotBasicPublishingCredentialsPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.ScmSiteSlotBasicPublishingCredentialsPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1912,7 +1912,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteContainer : Azure.Provisioning.Primitives.Resource
     {
-        public SiteContainer(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteContainer(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.SiteContainerAuthType> AuthType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.WebAppEnvironmentVariable> EnvironmentVariables { get { throw null; } set { } }
@@ -1930,7 +1930,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> UserManagedIdentityClientId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> UserName { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.SiteContainerVolumeMount> VolumeMounts { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteContainer FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteContainer FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1988,7 +1988,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteDeployment : Azure.Provisioning.Primitives.Resource
     {
-        public SiteDeployment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteDeployment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Author { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AuthorEmail { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Deployer { get { throw null; } set { } }
@@ -2002,7 +2002,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> StartOn { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> Status { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteDeployment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteDeployment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2050,14 +2050,14 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteDomainOwnershipIdentifier : Azure.Provisioning.Primitives.Resource
     {
-        public SiteDomainOwnershipIdentifier(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteDomainOwnershipIdentifier(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.AppService.WebSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Value { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteDomainOwnershipIdentifier FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteDomainOwnershipIdentifier FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2095,7 +2095,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteExtension : Azure.Provisioning.Primitives.Resource
     {
-        public SiteExtension(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteExtension(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DBType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Deployer { get { throw null; } }
@@ -2113,7 +2113,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<bool> SkipAppData { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> StartOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteExtension FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteExtension FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2156,7 +2156,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteFunction : Azure.Provisioning.Primitives.Resource
     {
-        public SiteFunction(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteFunction(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.BinaryData> Config { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ConfigHref { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<string> Files { get { throw null; } set { } }
@@ -2175,7 +2175,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TestData { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> TestDataHref { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteFunction FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteFunction FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2213,7 +2213,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteHostNameBinding : Azure.Provisioning.Primitives.Resource
     {
-        public SiteHostNameBinding(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteHostNameBinding(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AzureResourceName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceResourceType> AzureResourceType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.CustomHostNameDnsRecordType> CustomHostNameDnsRecordType { get { throw null; } set { } }
@@ -2228,7 +2228,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ThumbprintString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> VirtualIP { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteHostNameBinding FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteHostNameBinding FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_02_01;
@@ -2259,7 +2259,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteHybridConnectionNamespaceRelay : Azure.Provisioning.Primitives.Resource
     {
-        public SiteHybridConnectionNamespaceRelay(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteHybridConnectionNamespaceRelay(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Hostname { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -2272,11 +2272,11 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> ServiceBusNamespace { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ServiceBusSuffix { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteHybridConnectionNamespaceRelay FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteHybridConnectionNamespaceRelay FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public partial class SiteInstanceExtension : Azure.Provisioning.Primitives.Resource
     {
-        public SiteInstanceExtension(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteInstanceExtension(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DBType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Deployer { get { throw null; } }
@@ -2293,7 +2293,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<bool> SkipAppData { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> StartOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteInstanceExtension FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteInstanceExtension FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public partial class SiteLimits : Azure.Provisioning.Primitives.ProvisioningConstruct
     {
@@ -2321,7 +2321,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteNetworkConfig : Azure.Provisioning.Primitives.Resource
     {
-        public SiteNetworkConfig(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteNetworkConfig(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsSwiftSupported { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -2329,7 +2329,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.AppService.WebSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> SubnetResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteNetworkConfig FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteNetworkConfig FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_02_01;
@@ -2360,7 +2360,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SitePrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public SitePrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SitePrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<System.Net.IPAddress> IPAddresses { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -2370,7 +2370,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.PrivateLinkConnectionState> PrivateLinkServiceConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SitePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SitePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -2410,7 +2410,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SitePublicCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public SitePublicCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SitePublicCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.BinaryData> Blob { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -2419,7 +2419,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.PublicCertificateLocation> PublicCertificateLocation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ThumbprintString { get { throw null; } }
-        public static Azure.Provisioning.AppService.SitePublicCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SitePublicCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2457,7 +2457,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotDeployment : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotDeployment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotDeployment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Author { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AuthorEmail { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Deployer { get { throw null; } set { } }
@@ -2471,7 +2471,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> StartOn { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> Status { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteSlotDeployment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotDeployment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2509,14 +2509,14 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotDomainOwnershipIdentifier : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotDomainOwnershipIdentifier(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotDomainOwnershipIdentifier(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.AppService.WebSiteSlot? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Value { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteSlotDomainOwnershipIdentifier FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotDomainOwnershipIdentifier FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2554,7 +2554,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotExtension : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotExtension(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotExtension(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DBType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Deployer { get { throw null; } }
@@ -2572,7 +2572,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<bool> SkipAppData { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> StartOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteSlotExtension FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotExtension FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2610,7 +2610,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotFunction : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotFunction(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotFunction(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.BinaryData> Config { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ConfigHref { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<string> Files { get { throw null; } set { } }
@@ -2629,7 +2629,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TestData { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> TestDataHref { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteSlotFunction FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotFunction FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2667,7 +2667,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotHostNameBinding : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotHostNameBinding(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotHostNameBinding(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AzureResourceName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceResourceType> AzureResourceType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.CustomHostNameDnsRecordType> CustomHostNameDnsRecordType { get { throw null; } set { } }
@@ -2682,7 +2682,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ThumbprintString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> VirtualIP { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteSlotHostNameBinding FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotHostNameBinding FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_02_01;
@@ -2713,7 +2713,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotHybridConnectionNamespaceRelay : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotHybridConnectionNamespaceRelay(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotHybridConnectionNamespaceRelay(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Hostname { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -2726,11 +2726,11 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> ServiceBusNamespace { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ServiceBusSuffix { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteSlotHybridConnectionNamespaceRelay FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotHybridConnectionNamespaceRelay FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public partial class SiteSlotInstanceExtension : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotInstanceExtension(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotInstanceExtension(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DBType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Deployer { get { throw null; } }
@@ -2747,11 +2747,11 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<bool> SkipAppData { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> StartOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteSlotInstanceExtension FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotInstanceExtension FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public partial class SiteSlotNetworkConfig : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotNetworkConfig(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotNetworkConfig(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsSwiftSupported { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -2759,7 +2759,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.AppService.WebSiteSlot? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> SubnetResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteSlotNetworkConfig FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotNetworkConfig FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_02_01;
@@ -2790,7 +2790,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<System.Net.IPAddress> IPAddresses { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -2800,7 +2800,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.PrivateLinkConnectionState> PrivateLinkServiceConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SiteSlotPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2838,7 +2838,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotSiteContainer : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotSiteContainer(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotSiteContainer(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.SiteContainerAuthType> AuthType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.WebAppEnvironmentVariable> EnvironmentVariables { get { throw null; } set { } }
@@ -2856,7 +2856,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> UserManagedIdentityClientId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> UserName { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.SiteContainerVolumeMount> VolumeMounts { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteSlotSiteContainer FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotSiteContainer FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2894,7 +2894,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotVirtualNetworkConnection : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotVirtualNetworkConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotVirtualNetworkConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> CertBlob { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> CertThumbprintString { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DnsServers { get { throw null; } set { } }
@@ -2907,7 +2907,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.AppServiceVirtualNetworkRoute> Routes { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> VnetResourceId { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteSlotVirtualNetworkConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotVirtualNetworkConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2945,7 +2945,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteSlotVirtualNetworkConnectionGateway : Azure.Provisioning.Primitives.Resource
     {
-        public SiteSlotVirtualNetworkConnectionGateway(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteSlotVirtualNetworkConnectionGateway(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -2953,7 +2953,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> VnetName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> VpnPackageUri { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteSlotVirtualNetworkConnectionGateway FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteSlotVirtualNetworkConnectionGateway FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2991,7 +2991,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteVirtualNetworkConnection : Azure.Provisioning.Primitives.Resource
     {
-        public SiteVirtualNetworkConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteVirtualNetworkConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> CertBlob { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> CertThumbprintString { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DnsServers { get { throw null; } set { } }
@@ -3004,7 +3004,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.AppServiceVirtualNetworkRoute> Routes { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> VnetResourceId { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteVirtualNetworkConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteVirtualNetworkConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -3042,7 +3042,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SiteVirtualNetworkConnectionGateway : Azure.Provisioning.Primitives.Resource
     {
-        public SiteVirtualNetworkConnectionGateway(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SiteVirtualNetworkConnectionGateway(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -3050,7 +3050,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> VnetName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> VpnPackageUri { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.SiteVirtualNetworkConnectionGateway FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SiteVirtualNetworkConnectionGateway FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -3088,7 +3088,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class SlotConfigNames : Azure.Provisioning.Primitives.Resource
     {
-        public SlotConfigNames(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SlotConfigNames(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> AppSettingNames { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> AzureStorageConfigNames { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> ConnectionStringNames { get { throw null; } set { } }
@@ -3097,7 +3097,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.AppService.WebSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.SlotConfigNames FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.SlotConfigNames FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -3155,7 +3155,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSite : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSite(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSite(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> AllowConfigFileUpdates { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Branch { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.StaticSiteBuildProperties> BuildProperties { get { throw null; } set { } }
@@ -3182,7 +3182,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.StaticSiteTemplate> TemplateProperties { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.StaticSiteUserProvidedFunctionAppData> UserProvidedFunctionApps { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSite FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSite FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_08_01;
@@ -3208,7 +3208,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSiteBasicAuthProperty : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSiteBasicAuthProperty(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSiteBasicAuthProperty(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ApplicableEnvironmentsMode { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> Environments { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -3219,7 +3219,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> SecretState { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Uri> SecretUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSiteBasicAuthProperty FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSiteBasicAuthProperty FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_08_01;
@@ -3240,7 +3240,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSiteBuildDatabaseConnection : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSiteBuildDatabaseConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSiteBuildDatabaseConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.StaticSiteDatabaseConnectionConfigurationFileOverview> ConfigurationFiles { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ConnectionIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ConnectionString { get { throw null; } set { } }
@@ -3250,7 +3250,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> Region { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> ResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSiteBuildDatabaseConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSiteBuildDatabaseConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_08_01;
@@ -3271,7 +3271,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSiteBuildLinkedBackend : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSiteBuildLinkedBackend(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSiteBuildLinkedBackend(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> BackendResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -3280,7 +3280,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Region { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSiteBuildLinkedBackend FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSiteBuildLinkedBackend FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_08_01;
@@ -3313,7 +3313,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSiteBuildUserProvidedFunctionApp : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSiteBuildUserProvidedFunctionApp(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSiteBuildUserProvidedFunctionApp(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> FunctionAppRegion { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> FunctionAppResourceId { get { throw null; } set { } }
@@ -3321,7 +3321,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSiteBuildUserProvidedFunctionApp FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSiteBuildUserProvidedFunctionApp FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_12_01;
@@ -3338,7 +3338,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSiteCustomDomainOverview : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSiteCustomDomainOverview(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSiteCustomDomainOverview(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DomainName { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ErrorMessage { get { throw null; } }
@@ -3350,7 +3350,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ValidationMethod { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ValidationToken { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSiteCustomDomainOverview FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSiteCustomDomainOverview FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_08_01;
@@ -3371,7 +3371,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSiteDatabaseConnection : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSiteDatabaseConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSiteDatabaseConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.StaticSiteDatabaseConnectionConfigurationFileOverview> ConfigurationFiles { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ConnectionIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ConnectionString { get { throw null; } set { } }
@@ -3382,7 +3382,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> Region { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> ResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSiteDatabaseConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSiteDatabaseConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_08_01;
@@ -3419,7 +3419,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSiteLinkedBackend : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSiteLinkedBackend(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSiteLinkedBackend(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> BackendResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -3429,7 +3429,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Region { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSiteLinkedBackend FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSiteLinkedBackend FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_08_01;
@@ -3458,7 +3458,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSitePrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSitePrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSitePrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<System.Net.IPAddress> IPAddresses { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -3468,7 +3468,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.PrivateLinkConnectionState> PrivateLinkServiceConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSitePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSitePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_08_01;
@@ -3498,7 +3498,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class StaticSiteUserProvidedFunctionApp : Azure.Provisioning.Primitives.Resource
     {
-        public StaticSiteUserProvidedFunctionApp(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StaticSiteUserProvidedFunctionApp(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> FunctionAppRegion { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> FunctionAppResourceId { get { throw null; } set { } }
@@ -3507,7 +3507,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.AppService.StaticSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.StaticSiteUserProvidedFunctionApp FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.StaticSiteUserProvidedFunctionApp FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_12_01;
@@ -3593,7 +3593,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSite : Azure.Provisioning.Primitives.Resource
     {
-        public WebSite(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSite(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> AppServicePlanId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.WebSiteAvailabilityState> AvailabilityState { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ClientCertExclusionPaths { get { throw null; } set { } }
@@ -3654,7 +3654,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceUsageState> UsageState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> VirtualNetworkSubnetId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WorkloadProfileName { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.WebSite FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSite FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -3700,7 +3700,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteConfig : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteConfig(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteConfig(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AcrUserManagedIdentityId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> AllowIPSecurityRestrictionsForScmToUseMain { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> ApiDefinitionUri { get { throw null; } set { } }
@@ -3778,7 +3778,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> WebsiteTimeZone { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WindowsFxVersion { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> XManagedServiceIdentityId { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.WebSiteConfig FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteConfig FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -3816,7 +3816,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteExtension : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteExtension(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteExtension(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> Authors { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Comment { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } }
@@ -3842,7 +3842,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Title { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteExtension FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteExtension FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -3880,14 +3880,14 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteFtpPublishingCredentialsPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteFtpPublishingCredentialsPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteFtpPublishingCredentialsPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> Allow { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.AppService.WebSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteFtpPublishingCredentialsPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteFtpPublishingCredentialsPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -3925,7 +3925,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteHybridConnection : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteHybridConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteHybridConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Uri> BiztalkUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EntityConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EntityName { get { throw null; } set { } }
@@ -3937,7 +3937,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<int> Port { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ResourceConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteHybridConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteHybridConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -3975,7 +3975,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSitePremierAddon : Azure.Provisioning.Primitives.Resource
     {
-        public WebSitePremierAddon(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSitePremierAddon(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -3988,7 +3988,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Vendor { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.WebSitePremierAddon FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSitePremierAddon FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_04_01;
@@ -4017,7 +4017,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSitePrivateAccess : Azure.Provisioning.Primitives.Resource
     {
-        public WebSitePrivateAccess(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSitePrivateAccess(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -4025,7 +4025,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.AppService.WebSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.PrivateAccessVirtualNetwork> VirtualNetworks { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.WebSitePrivateAccess FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSitePrivateAccess FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4063,7 +4063,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlot : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlot(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlot(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> AppServicePlanId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.WebSiteAvailabilityState> AvailabilityState { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ClientCertExclusionPaths { get { throw null; } set { } }
@@ -4125,7 +4125,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.AppServiceUsageState> UsageState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> VirtualNetworkSubnetId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WorkloadProfileName { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.WebSiteSlot FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlot FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -4165,7 +4165,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlotConfig : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlotConfig(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlotConfig(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AcrUserManagedIdentityId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> AllowIPSecurityRestrictionsForScmToUseMain { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> ApiDefinitionUri { get { throw null; } set { } }
@@ -4243,7 +4243,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<string> WebsiteTimeZone { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WindowsFxVersion { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> XManagedServiceIdentityId { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.WebSiteSlotConfig FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlotConfig FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4281,7 +4281,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlotExtension : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlotExtension(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlotExtension(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> Authors { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Comment { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } }
@@ -4307,7 +4307,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Title { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteSlotExtension FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlotExtension FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4345,14 +4345,14 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlotFtpPublishingCredentialsPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlotFtpPublishingCredentialsPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlotFtpPublishingCredentialsPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> Allow { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.AppService.WebSiteSlot? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteSlotFtpPublishingCredentialsPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlotFtpPublishingCredentialsPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4390,7 +4390,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlotHybridConnection : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlotHybridConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlotHybridConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Uri> BiztalkUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EntityConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EntityName { get { throw null; } set { } }
@@ -4402,7 +4402,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<int> Port { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ResourceConnectionString { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteSlotHybridConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlotHybridConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4440,7 +4440,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlotPremierAddOn : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlotPremierAddOn(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlotPremierAddOn(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -4453,7 +4453,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Vendor { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.WebSiteSlotPremierAddOn FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlotPremierAddOn FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4491,7 +4491,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlotPrivateAccess : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlotPrivateAccess(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlotPrivateAccess(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -4499,7 +4499,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.AppService.WebSiteSlot? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.AppService.PrivateAccessVirtualNetwork> VirtualNetworks { get { throw null; } set { } }
-        public static Azure.Provisioning.AppService.WebSiteSlotPrivateAccess FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlotPrivateAccess FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4537,7 +4537,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlotPublicCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlotPublicCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlotPublicCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.BinaryData> Blob { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -4546,7 +4546,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.PublicCertificateLocation> PublicCertificateLocation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ThumbprintString { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteSlotPublicCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlotPublicCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4584,7 +4584,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSlotSourceControl : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSlotSourceControl(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSlotSourceControl(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Branch { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.GitHubActionConfiguration> GitHubActionConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -4597,7 +4597,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.AppService.WebSiteSlot? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> RepoUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteSlotSourceControl FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSlotSourceControl FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -4635,7 +4635,7 @@ namespace Azure.Provisioning.AppService
     }
     public partial class WebSiteSourceControl : Azure.Provisioning.Primitives.Resource
     {
-        public WebSiteSourceControl(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebSiteSourceControl(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Branch { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.AppService.GitHubActionConfiguration> GitHubActionConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -4648,7 +4648,7 @@ namespace Azure.Provisioning.AppService
         public Azure.Provisioning.AppService.WebSite? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> RepoUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.AppService.WebSiteSourceControl FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.AppService.WebSiteSourceControl FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppCertificate.cs
@@ -186,10 +186,15 @@ public partial class AppCertificate : Resource
     /// <summary>
     /// Creates a new AppCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the AppCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppCertificate resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppCertificate.</param>
-    public AppCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/certificates", resourceVersion ?? "2024-04-01")
+    public AppCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/certificates", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -359,11 +364,16 @@ public partial class AppCertificate : Resource
     /// <summary>
     /// Creates a reference to an existing AppCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the AppCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppCertificate resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppCertificate.</param>
     /// <returns>The existing AppCertificate resource.</returns>
-    public static AppCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this AppCertificate resource.

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceCertificate.cs
@@ -81,10 +81,15 @@ public partial class AppServiceCertificate : Resource
     /// <summary>
     /// Creates a new AppServiceCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceCertificate resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceCertificate.</param>
-    public AppServiceCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.CertificateRegistration/certificateOrders/certificates", resourceVersion ?? "2024-04-01")
+    public AppServiceCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.CertificateRegistration/certificateOrders/certificates", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -187,9 +192,14 @@ public partial class AppServiceCertificate : Resource
     /// <summary>
     /// Creates a reference to an existing AppServiceCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceCertificate resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceCertificate.</param>
     /// <returns>The existing AppServiceCertificate resource.</returns>
-    public static AppServiceCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppServiceCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceCertificateOrder.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceCertificateOrder.cs
@@ -181,10 +181,15 @@ public partial class AppServiceCertificateOrder : Resource
     /// <summary>
     /// Creates a new AppServiceCertificateOrder.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceCertificateOrder.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceCertificateOrder
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceCertificateOrder.</param>
-    public AppServiceCertificateOrder(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.CertificateRegistration/certificateOrders", resourceVersion ?? "2024-04-01")
+    public AppServiceCertificateOrder(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.CertificateRegistration/certificateOrders", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -303,9 +308,14 @@ public partial class AppServiceCertificateOrder : Resource
     /// <summary>
     /// Creates a reference to an existing AppServiceCertificateOrder.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceCertificateOrder.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceCertificateOrder
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceCertificateOrder.</param>
     /// <returns>The existing AppServiceCertificateOrder resource.</returns>
-    public static AppServiceCertificateOrder FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppServiceCertificateOrder FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceDomain.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceDomain.cs
@@ -183,10 +183,15 @@ public partial class AppServiceDomain : Resource
     /// <summary>
     /// Creates a new AppServiceDomain.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceDomain.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceDomain resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceDomain.</param>
-    public AppServiceDomain(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DomainRegistration/domains", resourceVersion ?? "2024-04-01")
+    public AppServiceDomain(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DomainRegistration/domains", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -310,9 +315,14 @@ public partial class AppServiceDomain : Resource
     /// <summary>
     /// Creates a reference to an existing AppServiceDomain.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceDomain.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceDomain resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceDomain.</param>
     /// <returns>The existing AppServiceDomain resource.</returns>
-    public static AppServiceDomain FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppServiceDomain FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceEnvironment.cs
@@ -184,10 +184,15 @@ public partial class AppServiceEnvironment : Resource
     /// <summary>
     /// Creates a new AppServiceEnvironment.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceEnvironment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceEnvironment resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceEnvironment.</param>
-    public AppServiceEnvironment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/hostingEnvironments", resourceVersion ?? "2024-04-01")
+    public AppServiceEnvironment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/hostingEnvironments", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -381,9 +386,14 @@ public partial class AppServiceEnvironment : Resource
     /// <summary>
     /// Creates a reference to an existing AppServiceEnvironment.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceEnvironment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceEnvironment resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceEnvironment.</param>
     /// <returns>The existing AppServiceEnvironment resource.</returns>
-    public static AppServiceEnvironment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppServiceEnvironment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServicePlan.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServicePlan.cs
@@ -225,10 +225,15 @@ public partial class AppServicePlan : Resource
     /// <summary>
     /// Creates a new AppServicePlan.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServicePlan.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServicePlan resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServicePlan.</param>
-    public AppServicePlan(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/serverfarms", resourceVersion ?? "2024-04-01")
+    public AppServicePlan(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/serverfarms", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -412,11 +417,16 @@ public partial class AppServicePlan : Resource
     /// <summary>
     /// Creates a reference to an existing AppServicePlan.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServicePlan.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServicePlan resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServicePlan.</param>
     /// <returns>The existing AppServicePlan resource.</returns>
-    public static AppServicePlan FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppServicePlan FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this AppServicePlan resource.

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServicePlanVirtualNetworkConnectionGateway.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServicePlanVirtualNetworkConnectionGateway.cs
@@ -56,10 +56,16 @@ public partial class AppServicePlanVirtualNetworkConnectionGateway : Resource
     /// <summary>
     /// Creates a new AppServicePlanVirtualNetworkConnectionGateway.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServicePlanVirtualNetworkConnectionGateway.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// AppServicePlanVirtualNetworkConnectionGateway resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServicePlanVirtualNetworkConnectionGateway.</param>
-    public AppServicePlanVirtualNetworkConnectionGateway(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/serverfarms/virtualNetworkConnections/gateways", resourceVersion)
+    public AppServicePlanVirtualNetworkConnectionGateway(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/serverfarms/virtualNetworkConnections/gateways", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -73,9 +79,15 @@ public partial class AppServicePlanVirtualNetworkConnectionGateway : Resource
     /// Creates a reference to an existing
     /// AppServicePlanVirtualNetworkConnectionGateway.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServicePlanVirtualNetworkConnectionGateway.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// AppServicePlanVirtualNetworkConnectionGateway resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServicePlanVirtualNetworkConnectionGateway.</param>
     /// <returns>The existing AppServicePlanVirtualNetworkConnectionGateway resource.</returns>
-    public static AppServicePlanVirtualNetworkConnectionGateway FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppServicePlanVirtualNetworkConnectionGateway FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceSourceControl.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AppServiceSourceControl.cs
@@ -68,10 +68,15 @@ public partial class AppServiceSourceControl : Resource
     /// <summary>
     /// Creates a new AppServiceSourceControl.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceSourceControl.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceSourceControl resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceSourceControl.</param>
-    public AppServiceSourceControl(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sourcecontrols", resourceVersion ?? "2024-04-01")
+    public AppServiceSourceControl(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sourcecontrols", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _expireOn = BicepValue<DateTimeOffset>.DefineProperty(this, "ExpireOn", ["properties", "expirationTime"]);
@@ -222,9 +227,14 @@ public partial class AppServiceSourceControl : Resource
     /// <summary>
     /// Creates a reference to an existing AppServiceSourceControl.
     /// </summary>
-    /// <param name="resourceName">Name of the AppServiceSourceControl.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AppServiceSourceControl resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AppServiceSourceControl.</param>
     /// <returns>The existing AppServiceSourceControl resource.</returns>
-    public static AppServiceSourceControl FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AppServiceSourceControl FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AseV3NetworkingConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/AseV3NetworkingConfiguration.cs
@@ -101,10 +101,15 @@ public partial class AseV3NetworkingConfiguration : Resource
     /// <summary>
     /// Creates a new AseV3NetworkingConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the AseV3NetworkingConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AseV3NetworkingConfiguration
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AseV3NetworkingConfiguration.</param>
-    public AseV3NetworkingConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/hostingEnvironments/configurations", resourceVersion ?? "2024-04-01")
+    public AseV3NetworkingConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/hostingEnvironments/configurations", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _allowNewPrivateEndpointConnections = BicepValue<bool>.DefineProperty(this, "AllowNewPrivateEndpointConnections", ["properties", "allowNewPrivateEndpointConnections"]);
@@ -285,9 +290,14 @@ public partial class AseV3NetworkingConfiguration : Resource
     /// <summary>
     /// Creates a reference to an existing AseV3NetworkingConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the AseV3NetworkingConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AseV3NetworkingConfiguration
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AseV3NetworkingConfiguration.</param>
     /// <returns>The existing AseV3NetworkingConfiguration resource.</returns>
-    public static AseV3NetworkingConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AseV3NetworkingConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/CustomDnsSuffixConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/CustomDnsSuffixConfiguration.cs
@@ -85,10 +85,15 @@ public partial class CustomDnsSuffixConfiguration : Resource
     /// <summary>
     /// Creates a new CustomDnsSuffixConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the CustomDnsSuffixConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CustomDnsSuffixConfiguration
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CustomDnsSuffixConfiguration.</param>
-    public CustomDnsSuffixConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/hostingEnvironments/configurations", resourceVersion ?? "2024-04-01")
+    public CustomDnsSuffixConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/hostingEnvironments/configurations", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _certificateUri = BicepValue<Uri>.DefineProperty(this, "CertificateUri", ["properties", "certificateUrl"]);
@@ -266,9 +271,14 @@ public partial class CustomDnsSuffixConfiguration : Resource
     /// <summary>
     /// Creates a reference to an existing CustomDnsSuffixConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the CustomDnsSuffixConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CustomDnsSuffixConfiguration
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CustomDnsSuffixConfiguration.</param>
     /// <returns>The existing CustomDnsSuffixConfiguration resource.</returns>
-    public static CustomDnsSuffixConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CustomDnsSuffixConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/DomainOwnershipIdentifier.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/DomainOwnershipIdentifier.cs
@@ -56,10 +56,15 @@ public partial class DomainOwnershipIdentifier : Resource
     /// <summary>
     /// Creates a new DomainOwnershipIdentifier.
     /// </summary>
-    /// <param name="resourceName">Name of the DomainOwnershipIdentifier.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DomainOwnershipIdentifier
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DomainOwnershipIdentifier.</param>
-    public DomainOwnershipIdentifier(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DomainRegistration/domains/domainOwnershipIdentifiers", resourceVersion ?? "2024-04-01")
+    public DomainOwnershipIdentifier(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DomainRegistration/domains/domainOwnershipIdentifiers", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -163,9 +168,14 @@ public partial class DomainOwnershipIdentifier : Resource
     /// <summary>
     /// Creates a reference to an existing DomainOwnershipIdentifier.
     /// </summary>
-    /// <param name="resourceName">Name of the DomainOwnershipIdentifier.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DomainOwnershipIdentifier
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DomainOwnershipIdentifier.</param>
     /// <returns>The existing DomainOwnershipIdentifier resource.</returns>
-    public static DomainOwnershipIdentifier FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static DomainOwnershipIdentifier FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/HostingEnvironmentMultiRolePool.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/HostingEnvironmentMultiRolePool.cs
@@ -87,10 +87,15 @@ public partial class HostingEnvironmentMultiRolePool : Resource
     /// <summary>
     /// Creates a new HostingEnvironmentMultiRolePool.
     /// </summary>
-    /// <param name="resourceName">Name of the HostingEnvironmentMultiRolePool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the HostingEnvironmentMultiRolePool
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the HostingEnvironmentMultiRolePool.</param>
-    public HostingEnvironmentMultiRolePool(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/hostingEnvironments/multiRolePools", resourceVersion ?? "2024-04-01")
+    public HostingEnvironmentMultiRolePool(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/hostingEnvironments/multiRolePools", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _computeMode = BicepValue<ComputeModeOption>.DefineProperty(this, "ComputeMode", ["properties", "computeMode"]);
@@ -264,9 +269,14 @@ public partial class HostingEnvironmentMultiRolePool : Resource
     /// <summary>
     /// Creates a reference to an existing HostingEnvironmentMultiRolePool.
     /// </summary>
-    /// <param name="resourceName">Name of the HostingEnvironmentMultiRolePool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the HostingEnvironmentMultiRolePool
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the HostingEnvironmentMultiRolePool.</param>
     /// <returns>The existing HostingEnvironmentMultiRolePool resource.</returns>
-    public static HostingEnvironmentMultiRolePool FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static HostingEnvironmentMultiRolePool FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/HostingEnvironmentPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/HostingEnvironmentPrivateEndpointConnection.cs
@@ -76,10 +76,16 @@ public partial class HostingEnvironmentPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new HostingEnvironmentPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the HostingEnvironmentPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// HostingEnvironmentPrivateEndpointConnection resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the HostingEnvironmentPrivateEndpointConnection.</param>
-    public HostingEnvironmentPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/hostingEnvironments/privateEndpointConnections", resourceVersion ?? "2024-04-01")
+    public HostingEnvironmentPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/hostingEnvironments/privateEndpointConnections", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _iPAddresses = BicepList<IPAddress>.DefineProperty(this, "IPAddresses", ["properties", "ipAddresses"]);
@@ -257,9 +263,15 @@ public partial class HostingEnvironmentPrivateEndpointConnection : Resource
     /// Creates a reference to an existing
     /// HostingEnvironmentPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the HostingEnvironmentPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// HostingEnvironmentPrivateEndpointConnection resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the HostingEnvironmentPrivateEndpointConnection.</param>
     /// <returns>The existing HostingEnvironmentPrivateEndpointConnection resource.</returns>
-    public static HostingEnvironmentPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static HostingEnvironmentPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/HostingEnvironmentWorkerPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/HostingEnvironmentWorkerPool.cs
@@ -87,10 +87,15 @@ public partial class HostingEnvironmentWorkerPool : Resource
     /// <summary>
     /// Creates a new HostingEnvironmentWorkerPool.
     /// </summary>
-    /// <param name="resourceName">Name of the HostingEnvironmentWorkerPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the HostingEnvironmentWorkerPool
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the HostingEnvironmentWorkerPool.</param>
-    public HostingEnvironmentWorkerPool(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/hostingEnvironments/workerPools", resourceVersion ?? "2024-04-01")
+    public HostingEnvironmentWorkerPool(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/hostingEnvironments/workerPools", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _computeMode = BicepValue<ComputeModeOption>.DefineProperty(this, "ComputeMode", ["properties", "computeMode"]);
@@ -264,9 +269,14 @@ public partial class HostingEnvironmentWorkerPool : Resource
     /// <summary>
     /// Creates a reference to an existing HostingEnvironmentWorkerPool.
     /// </summary>
-    /// <param name="resourceName">Name of the HostingEnvironmentWorkerPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the HostingEnvironmentWorkerPool
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the HostingEnvironmentWorkerPool.</param>
     /// <returns>The existing HostingEnvironmentWorkerPool resource.</returns>
-    public static HostingEnvironmentWorkerPool FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static HostingEnvironmentWorkerPool FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/KubeEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/KubeEnvironment.cs
@@ -129,10 +129,15 @@ public partial class KubeEnvironment : Resource
     /// <summary>
     /// Creates a new KubeEnvironment.
     /// </summary>
-    /// <param name="resourceName">Name of the KubeEnvironment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KubeEnvironment resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KubeEnvironment.</param>
-    public KubeEnvironment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/kubeEnvironments", resourceVersion ?? "2021-03-01")
+    public KubeEnvironment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/kubeEnvironments", resourceVersion ?? "2021-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -167,9 +172,14 @@ public partial class KubeEnvironment : Resource
     /// <summary>
     /// Creates a reference to an existing KubeEnvironment.
     /// </summary>
-    /// <param name="resourceName">Name of the KubeEnvironment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KubeEnvironment resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KubeEnvironment.</param>
     /// <returns>The existing KubeEnvironment resource.</returns>
-    public static KubeEnvironment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static KubeEnvironment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/LogsSiteConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/LogsSiteConfig.cs
@@ -76,10 +76,15 @@ public partial class LogsSiteConfig : Resource
     /// <summary>
     /// Creates a new LogsSiteConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the LogsSiteConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LogsSiteConfig resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogsSiteConfig.</param>
-    public LogsSiteConfig(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/config", resourceVersion ?? "2024-04-01")
+    public LogsSiteConfig(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/config", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _applicationLogs = BicepValue<ApplicationLogsConfig>.DefineProperty(this, "ApplicationLogs", ["properties", "applicationLogs"]);
@@ -256,9 +261,14 @@ public partial class LogsSiteConfig : Resource
     /// <summary>
     /// Creates a reference to an existing LogsSiteConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the LogsSiteConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LogsSiteConfig resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogsSiteConfig.</param>
     /// <returns>The existing LogsSiteConfig resource.</returns>
-    public static LogsSiteConfig FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static LogsSiteConfig FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/LogsSiteSlotConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/LogsSiteSlotConfig.cs
@@ -76,10 +76,15 @@ public partial class LogsSiteSlotConfig : Resource
     /// <summary>
     /// Creates a new LogsSiteSlotConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the LogsSiteSlotConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LogsSiteSlotConfig resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogsSiteSlotConfig.</param>
-    public LogsSiteSlotConfig(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/config", resourceVersion ?? "2024-04-01")
+    public LogsSiteSlotConfig(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/config", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _applicationLogs = BicepValue<ApplicationLogsConfig>.DefineProperty(this, "ApplicationLogs", ["properties", "applicationLogs"]);
@@ -256,9 +261,14 @@ public partial class LogsSiteSlotConfig : Resource
     /// <summary>
     /// Creates a reference to an existing LogsSiteSlotConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the LogsSiteSlotConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LogsSiteSlotConfig resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogsSiteSlotConfig.</param>
     /// <returns>The existing LogsSiteSlotConfig resource.</returns>
-    public static LogsSiteSlotConfig FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static LogsSiteSlotConfig FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/PublishingUser.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/PublishingUser.cs
@@ -74,10 +74,15 @@ public partial class PublishingUser : Resource
     /// <summary>
     /// Creates a new PublishingUser.
     /// </summary>
-    /// <param name="resourceName">Name of the PublishingUser.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PublishingUser resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PublishingUser.</param>
-    public PublishingUser(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/publishingUsers", resourceVersion ?? "2024-04-01")
+    public PublishingUser(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/publishingUsers", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -229,9 +234,14 @@ public partial class PublishingUser : Resource
     /// <summary>
     /// Creates a reference to an existing PublishingUser.
     /// </summary>
-    /// <param name="resourceName">Name of the PublishingUser.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PublishingUser resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PublishingUser.</param>
     /// <returns>The existing PublishingUser resource.</returns>
-    public static PublishingUser FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PublishingUser FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/ScmSiteBasicPublishingCredentialsPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/ScmSiteBasicPublishingCredentialsPolicy.cs
@@ -57,10 +57,15 @@ public partial class ScmSiteBasicPublishingCredentialsPolicy : Resource
     /// <summary>
     /// Creates a new ScmSiteBasicPublishingCredentialsPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ScmSiteBasicPublishingCredentialsPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ScmSiteBasicPublishingCredentialsPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ScmSiteBasicPublishingCredentialsPolicy.</param>
-    public ScmSiteBasicPublishingCredentialsPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/basicPublishingCredentialsPolicies", resourceVersion ?? "2024-04-01")
+    public ScmSiteBasicPublishingCredentialsPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/basicPublishingCredentialsPolicies", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _allow = BicepValue<bool>.DefineProperty(this, "Allow", ["properties", "allow"]);
@@ -235,9 +240,14 @@ public partial class ScmSiteBasicPublishingCredentialsPolicy : Resource
     /// Creates a reference to an existing
     /// ScmSiteBasicPublishingCredentialsPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ScmSiteBasicPublishingCredentialsPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ScmSiteBasicPublishingCredentialsPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ScmSiteBasicPublishingCredentialsPolicy.</param>
     /// <returns>The existing ScmSiteBasicPublishingCredentialsPolicy resource.</returns>
-    public static ScmSiteBasicPublishingCredentialsPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ScmSiteBasicPublishingCredentialsPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/ScmSiteSlotBasicPublishingCredentialsPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/ScmSiteSlotBasicPublishingCredentialsPolicy.cs
@@ -57,10 +57,16 @@ public partial class ScmSiteSlotBasicPublishingCredentialsPolicy : Resource
     /// <summary>
     /// Creates a new ScmSiteSlotBasicPublishingCredentialsPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ScmSiteSlotBasicPublishingCredentialsPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ScmSiteSlotBasicPublishingCredentialsPolicy resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ScmSiteSlotBasicPublishingCredentialsPolicy.</param>
-    public ScmSiteSlotBasicPublishingCredentialsPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies", resourceVersion ?? "2024-04-01")
+    public ScmSiteSlotBasicPublishingCredentialsPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _allow = BicepValue<bool>.DefineProperty(this, "Allow", ["properties", "allow"]);
@@ -235,9 +241,15 @@ public partial class ScmSiteSlotBasicPublishingCredentialsPolicy : Resource
     /// Creates a reference to an existing
     /// ScmSiteSlotBasicPublishingCredentialsPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ScmSiteSlotBasicPublishingCredentialsPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ScmSiteSlotBasicPublishingCredentialsPolicy resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ScmSiteSlotBasicPublishingCredentialsPolicy.</param>
     /// <returns>The existing ScmSiteSlotBasicPublishingCredentialsPolicy resource.</returns>
-    public static ScmSiteSlotBasicPublishingCredentialsPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ScmSiteSlotBasicPublishingCredentialsPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteContainer.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteContainer.cs
@@ -124,10 +124,15 @@ public partial class SiteContainer : Resource
     /// <summary>
     /// Creates a new SiteContainer.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteContainer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteContainer resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteContainer.</param>
-    public SiteContainer(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/sitecontainers", resourceVersion ?? "2024-04-01")
+    public SiteContainer(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/sitecontainers", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _authType = BicepValue<SiteContainerAuthType>.DefineProperty(this, "AuthType", ["properties", "authType"]);
@@ -312,9 +317,14 @@ public partial class SiteContainer : Resource
     /// <summary>
     /// Creates a reference to an existing SiteContainer.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteContainer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteContainer resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteContainer.</param>
     /// <returns>The existing SiteContainer resource.</returns>
-    public static SiteContainer FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteContainer FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteDeployment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteDeployment.cs
@@ -98,10 +98,15 @@ public partial class SiteDeployment : Resource
     /// <summary>
     /// Creates a new SiteDeployment.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteDeployment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteDeployment resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteDeployment.</param>
-    public SiteDeployment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/deployments", resourceVersion ?? "2024-04-01")
+    public SiteDeployment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/deployments", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _author = BicepValue<string>.DefineProperty(this, "Author", ["properties", "author"]);
@@ -282,9 +287,14 @@ public partial class SiteDeployment : Resource
     /// <summary>
     /// Creates a reference to an existing SiteDeployment.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteDeployment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteDeployment resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteDeployment.</param>
     /// <returns>The existing SiteDeployment resource.</returns>
-    public static SiteDeployment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteDeployment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteDomainOwnershipIdentifier.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteDomainOwnershipIdentifier.cs
@@ -56,10 +56,15 @@ public partial class SiteDomainOwnershipIdentifier : Resource
     /// <summary>
     /// Creates a new SiteDomainOwnershipIdentifier.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteDomainOwnershipIdentifier.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteDomainOwnershipIdentifier
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteDomainOwnershipIdentifier.</param>
-    public SiteDomainOwnershipIdentifier(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/domainOwnershipIdentifiers", resourceVersion ?? "2024-04-01")
+    public SiteDomainOwnershipIdentifier(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/domainOwnershipIdentifiers", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -233,9 +238,14 @@ public partial class SiteDomainOwnershipIdentifier : Resource
     /// <summary>
     /// Creates a reference to an existing SiteDomainOwnershipIdentifier.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteDomainOwnershipIdentifier.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteDomainOwnershipIdentifier
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteDomainOwnershipIdentifier.</param>
     /// <returns>The existing SiteDomainOwnershipIdentifier resource.</returns>
-    public static SiteDomainOwnershipIdentifier FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteDomainOwnershipIdentifier FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteExtension.cs
@@ -129,10 +129,15 @@ public partial class SiteExtension : Resource
     /// <summary>
     /// Creates a new SiteExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteExtension resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteExtension.</param>
-    public SiteExtension(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/extensions", resourceVersion ?? "2024-04-01")
+    public SiteExtension(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/extensions", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _connectionString = BicepValue<string>.DefineProperty(this, "ConnectionString", ["properties", "connectionString"]);
@@ -317,9 +322,14 @@ public partial class SiteExtension : Resource
     /// <summary>
     /// Creates a reference to an existing SiteExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteExtension resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteExtension.</param>
     /// <returns>The existing SiteExtension resource.</returns>
-    public static SiteExtension FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteExtension FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteFunction.cs
@@ -142,10 +142,15 @@ public partial class SiteFunction : Resource
     /// <summary>
     /// Creates a new SiteFunction.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteFunction.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteFunction resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteFunction.</param>
-    public SiteFunction(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/functions", resourceVersion ?? "2024-04-01")
+    public SiteFunction(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/functions", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _config = BicepValue<BinaryData>.DefineProperty(this, "Config", ["properties", "config"]);
@@ -331,9 +336,14 @@ public partial class SiteFunction : Resource
     /// <summary>
     /// Creates a reference to an existing SiteFunction.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteFunction.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteFunction resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteFunction.</param>
     /// <returns>The existing SiteFunction resource.</returns>
-    public static SiteFunction FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteFunction FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteHostNameBinding.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteHostNameBinding.cs
@@ -104,10 +104,15 @@ public partial class SiteHostNameBinding : Resource
     /// <summary>
     /// Creates a new SiteHostNameBinding.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteHostNameBinding.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteHostNameBinding resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteHostNameBinding.</param>
-    public SiteHostNameBinding(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/hostNameBindings", resourceVersion ?? "2024-04-01")
+    public SiteHostNameBinding(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/hostNameBindings", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _azureResourceName = BicepValue<string>.DefineProperty(this, "AzureResourceName", ["properties", "azureResourceName"]);
@@ -254,9 +259,14 @@ public partial class SiteHostNameBinding : Resource
     /// <summary>
     /// Creates a reference to an existing SiteHostNameBinding.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteHostNameBinding.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteHostNameBinding resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteHostNameBinding.</param>
     /// <returns>The existing SiteHostNameBinding resource.</returns>
-    public static SiteHostNameBinding FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteHostNameBinding FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteHybridConnectionNamespaceRelay.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteHybridConnectionNamespaceRelay.cs
@@ -96,10 +96,15 @@ public partial class SiteHybridConnectionNamespaceRelay : Resource
     /// <summary>
     /// Creates a new SiteHybridConnectionNamespaceRelay.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteHybridConnectionNamespaceRelay.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteHybridConnectionNamespaceRelay
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteHybridConnectionNamespaceRelay.</param>
-    public SiteHybridConnectionNamespaceRelay(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/hybridConnectionNamespaces/relays", resourceVersion)
+    public SiteHybridConnectionNamespaceRelay(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/hybridConnectionNamespaces/relays", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _relayName = BicepValue<string>.DefineProperty(this, "RelayName", ["properties", "relayName"], isRequired: true);
@@ -118,9 +123,14 @@ public partial class SiteHybridConnectionNamespaceRelay : Resource
     /// <summary>
     /// Creates a reference to an existing SiteHybridConnectionNamespaceRelay.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteHybridConnectionNamespaceRelay.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteHybridConnectionNamespaceRelay
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteHybridConnectionNamespaceRelay.</param>
     /// <returns>The existing SiteHybridConnectionNamespaceRelay resource.</returns>
-    public static SiteHybridConnectionNamespaceRelay FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteHybridConnectionNamespaceRelay FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteInstanceExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteInstanceExtension.cs
@@ -123,10 +123,15 @@ public partial class SiteInstanceExtension : Resource
     /// <summary>
     /// Creates a new SiteInstanceExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteInstanceExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteInstanceExtension resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteInstanceExtension.</param>
-    public SiteInstanceExtension(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/instances/extensions", resourceVersion)
+    public SiteInstanceExtension(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/instances/extensions", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _connectionString = BicepValue<string>.DefineProperty(this, "ConnectionString", ["properties", "connectionString"]);
@@ -149,9 +154,14 @@ public partial class SiteInstanceExtension : Resource
     /// <summary>
     /// Creates a reference to an existing SiteInstanceExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteInstanceExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteInstanceExtension resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteInstanceExtension.</param>
     /// <returns>The existing SiteInstanceExtension resource.</returns>
-    public static SiteInstanceExtension FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteInstanceExtension FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteNetworkConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteNetworkConfig.cs
@@ -65,10 +65,15 @@ public partial class SiteNetworkConfig : Resource
     /// <summary>
     /// Creates a new SiteNetworkConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteNetworkConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteNetworkConfig resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteNetworkConfig.</param>
-    public SiteNetworkConfig(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/networkConfig", resourceVersion ?? "2024-04-01")
+    public SiteNetworkConfig(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/networkConfig", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isSwiftSupported = BicepValue<bool>.DefineProperty(this, "IsSwiftSupported", ["properties", "swiftSupported"]);
@@ -208,9 +213,14 @@ public partial class SiteNetworkConfig : Resource
     /// <summary>
     /// Creates a reference to an existing SiteNetworkConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteNetworkConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteNetworkConfig resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteNetworkConfig.</param>
     /// <returns>The existing SiteNetworkConfig resource.</returns>
-    public static SiteNetworkConfig FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteNetworkConfig FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SitePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SitePrivateEndpointConnection.cs
@@ -77,10 +77,15 @@ public partial class SitePrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new SitePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SitePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SitePrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SitePrivateEndpointConnection.</param>
-    public SitePrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/privateEndpointConnections", resourceVersion ?? "2024-04-01")
+    public SitePrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/privateEndpointConnections", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _iPAddresses = BicepList<IPAddress>.DefineProperty(this, "IPAddresses", ["properties", "ipAddresses"]);
@@ -257,11 +262,16 @@ public partial class SitePrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing SitePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SitePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SitePrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SitePrivateEndpointConnection.</param>
     /// <returns>The existing SitePrivateEndpointConnection resource.</returns>
-    public static SitePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SitePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SitePrivateEndpointConnection

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SitePublicCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SitePublicCertificate.cs
@@ -68,10 +68,15 @@ public partial class SitePublicCertificate : Resource
     /// <summary>
     /// Creates a new SitePublicCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the SitePublicCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SitePublicCertificate resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SitePublicCertificate.</param>
-    public SitePublicCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/publicCertificates", resourceVersion ?? "2024-04-01")
+    public SitePublicCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/publicCertificates", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _blob = BicepValue<BinaryData>.DefineProperty(this, "Blob", ["properties", "blob"]);
@@ -247,9 +252,14 @@ public partial class SitePublicCertificate : Resource
     /// <summary>
     /// Creates a reference to an existing SitePublicCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the SitePublicCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SitePublicCertificate resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SitePublicCertificate.</param>
     /// <returns>The existing SitePublicCertificate resource.</returns>
-    public static SitePublicCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SitePublicCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotDeployment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotDeployment.cs
@@ -98,10 +98,15 @@ public partial class SiteSlotDeployment : Resource
     /// <summary>
     /// Creates a new SiteSlotDeployment.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotDeployment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotDeployment resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotDeployment.</param>
-    public SiteSlotDeployment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/deployments", resourceVersion ?? "2024-04-01")
+    public SiteSlotDeployment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/deployments", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _author = BicepValue<string>.DefineProperty(this, "Author", ["properties", "author"]);
@@ -282,9 +287,14 @@ public partial class SiteSlotDeployment : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotDeployment.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotDeployment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotDeployment resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotDeployment.</param>
     /// <returns>The existing SiteSlotDeployment resource.</returns>
-    public static SiteSlotDeployment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotDeployment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotDomainOwnershipIdentifier.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotDomainOwnershipIdentifier.cs
@@ -56,10 +56,15 @@ public partial class SiteSlotDomainOwnershipIdentifier : Resource
     /// <summary>
     /// Creates a new SiteSlotDomainOwnershipIdentifier.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotDomainOwnershipIdentifier.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotDomainOwnershipIdentifier
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotDomainOwnershipIdentifier.</param>
-    public SiteSlotDomainOwnershipIdentifier(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/domainOwnershipIdentifiers", resourceVersion ?? "2024-04-01")
+    public SiteSlotDomainOwnershipIdentifier(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/domainOwnershipIdentifiers", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -233,9 +238,14 @@ public partial class SiteSlotDomainOwnershipIdentifier : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotDomainOwnershipIdentifier.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotDomainOwnershipIdentifier.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotDomainOwnershipIdentifier
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotDomainOwnershipIdentifier.</param>
     /// <returns>The existing SiteSlotDomainOwnershipIdentifier resource.</returns>
-    public static SiteSlotDomainOwnershipIdentifier FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotDomainOwnershipIdentifier FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotExtension.cs
@@ -129,10 +129,15 @@ public partial class SiteSlotExtension : Resource
     /// <summary>
     /// Creates a new SiteSlotExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotExtension resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotExtension.</param>
-    public SiteSlotExtension(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/extensions", resourceVersion ?? "2024-04-01")
+    public SiteSlotExtension(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/extensions", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _connectionString = BicepValue<string>.DefineProperty(this, "ConnectionString", ["properties", "connectionString"]);
@@ -317,9 +322,14 @@ public partial class SiteSlotExtension : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotExtension resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotExtension.</param>
     /// <returns>The existing SiteSlotExtension resource.</returns>
-    public static SiteSlotExtension FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotExtension FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotFunction.cs
@@ -142,10 +142,15 @@ public partial class SiteSlotFunction : Resource
     /// <summary>
     /// Creates a new SiteSlotFunction.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotFunction.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotFunction resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotFunction.</param>
-    public SiteSlotFunction(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/functions", resourceVersion ?? "2024-04-01")
+    public SiteSlotFunction(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/functions", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _config = BicepValue<BinaryData>.DefineProperty(this, "Config", ["properties", "config"]);
@@ -331,9 +336,14 @@ public partial class SiteSlotFunction : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotFunction.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotFunction.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotFunction resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotFunction.</param>
     /// <returns>The existing SiteSlotFunction resource.</returns>
-    public static SiteSlotFunction FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotFunction FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotHostNameBinding.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotHostNameBinding.cs
@@ -104,10 +104,15 @@ public partial class SiteSlotHostNameBinding : Resource
     /// <summary>
     /// Creates a new SiteSlotHostNameBinding.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotHostNameBinding.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotHostNameBinding resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotHostNameBinding.</param>
-    public SiteSlotHostNameBinding(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/hostNameBindings", resourceVersion ?? "2024-04-01")
+    public SiteSlotHostNameBinding(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/hostNameBindings", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _azureResourceName = BicepValue<string>.DefineProperty(this, "AzureResourceName", ["properties", "azureResourceName"]);
@@ -254,9 +259,14 @@ public partial class SiteSlotHostNameBinding : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotHostNameBinding.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotHostNameBinding.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotHostNameBinding resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotHostNameBinding.</param>
     /// <returns>The existing SiteSlotHostNameBinding resource.</returns>
-    public static SiteSlotHostNameBinding FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotHostNameBinding FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotHybridConnectionNamespaceRelay.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotHybridConnectionNamespaceRelay.cs
@@ -96,10 +96,15 @@ public partial class SiteSlotHybridConnectionNamespaceRelay : Resource
     /// <summary>
     /// Creates a new SiteSlotHybridConnectionNamespaceRelay.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotHybridConnectionNamespaceRelay.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SiteSlotHybridConnectionNamespaceRelay resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotHybridConnectionNamespaceRelay.</param>
-    public SiteSlotHybridConnectionNamespaceRelay(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays", resourceVersion)
+    public SiteSlotHybridConnectionNamespaceRelay(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _relayName = BicepValue<string>.DefineProperty(this, "RelayName", ["properties", "relayName"], isRequired: true);
@@ -119,9 +124,14 @@ public partial class SiteSlotHybridConnectionNamespaceRelay : Resource
     /// Creates a reference to an existing
     /// SiteSlotHybridConnectionNamespaceRelay.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotHybridConnectionNamespaceRelay.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SiteSlotHybridConnectionNamespaceRelay resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotHybridConnectionNamespaceRelay.</param>
     /// <returns>The existing SiteSlotHybridConnectionNamespaceRelay resource.</returns>
-    public static SiteSlotHybridConnectionNamespaceRelay FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotHybridConnectionNamespaceRelay FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotInstanceExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotInstanceExtension.cs
@@ -123,10 +123,15 @@ public partial class SiteSlotInstanceExtension : Resource
     /// <summary>
     /// Creates a new SiteSlotInstanceExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotInstanceExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotInstanceExtension
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotInstanceExtension.</param>
-    public SiteSlotInstanceExtension(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/instances/extensions", resourceVersion)
+    public SiteSlotInstanceExtension(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/instances/extensions", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _connectionString = BicepValue<string>.DefineProperty(this, "ConnectionString", ["properties", "connectionString"]);
@@ -149,9 +154,14 @@ public partial class SiteSlotInstanceExtension : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotInstanceExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotInstanceExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotInstanceExtension
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotInstanceExtension.</param>
     /// <returns>The existing SiteSlotInstanceExtension resource.</returns>
-    public static SiteSlotInstanceExtension FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotInstanceExtension FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotNetworkConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotNetworkConfig.cs
@@ -65,10 +65,15 @@ public partial class SiteSlotNetworkConfig : Resource
     /// <summary>
     /// Creates a new SiteSlotNetworkConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotNetworkConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotNetworkConfig resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotNetworkConfig.</param>
-    public SiteSlotNetworkConfig(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/networkConfig", resourceVersion ?? "2024-04-01")
+    public SiteSlotNetworkConfig(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/networkConfig", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isSwiftSupported = BicepValue<bool>.DefineProperty(this, "IsSwiftSupported", ["properties", "swiftSupported"]);
@@ -208,9 +213,14 @@ public partial class SiteSlotNetworkConfig : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotNetworkConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotNetworkConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotNetworkConfig resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotNetworkConfig.</param>
     /// <returns>The existing SiteSlotNetworkConfig resource.</returns>
-    public static SiteSlotNetworkConfig FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotNetworkConfig FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotPrivateEndpointConnection.cs
@@ -76,10 +76,15 @@ public partial class SiteSlotPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new SiteSlotPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotPrivateEndpointConnection.</param>
-    public SiteSlotPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/privateEndpointConnections", resourceVersion ?? "2024-04-01")
+    public SiteSlotPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/privateEndpointConnections", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _iPAddresses = BicepList<IPAddress>.DefineProperty(this, "IPAddresses", ["properties", "ipAddresses"]);
@@ -256,9 +261,14 @@ public partial class SiteSlotPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotPrivateEndpointConnection.</param>
     /// <returns>The existing SiteSlotPrivateEndpointConnection resource.</returns>
-    public static SiteSlotPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotSiteContainer.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotSiteContainer.cs
@@ -124,10 +124,15 @@ public partial class SiteSlotSiteContainer : Resource
     /// <summary>
     /// Creates a new SiteSlotSiteContainer.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotSiteContainer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotSiteContainer resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotSiteContainer.</param>
-    public SiteSlotSiteContainer(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/sitecontainers", resourceVersion ?? "2024-04-01")
+    public SiteSlotSiteContainer(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/sitecontainers", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _authType = BicepValue<SiteContainerAuthType>.DefineProperty(this, "AuthType", ["properties", "authType"]);
@@ -312,9 +317,14 @@ public partial class SiteSlotSiteContainer : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotSiteContainer.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotSiteContainer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotSiteContainer resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotSiteContainer.</param>
     /// <returns>The existing SiteSlotSiteContainer resource.</returns>
-    public static SiteSlotSiteContainer FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotSiteContainer FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotVirtualNetworkConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotVirtualNetworkConnection.cs
@@ -96,10 +96,15 @@ public partial class SiteSlotVirtualNetworkConnection : Resource
     /// <summary>
     /// Creates a new SiteSlotVirtualNetworkConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotVirtualNetworkConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotVirtualNetworkConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotVirtualNetworkConnection.</param>
-    public SiteSlotVirtualNetworkConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/virtualNetworkConnections", resourceVersion ?? "2024-04-01")
+    public SiteSlotVirtualNetworkConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/virtualNetworkConnections", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _certBlob = BicepValue<string>.DefineProperty(this, "CertBlob", ["properties", "certBlob"]);
@@ -279,9 +284,14 @@ public partial class SiteSlotVirtualNetworkConnection : Resource
     /// <summary>
     /// Creates a reference to an existing SiteSlotVirtualNetworkConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotVirtualNetworkConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteSlotVirtualNetworkConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotVirtualNetworkConnection.</param>
     /// <returns>The existing SiteSlotVirtualNetworkConnection resource.</returns>
-    public static SiteSlotVirtualNetworkConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotVirtualNetworkConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotVirtualNetworkConnectionGateway.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteSlotVirtualNetworkConnectionGateway.cs
@@ -63,10 +63,15 @@ public partial class SiteSlotVirtualNetworkConnectionGateway : Resource
     /// <summary>
     /// Creates a new SiteSlotVirtualNetworkConnectionGateway.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotVirtualNetworkConnectionGateway.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SiteSlotVirtualNetworkConnectionGateway resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotVirtualNetworkConnectionGateway.</param>
-    public SiteSlotVirtualNetworkConnectionGateway(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/virtualNetworkConnections/gateways", resourceVersion ?? "2024-04-01")
+    public SiteSlotVirtualNetworkConnectionGateway(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/virtualNetworkConnections/gateways", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -242,9 +247,14 @@ public partial class SiteSlotVirtualNetworkConnectionGateway : Resource
     /// Creates a reference to an existing
     /// SiteSlotVirtualNetworkConnectionGateway.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteSlotVirtualNetworkConnectionGateway.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SiteSlotVirtualNetworkConnectionGateway resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteSlotVirtualNetworkConnectionGateway.</param>
     /// <returns>The existing SiteSlotVirtualNetworkConnectionGateway resource.</returns>
-    public static SiteSlotVirtualNetworkConnectionGateway FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteSlotVirtualNetworkConnectionGateway FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteVirtualNetworkConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteVirtualNetworkConnection.cs
@@ -96,10 +96,15 @@ public partial class SiteVirtualNetworkConnection : Resource
     /// <summary>
     /// Creates a new SiteVirtualNetworkConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteVirtualNetworkConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteVirtualNetworkConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteVirtualNetworkConnection.</param>
-    public SiteVirtualNetworkConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/virtualNetworkConnections", resourceVersion ?? "2024-04-01")
+    public SiteVirtualNetworkConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/virtualNetworkConnections", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _certBlob = BicepValue<string>.DefineProperty(this, "CertBlob", ["properties", "certBlob"]);
@@ -279,9 +284,14 @@ public partial class SiteVirtualNetworkConnection : Resource
     /// <summary>
     /// Creates a reference to an existing SiteVirtualNetworkConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteVirtualNetworkConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SiteVirtualNetworkConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteVirtualNetworkConnection.</param>
     /// <returns>The existing SiteVirtualNetworkConnection resource.</returns>
-    public static SiteVirtualNetworkConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteVirtualNetworkConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteVirtualNetworkConnectionGateway.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SiteVirtualNetworkConnectionGateway.cs
@@ -63,10 +63,15 @@ public partial class SiteVirtualNetworkConnectionGateway : Resource
     /// <summary>
     /// Creates a new SiteVirtualNetworkConnectionGateway.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteVirtualNetworkConnectionGateway.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SiteVirtualNetworkConnectionGateway resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteVirtualNetworkConnectionGateway.</param>
-    public SiteVirtualNetworkConnectionGateway(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/virtualNetworkConnections/gateways", resourceVersion ?? "2024-04-01")
+    public SiteVirtualNetworkConnectionGateway(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/virtualNetworkConnections/gateways", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -241,9 +246,14 @@ public partial class SiteVirtualNetworkConnectionGateway : Resource
     /// <summary>
     /// Creates a reference to an existing SiteVirtualNetworkConnectionGateway.
     /// </summary>
-    /// <param name="resourceName">Name of the SiteVirtualNetworkConnectionGateway.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SiteVirtualNetworkConnectionGateway resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SiteVirtualNetworkConnectionGateway.</param>
     /// <returns>The existing SiteVirtualNetworkConnectionGateway resource.</returns>
-    public static SiteVirtualNetworkConnectionGateway FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SiteVirtualNetworkConnectionGateway FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SlotConfigNames.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/SlotConfigNames.cs
@@ -69,10 +69,15 @@ public partial class SlotConfigNames : Resource
     /// <summary>
     /// Creates a new SlotConfigNames.
     /// </summary>
-    /// <param name="resourceName">Name of the SlotConfigNames.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SlotConfigNames resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SlotConfigNames.</param>
-    public SlotConfigNames(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/config", resourceVersion ?? "2024-04-01")
+    public SlotConfigNames(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/config", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _appSettingNames = BicepList<string>.DefineProperty(this, "AppSettingNames", ["properties", "appSettingNames"]);
@@ -248,9 +253,14 @@ public partial class SlotConfigNames : Resource
     /// <summary>
     /// Creates a reference to an existing SlotConfigNames.
     /// </summary>
-    /// <param name="resourceName">Name of the SlotConfigNames.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SlotConfigNames resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SlotConfigNames.</param>
     /// <returns>The existing SlotConfigNames resource.</returns>
-    public static SlotConfigNames FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SlotConfigNames FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSite.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSite.cs
@@ -186,10 +186,15 @@ public partial class StaticSite : Resource
     /// <summary>
     /// Creates a new StaticSite.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSite.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSite resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSite.</param>
-    public StaticSite(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites", resourceVersion ?? "2024-04-01")
+    public StaticSite(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -298,9 +303,14 @@ public partial class StaticSite : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSite.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSite.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSite resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSite.</param>
     /// <returns>The existing StaticSite resource.</returns>
-    public static StaticSite FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSite FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteBasicAuthProperty.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteBasicAuthProperty.cs
@@ -83,10 +83,15 @@ public partial class StaticSiteBasicAuthProperty : Resource
     /// <summary>
     /// Creates a new StaticSiteBasicAuthProperty.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteBasicAuthProperty.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteBasicAuthProperty
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteBasicAuthProperty.</param>
-    public StaticSiteBasicAuthProperty(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/basicAuth", resourceVersion ?? "2024-04-01")
+    public StaticSiteBasicAuthProperty(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/basicAuth", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _applicableEnvironmentsMode = BicepValue<string>.DefineProperty(this, "ApplicableEnvironmentsMode", ["properties", "applicableEnvironmentsMode"]);
@@ -179,9 +184,14 @@ public partial class StaticSiteBasicAuthProperty : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSiteBasicAuthProperty.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteBasicAuthProperty.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteBasicAuthProperty
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteBasicAuthProperty.</param>
     /// <returns>The existing StaticSiteBasicAuthProperty resource.</returns>
-    public static StaticSiteBasicAuthProperty FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSiteBasicAuthProperty FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteBuildDatabaseConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteBuildDatabaseConnection.cs
@@ -79,10 +79,15 @@ public partial class StaticSiteBuildDatabaseConnection : Resource
     /// <summary>
     /// Creates a new StaticSiteBuildDatabaseConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteBuildDatabaseConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteBuildDatabaseConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteBuildDatabaseConnection.</param>
-    public StaticSiteBuildDatabaseConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/builds/databaseConnections", resourceVersion ?? "2024-04-01")
+    public StaticSiteBuildDatabaseConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/builds/databaseConnections", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionIdentity = BicepValue<string>.DefineProperty(this, "ConnectionIdentity", ["properties", "connectionIdentity"]);
@@ -174,9 +179,14 @@ public partial class StaticSiteBuildDatabaseConnection : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSiteBuildDatabaseConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteBuildDatabaseConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteBuildDatabaseConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteBuildDatabaseConnection.</param>
     /// <returns>The existing StaticSiteBuildDatabaseConnection resource.</returns>
-    public static StaticSiteBuildDatabaseConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSiteBuildDatabaseConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteBuildLinkedBackend.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteBuildLinkedBackend.cs
@@ -68,10 +68,15 @@ public partial class StaticSiteBuildLinkedBackend : Resource
     /// <summary>
     /// Creates a new StaticSiteBuildLinkedBackend.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteBuildLinkedBackend.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteBuildLinkedBackend
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteBuildLinkedBackend.</param>
-    public StaticSiteBuildLinkedBackend(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/builds/linkedBackends", resourceVersion ?? "2024-04-01")
+    public StaticSiteBuildLinkedBackend(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/builds/linkedBackends", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _backendResourceId = BicepValue<ResourceIdentifier>.DefineProperty(this, "BackendResourceId", ["properties", "backendResourceId"]);
@@ -162,9 +167,14 @@ public partial class StaticSiteBuildLinkedBackend : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSiteBuildLinkedBackend.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteBuildLinkedBackend.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteBuildLinkedBackend
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteBuildLinkedBackend.</param>
     /// <returns>The existing StaticSiteBuildLinkedBackend resource.</returns>
-    public static StaticSiteBuildLinkedBackend FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSiteBuildLinkedBackend FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteBuildUserProvidedFunctionApp.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteBuildUserProvidedFunctionApp.cs
@@ -63,10 +63,15 @@ public partial class StaticSiteBuildUserProvidedFunctionApp : Resource
     /// <summary>
     /// Creates a new StaticSiteBuildUserProvidedFunctionApp.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteBuildUserProvidedFunctionApp.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// StaticSiteBuildUserProvidedFunctionApp resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteBuildUserProvidedFunctionApp.</param>
-    public StaticSiteBuildUserProvidedFunctionApp(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/builds/userProvidedFunctionApps", resourceVersion ?? "2024-04-01")
+    public StaticSiteBuildUserProvidedFunctionApp(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/builds/userProvidedFunctionApps", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _functionAppRegion = BicepValue<string>.DefineProperty(this, "FunctionAppRegion", ["properties", "functionAppRegion"]);
@@ -137,9 +142,14 @@ public partial class StaticSiteBuildUserProvidedFunctionApp : Resource
     /// Creates a reference to an existing
     /// StaticSiteBuildUserProvidedFunctionApp.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteBuildUserProvidedFunctionApp.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// StaticSiteBuildUserProvidedFunctionApp resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteBuildUserProvidedFunctionApp.</param>
     /// <returns>The existing StaticSiteBuildUserProvidedFunctionApp resource.</returns>
-    public static StaticSiteBuildUserProvidedFunctionApp FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSiteBuildUserProvidedFunctionApp FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteCustomDomainOverview.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteCustomDomainOverview.cs
@@ -87,10 +87,15 @@ public partial class StaticSiteCustomDomainOverview : Resource
     /// <summary>
     /// Creates a new StaticSiteCustomDomainOverview.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteCustomDomainOverview.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteCustomDomainOverview
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteCustomDomainOverview.</param>
-    public StaticSiteCustomDomainOverview(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/customDomains", resourceVersion ?? "2024-04-01")
+    public StaticSiteCustomDomainOverview(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/customDomains", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -184,9 +189,14 @@ public partial class StaticSiteCustomDomainOverview : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSiteCustomDomainOverview.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteCustomDomainOverview.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteCustomDomainOverview
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteCustomDomainOverview.</param>
     /// <returns>The existing StaticSiteCustomDomainOverview resource.</returns>
-    public static StaticSiteCustomDomainOverview FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSiteCustomDomainOverview FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteDatabaseConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteDatabaseConnection.cs
@@ -85,10 +85,15 @@ public partial class StaticSiteDatabaseConnection : Resource
     /// <summary>
     /// Creates a new StaticSiteDatabaseConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteDatabaseConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteDatabaseConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteDatabaseConnection.</param>
-    public StaticSiteDatabaseConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/databaseConnections", resourceVersion ?? "2024-04-01")
+    public StaticSiteDatabaseConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/databaseConnections", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionIdentity = BicepValue<string>.DefineProperty(this, "ConnectionIdentity", ["properties", "connectionIdentity"]);
@@ -181,9 +186,14 @@ public partial class StaticSiteDatabaseConnection : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSiteDatabaseConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteDatabaseConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteDatabaseConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteDatabaseConnection.</param>
     /// <returns>The existing StaticSiteDatabaseConnection resource.</returns>
-    public static StaticSiteDatabaseConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSiteDatabaseConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteLinkedBackend.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteLinkedBackend.cs
@@ -74,10 +74,15 @@ public partial class StaticSiteLinkedBackend : Resource
     /// <summary>
     /// Creates a new StaticSiteLinkedBackend.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteLinkedBackend.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteLinkedBackend resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteLinkedBackend.</param>
-    public StaticSiteLinkedBackend(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/linkedBackends", resourceVersion ?? "2024-04-01")
+    public StaticSiteLinkedBackend(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/linkedBackends", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _backendResourceId = BicepValue<ResourceIdentifier>.DefineProperty(this, "BackendResourceId", ["properties", "backendResourceId"]);
@@ -169,9 +174,14 @@ public partial class StaticSiteLinkedBackend : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSiteLinkedBackend.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteLinkedBackend.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteLinkedBackend resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteLinkedBackend.</param>
     /// <returns>The existing StaticSiteLinkedBackend resource.</returns>
-    public static StaticSiteLinkedBackend FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSiteLinkedBackend FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSitePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSitePrivateEndpointConnection.cs
@@ -76,10 +76,15 @@ public partial class StaticSitePrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new StaticSitePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSitePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// StaticSitePrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSitePrivateEndpointConnection.</param>
-    public StaticSitePrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/privateEndpointConnections", resourceVersion ?? "2024-04-01")
+    public StaticSitePrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/privateEndpointConnections", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _iPAddresses = BicepList<IPAddress>.DefineProperty(this, "IPAddresses", ["properties", "ipAddresses"]);
@@ -171,9 +176,14 @@ public partial class StaticSitePrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSitePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSitePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// StaticSitePrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSitePrivateEndpointConnection.</param>
     /// <returns>The existing StaticSitePrivateEndpointConnection resource.</returns>
-    public static StaticSitePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSitePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteUserProvidedFunctionApp.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/StaticSiteUserProvidedFunctionApp.cs
@@ -69,10 +69,15 @@ public partial class StaticSiteUserProvidedFunctionApp : Resource
     /// <summary>
     /// Creates a new StaticSiteUserProvidedFunctionApp.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteUserProvidedFunctionApp.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteUserProvidedFunctionApp
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteUserProvidedFunctionApp.</param>
-    public StaticSiteUserProvidedFunctionApp(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/staticSites/userProvidedFunctionApps", resourceVersion ?? "2024-04-01")
+    public StaticSiteUserProvidedFunctionApp(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/staticSites/userProvidedFunctionApps", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _functionAppRegion = BicepValue<string>.DefineProperty(this, "FunctionAppRegion", ["properties", "functionAppRegion"]);
@@ -143,9 +148,14 @@ public partial class StaticSiteUserProvidedFunctionApp : Resource
     /// <summary>
     /// Creates a reference to an existing StaticSiteUserProvidedFunctionApp.
     /// </summary>
-    /// <param name="resourceName">Name of the StaticSiteUserProvidedFunctionApp.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StaticSiteUserProvidedFunctionApp
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StaticSiteUserProvidedFunctionApp.</param>
     /// <returns>The existing StaticSiteUserProvidedFunctionApp resource.</returns>
-    public static StaticSiteUserProvidedFunctionApp FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StaticSiteUserProvidedFunctionApp FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSite.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSite.cs
@@ -422,10 +422,15 @@ public partial class WebSite : Resource
     /// <summary>
     /// Creates a new WebSite.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSite.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSite resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSite.</param>
-    public WebSite(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites", resourceVersion ?? "2024-04-01")
+    public WebSite(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -653,11 +658,16 @@ public partial class WebSite : Resource
     /// <summary>
     /// Creates a reference to an existing WebSite.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSite.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSite resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSite.</param>
     /// <returns>The existing WebSite resource.</returns>
-    public static WebSite FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSite FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this WebSite resource.

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteConfig.cs
@@ -514,10 +514,15 @@ public partial class WebSiteConfig : Resource
     /// <summary>
     /// Creates a new WebSiteConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteConfig resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteConfig.</param>
-    public WebSiteConfig(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/config", resourceVersion ?? "2024-04-01")
+    public WebSiteConfig(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/config", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _acrUserManagedIdentityId = BicepValue<string>.DefineProperty(this, "AcrUserManagedIdentityId", ["properties", "acrUserManagedIdentityID"]);
@@ -762,9 +767,14 @@ public partial class WebSiteConfig : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteConfig resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteConfig.</param>
     /// <returns>The existing WebSiteConfig resource.</returns>
-    public static WebSiteConfig FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteConfig FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteExtension.cs
@@ -172,10 +172,15 @@ public partial class WebSiteExtension : Resource
     /// <summary>
     /// Creates a new WebSiteExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteExtension resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteExtension.</param>
-    public WebSiteExtension(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/siteextensions", resourceVersion ?? "2024-04-01")
+    public WebSiteExtension(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/siteextensions", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _authors = BicepList<string>.DefineProperty(this, "Authors", ["properties", "authors"], isOutput: true);
@@ -368,9 +373,14 @@ public partial class WebSiteExtension : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteExtension resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteExtension.</param>
     /// <returns>The existing WebSiteExtension resource.</returns>
-    public static WebSiteExtension FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteExtension FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteFtpPublishingCredentialsPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteFtpPublishingCredentialsPolicy.cs
@@ -57,10 +57,15 @@ public partial class WebSiteFtpPublishingCredentialsPolicy : Resource
     /// <summary>
     /// Creates a new WebSiteFtpPublishingCredentialsPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteFtpPublishingCredentialsPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// WebSiteFtpPublishingCredentialsPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteFtpPublishingCredentialsPolicy.</param>
-    public WebSiteFtpPublishingCredentialsPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/basicPublishingCredentialsPolicies", resourceVersion ?? "2024-04-01")
+    public WebSiteFtpPublishingCredentialsPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/basicPublishingCredentialsPolicies", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _allow = BicepValue<bool>.DefineProperty(this, "Allow", ["properties", "allow"]);
@@ -235,9 +240,14 @@ public partial class WebSiteFtpPublishingCredentialsPolicy : Resource
     /// Creates a reference to an existing
     /// WebSiteFtpPublishingCredentialsPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteFtpPublishingCredentialsPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// WebSiteFtpPublishingCredentialsPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteFtpPublishingCredentialsPolicy.</param>
     /// <returns>The existing WebSiteFtpPublishingCredentialsPolicy resource.</returns>
-    public static WebSiteFtpPublishingCredentialsPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteFtpPublishingCredentialsPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteHybridConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteHybridConnection.cs
@@ -86,10 +86,15 @@ public partial class WebSiteHybridConnection : Resource
     /// <summary>
     /// Creates a new WebSiteHybridConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteHybridConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteHybridConnection resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteHybridConnection.</param>
-    public WebSiteHybridConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/hybridconnection", resourceVersion ?? "2024-04-01")
+    public WebSiteHybridConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/hybridconnection", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _biztalkUri = BicepValue<Uri>.DefineProperty(this, "BiztalkUri", ["properties", "biztalkUri"]);
@@ -268,9 +273,14 @@ public partial class WebSiteHybridConnection : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteHybridConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteHybridConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteHybridConnection resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteHybridConnection.</param>
     /// <returns>The existing WebSiteHybridConnection resource.</returns>
-    public static WebSiteHybridConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteHybridConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSitePremierAddon.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSitePremierAddon.cs
@@ -93,10 +93,15 @@ public partial class WebSitePremierAddon : Resource
     /// <summary>
     /// Creates a new WebSitePremierAddon.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSitePremierAddon.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSitePremierAddon resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSitePremierAddon.</param>
-    public WebSitePremierAddon(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/premieraddons", resourceVersion ?? "2024-04-01")
+    public WebSitePremierAddon(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/premieraddons", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class WebSitePremierAddon : Resource
     /// <summary>
     /// Creates a reference to an existing WebSitePremierAddon.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSitePremierAddon.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSitePremierAddon resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSitePremierAddon.</param>
     /// <returns>The existing WebSitePremierAddon resource.</returns>
-    public static WebSitePremierAddon FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSitePremierAddon FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSitePrivateAccess.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSitePrivateAccess.cs
@@ -63,10 +63,15 @@ public partial class WebSitePrivateAccess : Resource
     /// <summary>
     /// Creates a new WebSitePrivateAccess.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSitePrivateAccess.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSitePrivateAccess resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSitePrivateAccess.</param>
-    public WebSitePrivateAccess(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/privateAccess", resourceVersion ?? "2024-04-01")
+    public WebSitePrivateAccess(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/privateAccess", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isEnabled = BicepValue<bool>.DefineProperty(this, "IsEnabled", ["properties", "enabled"]);
@@ -241,9 +246,14 @@ public partial class WebSitePrivateAccess : Resource
     /// <summary>
     /// Creates a reference to an existing WebSitePrivateAccess.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSitePrivateAccess.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSitePrivateAccess resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSitePrivateAccess.</param>
     /// <returns>The existing WebSitePrivateAccess resource.</returns>
-    public static WebSitePrivateAccess FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSitePrivateAccess FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlot.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlot.cs
@@ -427,10 +427,15 @@ public partial class WebSiteSlot : Resource
     /// <summary>
     /// Creates a new WebSiteSlot.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlot.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlot resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlot.</param>
-    public WebSiteSlot(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots", resourceVersion ?? "2024-04-01")
+    public WebSiteSlot(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -659,11 +664,16 @@ public partial class WebSiteSlot : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSlot.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlot.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlot resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlot.</param>
     /// <returns>The existing WebSiteSlot resource.</returns>
-    public static WebSiteSlot FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlot FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this WebSiteSlot resource.

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotConfig.cs
@@ -514,10 +514,15 @@ public partial class WebSiteSlotConfig : Resource
     /// <summary>
     /// Creates a new WebSiteSlotConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotConfig resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotConfig.</param>
-    public WebSiteSlotConfig(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/config", resourceVersion ?? "2024-04-01")
+    public WebSiteSlotConfig(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/config", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _acrUserManagedIdentityId = BicepValue<string>.DefineProperty(this, "AcrUserManagedIdentityId", ["properties", "acrUserManagedIdentityID"]);
@@ -762,9 +767,14 @@ public partial class WebSiteSlotConfig : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSlotConfig.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotConfig.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotConfig resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotConfig.</param>
     /// <returns>The existing WebSiteSlotConfig resource.</returns>
-    public static WebSiteSlotConfig FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlotConfig FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotExtension.cs
@@ -172,10 +172,15 @@ public partial class WebSiteSlotExtension : Resource
     /// <summary>
     /// Creates a new WebSiteSlotExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotExtension resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotExtension.</param>
-    public WebSiteSlotExtension(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/siteextensions", resourceVersion ?? "2024-04-01")
+    public WebSiteSlotExtension(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/siteextensions", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _authors = BicepList<string>.DefineProperty(this, "Authors", ["properties", "authors"], isOutput: true);
@@ -368,9 +373,14 @@ public partial class WebSiteSlotExtension : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSlotExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotExtension resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotExtension.</param>
     /// <returns>The existing WebSiteSlotExtension resource.</returns>
-    public static WebSiteSlotExtension FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlotExtension FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotFtpPublishingCredentialsPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotFtpPublishingCredentialsPolicy.cs
@@ -57,10 +57,16 @@ public partial class WebSiteSlotFtpPublishingCredentialsPolicy : Resource
     /// <summary>
     /// Creates a new WebSiteSlotFtpPublishingCredentialsPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotFtpPublishingCredentialsPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// WebSiteSlotFtpPublishingCredentialsPolicy resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotFtpPublishingCredentialsPolicy.</param>
-    public WebSiteSlotFtpPublishingCredentialsPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies", resourceVersion ?? "2024-04-01")
+    public WebSiteSlotFtpPublishingCredentialsPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _allow = BicepValue<bool>.DefineProperty(this, "Allow", ["properties", "allow"]);
@@ -235,9 +241,15 @@ public partial class WebSiteSlotFtpPublishingCredentialsPolicy : Resource
     /// Creates a reference to an existing
     /// WebSiteSlotFtpPublishingCredentialsPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotFtpPublishingCredentialsPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// WebSiteSlotFtpPublishingCredentialsPolicy resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotFtpPublishingCredentialsPolicy.</param>
     /// <returns>The existing WebSiteSlotFtpPublishingCredentialsPolicy resource.</returns>
-    public static WebSiteSlotFtpPublishingCredentialsPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlotFtpPublishingCredentialsPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotHybridConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotHybridConnection.cs
@@ -86,10 +86,15 @@ public partial class WebSiteSlotHybridConnection : Resource
     /// <summary>
     /// Creates a new WebSiteSlotHybridConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotHybridConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotHybridConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotHybridConnection.</param>
-    public WebSiteSlotHybridConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/hybridconnection", resourceVersion ?? "2024-04-01")
+    public WebSiteSlotHybridConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/hybridconnection", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _biztalkUri = BicepValue<Uri>.DefineProperty(this, "BiztalkUri", ["properties", "biztalkUri"]);
@@ -268,9 +273,14 @@ public partial class WebSiteSlotHybridConnection : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSlotHybridConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotHybridConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotHybridConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotHybridConnection.</param>
     /// <returns>The existing WebSiteSlotHybridConnection resource.</returns>
-    public static WebSiteSlotHybridConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlotHybridConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotPremierAddOn.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotPremierAddOn.cs
@@ -93,10 +93,15 @@ public partial class WebSiteSlotPremierAddOn : Resource
     /// <summary>
     /// Creates a new WebSiteSlotPremierAddOn.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotPremierAddOn.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotPremierAddOn resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotPremierAddOn.</param>
-    public WebSiteSlotPremierAddOn(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/premieraddons", resourceVersion ?? "2024-04-01")
+    public WebSiteSlotPremierAddOn(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/premieraddons", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -276,9 +281,14 @@ public partial class WebSiteSlotPremierAddOn : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSlotPremierAddOn.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotPremierAddOn.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotPremierAddOn resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotPremierAddOn.</param>
     /// <returns>The existing WebSiteSlotPremierAddOn resource.</returns>
-    public static WebSiteSlotPremierAddOn FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlotPremierAddOn FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotPrivateAccess.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotPrivateAccess.cs
@@ -63,10 +63,15 @@ public partial class WebSiteSlotPrivateAccess : Resource
     /// <summary>
     /// Creates a new WebSiteSlotPrivateAccess.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotPrivateAccess.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotPrivateAccess resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotPrivateAccess.</param>
-    public WebSiteSlotPrivateAccess(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/privateAccess", resourceVersion ?? "2024-04-01")
+    public WebSiteSlotPrivateAccess(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/privateAccess", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isEnabled = BicepValue<bool>.DefineProperty(this, "IsEnabled", ["properties", "enabled"]);
@@ -241,9 +246,14 @@ public partial class WebSiteSlotPrivateAccess : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSlotPrivateAccess.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotPrivateAccess.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotPrivateAccess resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotPrivateAccess.</param>
     /// <returns>The existing WebSiteSlotPrivateAccess resource.</returns>
-    public static WebSiteSlotPrivateAccess FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlotPrivateAccess FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotPublicCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotPublicCertificate.cs
@@ -68,10 +68,15 @@ public partial class WebSiteSlotPublicCertificate : Resource
     /// <summary>
     /// Creates a new WebSiteSlotPublicCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotPublicCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotPublicCertificate
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotPublicCertificate.</param>
-    public WebSiteSlotPublicCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/publicCertificates", resourceVersion ?? "2024-04-01")
+    public WebSiteSlotPublicCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/publicCertificates", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _blob = BicepValue<BinaryData>.DefineProperty(this, "Blob", ["properties", "blob"]);
@@ -247,9 +252,14 @@ public partial class WebSiteSlotPublicCertificate : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSlotPublicCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotPublicCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotPublicCertificate
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotPublicCertificate.</param>
     /// <returns>The existing WebSiteSlotPublicCertificate resource.</returns>
-    public static WebSiteSlotPublicCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlotPublicCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotSourceControl.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSlotSourceControl.cs
@@ -96,10 +96,15 @@ public partial class WebSiteSlotSourceControl : Resource
     /// <summary>
     /// Creates a new WebSiteSlotSourceControl.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotSourceControl.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotSourceControl resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotSourceControl.</param>
-    public WebSiteSlotSourceControl(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/slots/sourcecontrols", resourceVersion ?? "2024-04-01")
+    public WebSiteSlotSourceControl(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/slots/sourcecontrols", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _branch = BicepValue<string>.DefineProperty(this, "Branch", ["properties", "branch"]);
@@ -279,9 +284,14 @@ public partial class WebSiteSlotSourceControl : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSlotSourceControl.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSlotSourceControl.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSlotSourceControl resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSlotSourceControl.</param>
     /// <returns>The existing WebSiteSlotSourceControl resource.</returns>
-    public static WebSiteSlotSourceControl FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSlotSourceControl FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSourceControl.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Generated/WebSiteSourceControl.cs
@@ -96,10 +96,15 @@ public partial class WebSiteSourceControl : Resource
     /// <summary>
     /// Creates a new WebSiteSourceControl.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSourceControl.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSourceControl resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSourceControl.</param>
-    public WebSiteSourceControl(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Web/sites/sourcecontrols", resourceVersion ?? "2024-04-01")
+    public WebSiteSourceControl(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Web/sites/sourcecontrols", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _branch = BicepValue<string>.DefineProperty(this, "Branch", ["properties", "branch"]);
@@ -279,9 +284,14 @@ public partial class WebSiteSourceControl : Resource
     /// <summary>
     /// Creates a reference to an existing WebSiteSourceControl.
     /// </summary>
-    /// <param name="resourceName">Name of the WebSiteSourceControl.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebSiteSourceControl resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebSiteSourceControl.</param>
     /// <returns>The existing WebSiteSourceControl resource.</returns>
-    public static WebSiteSourceControl FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebSiteSourceControl FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/api/Azure.Provisioning.ApplicationInsights.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/api/Azure.Provisioning.ApplicationInsights.netstandard2.0.cs
@@ -34,7 +34,7 @@ namespace Azure.Provisioning.ApplicationInsights
     }
     public partial class ApplicationInsightsComponent : Azure.Provisioning.Primitives.Resource
     {
-        public ApplicationInsightsComponent(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ApplicationInsightsComponent(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AppId { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ApplicationId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ApplicationInsights.ApplicationInsightsApplicationType> ApplicationType { get { throw null; } set { } }
@@ -67,9 +67,9 @@ namespace Azure.Provisioning.ApplicationInsights
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Guid> TenantId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> WorkspaceResourceId { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ApplicationInsights.ApplicationInsightsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ApplicationInsights.ApplicationInsightsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ApplicationInsights.ApplicationInsightsBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsComponent FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsComponent FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -88,7 +88,7 @@ namespace Azure.Provisioning.ApplicationInsights
     }
     public partial class ApplicationInsightsWebTest : Azure.Provisioning.Primitives.Resource
     {
-        public ApplicationInsightsWebTest(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ApplicationInsightsWebTest(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> FrequencyInSeconds { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -108,7 +108,7 @@ namespace Azure.Provisioning.ApplicationInsights
         public Azure.Provisioning.BicepValue<string> WebTest { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ApplicationInsights.WebTestKind> WebTestKind { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> WebTestName { get { throw null; } set { } }
-        public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsWebTest FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsWebTest FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -119,7 +119,7 @@ namespace Azure.Provisioning.ApplicationInsights
     }
     public partial class ApplicationInsightsWorkbook : Azure.Provisioning.Primitives.Resource
     {
-        public ApplicationInsightsWorkbook(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ApplicationInsightsWorkbook(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Category { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
@@ -138,7 +138,7 @@ namespace Azure.Provisioning.ApplicationInsights
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> UserId { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } set { } }
-        public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsWorkbook FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsWorkbook FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_02_12;
@@ -151,7 +151,7 @@ namespace Azure.Provisioning.ApplicationInsights
     }
     public partial class ApplicationInsightsWorkbookTemplate : Azure.Provisioning.Primitives.Resource
     {
-        public ApplicationInsightsWorkbookTemplate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ApplicationInsightsWorkbookTemplate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Author { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ApplicationInsights.WorkbookTemplateGallery> Galleries { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -162,7 +162,7 @@ namespace Azure.Provisioning.ApplicationInsights
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.BinaryData> TemplateData { get { throw null; } set { } }
-        public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsWorkbookTemplate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ApplicationInsights.ApplicationInsightsWorkbookTemplate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_11_20;

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
@@ -240,10 +240,15 @@ public partial class ApplicationInsightsComponent : Resource
     /// <summary>
     /// Creates a new ApplicationInsightsComponent.
     /// </summary>
-    /// <param name="resourceName">Name of the ApplicationInsightsComponent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ApplicationInsightsComponent
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ApplicationInsightsComponent.</param>
-    public ApplicationInsightsComponent(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Insights/components", resourceVersion ?? "2020-02-02")
+    public ApplicationInsightsComponent(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Insights/components", resourceVersion ?? "2020-02-02")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"], isRequired: true);
@@ -313,11 +318,16 @@ public partial class ApplicationInsightsComponent : Resource
     /// <summary>
     /// Creates a reference to an existing ApplicationInsightsComponent.
     /// </summary>
-    /// <param name="resourceName">Name of the ApplicationInsightsComponent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ApplicationInsightsComponent
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ApplicationInsightsComponent.</param>
     /// <returns>The existing ApplicationInsightsComponent resource.</returns>
-    public static ApplicationInsightsComponent FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ApplicationInsightsComponent FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ApplicationInsightsComponent
@@ -336,10 +346,10 @@ public partial class ApplicationInsightsComponent : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(ApplicationInsightsBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -352,13 +362,13 @@ public partial class ApplicationInsightsComponent : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(ApplicationInsightsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(ApplicationInsightsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{ApplicationInsightsBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsWebTest.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsWebTest.cs
@@ -143,10 +143,15 @@ public partial class ApplicationInsightsWebTest : Resource
     /// <summary>
     /// Creates a new ApplicationInsightsWebTest.
     /// </summary>
-    /// <param name="resourceName">Name of the ApplicationInsightsWebTest.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ApplicationInsightsWebTest
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ApplicationInsightsWebTest.</param>
-    public ApplicationInsightsWebTest(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Insights/webtests", resourceVersion ?? "2022-06-15")
+    public ApplicationInsightsWebTest(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Insights/webtests", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -198,9 +203,14 @@ public partial class ApplicationInsightsWebTest : Resource
     /// <summary>
     /// Creates a reference to an existing ApplicationInsightsWebTest.
     /// </summary>
-    /// <param name="resourceName">Name of the ApplicationInsightsWebTest.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ApplicationInsightsWebTest
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ApplicationInsightsWebTest.</param>
     /// <returns>The existing ApplicationInsightsWebTest resource.</returns>
-    public static ApplicationInsightsWebTest FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ApplicationInsightsWebTest FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsWorkbook.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsWorkbook.cs
@@ -134,10 +134,15 @@ public partial class ApplicationInsightsWorkbook : Resource
     /// <summary>
     /// Creates a new ApplicationInsightsWorkbook.
     /// </summary>
-    /// <param name="resourceName">Name of the ApplicationInsightsWorkbook.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ApplicationInsightsWorkbook
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ApplicationInsightsWorkbook.</param>
-    public ApplicationInsightsWorkbook(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Insights/workbooks", resourceVersion ?? "2023-06-01")
+    public ApplicationInsightsWorkbook(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Insights/workbooks", resourceVersion ?? "2023-06-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -198,9 +203,14 @@ public partial class ApplicationInsightsWorkbook : Resource
     /// <summary>
     /// Creates a reference to an existing ApplicationInsightsWorkbook.
     /// </summary>
-    /// <param name="resourceName">Name of the ApplicationInsightsWorkbook.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ApplicationInsightsWorkbook
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ApplicationInsightsWorkbook.</param>
     /// <returns>The existing ApplicationInsightsWorkbook resource.</returns>
-    public static ApplicationInsightsWorkbook FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ApplicationInsightsWorkbook FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsWorkbookTemplate.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsWorkbookTemplate.cs
@@ -96,10 +96,15 @@ public partial class ApplicationInsightsWorkbookTemplate : Resource
     /// <summary>
     /// Creates a new ApplicationInsightsWorkbookTemplate.
     /// </summary>
-    /// <param name="resourceName">Name of the ApplicationInsightsWorkbookTemplate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ApplicationInsightsWorkbookTemplate resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ApplicationInsightsWorkbookTemplate.</param>
-    public ApplicationInsightsWorkbookTemplate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Insights/workbooktemplates", resourceVersion ?? "2020-11-20")
+    public ApplicationInsightsWorkbookTemplate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Insights/workbooktemplates", resourceVersion ?? "2020-11-20")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -127,9 +132,14 @@ public partial class ApplicationInsightsWorkbookTemplate : Resource
     /// <summary>
     /// Creates a reference to an existing ApplicationInsightsWorkbookTemplate.
     /// </summary>
-    /// <param name="resourceName">Name of the ApplicationInsightsWorkbookTemplate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ApplicationInsightsWorkbookTemplate resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ApplicationInsightsWorkbookTemplate.</param>
     /// <returns>The existing ApplicationInsightsWorkbookTemplate resource.</returns>
-    public static ApplicationInsightsWorkbookTemplate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ApplicationInsightsWorkbookTemplate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CloudMachine/src/Azd.cs
+++ b/sdk/provisioning/Azure.Provisioning.CloudMachine/src/Azd.cs
@@ -42,7 +42,7 @@ internal static class Azd
         ModuleImport import = new("cm", $"cm.bicep")
         {
             Name = "cm",
-            Scope = new IdentifierExpression(rg.ResourceName)
+            Scope = new IdentifierExpression(rg.IdentifierName)
         };
         import.Parameters.Add(nameof(location), location);
         import.Parameters.Add(nameof(principalId), principalId);

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/api/Azure.Provisioning.CognitiveServices.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/api/Azure.Provisioning.CognitiveServices.netstandard2.0.cs
@@ -14,7 +14,7 @@ namespace Azure.Provisioning.CognitiveServices
     }
     public partial class CognitiveServicesAccount : Azure.Provisioning.Primitives.Resource
     {
-        public CognitiveServicesAccount(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CognitiveServicesAccount(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
@@ -25,9 +25,9 @@ namespace Azure.Provisioning.CognitiveServices
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CognitiveServices.CognitiveServicesSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.CognitiveServices.CognitiveServicesBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.CognitiveServices.CognitiveServicesBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.CognitiveServices.CognitiveServicesBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.CognitiveServices.CognitiveServicesAccount FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CognitiveServices.CognitiveServicesAccount FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.CognitiveServices.ServiceAccountApiKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -45,7 +45,7 @@ namespace Azure.Provisioning.CognitiveServices
     }
     public partial class CognitiveServicesAccountDeployment : Azure.Provisioning.Primitives.Resource
     {
-        public CognitiveServicesAccountDeployment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CognitiveServicesAccountDeployment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -53,7 +53,7 @@ namespace Azure.Provisioning.CognitiveServices
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CognitiveServices.CognitiveServicesAccountDeploymentProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CognitiveServices.CognitiveServicesSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CognitiveServices.CognitiveServicesAccountDeployment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CognitiveServices.CognitiveServicesAccountDeployment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_04_18;
@@ -200,7 +200,7 @@ namespace Azure.Provisioning.CognitiveServices
     }
     public partial class CognitiveServicesCommitmentPlan : Azure.Provisioning.Primitives.Resource
     {
-        public CognitiveServicesCommitmentPlan(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CognitiveServicesCommitmentPlan(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -210,7 +210,7 @@ namespace Azure.Provisioning.CognitiveServices
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CognitiveServices.CognitiveServicesSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CognitiveServices.CognitiveServicesCommitmentPlan FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CognitiveServices.CognitiveServicesCommitmentPlan FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_12_01;
@@ -352,7 +352,7 @@ namespace Azure.Provisioning.CognitiveServices
     }
     public partial class CommitmentPlan : Azure.Provisioning.Primitives.Resource
     {
-        public CommitmentPlan(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CommitmentPlan(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } set { } }
@@ -363,7 +363,7 @@ namespace Azure.Provisioning.CognitiveServices
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CognitiveServices.CognitiveServicesSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CognitiveServices.CommitmentPlan FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CognitiveServices.CommitmentPlan FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_04_18;
@@ -378,14 +378,14 @@ namespace Azure.Provisioning.CognitiveServices
     }
     public partial class CommitmentPlanAccountAssociation : Azure.Provisioning.Primitives.Resource
     {
-        public CommitmentPlanAccountAssociation(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CommitmentPlanAccountAssociation(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AccountId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.CognitiveServices.CognitiveServicesCommitmentPlan? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CognitiveServices.CommitmentPlanAccountAssociation FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CognitiveServices.CommitmentPlanAccountAssociation FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_12_01;

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccount.cs
@@ -86,10 +86,15 @@ public partial class CognitiveServicesAccount : Resource
     /// <summary>
     /// Creates a new CognitiveServicesAccount.
     /// </summary>
-    /// <param name="resourceName">Name of the CognitiveServicesAccount.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CognitiveServicesAccount resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CognitiveServicesAccount.</param>
-    public CognitiveServicesAccount(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.CognitiveServices/accounts", resourceVersion ?? "2024-10-01")
+    public CognitiveServicesAccount(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.CognitiveServices/accounts", resourceVersion ?? "2024-10-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -152,11 +157,16 @@ public partial class CognitiveServicesAccount : Resource
     /// <summary>
     /// Creates a reference to an existing CognitiveServicesAccount.
     /// </summary>
-    /// <param name="resourceName">Name of the CognitiveServicesAccount.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CognitiveServicesAccount resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CognitiveServicesAccount.</param>
     /// <returns>The existing CognitiveServicesAccount resource.</returns>
-    public static CognitiveServicesAccount FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CognitiveServicesAccount FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this CognitiveServicesAccount resource.
@@ -172,7 +182,7 @@ public partial class CognitiveServicesAccount : Resource
     /// <returns>The keys for this CognitiveServicesAccount resource.</returns>
     public ServiceAccountApiKeys GetKeys() =>
         ServiceAccountApiKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -182,10 +192,10 @@ public partial class CognitiveServicesAccount : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(CognitiveServicesBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -198,13 +208,13 @@ public partial class CognitiveServicesAccount : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(CognitiveServicesBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(CognitiveServicesBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{CognitiveServicesBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccountDeployment.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesAccountDeployment.cs
@@ -65,10 +65,15 @@ public partial class CognitiveServicesAccountDeployment : Resource
     /// <summary>
     /// Creates a new CognitiveServicesAccountDeployment.
     /// </summary>
-    /// <param name="resourceName">Name of the CognitiveServicesAccountDeployment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CognitiveServicesAccountDeployment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CognitiveServicesAccountDeployment.</param>
-    public CognitiveServicesAccountDeployment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.CognitiveServices/accounts/deployments", resourceVersion ?? "2024-10-01")
+    public CognitiveServicesAccountDeployment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.CognitiveServices/accounts/deployments", resourceVersion ?? "2024-10-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _properties = BicepValue<CognitiveServicesAccountDeploymentProperties>.DefineProperty(this, "Properties", ["properties"]);
@@ -128,9 +133,14 @@ public partial class CognitiveServicesAccountDeployment : Resource
     /// <summary>
     /// Creates a reference to an existing CognitiveServicesAccountDeployment.
     /// </summary>
-    /// <param name="resourceName">Name of the CognitiveServicesAccountDeployment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CognitiveServicesAccountDeployment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CognitiveServicesAccountDeployment.</param>
     /// <returns>The existing CognitiveServicesAccountDeployment resource.</returns>
-    public static CognitiveServicesAccountDeployment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CognitiveServicesAccountDeployment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesCommitmentPlan.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CognitiveServicesCommitmentPlan.cs
@@ -77,10 +77,15 @@ public partial class CognitiveServicesCommitmentPlan : Resource
     /// <summary>
     /// Creates a new CognitiveServicesCommitmentPlan.
     /// </summary>
-    /// <param name="resourceName">Name of the CognitiveServicesCommitmentPlan.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CognitiveServicesCommitmentPlan
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CognitiveServicesCommitmentPlan.</param>
-    public CognitiveServicesCommitmentPlan(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.CognitiveServices/commitmentPlans", resourceVersion ?? "2024-10-01")
+    public CognitiveServicesCommitmentPlan(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.CognitiveServices/commitmentPlans", resourceVersion ?? "2024-10-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -117,9 +122,14 @@ public partial class CognitiveServicesCommitmentPlan : Resource
     /// <summary>
     /// Creates a reference to an existing CognitiveServicesCommitmentPlan.
     /// </summary>
-    /// <param name="resourceName">Name of the CognitiveServicesCommitmentPlan.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CognitiveServicesCommitmentPlan
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CognitiveServicesCommitmentPlan.</param>
     /// <returns>The existing CognitiveServicesCommitmentPlan resource.</returns>
-    public static CognitiveServicesCommitmentPlan FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CognitiveServicesCommitmentPlan FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CommitmentPlan.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CommitmentPlan.cs
@@ -83,10 +83,15 @@ public partial class CommitmentPlan : Resource
     /// <summary>
     /// Creates a new CommitmentPlan.
     /// </summary>
-    /// <param name="resourceName">Name of the CommitmentPlan.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CommitmentPlan resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CommitmentPlan.</param>
-    public CommitmentPlan(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.CognitiveServices/accounts/commitmentPlans", resourceVersion ?? "2024-10-01")
+    public CommitmentPlan(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.CognitiveServices/accounts/commitmentPlans", resourceVersion ?? "2024-10-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"]);
@@ -149,9 +154,14 @@ public partial class CommitmentPlan : Resource
     /// <summary>
     /// Creates a reference to an existing CommitmentPlan.
     /// </summary>
-    /// <param name="resourceName">Name of the CommitmentPlan.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CommitmentPlan resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CommitmentPlan.</param>
     /// <returns>The existing CommitmentPlan resource.</returns>
-    public static CommitmentPlan FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CommitmentPlan FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CommitmentPlanAccountAssociation.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Generated/CommitmentPlanAccountAssociation.cs
@@ -58,10 +58,15 @@ public partial class CommitmentPlanAccountAssociation : Resource
     /// <summary>
     /// Creates a new CommitmentPlanAccountAssociation.
     /// </summary>
-    /// <param name="resourceName">Name of the CommitmentPlanAccountAssociation.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CommitmentPlanAccountAssociation
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CommitmentPlanAccountAssociation.</param>
-    public CommitmentPlanAccountAssociation(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.CognitiveServices/commitmentPlans/accountAssociations", resourceVersion ?? "2024-10-01")
+    public CommitmentPlanAccountAssociation(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.CognitiveServices/commitmentPlans/accountAssociations", resourceVersion ?? "2024-10-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _accountId = BicepValue<string>.DefineProperty(this, "AccountId", ["properties", "accountId"]);
@@ -95,9 +100,14 @@ public partial class CommitmentPlanAccountAssociation : Resource
     /// <summary>
     /// Creates a reference to an existing CommitmentPlanAccountAssociation.
     /// </summary>
-    /// <param name="resourceName">Name of the CommitmentPlanAccountAssociation.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CommitmentPlanAccountAssociation
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CommitmentPlanAccountAssociation.</param>
     /// <returns>The existing CommitmentPlanAccountAssociation resource.</returns>
-    public static CommitmentPlanAccountAssociation FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CommitmentPlanAccountAssociation FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Communication/api/Azure.Provisioning.Communication.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/api/Azure.Provisioning.Communication.netstandard2.0.cs
@@ -2,7 +2,7 @@ namespace Azure.Provisioning.Communication
 {
     public partial class CommunicationDomain : Azure.Provisioning.Primitives.Resource
     {
-        public CommunicationDomain(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CommunicationDomain(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DataLocation { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Communication.DomainManagement> DomainManagement { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> FromSenderDomain { get { throw null; } }
@@ -17,7 +17,7 @@ namespace Azure.Provisioning.Communication
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Communication.UserEngagementTracking> UserEngagementTracking { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Communication.DomainPropertiesVerificationRecords> VerificationRecords { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Communication.DomainPropertiesVerificationStates> VerificationStates { get { throw null; } }
-        public static Azure.Provisioning.Communication.CommunicationDomain FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Communication.CommunicationDomain FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2023_03_31;
@@ -27,7 +27,7 @@ namespace Azure.Provisioning.Communication
     }
     public partial class CommunicationService : Azure.Provisioning.Primitives.Resource
     {
-        public CommunicationService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CommunicationService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DataLocation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> HostName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -41,7 +41,7 @@ namespace Azure.Provisioning.Communication
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
-        public static Azure.Provisioning.Communication.CommunicationService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Communication.CommunicationService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.Communication.CommunicationServiceKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -140,7 +140,7 @@ namespace Azure.Provisioning.Communication
     }
     public partial class EmailService : Azure.Provisioning.Primitives.Resource
     {
-        public EmailService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EmailService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DataLocation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -148,7 +148,7 @@ namespace Azure.Provisioning.Communication
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Communication.EmailServicesProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Communication.EmailService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Communication.EmailService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2023_03_31;
@@ -170,7 +170,7 @@ namespace Azure.Provisioning.Communication
     }
     public partial class SenderUsername : Azure.Provisioning.Primitives.Resource
     {
-        public SenderUsername(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SenderUsername(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DataLocation { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -179,7 +179,7 @@ namespace Azure.Provisioning.Communication
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Communication.CommunicationServiceProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Username { get { throw null; } set { } }
-        public static Azure.Provisioning.Communication.SenderUsername FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Communication.SenderUsername FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2023_03_31;

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/CommunicationDomain.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/CommunicationDomain.cs
@@ -105,10 +105,15 @@ public partial class CommunicationDomain : Resource
     /// <summary>
     /// Creates a new CommunicationDomain.
     /// </summary>
-    /// <param name="resourceName">Name of the CommunicationDomain.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CommunicationDomain resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CommunicationDomain.</param>
-    public CommunicationDomain(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Communication/emailServices/domains", resourceVersion ?? "2023-04-01")
+    public CommunicationDomain(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Communication/emailServices/domains", resourceVersion ?? "2023-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -150,9 +155,14 @@ public partial class CommunicationDomain : Resource
     /// <summary>
     /// Creates a reference to an existing CommunicationDomain.
     /// </summary>
-    /// <param name="resourceName">Name of the CommunicationDomain.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CommunicationDomain resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CommunicationDomain.</param>
     /// <returns>The existing CommunicationDomain resource.</returns>
-    public static CommunicationDomain FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CommunicationDomain FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/CommunicationService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/CommunicationService.cs
@@ -103,10 +103,15 @@ public partial class CommunicationService : Resource
     /// <summary>
     /// Creates a new CommunicationService.
     /// </summary>
-    /// <param name="resourceName">Name of the CommunicationService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CommunicationService resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CommunicationService.</param>
-    public CommunicationService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Communication/communicationServices", resourceVersion ?? "2023-04-01")
+    public CommunicationService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Communication/communicationServices", resourceVersion ?? "2023-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -152,11 +157,16 @@ public partial class CommunicationService : Resource
     /// <summary>
     /// Creates a reference to an existing CommunicationService.
     /// </summary>
-    /// <param name="resourceName">Name of the CommunicationService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CommunicationService resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CommunicationService.</param>
     /// <returns>The existing CommunicationService resource.</returns>
-    public static CommunicationService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CommunicationService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this CommunicationService resource.
@@ -172,5 +182,5 @@ public partial class CommunicationService : Resource
     /// <returns>The keys for this CommunicationService resource.</returns>
     public CommunicationServiceKeys GetKeys() =>
         CommunicationServiceKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 }

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/EmailService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/EmailService.cs
@@ -63,10 +63,15 @@ public partial class EmailService : Resource
     /// <summary>
     /// Creates a new EmailService.
     /// </summary>
-    /// <param name="resourceName">Name of the EmailService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EmailService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EmailService.</param>
-    public EmailService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Communication/emailServices", resourceVersion ?? "2023-04-01")
+    public EmailService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Communication/emailServices", resourceVersion ?? "2023-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -101,9 +106,14 @@ public partial class EmailService : Resource
     /// <summary>
     /// Creates a reference to an existing EmailService.
     /// </summary>
-    /// <param name="resourceName">Name of the EmailService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EmailService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EmailService.</param>
     /// <returns>The existing EmailService resource.</returns>
-    public static EmailService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EmailService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/SenderUsername.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/SenderUsername.cs
@@ -69,10 +69,15 @@ public partial class SenderUsername : Resource
     /// <summary>
     /// Creates a new SenderUsername.
     /// </summary>
-    /// <param name="resourceName">Name of the SenderUsername.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SenderUsername resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SenderUsername.</param>
-    public SenderUsername(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Communication/emailServices/domains/senderUsernames", resourceVersion ?? "2023-04-01")
+    public SenderUsername(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Communication/emailServices/domains/senderUsernames", resourceVersion ?? "2023-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _displayName = BicepValue<string>.DefineProperty(this, "DisplayName", ["properties", "displayName"]);
@@ -108,9 +113,14 @@ public partial class SenderUsername : Resource
     /// <summary>
     /// Creates a reference to an existing SenderUsername.
     /// </summary>
-    /// <param name="resourceName">Name of the SenderUsername.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SenderUsername resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SenderUsername.</param>
     /// <returns>The existing SenderUsername resource.</returns>
-    public static SenderUsername FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SenderUsername FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/api/Azure.Provisioning.ContainerRegistry.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/api/Azure.Provisioning.ContainerRegistry.netstandard2.0.cs
@@ -7,7 +7,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ContainerRegistryAgentPool : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerRegistryAgentPool(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerRegistryAgentPool(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<int> Count { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -19,7 +19,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Tier { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> VirtualNetworkSubnetResourceId { get { throw null; } set { } }
-        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryAgentPool FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryAgentPool FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_06_01_preview;
@@ -277,7 +277,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ContainerRegistryPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerRegistryPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerRegistryPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryPrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -285,7 +285,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_09_01;
@@ -334,7 +334,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ContainerRegistryReplication : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerRegistryReplication(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerRegistryReplication(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsRegionEndpointEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -345,7 +345,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryZoneRedundancy> ZoneRedundancy { get { throw null; } set { } }
-        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryReplication FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryReplication FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -447,7 +447,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ContainerRegistryService : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerRegistryService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerRegistryService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepList<string> DataEndpointHostNames { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryEncryption> Encryption { get { throw null; } set { } }
@@ -469,9 +469,9 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryZoneRedundancy> ZoneRedundancy { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ContainerRegistry.ContainerRegistryBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ContainerRegistry.ContainerRegistryBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ContainerRegistry.ContainerRegistryBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -533,7 +533,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ContainerRegistryTask : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerRegistryTask(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerRegistryTask(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<int> AgentCpu { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AgentPoolName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
@@ -553,7 +553,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> TimeoutInSeconds { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryTriggerProperties> Trigger { get { throw null; } set { } }
-        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryTask FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryTask FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -572,7 +572,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ContainerRegistryTaskRun : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerRegistryTaskRun(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerRegistryTaskRun(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ForceUpdateTag { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
@@ -583,7 +583,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryRunContent> RunRequest { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryRunData> RunResult { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryTaskRun FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryTaskRun FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_06_01_preview;
@@ -622,7 +622,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ContainerRegistryToken : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerRegistryToken(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerRegistryToken(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryTokenCredentials> Credentials { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -632,7 +632,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> ScopeMapId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryTokenStatus> Status { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryToken FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryToken FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -714,7 +714,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ContainerRegistryWebhook : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerRegistryWebhook(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerRegistryWebhook(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ContainerRegistry.ContainerRegistryWebhookAction> Actions { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<string> CustomHeaders { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -727,7 +727,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryWebhookStatus> Status { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryWebhook FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ContainerRegistryWebhook FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -774,7 +774,7 @@ namespace Azure.Provisioning.ContainerRegistry
     }
     public partial class ScopeMap : Azure.Provisioning.Primitives.Resource
     {
-        public ScopeMap(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ScopeMap(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> Actions { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
@@ -784,7 +784,7 @@ namespace Azure.Provisioning.ContainerRegistry
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerRegistry.ContainerRegistryProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ScopeMapType { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ContainerRegistry.ScopeMap FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerRegistry.ScopeMap FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryAgentPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryAgentPool.cs
@@ -87,10 +87,15 @@ public partial class ContainerRegistryAgentPool : Resource
     /// <summary>
     /// Creates a new ContainerRegistryAgentPool.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryAgentPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryAgentPool
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryAgentPool.</param>
-    public ContainerRegistryAgentPool(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries/agentPools", resourceVersion ?? "2019-06-01-preview")
+    public ContainerRegistryAgentPool(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries/agentPools", resourceVersion ?? "2019-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -119,9 +124,14 @@ public partial class ContainerRegistryAgentPool : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerRegistryAgentPool.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryAgentPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryAgentPool
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryAgentPool.</param>
     /// <returns>The existing ContainerRegistryAgentPool resource.</returns>
-    public static ContainerRegistryAgentPool FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerRegistryAgentPool FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryPrivateEndpointConnection.cs
@@ -63,10 +63,16 @@ public partial class ContainerRegistryPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new ContainerRegistryPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerRegistryPrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryPrivateEndpointConnection.</param>
-    public ContainerRegistryPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries/privateEndpointConnections", resourceVersion ?? "2023-07-01")
+    public ContainerRegistryPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries/privateEndpointConnections", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<ContainerRegistryPrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -107,9 +113,15 @@ public partial class ContainerRegistryPrivateEndpointConnection : Resource
     /// Creates a reference to an existing
     /// ContainerRegistryPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerRegistryPrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryPrivateEndpointConnection.</param>
     /// <returns>The existing ContainerRegistryPrivateEndpointConnection resource.</returns>
-    public static ContainerRegistryPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerRegistryPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryReplication.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryReplication.cs
@@ -87,10 +87,15 @@ public partial class ContainerRegistryReplication : Resource
     /// <summary>
     /// Creates a new ContainerRegistryReplication.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryReplication.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryReplication
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryReplication.</param>
-    public ContainerRegistryReplication(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries/replications", resourceVersion ?? "2023-07-01")
+    public ContainerRegistryReplication(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries/replications", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -143,11 +148,16 @@ public partial class ContainerRegistryReplication : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerRegistryReplication.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryReplication.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryReplication
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryReplication.</param>
     /// <returns>The existing ContainerRegistryReplication resource.</returns>
-    public static ContainerRegistryReplication FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerRegistryReplication FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ContainerRegistryReplication

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
@@ -156,10 +156,15 @@ public partial class ContainerRegistryService : Resource
     /// <summary>
     /// Creates a new ContainerRegistryService.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryService resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryService.</param>
-    public ContainerRegistryService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries", resourceVersion ?? "2023-07-01")
+    public ContainerRegistryService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -228,11 +233,16 @@ public partial class ContainerRegistryService : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerRegistryService.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryService resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryService.</param>
     /// <returns>The existing ContainerRegistryService resource.</returns>
-    public static ContainerRegistryService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerRegistryService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ContainerRegistryService resource.
@@ -250,10 +260,10 @@ public partial class ContainerRegistryService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(ContainerRegistryBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -266,13 +276,13 @@ public partial class ContainerRegistryService : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(ContainerRegistryBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(ContainerRegistryBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{ContainerRegistryBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryTask.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryTask.cs
@@ -148,10 +148,15 @@ public partial class ContainerRegistryTask : Resource
     /// <summary>
     /// Creates a new ContainerRegistryTask.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryTask.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryTask resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryTask.</param>
-    public ContainerRegistryTask(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries/tasks", resourceVersion ?? "2019-04-01")
+    public ContainerRegistryTask(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries/tasks", resourceVersion ?? "2019-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -198,11 +203,16 @@ public partial class ContainerRegistryTask : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerRegistryTask.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryTask.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryTask resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryTask.</param>
     /// <returns>The existing ContainerRegistryTask resource.</returns>
-    public static ContainerRegistryTask FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerRegistryTask FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ContainerRegistryTask resource.

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryTaskRun.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryTaskRun.cs
@@ -92,10 +92,15 @@ public partial class ContainerRegistryTaskRun : Resource
     /// <summary>
     /// Creates a new ContainerRegistryTaskRun.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryTaskRun.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryTaskRun resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryTaskRun.</param>
-    public ContainerRegistryTaskRun(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries/taskRuns", resourceVersion ?? "2019-06-01-preview")
+    public ContainerRegistryTaskRun(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries/taskRuns", resourceVersion ?? "2019-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _forceUpdateTag = BicepValue<string>.DefineProperty(this, "ForceUpdateTag", ["properties", "forceUpdateTag"]);
@@ -123,9 +128,14 @@ public partial class ContainerRegistryTaskRun : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerRegistryTaskRun.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryTaskRun.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryTaskRun resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryTaskRun.</param>
     /// <returns>The existing ContainerRegistryTaskRun resource.</returns>
-    public static ContainerRegistryTaskRun FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerRegistryTaskRun FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryToken.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryToken.cs
@@ -77,10 +77,15 @@ public partial class ContainerRegistryToken : Resource
     /// <summary>
     /// Creates a new ContainerRegistryToken.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryToken.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryToken resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryToken.</param>
-    public ContainerRegistryToken(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries/tokens", resourceVersion ?? "2023-07-01")
+    public ContainerRegistryToken(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries/tokens", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _credentials = BicepValue<ContainerRegistryTokenCredentials>.DefineProperty(this, "Credentials", ["properties", "credentials"]);
@@ -117,11 +122,16 @@ public partial class ContainerRegistryToken : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerRegistryToken.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryToken.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryToken resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryToken.</param>
     /// <returns>The existing ContainerRegistryToken resource.</returns>
-    public static ContainerRegistryToken FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerRegistryToken FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ContainerRegistryToken resource.

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryWebhook.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryWebhook.cs
@@ -100,10 +100,15 @@ public partial class ContainerRegistryWebhook : Resource
     /// <summary>
     /// Creates a new ContainerRegistryWebhook.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryWebhook.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryWebhook resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryWebhook.</param>
-    public ContainerRegistryWebhook(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries/webhooks", resourceVersion ?? "2023-07-01")
+    public ContainerRegistryWebhook(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries/webhooks", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -158,11 +163,16 @@ public partial class ContainerRegistryWebhook : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerRegistryWebhook.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerRegistryWebhook.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerRegistryWebhook resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryWebhook.</param>
     /// <returns>The existing ContainerRegistryWebhook resource.</returns>
-    public static ContainerRegistryWebhook FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerRegistryWebhook FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ContainerRegistryWebhook resource.

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ScopeMap.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ScopeMap.cs
@@ -78,10 +78,15 @@ public partial class ScopeMap : Resource
     /// <summary>
     /// Creates a new ScopeMap.
     /// </summary>
-    /// <param name="resourceName">Name of the ScopeMap.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ScopeMap resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ScopeMap.</param>
-    public ScopeMap(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerRegistry/registries/scopeMaps", resourceVersion ?? "2023-07-01")
+    public ScopeMap(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerRegistry/registries/scopeMaps", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _actions = BicepList<string>.DefineProperty(this, "Actions", ["properties", "actions"]);
@@ -118,11 +123,16 @@ public partial class ScopeMap : Resource
     /// <summary>
     /// Creates a reference to an existing ScopeMap.
     /// </summary>
-    /// <param name="resourceName">Name of the ScopeMap.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ScopeMap resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ScopeMap.</param>
     /// <returns>The existing ScopeMap resource.</returns>
-    public static ScopeMap FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ScopeMap FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ScopeMap resource.

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/api/Azure.Provisioning.ContainerService.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/api/Azure.Provisioning.ContainerService.netstandard2.0.cs
@@ -28,7 +28,7 @@ namespace Azure.Provisioning.ContainerService
     }
     public partial class AgentPoolSnapshot : Azure.Provisioning.Primitives.Resource
     {
-        public AgentPoolSnapshot(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AgentPoolSnapshot(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> CreationDataSourceResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> EnableFips { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -42,7 +42,7 @@ namespace Azure.Provisioning.ContainerService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> VmSize { get { throw null; } }
-        public static Azure.Provisioning.ContainerService.AgentPoolSnapshot FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerService.AgentPoolSnapshot FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_08_01;
@@ -101,7 +101,7 @@ namespace Azure.Provisioning.ContainerService
     }
     public partial class ContainerServiceAgentPool : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerServiceAgentPool(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerServiceAgentPool(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> AvailabilityZones { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> CapacityReservationGroupId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> Count { get { throw null; } set { } }
@@ -149,7 +149,7 @@ namespace Azure.Provisioning.ContainerService
         public Azure.Provisioning.BicepValue<string> VmSize { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> VnetSubnetId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.WorkloadRuntime> WorkloadRuntime { get { throw null; } set { } }
-        public static Azure.Provisioning.ContainerService.ContainerServiceAgentPool FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerService.ContainerServiceAgentPool FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -266,7 +266,7 @@ namespace Azure.Provisioning.ContainerService
     }
     public partial class ContainerServiceMaintenanceConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerServiceMaintenanceConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerServiceMaintenanceConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.ContainerServiceMaintenanceWindow> MaintenanceWindow { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -274,7 +274,7 @@ namespace Azure.Provisioning.ContainerService
         public Azure.Provisioning.ContainerService.ContainerServiceManagedCluster? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ContainerService.ContainerServiceTimeInWeek> TimesInWeek { get { throw null; } set { } }
-        public static Azure.Provisioning.ContainerService.ContainerServiceMaintenanceConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerService.ContainerServiceMaintenanceConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_08_31;
@@ -371,7 +371,7 @@ namespace Azure.Provisioning.ContainerService
     }
     public partial class ContainerServiceManagedCluster : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerServiceManagedCluster(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerServiceManagedCluster(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.ManagedClusterAadProfile> AadProfile { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<Azure.Provisioning.ContainerService.ManagedClusterAddonProfile> AddonProfiles { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ContainerService.ManagedClusterAgentPoolProfile> AgentPoolProfiles { get { throw null; } set { } }
@@ -419,9 +419,9 @@ namespace Azure.Provisioning.ContainerService
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.UpgradeOverrideSettings> UpgradeOverrideSettings { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.ManagedClusterWindowsProfile> WindowsProfile { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.ManagedClusterWorkloadAutoScalerProfile> WorkloadAutoScalerProfile { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ContainerService.ContainerServiceBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ContainerService.ContainerServiceBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ContainerService.ContainerServiceBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.ContainerService.ContainerServiceManagedCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerService.ContainerServiceManagedCluster FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -560,7 +560,7 @@ namespace Azure.Provisioning.ContainerService
     }
     public partial class ContainerServicePrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerServicePrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerServicePrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.ContainerServicePrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -568,7 +568,7 @@ namespace Azure.Provisioning.ContainerService
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ContainerService.ContainerServicePrivateEndpointConnectionProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ContainerService.ContainerServicePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerService.ContainerServicePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_08_31;
@@ -684,7 +684,7 @@ namespace Azure.Provisioning.ContainerService
     }
     public partial class ContainerServiceTrustedAccessRoleBinding : Azure.Provisioning.Primitives.Resource
     {
-        public ContainerServiceTrustedAccessRoleBinding(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ContainerServiceTrustedAccessRoleBinding(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.ContainerService.ContainerServiceManagedCluster? Parent { get { throw null; } set { } }
@@ -692,7 +692,7 @@ namespace Azure.Provisioning.ContainerService
         public Azure.Provisioning.BicepList<string> Roles { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> SourceResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ContainerService.ContainerServiceTrustedAccessRoleBinding FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ContainerService.ContainerServiceTrustedAccessRoleBinding FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_08_31;

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/AgentPoolSnapshot.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/AgentPoolSnapshot.cs
@@ -102,10 +102,15 @@ public partial class AgentPoolSnapshot : Resource
     /// <summary>
     /// Creates a new AgentPoolSnapshot.
     /// </summary>
-    /// <param name="resourceName">Name of the AgentPoolSnapshot.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AgentPoolSnapshot resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AgentPoolSnapshot.</param>
-    public AgentPoolSnapshot(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerService/snapshots", resourceVersion ?? "2024-08-01")
+    public AgentPoolSnapshot(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerService/snapshots", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -281,9 +286,14 @@ public partial class AgentPoolSnapshot : Resource
     /// <summary>
     /// Creates a reference to an existing AgentPoolSnapshot.
     /// </summary>
-    /// <param name="resourceName">Name of the AgentPoolSnapshot.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AgentPoolSnapshot resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AgentPoolSnapshot.</param>
     /// <returns>The existing AgentPoolSnapshot resource.</returns>
-    public static AgentPoolSnapshot FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AgentPoolSnapshot FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceAgentPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceAgentPool.cs
@@ -367,10 +367,15 @@ public partial class ContainerServiceAgentPool : Resource
     /// <summary>
     /// Creates a new ContainerServiceAgentPool.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServiceAgentPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerServiceAgentPool
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServiceAgentPool.</param>
-    public ContainerServiceAgentPool(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerService/managedClusters/agentPools", resourceVersion ?? "2024-08-01")
+    public ContainerServiceAgentPool(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerService/managedClusters/agentPools", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _availabilityZones = BicepList<string>.DefineProperty(this, "AvailabilityZones", ["properties", "availabilityZones"]);
@@ -685,11 +690,16 @@ public partial class ContainerServiceAgentPool : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerServiceAgentPool.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServiceAgentPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerServiceAgentPool
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServiceAgentPool.</param>
     /// <returns>The existing ContainerServiceAgentPool resource.</returns>
-    public static ContainerServiceAgentPool FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerServiceAgentPool FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ContainerServiceAgentPool resource.

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceMaintenanceConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceMaintenanceConfiguration.cs
@@ -64,10 +64,16 @@ public partial class ContainerServiceMaintenanceConfiguration : Resource
     /// <summary>
     /// Creates a new ContainerServiceMaintenanceConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServiceMaintenanceConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerServiceMaintenanceConfiguration resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServiceMaintenanceConfiguration.</param>
-    public ContainerServiceMaintenanceConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerService/managedClusters/maintenanceConfigurations", resourceVersion ?? "2024-08-01")
+    public ContainerServiceMaintenanceConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerService/managedClusters/maintenanceConfigurations", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _maintenanceWindow = BicepValue<ContainerServiceMaintenanceWindow>.DefineProperty(this, "MaintenanceWindow", ["properties", "maintenanceWindow"]);
@@ -343,9 +349,15 @@ public partial class ContainerServiceMaintenanceConfiguration : Resource
     /// Creates a reference to an existing
     /// ContainerServiceMaintenanceConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServiceMaintenanceConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerServiceMaintenanceConfiguration resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServiceMaintenanceConfiguration.</param>
     /// <returns>The existing ContainerServiceMaintenanceConfiguration resource.</returns>
-    public static ContainerServiceMaintenanceConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerServiceMaintenanceConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
@@ -341,10 +341,15 @@ public partial class ContainerServiceManagedCluster : Resource
     /// <summary>
     /// Creates a new ContainerServiceManagedCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServiceManagedCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerServiceManagedCluster
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServiceManagedCluster.</param>
-    public ContainerServiceManagedCluster(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerService/managedClusters", resourceVersion ?? "2024-08-01")
+    public ContainerServiceManagedCluster(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerService/managedClusters", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -659,11 +664,16 @@ public partial class ContainerServiceManagedCluster : Resource
     /// <summary>
     /// Creates a reference to an existing ContainerServiceManagedCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServiceManagedCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ContainerServiceManagedCluster
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServiceManagedCluster.</param>
     /// <returns>The existing ContainerServiceManagedCluster resource.</returns>
-    public static ContainerServiceManagedCluster FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerServiceManagedCluster FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ContainerServiceManagedCluster
@@ -682,10 +692,10 @@ public partial class ContainerServiceManagedCluster : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(ContainerServiceBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -698,13 +708,13 @@ public partial class ContainerServiceManagedCluster : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(ContainerServiceBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(ContainerServiceBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{ContainerServiceBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServicePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServicePrivateEndpointConnection.cs
@@ -63,10 +63,16 @@ public partial class ContainerServicePrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new ContainerServicePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServicePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerServicePrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServicePrivateEndpointConnection.</param>
-    public ContainerServicePrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerService/managedClusters/privateEndpointConnections", resourceVersion ?? "2024-08-01")
+    public ContainerServicePrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerService/managedClusters/privateEndpointConnections", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<ContainerServicePrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -342,9 +348,15 @@ public partial class ContainerServicePrivateEndpointConnection : Resource
     /// Creates a reference to an existing
     /// ContainerServicePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServicePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerServicePrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServicePrivateEndpointConnection.</param>
     /// <returns>The existing ContainerServicePrivateEndpointConnection resource.</returns>
-    public static ContainerServicePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerServicePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceTrustedAccessRoleBinding.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceTrustedAccessRoleBinding.cs
@@ -66,10 +66,16 @@ public partial class ContainerServiceTrustedAccessRoleBinding : Resource
     /// <summary>
     /// Creates a new ContainerServiceTrustedAccessRoleBinding.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServiceTrustedAccessRoleBinding.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerServiceTrustedAccessRoleBinding resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServiceTrustedAccessRoleBinding.</param>
-    public ContainerServiceTrustedAccessRoleBinding(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings", resourceVersion ?? "2024-08-01")
+    public ContainerServiceTrustedAccessRoleBinding(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _roles = BicepList<string>.DefineProperty(this, "Roles", ["properties", "roles"], isRequired: true);
@@ -345,9 +351,15 @@ public partial class ContainerServiceTrustedAccessRoleBinding : Resource
     /// Creates a reference to an existing
     /// ContainerServiceTrustedAccessRoleBinding.
     /// </summary>
-    /// <param name="resourceName">Name of the ContainerServiceTrustedAccessRoleBinding.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ContainerServiceTrustedAccessRoleBinding resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ContainerServiceTrustedAccessRoleBinding.</param>
     /// <returns>The existing ContainerServiceTrustedAccessRoleBinding resource.</returns>
-    public static ContainerServiceTrustedAccessRoleBinding FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ContainerServiceTrustedAccessRoleBinding FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/api/Azure.Provisioning.CosmosDB.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/api/Azure.Provisioning.CosmosDB.netstandard2.0.cs
@@ -73,7 +73,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CassandraCluster : Azure.Provisioning.Primitives.Resource
     {
-        public CassandraCluster(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CassandraCluster(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -81,7 +81,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CassandraClusterProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CassandraCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CassandraCluster FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_10_15;
@@ -153,13 +153,13 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CassandraDataCenter : Azure.Provisioning.Primitives.Resource
     {
-        public CassandraDataCenter(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CassandraDataCenter(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.CosmosDB.CassandraCluster? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CassandraDataCenterProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.CassandraDataCenter FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CassandraDataCenter FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_10_15;
@@ -210,7 +210,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CassandraKeyspace : Azure.Provisioning.Primitives.Resource
     {
-        public CassandraKeyspace(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CassandraKeyspace(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -221,7 +221,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<string> ResourceKeyspaceName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CassandraKeyspace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CassandraKeyspace FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -260,7 +260,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CassandraKeyspaceThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public CassandraKeyspaceThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CassandraKeyspaceThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -269,7 +269,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CassandraKeyspaceThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CassandraKeyspaceThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -323,7 +323,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CassandraTable : Azure.Provisioning.Primitives.Resource
     {
-        public CassandraTable(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CassandraTable(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -333,7 +333,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CassandraTableResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CassandraTable FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CassandraTable FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -380,7 +380,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CassandraTableThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public CassandraTableThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CassandraTableThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -389,7 +389,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CassandraTableThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CassandraTableThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -435,7 +435,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CassandraViewGetResult : Azure.Provisioning.Primitives.Resource
     {
-        public CassandraViewGetResult(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CassandraViewGetResult(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -445,7 +445,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CassandraViewResource> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CassandraViewGetResult FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CassandraViewGetResult FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -484,7 +484,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CassandraViewThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public CassandraViewThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CassandraViewThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -493,7 +493,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CassandraViewThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CassandraViewThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -578,7 +578,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBAccount : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBAccount(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBAccount(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.AnalyticalStorageSchemaType> AnalyticalStorageSchemaType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBServerVersion> ApiServerVersion { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBAccountBackupPolicy> BackupPolicy { get { throw null; } set { } }
@@ -630,9 +630,9 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.CosmosDB.CosmosDBVirtualNetworkRule> VirtualNetworkRules { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.CosmosDB.CosmosDBAccountLocation> WriteLocations { get { throw null; } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.CosmosDB.CosmosDBBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.CosmosDB.CosmosDBBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.CosmosDB.CosmosDBBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.CosmosDB.CosmosDBAccount FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBAccount FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.CosmosDB.CosmosDBAccountKeyList GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -823,7 +823,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBFirewallRule : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBFirewallRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBFirewallRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> EndIPAddress { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -831,7 +831,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> StartIPAddress { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBFirewallRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBFirewallRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_07_01;
@@ -902,7 +902,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBPrivateLinkServiceConnectionStateProperty> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> GroupId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -911,7 +911,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -988,7 +988,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBService : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> InstanceCount { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBServiceSize> InstanceSize { get { throw null; } set { } }
@@ -997,7 +997,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBServiceProperties> Properties { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBServiceType> ServiceType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1072,13 +1072,13 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlClientEncryptionKey : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlClientEncryptionKey(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlClientEncryptionKey(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.CosmosDB.CosmosDBSqlDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBSqlClientEncryptionKeyResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlClientEncryptionKey FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlClientEncryptionKey FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1126,7 +1126,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlContainer : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlContainer(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlContainer(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1136,7 +1136,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBSqlContainerResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlContainer FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlContainer FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1191,7 +1191,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlContainerThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlContainerThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlContainerThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1200,7 +1200,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlContainerThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlContainerThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1233,7 +1233,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlDatabase : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlDatabase(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlDatabase(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1243,7 +1243,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBSqlDatabaseResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlDatabase FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlDatabase FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1289,7 +1289,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlDatabaseThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlDatabaseThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlDatabaseThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1298,7 +1298,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlDatabaseThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlDatabaseThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1331,7 +1331,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlRoleAssignment : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlRoleAssignment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlRoleAssignment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.CosmosDB.CosmosDBAccount? Parent { get { throw null; } set { } }
@@ -1339,7 +1339,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> RoleDefinitionId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Scope { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlRoleAssignment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlRoleAssignment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1372,7 +1372,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlRoleDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlRoleDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlRoleDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> AssignableScopes { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
@@ -1381,7 +1381,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBSqlRoleDefinitionType> RoleDefinitionType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> RoleName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlRoleDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlRoleDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1425,7 +1425,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlStoredProcedure : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlStoredProcedure(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlStoredProcedure(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1435,7 +1435,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBSqlStoredProcedureResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlStoredProcedure FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlStoredProcedure FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1474,7 +1474,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlTrigger : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlTrigger(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlTrigger(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1484,7 +1484,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBSqlTriggerResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlTrigger FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlTrigger FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1538,7 +1538,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBSqlUserDefinedFunction : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBSqlUserDefinedFunction(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBSqlUserDefinedFunction(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1548,7 +1548,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBSqlUserDefinedFunctionResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBSqlUserDefinedFunction FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBSqlUserDefinedFunction FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1599,7 +1599,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBTable : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBTable(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBTable(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1609,7 +1609,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBTableResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBTable FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBTable FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1662,7 +1662,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBThroughputPool : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBThroughputPool(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBThroughputPool(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> MaxThroughput { get { throw null; } set { } }
@@ -1670,7 +1670,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBStatus> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBThroughputPool FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBThroughputPool FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_02_15_preview;
@@ -1678,7 +1678,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosDBThroughputPoolAccount : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosDBThroughputPoolAccount(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosDBThroughputPoolAccount(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AccountInstanceId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> AccountLocation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> AccountResourceIdentifier { get { throw null; } set { } }
@@ -1687,7 +1687,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.CosmosDB.CosmosDBThroughputPool? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.CosmosDBStatus> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.CosmosDBThroughputPoolAccount FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosDBThroughputPoolAccount FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_02_15_preview;
@@ -1718,7 +1718,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class CosmosTableThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public CosmosTableThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CosmosTableThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1727,7 +1727,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.CosmosTableThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.CosmosTableThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1778,7 +1778,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class DataTransferJobGetResult : Azure.Provisioning.Primitives.Resource
     {
-        public DataTransferJobGetResult(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public DataTransferJobGetResult(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.DataTransferDataSourceSink> Destination { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.TimeSpan> Duration { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ErrorResponse> Error { get { throw null; } }
@@ -1795,7 +1795,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<long> TotalCount { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> WorkerCount { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.DataTransferJobGetResult FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.DataTransferJobGetResult FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -1992,7 +1992,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class GraphResourceGetResult : Azure.Provisioning.Primitives.Resource
     {
-        public GraphResourceGetResult(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public GraphResourceGetResult(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2002,7 +2002,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> ResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.GraphResourceGetResult FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.GraphResourceGetResult FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2035,7 +2035,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class GremlinDatabase : Azure.Provisioning.Primitives.Resource
     {
-        public GremlinDatabase(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public GremlinDatabase(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2045,7 +2045,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.GremlinDatabaseResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.GremlinDatabase FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.GremlinDatabase FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2097,7 +2097,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class GremlinDatabaseThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public GremlinDatabaseThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public GremlinDatabaseThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2106,7 +2106,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.GremlinDatabaseThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.GremlinDatabaseThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2139,7 +2139,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class GremlinGraph : Azure.Provisioning.Primitives.Resource
     {
-        public GremlinGraph(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public GremlinGraph(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2149,7 +2149,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.GremlinGraphResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.GremlinGraph FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.GremlinGraph FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2201,7 +2201,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class GremlinGraphThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public GremlinGraphThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public GremlinGraphThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2210,7 +2210,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.GremlinGraphThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.GremlinGraphThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2262,7 +2262,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class MongoCluster : Azure.Provisioning.Primitives.Resource
     {
-        public MongoCluster(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public MongoCluster(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AdministratorLogin { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AdministratorLoginPassword { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.MongoClusterStatus> ClusterStatus { get { throw null; } }
@@ -2278,7 +2278,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<string> ServerVersion { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.MongoCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.MongoCluster FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_07_01;
@@ -2302,7 +2302,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class MongoDBCollection : Azure.Provisioning.Primitives.Resource
     {
-        public MongoDBCollection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public MongoDBCollection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2312,7 +2312,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.MongoDBCollectionResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.MongoDBCollection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.MongoDBCollection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2361,7 +2361,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class MongoDBCollectionThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public MongoDBCollectionThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public MongoDBCollectionThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2370,7 +2370,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.MongoDBCollectionThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.MongoDBCollectionThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2403,7 +2403,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class MongoDBDatabase : Azure.Provisioning.Primitives.Resource
     {
-        public MongoDBDatabase(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public MongoDBDatabase(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2413,7 +2413,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.MongoDBDatabaseResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.MongoDBDatabase FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.MongoDBDatabase FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2459,7 +2459,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class MongoDBDatabaseThroughputSetting : Azure.Provisioning.Primitives.Resource
     {
-        public MongoDBDatabaseThroughputSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public MongoDBDatabaseThroughputSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2468,7 +2468,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.ThroughputSettingsResourceInfo> Resource { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.MongoDBDatabaseThroughputSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.MongoDBDatabaseThroughputSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2531,7 +2531,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class MongoDBRoleDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public MongoDBRoleDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public MongoDBRoleDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DatabaseName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.CosmosDB.MongoDBRoleDefinitionType> DefinitionType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -2541,7 +2541,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<string> RoleName { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.CosmosDB.MongoDBRole> Roles { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.CosmosDB.MongoDBRoleDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.MongoDBRoleDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -2579,7 +2579,7 @@ namespace Azure.Provisioning.CosmosDB
     }
     public partial class MongoDBUserDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public MongoDBUserDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public MongoDBUserDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> CustomData { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DatabaseName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -2590,7 +2590,7 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepList<Azure.Provisioning.CosmosDB.MongoDBRole> Roles { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> UserName { get { throw null; } set { } }
-        public static Azure.Provisioning.CosmosDB.MongoDBUserDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.CosmosDB.MongoDBUserDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraCluster.cs
@@ -64,10 +64,15 @@ public partial class CassandraCluster : Resource
     /// <summary>
     /// Creates a new CassandraCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraCluster resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraCluster.</param>
-    public CassandraCluster(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/cassandraClusters", resourceVersion ?? "2024-08-15")
+    public CassandraCluster(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/cassandraClusters", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -142,9 +147,14 @@ public partial class CassandraCluster : Resource
     /// <summary>
     /// Creates a reference to an existing CassandraCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraCluster resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraCluster.</param>
     /// <returns>The existing CassandraCluster resource.</returns>
-    public static CassandraCluster FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CassandraCluster FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraDataCenter.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraDataCenter.cs
@@ -51,10 +51,15 @@ public partial class CassandraDataCenter : Resource
     /// <summary>
     /// Creates a new CassandraDataCenter.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraDataCenter.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraDataCenter resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraDataCenter.</param>
-    public CassandraDataCenter(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/cassandraClusters/dataCenters", resourceVersion ?? "2024-08-15")
+    public CassandraDataCenter(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/cassandraClusters/dataCenters", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _properties = BicepValue<CassandraDataCenterProperties>.DefineProperty(this, "Properties", ["properties"]);
@@ -127,9 +132,14 @@ public partial class CassandraDataCenter : Resource
     /// <summary>
     /// Creates a reference to an existing CassandraDataCenter.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraDataCenter.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraDataCenter resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraDataCenter.</param>
     /// <returns>The existing CassandraDataCenter resource.</returns>
-    public static CassandraDataCenter FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CassandraDataCenter FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraKeyspace.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraKeyspace.cs
@@ -83,10 +83,15 @@ public partial class CassandraKeyspace : Resource
     /// <summary>
     /// Creates a new CassandraKeyspace.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraKeyspace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraKeyspace resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraKeyspace.</param>
-    public CassandraKeyspace(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces", resourceVersion ?? "2024-08-15")
+    public CassandraKeyspace(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -239,9 +244,14 @@ public partial class CassandraKeyspace : Resource
     /// <summary>
     /// Creates a reference to an existing CassandraKeyspace.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraKeyspace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraKeyspace resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraKeyspace.</param>
     /// <returns>The existing CassandraKeyspace resource.</returns>
-    public static CassandraKeyspace FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CassandraKeyspace FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraKeyspaceThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraKeyspaceThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class CassandraKeyspaceThroughputSetting : Resource
     /// <summary>
     /// Creates a new CassandraKeyspaceThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraKeyspaceThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraKeyspaceThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraKeyspaceThroughputSetting.</param>
-    public CassandraKeyspaceThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/throughputSettings", resourceVersion ?? "2024-08-15")
+    public CassandraKeyspaceThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class CassandraKeyspaceThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing CassandraKeyspaceThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraKeyspaceThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraKeyspaceThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraKeyspaceThroughputSetting.</param>
     /// <returns>The existing CassandraKeyspaceThroughputSetting resource.</returns>
-    public static CassandraKeyspaceThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CassandraKeyspaceThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraTable.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraTable.cs
@@ -76,10 +76,15 @@ public partial class CassandraTable : Resource
     /// <summary>
     /// Creates a new CassandraTable.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraTable.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraTable resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraTable.</param>
-    public CassandraTable(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables", resourceVersion ?? "2024-08-15")
+    public CassandraTable(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class CassandraTable : Resource
     /// <summary>
     /// Creates a reference to an existing CassandraTable.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraTable.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraTable resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraTable.</param>
     /// <returns>The existing CassandraTable resource.</returns>
-    public static CassandraTable FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CassandraTable FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraTableThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraTableThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class CassandraTableThroughputSetting : Resource
     /// <summary>
     /// Creates a new CassandraTableThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraTableThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraTableThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraTableThroughputSetting.</param>
-    public CassandraTableThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables/throughputSettings", resourceVersion ?? "2024-08-15")
+    public CassandraTableThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class CassandraTableThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing CassandraTableThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraTableThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraTableThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraTableThroughputSetting.</param>
     /// <returns>The existing CassandraTableThroughputSetting resource.</returns>
-    public static CassandraTableThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CassandraTableThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraViewGetResult.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraViewGetResult.cs
@@ -76,10 +76,15 @@ public partial class CassandraViewGetResult : Resource
     /// <summary>
     /// Creates a new CassandraViewGetResult.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraViewGetResult.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraViewGetResult resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraViewGetResult.</param>
-    public CassandraViewGetResult(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views", resourceVersion ?? "2024-08-15")
+    public CassandraViewGetResult(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class CassandraViewGetResult : Resource
     /// <summary>
     /// Creates a reference to an existing CassandraViewGetResult.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraViewGetResult.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraViewGetResult resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraViewGetResult.</param>
     /// <returns>The existing CassandraViewGetResult resource.</returns>
-    public static CassandraViewGetResult FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CassandraViewGetResult FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraViewThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraViewThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class CassandraViewThroughputSetting : Resource
     /// <summary>
     /// Creates a new CassandraViewThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraViewThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraViewThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraViewThroughputSetting.</param>
-    public CassandraViewThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views/throughputSettings", resourceVersion ?? "2024-08-15")
+    public CassandraViewThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class CassandraViewThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing CassandraViewThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CassandraViewThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CassandraViewThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CassandraViewThroughputSetting.</param>
     /// <returns>The existing CassandraViewThroughputSetting resource.</returns>
-    public static CassandraViewThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CassandraViewThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
@@ -378,10 +378,15 @@ public partial class CosmosDBAccount : Resource
     /// <summary>
     /// Creates a new CosmosDBAccount.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBAccount.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBAccount resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBAccount.</param>
-    public CosmosDBAccount(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts", resourceVersion ?? "2024-08-15")
+    public CosmosDBAccount(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -575,11 +580,16 @@ public partial class CosmosDBAccount : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBAccount.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBAccount.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBAccount resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBAccount.</param>
     /// <returns>The existing CosmosDBAccount resource.</returns>
-    public static CosmosDBAccount FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBAccount FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this CosmosDBAccount resource.
@@ -595,7 +605,7 @@ public partial class CosmosDBAccount : Resource
     /// <returns>The keys for this CosmosDBAccount resource.</returns>
     public CosmosDBAccountKeyList GetKeys() =>
         CosmosDBAccountKeyList.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -605,10 +615,10 @@ public partial class CosmosDBAccount : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(CosmosDBBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -621,13 +631,13 @@ public partial class CosmosDBAccount : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(CosmosDBBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(CosmosDBBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{CosmosDBBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBFirewallRule.cs
@@ -64,10 +64,15 @@ public partial class CosmosDBFirewallRule : Resource
     /// <summary>
     /// Creates a new CosmosDBFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBFirewallRule resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBFirewallRule.</param>
-    public CosmosDBFirewallRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/mongoClusters/firewallRules", resourceVersion ?? "2024-07-01")
+    public CosmosDBFirewallRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/mongoClusters/firewallRules", resourceVersion ?? "2024-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _endIPAddress = BicepValue<string>.DefineProperty(this, "EndIPAddress", ["properties", "endIpAddress"], isRequired: true);
@@ -92,9 +97,14 @@ public partial class CosmosDBFirewallRule : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBFirewallRule resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBFirewallRule.</param>
     /// <returns>The existing CosmosDBFirewallRule resource.</returns>
-    public static CosmosDBFirewallRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBFirewallRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBPrivateEndpointConnection.cs
@@ -68,10 +68,15 @@ public partial class CosmosDBPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new CosmosDBPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBPrivateEndpointConnection.</param>
-    public CosmosDBPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections", resourceVersion ?? "2024-08-15")
+    public CosmosDBPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<CosmosDBPrivateLinkServiceConnectionStateProperty>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -222,9 +227,14 @@ public partial class CosmosDBPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBPrivateEndpointConnection.</param>
     /// <returns>The existing CosmosDBPrivateEndpointConnection resource.</returns>
-    public static CosmosDBPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBService.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBService.cs
@@ -79,10 +79,15 @@ public partial class CosmosDBService : Resource
     /// <summary>
     /// Creates a new CosmosDBService.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBService resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBService.</param>
-    public CosmosDBService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/services", resourceVersion ?? "2024-08-15")
+    public CosmosDBService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/services", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _instanceCount = BicepValue<int>.DefineProperty(this, "InstanceCount", ["properties", "instanceCount"]);
@@ -233,9 +238,14 @@ public partial class CosmosDBService : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBService.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBService resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBService.</param>
     /// <returns>The existing CosmosDBService resource.</returns>
-    public static CosmosDBService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlClientEncryptionKey.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlClientEncryptionKey.cs
@@ -50,10 +50,15 @@ public partial class CosmosDBSqlClientEncryptionKey : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlClientEncryptionKey.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlClientEncryptionKey.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlClientEncryptionKey
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlClientEncryptionKey.</param>
-    public CosmosDBSqlClientEncryptionKey(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/clientEncryptionKeys", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlClientEncryptionKey(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/clientEncryptionKeys", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _resource = BicepValue<CosmosDBSqlClientEncryptionKeyResourceInfo>.DefineProperty(this, "Resource", ["properties", "resource"], isRequired: true);
@@ -201,9 +206,14 @@ public partial class CosmosDBSqlClientEncryptionKey : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlClientEncryptionKey.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlClientEncryptionKey.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlClientEncryptionKey
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlClientEncryptionKey.</param>
     /// <returns>The existing CosmosDBSqlClientEncryptionKey resource.</returns>
-    public static CosmosDBSqlClientEncryptionKey FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlClientEncryptionKey FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlContainer.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlContainer.cs
@@ -76,10 +76,15 @@ public partial class CosmosDBSqlContainer : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlContainer.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlContainer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlContainer resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlContainer.</param>
-    public CosmosDBSqlContainer(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlContainer(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class CosmosDBSqlContainer : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlContainer.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlContainer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlContainer resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlContainer.</param>
     /// <returns>The existing CosmosDBSqlContainer resource.</returns>
-    public static CosmosDBSqlContainer FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlContainer FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlContainerThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlContainerThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class CosmosDBSqlContainerThroughputSetting : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlContainerThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlContainerThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// CosmosDBSqlContainerThroughputSetting resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlContainerThroughputSetting.</param>
-    public CosmosDBSqlContainerThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlContainerThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -224,9 +229,14 @@ public partial class CosmosDBSqlContainerThroughputSetting : Resource
     /// Creates a reference to an existing
     /// CosmosDBSqlContainerThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlContainerThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// CosmosDBSqlContainerThroughputSetting resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlContainerThroughputSetting.</param>
     /// <returns>The existing CosmosDBSqlContainerThroughputSetting resource.</returns>
-    public static CosmosDBSqlContainerThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlContainerThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlDatabase.cs
@@ -76,10 +76,15 @@ public partial class CosmosDBSqlDatabase : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlDatabase resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlDatabase.</param>
-    public CosmosDBSqlDatabase(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlDatabase(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class CosmosDBSqlDatabase : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlDatabase resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlDatabase.</param>
     /// <returns>The existing CosmosDBSqlDatabase resource.</returns>
-    public static CosmosDBSqlDatabase FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlDatabase FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlDatabaseThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlDatabaseThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class CosmosDBSqlDatabaseThroughputSetting : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlDatabaseThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlDatabaseThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// CosmosDBSqlDatabaseThroughputSetting resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlDatabaseThroughputSetting.</param>
-    public CosmosDBSqlDatabaseThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlDatabaseThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class CosmosDBSqlDatabaseThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlDatabaseThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlDatabaseThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// CosmosDBSqlDatabaseThroughputSetting resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlDatabaseThroughputSetting.</param>
     /// <returns>The existing CosmosDBSqlDatabaseThroughputSetting resource.</returns>
-    public static CosmosDBSqlDatabaseThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlDatabaseThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlRoleAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlRoleAssignment.cs
@@ -66,10 +66,15 @@ public partial class CosmosDBSqlRoleAssignment : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlRoleAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlRoleAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlRoleAssignment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlRoleAssignment.</param>
-    public CosmosDBSqlRoleAssignment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlRoleAssignment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _principalId = BicepValue<Guid>.DefineProperty(this, "PrincipalId", ["properties", "principalId"]);
@@ -219,9 +224,14 @@ public partial class CosmosDBSqlRoleAssignment : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlRoleAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlRoleAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlRoleAssignment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlRoleAssignment.</param>
     /// <returns>The existing CosmosDBSqlRoleAssignment resource.</returns>
-    public static CosmosDBSqlRoleAssignment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlRoleAssignment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlRoleDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlRoleDefinition.cs
@@ -75,10 +75,15 @@ public partial class CosmosDBSqlRoleDefinition : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlRoleDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlRoleDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlRoleDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlRoleDefinition.</param>
-    public CosmosDBSqlRoleDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlRoleDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _assignableScopes = BicepList<string>.DefineProperty(this, "AssignableScopes", ["properties", "assignableScopes"]);
@@ -229,9 +234,14 @@ public partial class CosmosDBSqlRoleDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlRoleDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlRoleDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlRoleDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlRoleDefinition.</param>
     /// <returns>The existing CosmosDBSqlRoleDefinition resource.</returns>
-    public static CosmosDBSqlRoleDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlRoleDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlStoredProcedure.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlStoredProcedure.cs
@@ -76,10 +76,15 @@ public partial class CosmosDBSqlStoredProcedure : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlStoredProcedure.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlStoredProcedure.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlStoredProcedure
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlStoredProcedure.</param>
-    public CosmosDBSqlStoredProcedure(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlStoredProcedure(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class CosmosDBSqlStoredProcedure : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlStoredProcedure.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlStoredProcedure.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlStoredProcedure
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlStoredProcedure.</param>
     /// <returns>The existing CosmosDBSqlStoredProcedure resource.</returns>
-    public static CosmosDBSqlStoredProcedure FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlStoredProcedure FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlTrigger.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlTrigger.cs
@@ -76,10 +76,15 @@ public partial class CosmosDBSqlTrigger : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlTrigger.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlTrigger.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlTrigger resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlTrigger.</param>
-    public CosmosDBSqlTrigger(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlTrigger(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class CosmosDBSqlTrigger : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlTrigger.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlTrigger.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlTrigger resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlTrigger.</param>
     /// <returns>The existing CosmosDBSqlTrigger resource.</returns>
-    public static CosmosDBSqlTrigger FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlTrigger FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlUserDefinedFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlUserDefinedFunction.cs
@@ -76,10 +76,15 @@ public partial class CosmosDBSqlUserDefinedFunction : Resource
     /// <summary>
     /// Creates a new CosmosDBSqlUserDefinedFunction.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlUserDefinedFunction.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlUserDefinedFunction
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlUserDefinedFunction.</param>
-    public CosmosDBSqlUserDefinedFunction(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions", resourceVersion ?? "2024-08-15")
+    public CosmosDBSqlUserDefinedFunction(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class CosmosDBSqlUserDefinedFunction : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBSqlUserDefinedFunction.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBSqlUserDefinedFunction.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBSqlUserDefinedFunction
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBSqlUserDefinedFunction.</param>
     /// <returns>The existing CosmosDBSqlUserDefinedFunction resource.</returns>
-    public static CosmosDBSqlUserDefinedFunction FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBSqlUserDefinedFunction FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBTable.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBTable.cs
@@ -76,10 +76,15 @@ public partial class CosmosDBTable : Resource
     /// <summary>
     /// Creates a new CosmosDBTable.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBTable.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBTable resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBTable.</param>
-    public CosmosDBTable(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/tables", resourceVersion ?? "2024-08-15")
+    public CosmosDBTable(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/tables", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class CosmosDBTable : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBTable.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBTable.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBTable resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBTable.</param>
     /// <returns>The existing CosmosDBTable resource.</returns>
-    public static CosmosDBTable FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBTable FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBThroughputPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBThroughputPool.cs
@@ -63,10 +63,15 @@ public partial class CosmosDBThroughputPool : Resource
     /// <summary>
     /// Creates a new CosmosDBThroughputPool.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBThroughputPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBThroughputPool resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBThroughputPool.</param>
-    public CosmosDBThroughputPool(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/throughputPools", resourceVersion ?? "2024-02-15-preview")
+    public CosmosDBThroughputPool(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/throughputPools", resourceVersion ?? "2024-02-15-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -91,9 +96,14 @@ public partial class CosmosDBThroughputPool : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBThroughputPool.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBThroughputPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBThroughputPool resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBThroughputPool.</param>
     /// <returns>The existing CosmosDBThroughputPool resource.</returns>
-    public static CosmosDBThroughputPool FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBThroughputPool FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBThroughputPoolAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBThroughputPoolAccount.cs
@@ -69,10 +69,15 @@ public partial class CosmosDBThroughputPoolAccount : Resource
     /// <summary>
     /// Creates a new CosmosDBThroughputPoolAccount.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBThroughputPoolAccount.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBThroughputPoolAccount
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBThroughputPoolAccount.</param>
-    public CosmosDBThroughputPoolAccount(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/throughputPools/throughputPoolAccounts", resourceVersion ?? "2024-02-15-preview")
+    public CosmosDBThroughputPoolAccount(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/throughputPools/throughputPoolAccounts", resourceVersion ?? "2024-02-15-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _accountLocation = BicepValue<AzureLocation>.DefineProperty(this, "AccountLocation", ["properties", "accountLocation"]);
@@ -98,9 +103,14 @@ public partial class CosmosDBThroughputPoolAccount : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosDBThroughputPoolAccount.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosDBThroughputPoolAccount.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosDBThroughputPoolAccount
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBThroughputPoolAccount.</param>
     /// <returns>The existing CosmosDBThroughputPoolAccount resource.</returns>
-    public static CosmosDBThroughputPoolAccount FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosDBThroughputPoolAccount FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosTableThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosTableThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class CosmosTableThroughputSetting : Resource
     /// <summary>
     /// Creates a new CosmosTableThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosTableThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosTableThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosTableThroughputSetting.</param>
-    public CosmosTableThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/tables/throughputSettings", resourceVersion ?? "2024-08-15")
+    public CosmosTableThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/tables/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class CosmosTableThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing CosmosTableThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the CosmosTableThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CosmosTableThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CosmosTableThroughputSetting.</param>
     /// <returns>The existing CosmosTableThroughputSetting resource.</returns>
-    public static CosmosTableThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CosmosTableThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/DataTransferJobGetResult.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/DataTransferJobGetResult.cs
@@ -138,10 +138,15 @@ public partial class DataTransferJobGetResult : Resource
     /// <summary>
     /// Creates a new DataTransferJobGetResult.
     /// </summary>
-    /// <param name="resourceName">Name of the DataTransferJobGetResult.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DataTransferJobGetResult resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DataTransferJobGetResult.</param>
-    public DataTransferJobGetResult(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/dataTransferJobs", resourceVersion ?? "2024-08-15")
+    public DataTransferJobGetResult(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/dataTransferJobs", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _properties = BicepValue<DataTransferJobProperties>.DefineProperty(this, "Properties", ["properties"], isRequired: true);
@@ -300,9 +305,14 @@ public partial class DataTransferJobGetResult : Resource
     /// <summary>
     /// Creates a reference to an existing DataTransferJobGetResult.
     /// </summary>
-    /// <param name="resourceName">Name of the DataTransferJobGetResult.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DataTransferJobGetResult resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DataTransferJobGetResult.</param>
     /// <returns>The existing DataTransferJobGetResult resource.</returns>
-    public static DataTransferJobGetResult FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static DataTransferJobGetResult FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GraphResourceGetResult.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GraphResourceGetResult.cs
@@ -76,10 +76,15 @@ public partial class GraphResourceGetResult : Resource
     /// <summary>
     /// Creates a new GraphResourceGetResult.
     /// </summary>
-    /// <param name="resourceName">Name of the GraphResourceGetResult.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GraphResourceGetResult resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GraphResourceGetResult.</param>
-    public GraphResourceGetResult(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/graphs", resourceVersion ?? "2024-08-15")
+    public GraphResourceGetResult(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/graphs", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class GraphResourceGetResult : Resource
     /// <summary>
     /// Creates a reference to an existing GraphResourceGetResult.
     /// </summary>
-    /// <param name="resourceName">Name of the GraphResourceGetResult.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GraphResourceGetResult resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GraphResourceGetResult.</param>
     /// <returns>The existing GraphResourceGetResult resource.</returns>
-    public static GraphResourceGetResult FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static GraphResourceGetResult FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinDatabase.cs
@@ -76,10 +76,15 @@ public partial class GremlinDatabase : Resource
     /// <summary>
     /// Creates a new GremlinDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the GremlinDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GremlinDatabase resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GremlinDatabase.</param>
-    public GremlinDatabase(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/gremlinDatabases", resourceVersion ?? "2024-08-15")
+    public GremlinDatabase(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/gremlinDatabases", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class GremlinDatabase : Resource
     /// <summary>
     /// Creates a reference to an existing GremlinDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the GremlinDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GremlinDatabase resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GremlinDatabase.</param>
     /// <returns>The existing GremlinDatabase resource.</returns>
-    public static GremlinDatabase FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static GremlinDatabase FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinDatabaseThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinDatabaseThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class GremlinDatabaseThroughputSetting : Resource
     /// <summary>
     /// Creates a new GremlinDatabaseThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the GremlinDatabaseThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GremlinDatabaseThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GremlinDatabaseThroughputSetting.</param>
-    public GremlinDatabaseThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/throughputSettings", resourceVersion ?? "2024-08-15")
+    public GremlinDatabaseThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class GremlinDatabaseThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing GremlinDatabaseThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the GremlinDatabaseThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GremlinDatabaseThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GremlinDatabaseThroughputSetting.</param>
     /// <returns>The existing GremlinDatabaseThroughputSetting resource.</returns>
-    public static GremlinDatabaseThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static GremlinDatabaseThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinGraph.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinGraph.cs
@@ -76,10 +76,15 @@ public partial class GremlinGraph : Resource
     /// <summary>
     /// Creates a new GremlinGraph.
     /// </summary>
-    /// <param name="resourceName">Name of the GremlinGraph.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GremlinGraph resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GremlinGraph.</param>
-    public GremlinGraph(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs", resourceVersion ?? "2024-08-15")
+    public GremlinGraph(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class GremlinGraph : Resource
     /// <summary>
     /// Creates a reference to an existing GremlinGraph.
     /// </summary>
-    /// <param name="resourceName">Name of the GremlinGraph.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GremlinGraph resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GremlinGraph.</param>
     /// <returns>The existing GremlinGraph resource.</returns>
-    public static GremlinGraph FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static GremlinGraph FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinGraphThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinGraphThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class GremlinGraphThroughputSetting : Resource
     /// <summary>
     /// Creates a new GremlinGraphThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the GremlinGraphThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GremlinGraphThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GremlinGraphThroughputSetting.</param>
-    public GremlinGraphThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs/throughputSettings", resourceVersion ?? "2024-08-15")
+    public GremlinGraphThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class GremlinGraphThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing GremlinGraphThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the GremlinGraphThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GremlinGraphThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GremlinGraphThroughputSetting.</param>
     /// <returns>The existing GremlinGraphThroughputSetting resource.</returns>
-    public static GremlinGraphThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static GremlinGraphThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoCluster.cs
@@ -112,10 +112,15 @@ public partial class MongoCluster : Resource
     /// <summary>
     /// Creates a new MongoCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoCluster resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoCluster.</param>
-    public MongoCluster(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/mongoClusters", resourceVersion ?? "2024-07-01")
+    public MongoCluster(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/mongoClusters", resourceVersion ?? "2024-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -148,9 +153,14 @@ public partial class MongoCluster : Resource
     /// <summary>
     /// Creates a reference to an existing MongoCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoCluster resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoCluster.</param>
     /// <returns>The existing MongoCluster resource.</returns>
-    public static MongoCluster FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static MongoCluster FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBCollection.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBCollection.cs
@@ -76,10 +76,15 @@ public partial class MongoDBCollection : Resource
     /// <summary>
     /// Creates a new MongoDBCollection.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBCollection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBCollection resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBCollection.</param>
-    public MongoDBCollection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections", resourceVersion ?? "2024-08-15")
+    public MongoDBCollection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class MongoDBCollection : Resource
     /// <summary>
     /// Creates a reference to an existing MongoDBCollection.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBCollection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBCollection resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBCollection.</param>
     /// <returns>The existing MongoDBCollection resource.</returns>
-    public static MongoDBCollection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static MongoDBCollection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBCollectionThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBCollectionThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class MongoDBCollectionThroughputSetting : Resource
     /// <summary>
     /// Creates a new MongoDBCollectionThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBCollectionThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBCollectionThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBCollectionThroughputSetting.</param>
-    public MongoDBCollectionThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings", resourceVersion ?? "2024-08-15")
+    public MongoDBCollectionThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class MongoDBCollectionThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing MongoDBCollectionThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBCollectionThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBCollectionThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBCollectionThroughputSetting.</param>
     /// <returns>The existing MongoDBCollectionThroughputSetting resource.</returns>
-    public static MongoDBCollectionThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static MongoDBCollectionThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBDatabase.cs
@@ -76,10 +76,15 @@ public partial class MongoDBDatabase : Resource
     /// <summary>
     /// Creates a new MongoDBDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBDatabase resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBDatabase.</param>
-    public MongoDBDatabase(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases", resourceVersion ?? "2024-08-15")
+    public MongoDBDatabase(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -231,9 +236,14 @@ public partial class MongoDBDatabase : Resource
     /// <summary>
     /// Creates a reference to an existing MongoDBDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBDatabase resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBDatabase.</param>
     /// <returns>The existing MongoDBDatabase resource.</returns>
-    public static MongoDBDatabase FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static MongoDBDatabase FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBDatabaseThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBDatabaseThroughputSetting.cs
@@ -69,10 +69,15 @@ public partial class MongoDBDatabaseThroughputSetting : Resource
     /// <summary>
     /// Creates a new MongoDBDatabaseThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBDatabaseThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBDatabaseThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBDatabaseThroughputSetting.</param>
-    public MongoDBDatabaseThroughputSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings", resourceVersion ?? "2024-08-15")
+    public MongoDBDatabaseThroughputSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -223,9 +228,14 @@ public partial class MongoDBDatabaseThroughputSetting : Resource
     /// <summary>
     /// Creates a reference to an existing MongoDBDatabaseThroughputSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBDatabaseThroughputSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBDatabaseThroughputSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBDatabaseThroughputSetting.</param>
     /// <returns>The existing MongoDBDatabaseThroughputSetting resource.</returns>
-    public static MongoDBDatabaseThroughputSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static MongoDBDatabaseThroughputSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBRoleDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBRoleDefinition.cs
@@ -80,10 +80,15 @@ public partial class MongoDBRoleDefinition : Resource
     /// <summary>
     /// Creates a new MongoDBRoleDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBRoleDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBRoleDefinition resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBRoleDefinition.</param>
-    public MongoDBRoleDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions", resourceVersion ?? "2024-08-15")
+    public MongoDBRoleDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _databaseName = BicepValue<string>.DefineProperty(this, "DatabaseName", ["properties", "databaseName"]);
@@ -235,9 +240,14 @@ public partial class MongoDBRoleDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing MongoDBRoleDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBRoleDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBRoleDefinition resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBRoleDefinition.</param>
     /// <returns>The existing MongoDBRoleDefinition resource.</returns>
-    public static MongoDBRoleDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static MongoDBRoleDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBUserDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBUserDefinition.cs
@@ -84,10 +84,15 @@ public partial class MongoDBUserDefinition : Resource
     /// <summary>
     /// Creates a new MongoDBUserDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBUserDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBUserDefinition resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBUserDefinition.</param>
-    public MongoDBUserDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions", resourceVersion ?? "2024-08-15")
+    public MongoDBUserDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions", resourceVersion ?? "2024-08-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _customData = BicepValue<string>.DefineProperty(this, "CustomData", ["properties", "customData"]);
@@ -240,9 +245,14 @@ public partial class MongoDBUserDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing MongoDBUserDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the MongoDBUserDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MongoDBUserDefinition resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MongoDBUserDefinition.</param>
     /// <returns>The existing MongoDBUserDefinition resource.</returns>
-    public static MongoDBUserDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static MongoDBUserDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Deployment/src/ProvisioningPlan.Deploy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/src/ProvisioningPlan.Deploy.cs
@@ -224,7 +224,7 @@ public static class ProvisioningPlanExtensions
         // Patch up output references
         foreach (ProvisioningOutput output in plan.Infrastructure.GetResources().OfType<ProvisioningOutput>())
         {
-            if (outputs.TryGetValue(output.ResourceName, out object? value) &&
+            if (outputs.TryGetValue(output.IdentifierName, out object? value) &&
                 value is not null)
             {
                 output.Value = value;

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/api/Azure.Provisioning.EventGrid.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/api/Azure.Provisioning.EventGrid.netstandard2.0.cs
@@ -40,7 +40,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class CaCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public CaCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public CaCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EncodedCertificate { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> ExpiryTimeInUtc { get { throw null; } }
@@ -50,7 +50,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.EventGrid.EventGridNamespace? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.CaCertificateProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.CaCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.CaCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;
@@ -187,7 +187,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class DomainEventSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public DomainEventSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public DomainEventSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterDestination> DeadLetterDestination { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterWithResourceIdentity> DeadLetterWithResourceIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeliveryWithResourceIdentity> DeliveryWithResourceIdentity { get { throw null; } set { } }
@@ -203,7 +203,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventSubscriptionRetryPolicy> RetryPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Topic { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.DomainEventSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.DomainEventSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_06_01;
@@ -215,13 +215,13 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class DomainTopic : Azure.Provisioning.Primitives.Resource
     {
-        public DomainTopic(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public DomainTopic(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.EventGrid.EventGridDomain? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DomainTopicProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.DomainTopic FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.DomainTopic FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -235,7 +235,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class DomainTopicEventSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public DomainTopicEventSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public DomainTopicEventSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterDestination> DeadLetterDestination { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterWithResourceIdentity> DeadLetterWithResourceIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeliveryWithResourceIdentity> DeliveryWithResourceIdentity { get { throw null; } set { } }
@@ -251,7 +251,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventSubscriptionRetryPolicy> RetryPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Topic { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.DomainTopicEventSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.DomainTopicEventSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_06_01;
@@ -315,7 +315,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridDomain : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridDomain(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridDomain(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> AutoCreateTopicWithFirstSubscription { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> AutoDeleteTopicWithLastSubscription { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DataResidencyBoundary> DataResidencyBoundary { get { throw null; } set { } }
@@ -337,7 +337,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridSku> SkuName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.EventGridDomain FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridDomain FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -351,7 +351,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridDomainPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridDomainPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridDomainPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridPrivateEndpointConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> GroupIds { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -360,7 +360,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridResourceProvisioningState> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.EventGridDomainPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridDomainPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_06_01;
@@ -416,7 +416,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridNamespace : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridNamespace(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridNamespace(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.EventGrid.EventGridInboundIPRule> InboundIPRules { get { throw null; } set { } }
@@ -432,7 +432,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.TopicsConfiguration> TopicsConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.TopicSpacesConfiguration> TopicSpacesConfiguration { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.EventGridNamespace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridNamespace FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;
@@ -440,7 +440,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridNamespaceClientGroup : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridNamespaceClientGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridNamespaceClientGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -448,7 +448,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.ClientGroupProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Query { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.EventGridNamespaceClientGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridNamespaceClientGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;
@@ -466,7 +466,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridNamespaceClientResource : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridNamespaceClientResource(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridNamespaceClientResource(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepDictionary<System.BinaryData> Attributes { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AuthenticationName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.ClientCertificateAuthentication> ClientCertificateAuthentication { get { throw null; } set { } }
@@ -477,7 +477,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridNamespaceClientProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridNamespaceClientState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.EventGridNamespaceClientResource FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridNamespaceClientResource FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;
@@ -490,7 +490,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridNamespacePermissionBinding : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridNamespacePermissionBinding(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridNamespacePermissionBinding(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ClientGroupName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -500,7 +500,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PermissionBindingProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TopicSpaceName { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.EventGridNamespacePermissionBinding FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridNamespacePermissionBinding FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;
@@ -515,7 +515,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridPartnerNamespacePrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridPartnerNamespacePrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridPartnerNamespacePrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridPrivateEndpointConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> GroupIds { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -524,7 +524,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridResourceProvisioningState> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.EventGridPartnerNamespacePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridPartnerNamespacePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
@@ -582,7 +582,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridTopic : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridTopic(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridTopic(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DataResidencyBoundary> DataResidencyBoundary { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> Endpoint { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerTopicEventTypeInfo> EventTypeInfo { get { throw null; } set { } }
@@ -604,7 +604,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridSku> SkuName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.EventGridTopic FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridTopic FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -620,7 +620,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventGridTopicPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public EventGridTopicPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventGridTopicPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridPrivateEndpointConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> GroupIds { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -629,7 +629,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridResourceProvisioningState> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.EventGridTopicPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventGridTopicPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2018_01_01;
@@ -663,7 +663,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class EventSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public EventSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterDestination> DeadLetterDestination { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterWithResourceIdentity> DeadLetterWithResourceIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeliveryWithResourceIdentity> DeliveryWithResourceIdentity { get { throw null; } set { } }
@@ -678,7 +678,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventSubscriptionRetryPolicy> RetryPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Topic { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.EventSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.EventSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -817,7 +817,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class NamespaceTopic : Azure.Provisioning.Primitives.Resource
     {
-        public NamespaceTopic(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public NamespaceTopic(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<int> EventRetentionInDays { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventInputSchema> InputSchema { get { throw null; } set { } }
@@ -826,7 +826,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.NamespaceTopicProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PublisherType> PublisherType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.NamespaceTopic FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.NamespaceTopic FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;
@@ -834,7 +834,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class NamespaceTopicEventSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public NamespaceTopicEventSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public NamespaceTopicEventSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeliveryConfiguration> DeliveryConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeliverySchema> EventDeliverySchema { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> ExpireOn { get { throw null; } set { } }
@@ -844,7 +844,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.EventGrid.NamespaceTopic? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.SubscriptionProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.NamespaceTopicEventSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.NamespaceTopicEventSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;
@@ -960,7 +960,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class PartnerConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public PartnerConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PartnerConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
@@ -968,7 +968,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerConfigurationProvisioningState> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.PartnerConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.PartnerConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
@@ -986,7 +986,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class PartnerDestination : Azure.Provisioning.Primitives.Resource
     {
-        public PartnerDestination(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PartnerDestination(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerDestinationActivationState> ActivationState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Uri> EndpointBaseUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EndpointServiceContext { get { throw null; } set { } }
@@ -999,7 +999,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerDestinationProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.PartnerDestination FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.PartnerDestination FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;
@@ -1036,7 +1036,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class PartnerNamespace : Azure.Provisioning.Primitives.Resource
     {
-        public PartnerNamespace(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PartnerNamespace(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Uri> Endpoint { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.EventGrid.EventGridInboundIPRule> InboundIPRules { get { throw null; } set { } }
@@ -1051,7 +1051,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventGridPublicNetworkAccess> PublicNetworkAccess { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.PartnerNamespace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.PartnerNamespace FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
@@ -1060,7 +1060,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class PartnerNamespaceChannel : Azure.Provisioning.Primitives.Resource
     {
-        public PartnerNamespaceChannel(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PartnerNamespaceChannel(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerNamespaceChannelType> ChannelType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> ExpireOnIfNotActivated { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -1072,7 +1072,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerNamespaceChannelProvisioningState> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerTopicReadinessState> ReadinessState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.PartnerNamespaceChannel FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.PartnerNamespaceChannel FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
@@ -1106,7 +1106,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class PartnerRegistration : Azure.Provisioning.Primitives.Resource
     {
-        public PartnerRegistration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PartnerRegistration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -1114,7 +1114,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerRegistrationProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.PartnerRegistration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.PartnerRegistration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
@@ -1132,7 +1132,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class PartnerTopic : Azure.Provisioning.Primitives.Resource
     {
-        public PartnerTopic(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PartnerTopic(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerTopicActivationState> ActivationState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PartnerTopicEventTypeInfo> EventTypeInfo { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> ExpireOnIfNotActivated { get { throw null; } set { } }
@@ -1147,7 +1147,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<string> Source { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.PartnerTopic FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.PartnerTopic FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
@@ -1162,7 +1162,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class PartnerTopicEventSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public PartnerTopicEventSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PartnerTopicEventSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterDestination> DeadLetterDestination { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterWithResourceIdentity> DeadLetterWithResourceIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeliveryWithResourceIdentity> DeliveryWithResourceIdentity { get { throw null; } set { } }
@@ -1178,7 +1178,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventSubscriptionRetryPolicy> RetryPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Topic { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.PartnerTopicEventSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.PartnerTopicEventSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
@@ -1423,7 +1423,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class SystemTopic : Azure.Provisioning.Primitives.Resource
     {
-        public SystemTopic(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SystemTopic(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -1434,7 +1434,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> TopicType { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.SystemTopic FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.SystemTopic FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_12_01;
@@ -1444,7 +1444,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class SystemTopicEventSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public SystemTopicEventSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SystemTopicEventSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterDestination> DeadLetterDestination { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterWithResourceIdentity> DeadLetterWithResourceIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeliveryWithResourceIdentity> DeliveryWithResourceIdentity { get { throw null; } set { } }
@@ -1460,7 +1460,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventSubscriptionRetryPolicy> RetryPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Topic { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.SystemTopicEventSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.SystemTopicEventSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_12_01;
@@ -1479,7 +1479,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class TopicEventSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public TopicEventSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public TopicEventSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterDestination> DeadLetterDestination { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeadLetterWithResourceIdentity> DeadLetterWithResourceIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.DeliveryWithResourceIdentity> DeliveryWithResourceIdentity { get { throw null; } set { } }
@@ -1495,7 +1495,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.EventSubscriptionRetryPolicy> RetryPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Topic { get { throw null; } }
-        public static Azure.Provisioning.EventGrid.TopicEventSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.TopicEventSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2018_01_01;
@@ -1515,7 +1515,7 @@ namespace Azure.Provisioning.EventGrid
     }
     public partial class TopicSpace : Azure.Provisioning.Primitives.Resource
     {
-        public TopicSpace(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public TopicSpace(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -1523,7 +1523,7 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.TopicSpaceProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<string> TopicTemplates { get { throw null; } set { } }
-        public static Azure.Provisioning.EventGrid.TopicSpace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventGrid.TopicSpace FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_06_01_preview;

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/CaCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/CaCertificate.cs
@@ -74,10 +74,15 @@ public partial class CaCertificate : Resource
     /// <summary>
     /// Creates a new CaCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the CaCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CaCertificate resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CaCertificate.</param>
-    public CaCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/namespaces/caCertificates", resourceVersion ?? "2024-06-01-preview")
+    public CaCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/namespaces/caCertificates", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -104,9 +109,14 @@ public partial class CaCertificate : Resource
     /// <summary>
     /// Creates a reference to an existing CaCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the CaCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the CaCertificate resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the CaCertificate.</param>
     /// <returns>The existing CaCertificate resource.</returns>
-    public static CaCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static CaCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainEventSubscription.cs
@@ -150,10 +150,15 @@ public partial class DomainEventSubscription : Resource
     /// <summary>
     /// Creates a new DomainEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the DomainEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DomainEventSubscription resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DomainEventSubscription.</param>
-    public DomainEventSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/domains/eventSubscriptions", resourceVersion ?? "2022-06-15")
+    public DomainEventSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/domains/eventSubscriptions", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _deadLetterDestination = BicepValue<DeadLetterDestination>.DefineProperty(this, "DeadLetterDestination", ["properties", "deadLetterDestination"]);
@@ -206,9 +211,14 @@ public partial class DomainEventSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing DomainEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the DomainEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DomainEventSubscription resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DomainEventSubscription.</param>
     /// <returns>The existing DomainEventSubscription resource.</returns>
-    public static DomainEventSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static DomainEventSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainTopic.cs
@@ -51,10 +51,15 @@ public partial class DomainTopic : Resource
     /// <summary>
     /// Creates a new DomainTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the DomainTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DomainTopic resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DomainTopic.</param>
-    public DomainTopic(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/domains/topics", resourceVersion ?? "2022-06-15")
+    public DomainTopic(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/domains/topics", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _id = BicepValue<ResourceIdentifier>.DefineProperty(this, "Id", ["id"], isOutput: true);
@@ -97,11 +102,16 @@ public partial class DomainTopic : Resource
     /// <summary>
     /// Creates a reference to an existing DomainTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the DomainTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DomainTopic resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DomainTopic.</param>
     /// <returns>The existing DomainTopic resource.</returns>
-    public static DomainTopic FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static DomainTopic FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this DomainTopic resource.

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainTopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainTopicEventSubscription.cs
@@ -150,10 +150,15 @@ public partial class DomainTopicEventSubscription : Resource
     /// <summary>
     /// Creates a new DomainTopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the DomainTopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DomainTopicEventSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DomainTopicEventSubscription.</param>
-    public DomainTopicEventSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/domains/topics/eventSubscriptions", resourceVersion ?? "2022-06-15")
+    public DomainTopicEventSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/domains/topics/eventSubscriptions", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _deadLetterDestination = BicepValue<DeadLetterDestination>.DefineProperty(this, "DeadLetterDestination", ["properties", "deadLetterDestination"]);
@@ -206,9 +211,14 @@ public partial class DomainTopicEventSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing DomainTopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the DomainTopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DomainTopicEventSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DomainTopicEventSubscription.</param>
     /// <returns>The existing DomainTopicEventSubscription resource.</returns>
-    public static DomainTopicEventSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static DomainTopicEventSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridDomain.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridDomain.cs
@@ -195,10 +195,15 @@ public partial class EventGridDomain : Resource
     /// <summary>
     /// Creates a new EventGridDomain.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridDomain.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridDomain resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridDomain.</param>
-    public EventGridDomain(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/domains", resourceVersion ?? "2022-06-15")
+    public EventGridDomain(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/domains", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -257,11 +262,16 @@ public partial class EventGridDomain : Resource
     /// <summary>
     /// Creates a reference to an existing EventGridDomain.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridDomain.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridDomain resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridDomain.</param>
     /// <returns>The existing EventGridDomain resource.</returns>
-    public static EventGridDomain FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridDomain FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this EventGridDomain resource.

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridDomainPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridDomainPrivateEndpointConnection.cs
@@ -69,10 +69,16 @@ public partial class EventGridDomainPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new EventGridDomainPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridDomainPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventGridDomainPrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridDomainPrivateEndpointConnection.</param>
-    public EventGridDomainPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/domains/privateEndpointConnections", resourceVersion ?? "2022-06-15")
+    public EventGridDomainPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/domains/privateEndpointConnections", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<EventGridPrivateEndpointConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -119,9 +125,15 @@ public partial class EventGridDomainPrivateEndpointConnection : Resource
     /// Creates a reference to an existing
     /// EventGridDomainPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridDomainPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventGridDomainPrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridDomainPrivateEndpointConnection.</param>
     /// <returns>The existing EventGridDomainPrivateEndpointConnection resource.</returns>
-    public static EventGridDomainPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridDomainPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespace.cs
@@ -124,10 +124,15 @@ public partial class EventGridNamespace : Resource
     /// <summary>
     /// Creates a new EventGridNamespace.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridNamespace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridNamespace resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespace.</param>
-    public EventGridNamespace(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/namespaces", resourceVersion ?? "2024-06-01-preview")
+    public EventGridNamespace(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/namespaces", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -160,9 +165,14 @@ public partial class EventGridNamespace : Resource
     /// <summary>
     /// Creates a reference to an existing EventGridNamespace.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridNamespace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridNamespace resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespace.</param>
     /// <returns>The existing EventGridNamespace resource.</returns>
-    public static EventGridNamespace FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridNamespace FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespaceClientGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespaceClientGroup.cs
@@ -63,10 +63,15 @@ public partial class EventGridNamespaceClientGroup : Resource
     /// <summary>
     /// Creates a new EventGridNamespaceClientGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridNamespaceClientGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridNamespaceClientGroup
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespaceClientGroup.</param>
-    public EventGridNamespaceClientGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/namespaces/clientGroups", resourceVersion ?? "2024-06-01-preview")
+    public EventGridNamespaceClientGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/namespaces/clientGroups", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -91,9 +96,14 @@ public partial class EventGridNamespaceClientGroup : Resource
     /// <summary>
     /// Creates a reference to an existing EventGridNamespaceClientGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridNamespaceClientGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridNamespaceClientGroup
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespaceClientGroup.</param>
     /// <returns>The existing EventGridNamespaceClientGroup resource.</returns>
-    public static EventGridNamespaceClientGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridNamespaceClientGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespaceClientResource.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespaceClientResource.cs
@@ -99,10 +99,15 @@ public partial class EventGridNamespaceClientResource : Resource
     /// <summary>
     /// Creates a new EventGridNamespaceClientResource.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridNamespaceClientResource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridNamespaceClientResource
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespaceClientResource.</param>
-    public EventGridNamespaceClientResource(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/namespaces/clients", resourceVersion ?? "2024-06-01-preview")
+    public EventGridNamespaceClientResource(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/namespaces/clients", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _attributes = BicepDictionary<BinaryData>.DefineProperty(this, "Attributes", ["properties", "attributes"]);
@@ -130,9 +135,14 @@ public partial class EventGridNamespaceClientResource : Resource
     /// <summary>
     /// Creates a reference to an existing EventGridNamespaceClientResource.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridNamespaceClientResource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridNamespaceClientResource
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespaceClientResource.</param>
     /// <returns>The existing EventGridNamespaceClientResource resource.</returns>
-    public static EventGridNamespaceClientResource FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridNamespaceClientResource FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespacePermissionBinding.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespacePermissionBinding.cs
@@ -78,10 +78,15 @@ public partial class EventGridNamespacePermissionBinding : Resource
     /// <summary>
     /// Creates a new EventGridNamespacePermissionBinding.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridNamespacePermissionBinding.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventGridNamespacePermissionBinding resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespacePermissionBinding.</param>
-    public EventGridNamespacePermissionBinding(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/namespaces/permissionBindings", resourceVersion ?? "2024-06-01-preview")
+    public EventGridNamespacePermissionBinding(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/namespaces/permissionBindings", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _clientGroupName = BicepValue<string>.DefineProperty(this, "ClientGroupName", ["properties", "clientGroupName"]);
@@ -108,9 +113,14 @@ public partial class EventGridNamespacePermissionBinding : Resource
     /// <summary>
     /// Creates a reference to an existing EventGridNamespacePermissionBinding.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridNamespacePermissionBinding.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventGridNamespacePermissionBinding resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespacePermissionBinding.</param>
     /// <returns>The existing EventGridNamespacePermissionBinding resource.</returns>
-    public static EventGridNamespacePermissionBinding FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridNamespacePermissionBinding FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridPartnerNamespacePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridPartnerNamespacePrivateEndpointConnection.cs
@@ -69,10 +69,16 @@ public partial class EventGridPartnerNamespacePrivateEndpointConnection : Resour
     /// <summary>
     /// Creates a new EventGridPartnerNamespacePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridPartnerNamespacePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventGridPartnerNamespacePrivateEndpointConnection resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridPartnerNamespacePrivateEndpointConnection.</param>
-    public EventGridPartnerNamespacePrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/partnerNamespaces/privateEndpointConnections", resourceVersion ?? "2022-06-15")
+    public EventGridPartnerNamespacePrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/partnerNamespaces/privateEndpointConnections", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<EventGridPrivateEndpointConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -105,9 +111,15 @@ public partial class EventGridPartnerNamespacePrivateEndpointConnection : Resour
     /// Creates a reference to an existing
     /// EventGridPartnerNamespacePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridPartnerNamespacePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventGridPartnerNamespacePrivateEndpointConnection resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridPartnerNamespacePrivateEndpointConnection.</param>
     /// <returns>The existing EventGridPartnerNamespacePrivateEndpointConnection resource.</returns>
-    public static EventGridPartnerNamespacePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridPartnerNamespacePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridTopic.cs
@@ -167,10 +167,15 @@ public partial class EventGridTopic : Resource
     /// <summary>
     /// Creates a new EventGridTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridTopic resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridTopic.</param>
-    public EventGridTopic(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/topics", resourceVersion ?? "2022-06-15")
+    public EventGridTopic(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/topics", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -239,11 +244,16 @@ public partial class EventGridTopic : Resource
     /// <summary>
     /// Creates a reference to an existing EventGridTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventGridTopic resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridTopic.</param>
     /// <returns>The existing EventGridTopic resource.</returns>
-    public static EventGridTopic FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridTopic FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this EventGridTopic resource.

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridTopicPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridTopicPrivateEndpointConnection.cs
@@ -69,10 +69,15 @@ public partial class EventGridTopicPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new EventGridTopicPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridTopicPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventGridTopicPrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridTopicPrivateEndpointConnection.</param>
-    public EventGridTopicPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/topics/privateEndpointConnections", resourceVersion ?? "2022-06-15")
+    public EventGridTopicPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/topics/privateEndpointConnections", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<EventGridPrivateEndpointConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -129,9 +134,14 @@ public partial class EventGridTopicPrivateEndpointConnection : Resource
     /// Creates a reference to an existing
     /// EventGridTopicPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the EventGridTopicPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventGridTopicPrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventGridTopicPrivateEndpointConnection.</param>
     /// <returns>The existing EventGridTopicPrivateEndpointConnection resource.</returns>
-    public static EventGridTopicPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventGridTopicPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventSubscription.cs
@@ -145,10 +145,15 @@ public partial class EventSubscription : Resource
     /// <summary>
     /// Creates a new EventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the EventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventSubscription resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventSubscription.</param>
-    public EventSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/eventSubscriptions", resourceVersion ?? "2022-06-15")
+    public EventSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/eventSubscriptions", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _deadLetterDestination = BicepValue<DeadLetterDestination>.DefineProperty(this, "DeadLetterDestination", ["properties", "deadLetterDestination"]);
@@ -210,11 +215,16 @@ public partial class EventSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing EventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the EventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventSubscription resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventSubscription.</param>
     /// <returns>The existing EventSubscription resource.</returns>
-    public static EventSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this EventSubscription resource.

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/NamespaceTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/NamespaceTopic.cs
@@ -71,10 +71,15 @@ public partial class NamespaceTopic : Resource
     /// <summary>
     /// Creates a new NamespaceTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the NamespaceTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the NamespaceTopic resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the NamespaceTopic.</param>
-    public NamespaceTopic(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/namespaces/topics", resourceVersion ?? "2024-06-01-preview")
+    public NamespaceTopic(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/namespaces/topics", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _eventRetentionInDays = BicepValue<int>.DefineProperty(this, "EventRetentionInDays", ["properties", "eventRetentionInDays"]);
@@ -100,9 +105,14 @@ public partial class NamespaceTopic : Resource
     /// <summary>
     /// Creates a reference to an existing NamespaceTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the NamespaceTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the NamespaceTopic resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the NamespaceTopic.</param>
     /// <returns>The existing NamespaceTopic resource.</returns>
-    public static NamespaceTopic FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static NamespaceTopic FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/NamespaceTopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/NamespaceTopicEventSubscription.cs
@@ -77,10 +77,15 @@ public partial class NamespaceTopicEventSubscription : Resource
     /// <summary>
     /// Creates a new NamespaceTopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the NamespaceTopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the NamespaceTopicEventSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the NamespaceTopicEventSubscription.</param>
-    public NamespaceTopicEventSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/namespaces/topics/eventSubscriptions", resourceVersion ?? "2024-06-01-preview")
+    public NamespaceTopicEventSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/namespaces/topics/eventSubscriptions", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _deliveryConfiguration = BicepValue<DeliveryConfiguration>.DefineProperty(this, "DeliveryConfiguration", ["properties", "deliveryConfiguration"]);
@@ -107,9 +112,14 @@ public partial class NamespaceTopicEventSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing NamespaceTopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the NamespaceTopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the NamespaceTopicEventSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the NamespaceTopicEventSubscription.</param>
     /// <returns>The existing NamespaceTopicEventSubscription resource.</returns>
-    public static NamespaceTopicEventSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static NamespaceTopicEventSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerConfiguration.cs
@@ -63,10 +63,15 @@ public partial class PartnerConfiguration : Resource
     /// <summary>
     /// Creates a new PartnerConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerConfiguration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerConfiguration.</param>
-    public PartnerConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/partnerConfigurations", resourceVersion ?? "2022-06-15")
+    public PartnerConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/partnerConfigurations", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -96,9 +101,14 @@ public partial class PartnerConfiguration : Resource
     /// <summary>
     /// Creates a reference to an existing PartnerConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerConfiguration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerConfiguration.</param>
     /// <returns>The existing PartnerConfiguration resource.</returns>
-    public static PartnerConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PartnerConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerDestination.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerDestination.cs
@@ -95,10 +95,15 @@ public partial class PartnerDestination : Resource
     /// <summary>
     /// Creates a new PartnerDestination.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerDestination.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerDestination resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerDestination.</param>
-    public PartnerDestination(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/partnerDestinations", resourceVersion ?? "2024-06-01-preview")
+    public PartnerDestination(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/partnerDestinations", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -128,9 +133,14 @@ public partial class PartnerDestination : Resource
     /// <summary>
     /// Creates a reference to an existing PartnerDestination.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerDestination.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerDestination resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerDestination.</param>
     /// <returns>The existing PartnerDestination resource.</returns>
-    public static PartnerDestination FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PartnerDestination FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerNamespace.cs
@@ -120,10 +120,15 @@ public partial class PartnerNamespace : Resource
     /// <summary>
     /// Creates a new PartnerNamespace.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerNamespace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerNamespace resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerNamespace.</param>
-    public PartnerNamespace(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/partnerNamespaces", resourceVersion ?? "2022-06-15")
+    public PartnerNamespace(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/partnerNamespaces", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -160,9 +165,14 @@ public partial class PartnerNamespace : Resource
     /// <summary>
     /// Creates a reference to an existing PartnerNamespace.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerNamespace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerNamespace resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerNamespace.</param>
     /// <returns>The existing PartnerNamespace resource.</returns>
-    public static PartnerNamespace FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PartnerNamespace FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerNamespaceChannel.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerNamespaceChannel.cs
@@ -101,10 +101,15 @@ public partial class PartnerNamespaceChannel : Resource
     /// <summary>
     /// Creates a new PartnerNamespaceChannel.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerNamespaceChannel.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerNamespaceChannel resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerNamespaceChannel.</param>
-    public PartnerNamespaceChannel(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/partnerNamespaces/channels", resourceVersion ?? "2022-06-15")
+    public PartnerNamespaceChannel(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/partnerNamespaces/channels", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _channelType = BicepValue<PartnerNamespaceChannelType>.DefineProperty(this, "ChannelType", ["properties", "channelType"]);
@@ -138,9 +143,14 @@ public partial class PartnerNamespaceChannel : Resource
     /// <summary>
     /// Creates a reference to an existing PartnerNamespaceChannel.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerNamespaceChannel.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerNamespaceChannel resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerNamespaceChannel.</param>
     /// <returns>The existing PartnerNamespaceChannel resource.</returns>
-    public static PartnerNamespaceChannel FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PartnerNamespaceChannel FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerRegistration.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerRegistration.cs
@@ -65,10 +65,15 @@ public partial class PartnerRegistration : Resource
     /// <summary>
     /// Creates a new PartnerRegistration.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerRegistration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerRegistration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerRegistration.</param>
-    public PartnerRegistration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/partnerRegistrations", resourceVersion ?? "2022-06-15")
+    public PartnerRegistration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/partnerRegistrations", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -98,9 +103,14 @@ public partial class PartnerRegistration : Resource
     /// <summary>
     /// Creates a reference to an existing PartnerRegistration.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerRegistration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerRegistration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerRegistration.</param>
     /// <returns>The existing PartnerRegistration resource.</returns>
-    public static PartnerRegistration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PartnerRegistration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerTopic.cs
@@ -112,10 +112,15 @@ public partial class PartnerTopic : Resource
     /// <summary>
     /// Creates a new PartnerTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerTopic resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerTopic.</param>
-    public PartnerTopic(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/partnerTopics", resourceVersion ?? "2022-06-15")
+    public PartnerTopic(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/partnerTopics", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -152,9 +157,14 @@ public partial class PartnerTopic : Resource
     /// <summary>
     /// Creates a reference to an existing PartnerTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerTopic resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerTopic.</param>
     /// <returns>The existing PartnerTopic resource.</returns>
-    public static PartnerTopic FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PartnerTopic FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerTopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerTopicEventSubscription.cs
@@ -150,10 +150,15 @@ public partial class PartnerTopicEventSubscription : Resource
     /// <summary>
     /// Creates a new PartnerTopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerTopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerTopicEventSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerTopicEventSubscription.</param>
-    public PartnerTopicEventSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/partnerTopics/eventSubscriptions", resourceVersion ?? "2022-06-15")
+    public PartnerTopicEventSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/partnerTopics/eventSubscriptions", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _deadLetterDestination = BicepValue<DeadLetterDestination>.DefineProperty(this, "DeadLetterDestination", ["properties", "deadLetterDestination"]);
@@ -191,9 +196,14 @@ public partial class PartnerTopicEventSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing PartnerTopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the PartnerTopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PartnerTopicEventSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PartnerTopicEventSubscription.</param>
     /// <returns>The existing PartnerTopicEventSubscription resource.</returns>
-    public static PartnerTopicEventSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PartnerTopicEventSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/SystemTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/SystemTopic.cs
@@ -81,10 +81,15 @@ public partial class SystemTopic : Resource
     /// <summary>
     /// Creates a new SystemTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the SystemTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SystemTopic resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SystemTopic.</param>
-    public SystemTopic(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/systemTopics", resourceVersion ?? "2022-06-15")
+    public SystemTopic(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/systemTopics", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -122,9 +127,14 @@ public partial class SystemTopic : Resource
     /// <summary>
     /// Creates a reference to an existing SystemTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the SystemTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SystemTopic resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SystemTopic.</param>
     /// <returns>The existing SystemTopic resource.</returns>
-    public static SystemTopic FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SystemTopic FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/SystemTopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/SystemTopicEventSubscription.cs
@@ -150,10 +150,15 @@ public partial class SystemTopicEventSubscription : Resource
     /// <summary>
     /// Creates a new SystemTopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the SystemTopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SystemTopicEventSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SystemTopicEventSubscription.</param>
-    public SystemTopicEventSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/systemTopics/eventSubscriptions", resourceVersion ?? "2022-06-15")
+    public SystemTopicEventSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/systemTopics/eventSubscriptions", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _deadLetterDestination = BicepValue<DeadLetterDestination>.DefineProperty(this, "DeadLetterDestination", ["properties", "deadLetterDestination"]);
@@ -196,9 +201,14 @@ public partial class SystemTopicEventSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing SystemTopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the SystemTopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SystemTopicEventSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SystemTopicEventSubscription.</param>
     /// <returns>The existing SystemTopicEventSubscription resource.</returns>
-    public static SystemTopicEventSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SystemTopicEventSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/TopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/TopicEventSubscription.cs
@@ -150,10 +150,15 @@ public partial class TopicEventSubscription : Resource
     /// <summary>
     /// Creates a new TopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the TopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TopicEventSubscription resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TopicEventSubscription.</param>
-    public TopicEventSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/topics/eventSubscriptions", resourceVersion ?? "2022-06-15")
+    public TopicEventSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/topics/eventSubscriptions", resourceVersion ?? "2022-06-15")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _deadLetterDestination = BicepValue<DeadLetterDestination>.DefineProperty(this, "DeadLetterDestination", ["properties", "deadLetterDestination"]);
@@ -216,9 +221,14 @@ public partial class TopicEventSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing TopicEventSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the TopicEventSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TopicEventSubscription resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TopicEventSubscription.</param>
     /// <returns>The existing TopicEventSubscription resource.</returns>
-    public static TopicEventSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static TopicEventSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/TopicSpace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/TopicSpace.cs
@@ -68,10 +68,15 @@ public partial class TopicSpace : Resource
     /// <summary>
     /// Creates a new TopicSpace.
     /// </summary>
-    /// <param name="resourceName">Name of the TopicSpace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TopicSpace resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TopicSpace.</param>
-    public TopicSpace(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventGrid/namespaces/topicSpaces", resourceVersion ?? "2024-06-01-preview")
+    public TopicSpace(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventGrid/namespaces/topicSpaces", resourceVersion ?? "2024-06-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -96,9 +101,14 @@ public partial class TopicSpace : Resource
     /// <summary>
     /// Creates a reference to an existing TopicSpace.
     /// </summary>
-    /// <param name="resourceName">Name of the TopicSpace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TopicSpace resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TopicSpace.</param>
     /// <returns>The existing TopicSpace resource.</returns>
-    public static TopicSpace FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static TopicSpace FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/api/Azure.Provisioning.EventHubs.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/api/Azure.Provisioning.EventHubs.netstandard2.0.cs
@@ -23,7 +23,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHub : Azure.Provisioning.Primitives.Resource
     {
-        public EventHub(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHub(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventHubs.CaptureDescription> CaptureDescription { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -36,7 +36,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventHubs.EventHubEntityStatus> Status { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
-        public static Azure.Provisioning.EventHubs.EventHub FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHub FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_04_01;
@@ -47,14 +47,14 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubAuthorizationRule : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubAuthorizationRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubAuthorizationRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.EventHubs.EventHub? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.EventHubs.EventHubsAccessRight> Rights { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventHubs.EventHubAuthorizationRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubAuthorizationRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.EventHubs.EventHubsAccessKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -111,7 +111,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsApplicationGroup : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsApplicationGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsApplicationGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ClientAppGroupIdentifier { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsEnabled { get { throw null; } set { } }
@@ -120,7 +120,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.EventHubs.EventHubsNamespace? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.EventHubs.EventHubsApplicationGroupPolicy> Policies { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventHubs.EventHubsApplicationGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsApplicationGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_01_01;
@@ -168,7 +168,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsCluster : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsCluster(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsCluster(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -181,9 +181,9 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.EventHubs.EventHubsCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsCluster FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -216,7 +216,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsConsumerGroup : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsConsumerGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsConsumerGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -225,7 +225,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> UserMetadata { get { throw null; } set { } }
-        public static Azure.Provisioning.EventHubs.EventHubsConsumerGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsConsumerGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -238,7 +238,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsDisasterRecovery : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsDisasterRecovery(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsDisasterRecovery(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AlternateName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -249,7 +249,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventHubs.EventHubsDisasterRecoveryProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventHubs.EventHubsDisasterRecoveryRole> Role { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventHubs.EventHubsDisasterRecovery FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsDisasterRecovery FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -301,7 +301,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsNamespace : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsNamespace(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsNamespace(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AlternateName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> ClusterArmId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
@@ -327,9 +327,9 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> ZoneRedundant { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.EventHubs.EventHubsBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.EventHubs.EventHubsNamespace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsNamespace FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -344,14 +344,14 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsNamespaceAuthorizationRule : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsNamespaceAuthorizationRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsNamespaceAuthorizationRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.EventHubs.EventHubsNamespace? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.EventHubs.EventHubsAccessRight> Rights { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventHubs.EventHubsNamespaceAuthorizationRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsNamespaceAuthorizationRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.EventHubs.EventHubsAccessKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -369,7 +369,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsNetworkRuleSet : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsNetworkRuleSet(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsNetworkRuleSet(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventHubs.EventHubsNetworkRuleSetDefaultAction> DefaultAction { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.EventHubs.EventHubsNetworkRuleSetIPRules> IPRules { get { throw null; } set { } }
@@ -380,7 +380,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> TrustedServiceAccessEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.EventHubs.EventHubsNetworkRuleSetVirtualNetworkRules> VirtualNetworkRules { get { throw null; } set { } }
-        public static Azure.Provisioning.EventHubs.EventHubsNetworkRuleSet FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsNetworkRuleSet FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_04_01;
@@ -408,7 +408,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventHubs.EventHubsPrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -417,7 +417,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventHubs.EventHubsPrivateEndpointConnectionProvisioningState> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.EventHubs.EventHubsPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -478,7 +478,7 @@ namespace Azure.Provisioning.EventHubs
     }
     public partial class EventHubsSchemaGroup : Azure.Provisioning.Primitives.Resource
     {
-        public EventHubsSchemaGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EventHubsSchemaGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedAtUtc { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> GroupProperties { get { throw null; } set { } }
@@ -490,7 +490,7 @@ namespace Azure.Provisioning.EventHubs
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventHubs.EventHubsSchemaType> SchemaType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedAtUtc { get { throw null; } }
-        public static Azure.Provisioning.EventHubs.EventHubsSchemaGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.EventHubs.EventHubsSchemaGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_09_01;

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHub.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHub.cs
@@ -94,10 +94,15 @@ public partial class EventHub : Resource
     /// <summary>
     /// Creates a new EventHub.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHub.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHub resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHub.</param>
-    public EventHub(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/eventhubs", resourceVersion ?? "2024-01-01")
+    public EventHub(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/eventhubs", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _captureDescription = BicepValue<CaptureDescription>.DefineProperty(this, "CaptureDescription", ["properties", "captureDescription"]);
@@ -142,9 +147,14 @@ public partial class EventHub : Resource
     /// <summary>
     /// Creates a reference to an existing EventHub.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHub.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHub resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHub.</param>
     /// <returns>The existing EventHub resource.</returns>
-    public static EventHub FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHub FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubAuthorizationRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubAuthorizationRule.cs
@@ -59,10 +59,15 @@ public partial class EventHubAuthorizationRule : Resource
     /// <summary>
     /// Creates a new EventHubAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubAuthorizationRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubAuthorizationRule.</param>
-    public EventHubAuthorizationRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/eventhubs/authorizationRules", resourceVersion ?? "2024-01-01")
+    public EventHubAuthorizationRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/eventhubs/authorizationRules", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _rights = BicepList<EventHubsAccessRight>.DefineProperty(this, "Rights", ["properties", "rights"]);
@@ -101,11 +106,16 @@ public partial class EventHubAuthorizationRule : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubAuthorizationRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubAuthorizationRule.</param>
     /// <returns>The existing EventHubAuthorizationRule resource.</returns>
-    public static EventHubAuthorizationRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubAuthorizationRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this EventHubAuthorizationRule resource.
@@ -121,5 +131,5 @@ public partial class EventHubAuthorizationRule : Resource
     /// <returns>The keys for this EventHubAuthorizationRule resource.</returns>
     public EventHubsAccessKeys GetKeys() =>
         EventHubsAccessKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsApplicationGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsApplicationGroup.cs
@@ -81,10 +81,15 @@ public partial class EventHubsApplicationGroup : Resource
     /// <summary>
     /// Creates a new EventHubsApplicationGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsApplicationGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsApplicationGroup
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsApplicationGroup.</param>
-    public EventHubsApplicationGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/applicationGroups", resourceVersion ?? "2024-01-01")
+    public EventHubsApplicationGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/applicationGroups", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _clientAppGroupIdentifier = BicepValue<string>.DefineProperty(this, "ClientAppGroupIdentifier", ["properties", "clientAppGroupIdentifier"]);
@@ -115,9 +120,14 @@ public partial class EventHubsApplicationGroup : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsApplicationGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsApplicationGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsApplicationGroup
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsApplicationGroup.</param>
     /// <returns>The existing EventHubsApplicationGroup resource.</returns>
-    public static EventHubsApplicationGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsApplicationGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
@@ -98,10 +98,15 @@ public partial class EventHubsCluster : Resource
     /// <summary>
     /// Creates a new EventHubsCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsCluster resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsCluster.</param>
-    public EventHubsCluster(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/clusters", resourceVersion ?? "2024-01-01")
+    public EventHubsCluster(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/clusters", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -141,11 +146,16 @@ public partial class EventHubsCluster : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsCluster resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsCluster.</param>
     /// <returns>The existing EventHubsCluster resource.</returns>
-    public static EventHubsCluster FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsCluster FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this EventHubsCluster resource.
@@ -163,10 +173,10 @@ public partial class EventHubsCluster : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(EventHubsBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -179,13 +189,13 @@ public partial class EventHubsCluster : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(EventHubsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(EventHubsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsConsumerGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsConsumerGroup.cs
@@ -72,10 +72,15 @@ public partial class EventHubsConsumerGroup : Resource
     /// <summary>
     /// Creates a new EventHubsConsumerGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsConsumerGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsConsumerGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsConsumerGroup.</param>
-    public EventHubsConsumerGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/eventhubs/consumergroups", resourceVersion ?? "2024-01-01")
+    public EventHubsConsumerGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/eventhubs/consumergroups", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _userMetadata = BicepValue<string>.DefineProperty(this, "UserMetadata", ["properties", "userMetadata"]);
@@ -116,11 +121,16 @@ public partial class EventHubsConsumerGroup : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsConsumerGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsConsumerGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsConsumerGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsConsumerGroup.</param>
     /// <returns>The existing EventHubsConsumerGroup resource.</returns>
-    public static EventHubsConsumerGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsConsumerGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this EventHubsConsumerGroup resource.

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsDisasterRecovery.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsDisasterRecovery.cs
@@ -85,10 +85,15 @@ public partial class EventHubsDisasterRecovery : Resource
     /// <summary>
     /// Creates a new EventHubsDisasterRecovery.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsDisasterRecovery.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsDisasterRecovery
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsDisasterRecovery.</param>
-    public EventHubsDisasterRecovery(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/disasterRecoveryConfigs", resourceVersion ?? "2024-01-01")
+    public EventHubsDisasterRecovery(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/disasterRecoveryConfigs", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _alternateName = BicepValue<string>.DefineProperty(this, "AlternateName", ["properties", "alternateName"]);
@@ -131,11 +136,16 @@ public partial class EventHubsDisasterRecovery : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsDisasterRecovery.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsDisasterRecovery.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsDisasterRecovery
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsDisasterRecovery.</param>
     /// <returns>The existing EventHubsDisasterRecovery resource.</returns>
-    public static EventHubsDisasterRecovery FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsDisasterRecovery FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this EventHubsDisasterRecovery resource.

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
@@ -181,10 +181,15 @@ public partial class EventHubsNamespace : Resource
     /// <summary>
     /// Creates a new EventHubsNamespace.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsNamespace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsNamespace resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsNamespace.</param>
-    public EventHubsNamespace(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces", resourceVersion ?? "2024-01-01")
+    public EventHubsNamespace(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -252,11 +257,16 @@ public partial class EventHubsNamespace : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsNamespace.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsNamespace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsNamespace resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsNamespace.</param>
     /// <returns>The existing EventHubsNamespace resource.</returns>
-    public static EventHubsNamespace FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsNamespace FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this EventHubsNamespace resource.
@@ -274,10 +284,10 @@ public partial class EventHubsNamespace : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(EventHubsBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -290,13 +300,13 @@ public partial class EventHubsNamespace : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(EventHubsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(EventHubsBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{EventHubsBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespaceAuthorizationRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespaceAuthorizationRule.cs
@@ -59,10 +59,15 @@ public partial class EventHubsNamespaceAuthorizationRule : Resource
     /// <summary>
     /// Creates a new EventHubsNamespaceAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsNamespaceAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventHubsNamespaceAuthorizationRule resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsNamespaceAuthorizationRule.</param>
-    public EventHubsNamespaceAuthorizationRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/authorizationRules", resourceVersion ?? "2024-01-01")
+    public EventHubsNamespaceAuthorizationRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/authorizationRules", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _rights = BicepList<EventHubsAccessRight>.DefineProperty(this, "Rights", ["properties", "rights"]);
@@ -101,11 +106,16 @@ public partial class EventHubsNamespaceAuthorizationRule : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsNamespaceAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsNamespaceAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// EventHubsNamespaceAuthorizationRule resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsNamespaceAuthorizationRule.</param>
     /// <returns>The existing EventHubsNamespaceAuthorizationRule resource.</returns>
-    public static EventHubsNamespaceAuthorizationRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsNamespaceAuthorizationRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this
@@ -122,5 +132,5 @@ public partial class EventHubsNamespaceAuthorizationRule : Resource
     /// <returns>The keys for this EventHubsNamespaceAuthorizationRule resource.</returns>
     public EventHubsAccessKeys GetKeys() =>
         EventHubsAccessKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNetworkRuleSet.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNetworkRuleSet.cs
@@ -84,10 +84,15 @@ public partial class EventHubsNetworkRuleSet : Resource
     /// <summary>
     /// Creates a new EventHubsNetworkRuleSet.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsNetworkRuleSet.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsNetworkRuleSet resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsNetworkRuleSet.</param>
-    public EventHubsNetworkRuleSet(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/networkRuleSets", resourceVersion ?? "2024-01-01")
+    public EventHubsNetworkRuleSet(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/networkRuleSets", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _defaultAction = BicepValue<EventHubsNetworkRuleSetDefaultAction>.DefineProperty(this, "DefaultAction", ["properties", "defaultAction"]);
@@ -130,9 +135,14 @@ public partial class EventHubsNetworkRuleSet : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsNetworkRuleSet.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsNetworkRuleSet.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsNetworkRuleSet resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsNetworkRuleSet.</param>
     /// <returns>The existing EventHubsNetworkRuleSet resource.</returns>
-    public static EventHubsNetworkRuleSet FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsNetworkRuleSet FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsPrivateEndpointConnection.cs
@@ -68,10 +68,15 @@ public partial class EventHubsPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new EventHubsPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsPrivateEndpointConnection.</param>
-    public EventHubsPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/privateEndpointConnections", resourceVersion ?? "2024-01-01")
+    public EventHubsPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/privateEndpointConnections", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<EventHubsPrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -107,9 +112,14 @@ public partial class EventHubsPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsPrivateEndpointConnection.</param>
     /// <returns>The existing EventHubsPrivateEndpointConnection resource.</returns>
-    public static EventHubsPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsSchemaGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsSchemaGroup.cs
@@ -88,10 +88,15 @@ public partial class EventHubsSchemaGroup : Resource
     /// <summary>
     /// Creates a new EventHubsSchemaGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsSchemaGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsSchemaGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsSchemaGroup.</param>
-    public EventHubsSchemaGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.EventHub/namespaces/schemagroups", resourceVersion ?? "2024-01-01")
+    public EventHubsSchemaGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.EventHub/namespaces/schemagroups", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _groupProperties = BicepDictionary<string>.DefineProperty(this, "GroupProperties", ["properties", "groupProperties"]);
@@ -145,9 +150,14 @@ public partial class EventHubsSchemaGroup : Resource
     /// <summary>
     /// Creates a reference to an existing EventHubsSchemaGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the EventHubsSchemaGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EventHubsSchemaGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EventHubsSchemaGroup.</param>
     /// <returns>The existing EventHubsSchemaGroup resource.</returns>
-    public static EventHubsSchemaGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EventHubsSchemaGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/api/Azure.Provisioning.KeyVault.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/api/Azure.Provisioning.KeyVault.netstandard2.0.cs
@@ -219,7 +219,7 @@ namespace Azure.Provisioning.KeyVault
     }
     public partial class KeyVaultPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public KeyVaultPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public KeyVaultPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KeyVault.KeyVaultPrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -230,7 +230,7 @@ namespace Azure.Provisioning.KeyVault
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KeyVault.KeyVaultPrivateEndpointConnectionProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } }
-        public static Azure.Provisioning.KeyVault.KeyVaultPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.KeyVault.KeyVaultPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_06_01;
@@ -306,7 +306,7 @@ namespace Azure.Provisioning.KeyVault
     }
     public partial class KeyVaultSecret : Azure.Provisioning.Primitives.Resource
     {
-        public KeyVaultSecret(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public KeyVaultSecret(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -314,7 +314,7 @@ namespace Azure.Provisioning.KeyVault
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KeyVault.SecretProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.KeyVault.KeyVaultSecret FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.KeyVault.KeyVaultSecret FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -334,16 +334,16 @@ namespace Azure.Provisioning.KeyVault
     }
     public partial class KeyVaultService : Azure.Provisioning.Primitives.Resource
     {
-        public KeyVaultService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public KeyVaultService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KeyVault.KeyVaultProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KeyVault.KeyVaultBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KeyVault.KeyVaultBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KeyVault.KeyVaultBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.KeyVault.KeyVaultService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.KeyVault.KeyVaultService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -386,7 +386,7 @@ namespace Azure.Provisioning.KeyVault
     }
     public partial class ManagedHsm : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedHsm(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedHsm(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -394,7 +394,7 @@ namespace Azure.Provisioning.KeyVault
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KeyVault.ManagedHsmSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.KeyVault.ManagedHsm FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.KeyVault.ManagedHsm FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_10_01;
@@ -458,7 +458,7 @@ namespace Azure.Provisioning.KeyVault
     }
     public partial class ManagedHsmPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedHsmPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedHsmPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -470,7 +470,7 @@ namespace Azure.Provisioning.KeyVault
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KeyVault.ManagedHsmSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.KeyVault.ManagedHsmPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.KeyVault.ManagedHsmPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_10_01;

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultPrivateEndpointConnection.cs
@@ -83,10 +83,15 @@ public partial class KeyVaultPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new KeyVaultPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the KeyVaultPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KeyVaultPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KeyVaultPrivateEndpointConnection.</param>
-    public KeyVaultPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.KeyVault/vaults/privateEndpointConnections", resourceVersion ?? "2023-07-01")
+    public KeyVaultPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.KeyVault/vaults/privateEndpointConnections", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<KeyVaultPrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -164,9 +169,14 @@ public partial class KeyVaultPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing KeyVaultPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the KeyVaultPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KeyVaultPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KeyVaultPrivateEndpointConnection.</param>
     /// <returns>The existing KeyVaultPrivateEndpointConnection resource.</returns>
-    public static KeyVaultPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static KeyVaultPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultSecret.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultSecret.cs
@@ -66,10 +66,15 @@ public partial class KeyVaultSecret : Resource
     /// <summary>
     /// Creates a new KeyVaultSecret.
     /// </summary>
-    /// <param name="resourceName">Name of the KeyVaultSecret.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KeyVaultSecret resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KeyVaultSecret.</param>
-    public KeyVaultSecret(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.KeyVault/vaults/secrets", resourceVersion ?? "2023-07-01")
+    public KeyVaultSecret(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.KeyVault/vaults/secrets", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _properties = BicepValue<SecretProperties>.DefineProperty(this, "Properties", ["properties"], isRequired: true);
@@ -144,11 +149,16 @@ public partial class KeyVaultSecret : Resource
     /// <summary>
     /// Creates a reference to an existing KeyVaultSecret.
     /// </summary>
-    /// <param name="resourceName">Name of the KeyVaultSecret.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KeyVaultSecret resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KeyVaultSecret.</param>
     /// <returns>The existing KeyVaultSecret resource.</returns>
-    public static KeyVaultSecret FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static KeyVaultSecret FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this KeyVaultSecret resource.

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
@@ -62,10 +62,15 @@ public partial class KeyVaultService : Resource
     /// <summary>
     /// Creates a new KeyVaultService.
     /// </summary>
-    /// <param name="resourceName">Name of the KeyVaultService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KeyVaultService resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KeyVaultService.</param>
-    public KeyVaultService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.KeyVault/vaults", resourceVersion ?? "2023-07-01")
+    public KeyVaultService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.KeyVault/vaults", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -139,11 +144,16 @@ public partial class KeyVaultService : Resource
     /// <summary>
     /// Creates a reference to an existing KeyVaultService.
     /// </summary>
-    /// <param name="resourceName">Name of the KeyVaultService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KeyVaultService resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KeyVaultService.</param>
     /// <returns>The existing KeyVaultService resource.</returns>
-    public static KeyVaultService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static KeyVaultService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this KeyVaultService resource.
@@ -161,10 +171,10 @@ public partial class KeyVaultService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(KeyVaultBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -177,13 +187,13 @@ public partial class KeyVaultService : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(KeyVaultBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(KeyVaultBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{KeyVaultBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/ManagedHsm.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/ManagedHsm.cs
@@ -64,10 +64,15 @@ public partial class ManagedHsm : Resource
     /// <summary>
     /// Creates a new ManagedHsm.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedHsm.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedHsm resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedHsm.</param>
-    public ManagedHsm(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.KeyVault/managedHSMs", resourceVersion ?? "2023-07-01")
+    public ManagedHsm(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.KeyVault/managedHSMs", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -122,9 +127,14 @@ public partial class ManagedHsm : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedHsm.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedHsm.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedHsm resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedHsm.</param>
     /// <returns>The existing ManagedHsm resource.</returns>
-    public static ManagedHsm FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedHsm FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/ManagedHsmPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/ManagedHsmPrivateEndpointConnection.cs
@@ -90,10 +90,15 @@ public partial class ManagedHsmPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new ManagedHsmPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedHsmPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedHsmPrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedHsmPrivateEndpointConnection.</param>
-    public ManagedHsmPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.KeyVault/managedHSMs/privateEndpointConnections", resourceVersion ?? "2023-07-01")
+    public ManagedHsmPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.KeyVault/managedHSMs/privateEndpointConnections", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -152,9 +157,14 @@ public partial class ManagedHsmPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedHsmPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedHsmPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedHsmPrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedHsmPrivateEndpointConnection.</param>
     /// <returns>The existing ManagedHsmPrivateEndpointConnection resource.</returns>
-    public static ManagedHsmPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedHsmPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/api/Azure.Provisioning.Kubernetes.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/api/Azure.Provisioning.Kubernetes.netstandard2.0.cs
@@ -2,7 +2,7 @@ namespace Azure.Provisioning.Kubernetes
 {
     public partial class ConnectedCluster : Azure.Provisioning.Primitives.Resource
     {
-        public ConnectedCluster(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ConnectedCluster(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AgentPublicKeyCertificate { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AgentVersion { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Kubernetes.ConnectivityStatus> ConnectivityStatus { get { throw null; } }
@@ -23,9 +23,9 @@ namespace Azure.Provisioning.Kubernetes
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> TotalCoreCount { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> TotalNodeCount { get { throw null; } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Kubernetes.KubernetesBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Kubernetes.KubernetesBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Kubernetes.KubernetesBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.Kubernetes.ConnectedCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Kubernetes.ConnectedCluster FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
@@ -151,10 +151,15 @@ public partial class ConnectedCluster : Resource
     /// <summary>
     /// Creates a new ConnectedCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the ConnectedCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ConnectedCluster resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ConnectedCluster.</param>
-    public ConnectedCluster(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Kubernetes/connectedClusters", resourceVersion ?? "2024-01-01")
+    public ConnectedCluster(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Kubernetes/connectedClusters", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _agentPublicKeyCertificate = BicepValue<string>.DefineProperty(this, "AgentPublicKeyCertificate", ["properties", "agentPublicKeyCertificate"], isRequired: true);
@@ -207,11 +212,16 @@ public partial class ConnectedCluster : Resource
     /// <summary>
     /// Creates a reference to an existing ConnectedCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the ConnectedCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ConnectedCluster resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ConnectedCluster.</param>
     /// <returns>The existing ConnectedCluster resource.</returns>
-    public static ConnectedCluster FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ConnectedCluster FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ConnectedCluster resource.
@@ -229,10 +239,10 @@ public partial class ConnectedCluster : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(KubernetesBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -245,13 +255,13 @@ public partial class ConnectedCluster : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(KubernetesBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(KubernetesBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{KubernetesBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/api/Azure.Provisioning.KubernetesConfiguration.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/api/Azure.Provisioning.KubernetesConfiguration.netstandard2.0.cs
@@ -41,7 +41,7 @@ namespace Azure.Provisioning.KubernetesConfiguration
     }
     public partial class KubernetesClusterExtension : Azure.Provisioning.Primitives.Resource
     {
-        public KubernetesClusterExtension(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public KubernetesClusterExtension(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagedServiceIdentity> AksAssignedIdentity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> AutoUpgradeMinorVersion { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<string> ConfigurationProtectedSettings { get { throw null; } set { } }
@@ -62,9 +62,9 @@ namespace Azure.Provisioning.KubernetesConfiguration
         public Azure.Provisioning.BicepList<Azure.Provisioning.KubernetesConfiguration.KubernetesClusterExtensionStatus> Statuses { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.KubernetesConfiguration.KubernetesClusterExtension FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.KubernetesConfiguration.KubernetesClusterExtension FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_03_01;
@@ -179,7 +179,7 @@ namespace Azure.Provisioning.KubernetesConfiguration
     }
     public partial class KubernetesFluxConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public KubernetesFluxConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public KubernetesFluxConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KubernetesConfiguration.KubernetesAzureBlob> AzureBlob { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KubernetesConfiguration.KubernetesBucket> Bucket { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KubernetesConfiguration.KubernetesFluxComplianceState> ComplianceState { get { throw null; } }
@@ -200,9 +200,9 @@ namespace Azure.Provisioning.KubernetesConfiguration
         public Azure.Provisioning.BicepList<Azure.Provisioning.KubernetesConfiguration.KubernetesObjectStatus> Statuses { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> StatusUpdatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.KubernetesConfiguration.KubernetesFluxConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.KubernetesConfiguration.KubernetesFluxConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_03_01;
@@ -281,7 +281,7 @@ namespace Azure.Provisioning.KubernetesConfiguration
     }
     public partial class KubernetesSourceControlConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public KubernetesSourceControlConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public KubernetesSourceControlConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KubernetesConfiguration.KubernetesConfigurationComplianceStatus> ComplianceStatus { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> ConfigurationProtectedSettings { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.KubernetesConfiguration.HelmOperatorProperties> HelmOperatorProperties { get { throw null; } set { } }
@@ -298,7 +298,7 @@ namespace Azure.Provisioning.KubernetesConfiguration
         public Azure.Provisioning.BicepValue<System.Uri> RepositoryUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> SshKnownHostsContents { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.KubernetesConfiguration.KubernetesSourceControlConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.KubernetesConfiguration.KubernetesSourceControlConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_03_01;

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesClusterExtension.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesClusterExtension.cs
@@ -156,10 +156,15 @@ public partial class KubernetesClusterExtension : Resource
     /// <summary>
     /// Creates a new KubernetesClusterExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the KubernetesClusterExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KubernetesClusterExtension
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KubernetesClusterExtension.</param>
-    public KubernetesClusterExtension(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.KubernetesConfiguration/extensions", resourceVersion ?? "2023-05-01")
+    public KubernetesClusterExtension(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.KubernetesConfiguration/extensions", resourceVersion ?? "2023-05-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _aksAssignedIdentity = BicepValue<ManagedServiceIdentity>.DefineProperty(this, "AksAssignedIdentity", ["properties", "aksAssignedIdentity"]);
@@ -212,11 +217,16 @@ public partial class KubernetesClusterExtension : Resource
     /// <summary>
     /// Creates a reference to an existing KubernetesClusterExtension.
     /// </summary>
-    /// <param name="resourceName">Name of the KubernetesClusterExtension.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KubernetesClusterExtension
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KubernetesClusterExtension.</param>
     /// <returns>The existing KubernetesClusterExtension resource.</returns>
-    public static KubernetesClusterExtension FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static KubernetesClusterExtension FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -226,10 +236,10 @@ public partial class KubernetesClusterExtension : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(KubernetesConfigurationBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -242,13 +252,13 @@ public partial class KubernetesClusterExtension : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(KubernetesConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(KubernetesConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
@@ -153,10 +153,15 @@ public partial class KubernetesFluxConfiguration : Resource
     /// <summary>
     /// Creates a new KubernetesFluxConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the KubernetesFluxConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KubernetesFluxConfiguration
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KubernetesFluxConfiguration.</param>
-    public KubernetesFluxConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.KubernetesConfiguration/fluxConfigurations", resourceVersion ?? "2023-05-01")
+    public KubernetesFluxConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.KubernetesConfiguration/fluxConfigurations", resourceVersion ?? "2023-05-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _azureBlob = BicepValue<KubernetesAzureBlob>.DefineProperty(this, "AzureBlob", ["properties", "azureBlob"]);
@@ -214,11 +219,16 @@ public partial class KubernetesFluxConfiguration : Resource
     /// <summary>
     /// Creates a reference to an existing KubernetesFluxConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the KubernetesFluxConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the KubernetesFluxConfiguration
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KubernetesFluxConfiguration.</param>
     /// <returns>The existing KubernetesFluxConfiguration resource.</returns>
-    public static KubernetesFluxConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static KubernetesFluxConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -228,10 +238,10 @@ public partial class KubernetesFluxConfiguration : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(KubernetesConfigurationBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -244,13 +254,13 @@ public partial class KubernetesFluxConfiguration : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(KubernetesConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(KubernetesConfigurationBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{KubernetesConfigurationBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesSourceControlConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesSourceControlConfiguration.cs
@@ -121,10 +121,15 @@ public partial class KubernetesSourceControlConfiguration : Resource
     /// <summary>
     /// Creates a new KubernetesSourceControlConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the KubernetesSourceControlConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// KubernetesSourceControlConfiguration resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KubernetesSourceControlConfiguration.</param>
-    public KubernetesSourceControlConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.KubernetesConfiguration/sourceControlConfigurations", resourceVersion ?? "2023-05-01")
+    public KubernetesSourceControlConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.KubernetesConfiguration/sourceControlConfigurations", resourceVersion ?? "2023-05-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _configurationProtectedSettings = BicepDictionary<string>.DefineProperty(this, "ConfigurationProtectedSettings", ["properties", "configurationProtectedSettings"]);
@@ -178,9 +183,14 @@ public partial class KubernetesSourceControlConfiguration : Resource
     /// <summary>
     /// Creates a reference to an existing KubernetesSourceControlConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the KubernetesSourceControlConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// KubernetesSourceControlConfiguration resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the KubernetesSourceControlConfiguration.</param>
     /// <returns>The existing KubernetesSourceControlConfiguration resource.</returns>
-    public static KubernetesSourceControlConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static KubernetesSourceControlConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/api/Azure.Provisioning.OperationalInsights.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/api/Azure.Provisioning.OperationalInsights.netstandard2.0.cs
@@ -2,7 +2,7 @@ namespace Azure.Provisioning.OperationalInsights
 {
     public partial class LogAnalyticsQuery : Azure.Provisioning.Primitives.Resource
     {
-        public LogAnalyticsQuery(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public LogAnalyticsQuery(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Guid> ApplicationId { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Author { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Body { get { throw null; } set { } }
@@ -16,7 +16,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.LogAnalyticsQueryRelatedMetadata> Related { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<Azure.Provisioning.BicepList<string>> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.LogAnalyticsQuery FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.LogAnalyticsQuery FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_09_01;
@@ -25,7 +25,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class LogAnalyticsQueryPack : Azure.Provisioning.Primitives.Resource
     {
-        public LogAnalyticsQueryPack(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public LogAnalyticsQueryPack(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -35,7 +35,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<System.Guid> QueryPackId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.LogAnalyticsQueryPack FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.LogAnalyticsQueryPack FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_09_01;
@@ -62,7 +62,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class OperationalInsightsCluster : Azure.Provisioning.Primitives.Resource
     {
-        public OperationalInsightsCluster(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OperationalInsightsCluster(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.OperationalInsights.OperationalInsightsClusterAssociatedWorkspace> AssociatedWorkspaces { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.OperationalInsightsBillingType> BillingType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.OperationalInsightsCapacityReservationProperties> CapacityReservationProperties { get { throw null; } set { } }
@@ -80,7 +80,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.OperationalInsightsClusterSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.OperationalInsightsCluster FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.OperationalInsightsCluster FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -174,7 +174,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class OperationalInsightsDataExport : Azure.Provisioning.Primitives.Resource
     {
-        public OperationalInsightsDataExport(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OperationalInsightsDataExport(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Guid> DataExportId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.OperationalInsightsDataExportDestinationType> DestinationType { get { throw null; } }
@@ -187,7 +187,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> ResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<string> TableNames { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.OperationalInsightsDataExport FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.OperationalInsightsDataExport FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_08_01;
@@ -210,7 +210,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class OperationalInsightsDataSource : Azure.Provisioning.Primitives.Resource
     {
-        public OperationalInsightsDataSource(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OperationalInsightsDataSource(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.OperationalInsightsDataSourceKind> Kind { get { throw null; } set { } }
@@ -219,7 +219,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<System.BinaryData> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.OperationalInsightsDataSource FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.OperationalInsightsDataSource FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_08_01;
@@ -280,7 +280,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class OperationalInsightsLinkedService : Azure.Provisioning.Primitives.Resource
     {
-        public OperationalInsightsLinkedService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OperationalInsightsLinkedService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.OperationalInsights.OperationalInsightsWorkspace? Parent { get { throw null; } set { } }
@@ -289,7 +289,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> WriteAccessResourceId { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.OperationalInsightsLinkedService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.OperationalInsightsLinkedService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_08_01;
@@ -305,14 +305,14 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class OperationalInsightsLinkedStorageAccounts : Azure.Provisioning.Primitives.Resource
     {
-        public OperationalInsightsLinkedStorageAccounts(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OperationalInsightsLinkedStorageAccounts(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.OperationalInsightsDataSourceType> DataSourceType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.OperationalInsights.OperationalInsightsWorkspace? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Core.ResourceIdentifier> StorageAccountIds { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.OperationalInsights.OperationalInsightsLinkedStorageAccounts FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.OperationalInsightsLinkedStorageAccounts FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_08_01;
@@ -332,7 +332,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class OperationalInsightsSavedSearch : Azure.Provisioning.Primitives.Resource
     {
-        public OperationalInsightsSavedSearch(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OperationalInsightsSavedSearch(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Category { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } set { } }
@@ -345,7 +345,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.OperationalInsights.OperationalInsightsTag> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<long> Version { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.OperationalInsightsSavedSearch FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.OperationalInsightsSavedSearch FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_03_20;
@@ -379,7 +379,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class OperationalInsightsTable : Azure.Provisioning.Primitives.Resource
     {
-        public OperationalInsightsTable(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OperationalInsightsTable(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<int> ArchiveRetentionInDays { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsRetentionInDaysAsDefault { get { throw null; } }
@@ -396,7 +396,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.OperationalInsightsTableSearchResults> SearchResults { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> TotalRetentionInDays { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.OperationalInsightsTable FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.OperationalInsightsTable FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_08_01;
@@ -470,7 +470,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class OperationalInsightsWorkspace : Azure.Provisioning.Primitives.Resource
     {
-        public OperationalInsightsWorkspace(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OperationalInsightsWorkspace(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Guid> CustomerId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> DefaultDataCollectionRuleResourceId { get { throw null; } set { } }
@@ -491,7 +491,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.OperationalInsights.OperationalInsightsWorkspaceCapping> WorkspaceCapping { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.OperationalInsightsWorkspace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.OperationalInsightsWorkspace FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.OperationalInsights.OperationalInsightsWorkspaceSharedKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -584,7 +584,7 @@ namespace Azure.Provisioning.OperationalInsights
     }
     public partial class StorageInsight : Azure.Provisioning.Primitives.Resource
     {
-        public StorageInsight(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StorageInsight(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> Containers { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -595,7 +595,7 @@ namespace Azure.Provisioning.OperationalInsights
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<string> Tables { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.OperationalInsights.StorageInsight FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.OperationalInsights.StorageInsight FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_03_20;

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/LogAnalyticsQuery.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/LogAnalyticsQuery.cs
@@ -111,10 +111,15 @@ public partial class LogAnalyticsQuery : Resource
     /// <summary>
     /// Creates a new LogAnalyticsQuery.
     /// </summary>
-    /// <param name="resourceName">Name of the LogAnalyticsQuery.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LogAnalyticsQuery resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogAnalyticsQuery.</param>
-    public LogAnalyticsQuery(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/queryPacks/queries", resourceVersion ?? "2023-09-01")
+    public LogAnalyticsQuery(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/queryPacks/queries", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _body = BicepValue<string>.DefineProperty(this, "Body", ["properties", "body"]);
@@ -150,9 +155,14 @@ public partial class LogAnalyticsQuery : Resource
     /// <summary>
     /// Creates a reference to an existing LogAnalyticsQuery.
     /// </summary>
-    /// <param name="resourceName">Name of the LogAnalyticsQuery.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LogAnalyticsQuery resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogAnalyticsQuery.</param>
     /// <returns>The existing LogAnalyticsQuery resource.</returns>
-    public static LogAnalyticsQuery FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static LogAnalyticsQuery FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/LogAnalyticsQueryPack.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/LogAnalyticsQueryPack.cs
@@ -78,10 +78,15 @@ public partial class LogAnalyticsQueryPack : Resource
     /// <summary>
     /// Creates a new LogAnalyticsQueryPack.
     /// </summary>
-    /// <param name="resourceName">Name of the LogAnalyticsQueryPack.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LogAnalyticsQueryPack resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogAnalyticsQueryPack.</param>
-    public LogAnalyticsQueryPack(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/queryPacks", resourceVersion ?? "2023-09-01")
+    public LogAnalyticsQueryPack(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/queryPacks", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -113,9 +118,14 @@ public partial class LogAnalyticsQueryPack : Resource
     /// <summary>
     /// Creates a reference to an existing LogAnalyticsQueryPack.
     /// </summary>
-    /// <param name="resourceName">Name of the LogAnalyticsQueryPack.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LogAnalyticsQueryPack resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogAnalyticsQueryPack.</param>
     /// <returns>The existing LogAnalyticsQueryPack resource.</returns>
-    public static LogAnalyticsQueryPack FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static LogAnalyticsQueryPack FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsCluster.cs
@@ -131,10 +131,15 @@ public partial class OperationalInsightsCluster : Resource
     /// <summary>
     /// Creates a new OperationalInsightsCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsCluster
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsCluster.</param>
-    public OperationalInsightsCluster(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/clusters", resourceVersion ?? "2023-09-01")
+    public OperationalInsightsCluster(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/clusters", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -189,11 +194,16 @@ public partial class OperationalInsightsCluster : Resource
     /// <summary>
     /// Creates a reference to an existing OperationalInsightsCluster.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsCluster.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsCluster
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsCluster.</param>
     /// <returns>The existing OperationalInsightsCluster resource.</returns>
-    public static OperationalInsightsCluster FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OperationalInsightsCluster FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this OperationalInsightsCluster

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsDataExport.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsDataExport.cs
@@ -95,10 +95,15 @@ public partial class OperationalInsightsDataExport : Resource
     /// <summary>
     /// Creates a new OperationalInsightsDataExport.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsDataExport.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsDataExport
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsDataExport.</param>
-    public OperationalInsightsDataExport(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/workspaces/dataExports", resourceVersion ?? "2023-09-01")
+    public OperationalInsightsDataExport(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/workspaces/dataExports", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _createdOn = BicepValue<DateTimeOffset>.DefineProperty(this, "CreatedOn", ["properties", "createdDate"]);
@@ -133,9 +138,14 @@ public partial class OperationalInsightsDataExport : Resource
     /// <summary>
     /// Creates a reference to an existing OperationalInsightsDataExport.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsDataExport.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsDataExport
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsDataExport.</param>
     /// <returns>The existing OperationalInsightsDataExport resource.</returns>
-    public static OperationalInsightsDataExport FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OperationalInsightsDataExport FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsDataSource.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsDataSource.cs
@@ -84,10 +84,15 @@ public partial class OperationalInsightsDataSource : Resource
     /// <summary>
     /// Creates a new OperationalInsightsDataSource.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsDataSource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsDataSource
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsDataSource.</param>
-    public OperationalInsightsDataSource(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/workspaces/dataSources", resourceVersion ?? "2023-09-01")
+    public OperationalInsightsDataSource(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/workspaces/dataSources", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<OperationalInsightsDataSourceKind>.DefineProperty(this, "Kind", ["kind"], isRequired: true);
@@ -118,9 +123,14 @@ public partial class OperationalInsightsDataSource : Resource
     /// <summary>
     /// Creates a reference to an existing OperationalInsightsDataSource.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsDataSource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsDataSource
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsDataSource.</param>
     /// <returns>The existing OperationalInsightsDataSource resource.</returns>
-    public static OperationalInsightsDataSource FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OperationalInsightsDataSource FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsLinkedService.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsLinkedService.cs
@@ -71,10 +71,15 @@ public partial class OperationalInsightsLinkedService : Resource
     /// <summary>
     /// Creates a new OperationalInsightsLinkedService.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsLinkedService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsLinkedService
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsLinkedService.</param>
-    public OperationalInsightsLinkedService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/workspaces/linkedServices", resourceVersion ?? "2023-09-01")
+    public OperationalInsightsLinkedService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/workspaces/linkedServices", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _provisioningState = BicepValue<OperationalInsightsLinkedServiceEntityStatus>.DefineProperty(this, "ProvisioningState", ["properties", "provisioningState"]);
@@ -105,9 +110,14 @@ public partial class OperationalInsightsLinkedService : Resource
     /// <summary>
     /// Creates a reference to an existing OperationalInsightsLinkedService.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsLinkedService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsLinkedService
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsLinkedService.</param>
     /// <returns>The existing OperationalInsightsLinkedService resource.</returns>
-    public static OperationalInsightsLinkedService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OperationalInsightsLinkedService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsLinkedStorageAccounts.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsLinkedStorageAccounts.cs
@@ -57,10 +57,16 @@ public partial class OperationalInsightsLinkedStorageAccounts : Resource
     /// <summary>
     /// Creates a new OperationalInsightsLinkedStorageAccounts.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsLinkedStorageAccounts.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// OperationalInsightsLinkedStorageAccounts resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsLinkedStorageAccounts.</param>
-    public OperationalInsightsLinkedStorageAccounts(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/workspaces/linkedStorageAccounts", resourceVersion ?? "2023-09-01")
+    public OperationalInsightsLinkedStorageAccounts(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/workspaces/linkedStorageAccounts", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _dataSourceType = BicepValue<OperationalInsightsDataSourceType>.DefineProperty(this, "DataSourceType", ["properties", "dataSourceType"], isRequired: true);
@@ -90,9 +96,15 @@ public partial class OperationalInsightsLinkedStorageAccounts : Resource
     /// Creates a reference to an existing
     /// OperationalInsightsLinkedStorageAccounts.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsLinkedStorageAccounts.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// OperationalInsightsLinkedStorageAccounts resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsLinkedStorageAccounts.</param>
     /// <returns>The existing OperationalInsightsLinkedStorageAccounts resource.</returns>
-    public static OperationalInsightsLinkedStorageAccounts FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OperationalInsightsLinkedStorageAccounts FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsSavedSearch.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsSavedSearch.cs
@@ -101,10 +101,15 @@ public partial class OperationalInsightsSavedSearch : Resource
     /// <summary>
     /// Creates a new OperationalInsightsSavedSearch.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsSavedSearch.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsSavedSearch
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsSavedSearch.</param>
-    public OperationalInsightsSavedSearch(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/workspaces/savedSearches", resourceVersion ?? "2023-09-01")
+    public OperationalInsightsSavedSearch(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/workspaces/savedSearches", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _category = BicepValue<string>.DefineProperty(this, "Category", ["properties", "category"], isRequired: true);
@@ -159,9 +164,14 @@ public partial class OperationalInsightsSavedSearch : Resource
     /// <summary>
     /// Creates a reference to an existing OperationalInsightsSavedSearch.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsSavedSearch.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsSavedSearch
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsSavedSearch.</param>
     /// <returns>The existing OperationalInsightsSavedSearch resource.</returns>
-    public static OperationalInsightsSavedSearch FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OperationalInsightsSavedSearch FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsTable.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsTable.cs
@@ -126,10 +126,15 @@ public partial class OperationalInsightsTable : Resource
     /// <summary>
     /// Creates a new OperationalInsightsTable.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsTable.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsTable resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsTable.</param>
-    public OperationalInsightsTable(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/workspaces/tables", resourceVersion ?? "2023-09-01")
+    public OperationalInsightsTable(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/workspaces/tables", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _plan = BicepValue<OperationalInsightsTablePlan>.DefineProperty(this, "Plan", ["properties", "plan"]);
@@ -173,9 +178,14 @@ public partial class OperationalInsightsTable : Resource
     /// <summary>
     /// Creates a reference to an existing OperationalInsightsTable.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsTable.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsTable resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsTable.</param>
     /// <returns>The existing OperationalInsightsTable resource.</returns>
-    public static OperationalInsightsTable FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OperationalInsightsTable FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsWorkspace.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/OperationalInsightsWorkspace.cs
@@ -150,10 +150,15 @@ public partial class OperationalInsightsWorkspace : Resource
     /// <summary>
     /// Creates a new OperationalInsightsWorkspace.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsWorkspace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsWorkspace
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsWorkspace.</param>
-    public OperationalInsightsWorkspace(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/workspaces", resourceVersion ?? "2023-09-01")
+    public OperationalInsightsWorkspace(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/workspaces", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -216,11 +221,16 @@ public partial class OperationalInsightsWorkspace : Resource
     /// <summary>
     /// Creates a reference to an existing OperationalInsightsWorkspace.
     /// </summary>
-    /// <param name="resourceName">Name of the OperationalInsightsWorkspace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OperationalInsightsWorkspace
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OperationalInsightsWorkspace.</param>
     /// <returns>The existing OperationalInsightsWorkspace resource.</returns>
-    public static OperationalInsightsWorkspace FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OperationalInsightsWorkspace FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this OperationalInsightsWorkspace
@@ -237,5 +247,5 @@ public partial class OperationalInsightsWorkspace : Resource
     /// <returns>The keys for this OperationalInsightsWorkspace resource.</returns>
     public OperationalInsightsWorkspaceSharedKeys GetKeys() =>
         OperationalInsightsWorkspaceSharedKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 }

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/StorageInsight.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Generated/StorageInsight.cs
@@ -82,10 +82,15 @@ public partial class StorageInsight : Resource
     /// <summary>
     /// Creates a new StorageInsight.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageInsight.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageInsight resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageInsight.</param>
-    public StorageInsight(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.OperationalInsights/workspaces/storageInsightConfigs", resourceVersion ?? "2023-09-01")
+    public StorageInsight(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.OperationalInsights/workspaces/storageInsightConfigs", resourceVersion ?? "2023-09-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _containers = BicepList<string>.DefineProperty(this, "Containers", ["properties", "containers"]);
@@ -123,9 +128,14 @@ public partial class StorageInsight : Resource
     /// <summary>
     /// Creates a reference to an existing StorageInsight.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageInsight.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageInsight resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageInsight.</param>
     /// <returns>The existing StorageInsight resource.</returns>
-    public static StorageInsight FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StorageInsight FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.netstandard2.0.cs
@@ -6,7 +6,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AllowedValues { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DataType { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DefaultValue { get { throw null; } }
@@ -17,7 +17,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<string> Source { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Value { get { throw null; } set { } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
@@ -26,14 +26,14 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlDatabase : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlDatabase(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlDatabase(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Charset { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Collation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.PostgreSql.PostgreSqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlDatabase FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlDatabase FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -44,14 +44,14 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlFirewallRule : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlFirewallRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlFirewallRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Net.IPAddress> EndIPAddress { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.PostgreSql.PostgreSqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Net.IPAddress> StartIPAddress { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlFirewallRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlFirewallRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -62,7 +62,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlFlexibleServer : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlFlexibleServer(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlFlexibleServer(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AdministratorLogin { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AdministratorLoginPassword { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerAuthConfig> AuthConfig { get { throw null; } set { } }
@@ -90,7 +90,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerVersion> Version { get { throw null; } set { } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -102,7 +102,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlFlexibleServerActiveDirectoryAdministrator : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlFlexibleServerActiveDirectoryAdministrator(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlFlexibleServerActiveDirectoryAdministrator(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ObjectId { get { throw null; } }
@@ -111,7 +111,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerPrincipalType> PrincipalType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Guid> TenantId { get { throw null; } set { } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerActiveDirectoryAdministrator FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerActiveDirectoryAdministrator FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_06_01;
@@ -140,7 +140,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlFlexibleServerConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlFlexibleServerConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlFlexibleServerConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AllowedValues { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerConfigurationDataType> DataType { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DefaultValue { get { throw null; } }
@@ -156,7 +156,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Unit { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Value { get { throw null; } set { } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_06_01;
@@ -183,14 +183,14 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlFlexibleServerDatabase : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlFlexibleServerDatabase(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlFlexibleServerDatabase(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Charset { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Collation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerDatabase FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerDatabase FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_06_01;
@@ -211,14 +211,14 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlFlexibleServerFirewallRule : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlFlexibleServerFirewallRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlFlexibleServerFirewallRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Net.IPAddress> EndIPAddress { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Net.IPAddress> StartIPAddress { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerFirewallRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServerFirewallRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_06_01;
@@ -392,7 +392,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlMigration : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlMigration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlMigration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlMigrationCancel> Cancel { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlMigrationStatus> CurrentStatus { get { throw null; } }
         public Azure.Provisioning.BicepList<string> DbsToCancelMigrationOn { get { throw null; } set { } }
@@ -419,7 +419,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlServerMetadata> TargetDbServerMetadata { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> TargetDbServerResourceId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlMigrationTriggerCutover> TriggerCutover { get { throw null; } set { } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlMigration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlMigration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_06_01;
@@ -510,7 +510,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlPrivateLinkServiceConnectionStateProperty> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -518,7 +518,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2018_06_01;
@@ -562,7 +562,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlServer : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlServer(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlServer(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AdministratorLogin { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> ByokEnforcement { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> EarliestRestoreOn { get { throw null; } }
@@ -586,7 +586,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlServerState> UserVisibleState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlServerVersion> Version { get { throw null; } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlServer FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlServer FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -597,7 +597,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlServerAdministrator : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlServerAdministrator(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlServerAdministrator(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlAdministratorType> AdministratorType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> LoginAccountName { get { throw null; } set { } }
@@ -606,7 +606,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<System.Guid> SecureId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Guid> TenantId { get { throw null; } set { } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlServerAdministrator FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlServerAdministrator FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
@@ -615,7 +615,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlServerKey : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlServerKey(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlServerKey(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } }
@@ -624,7 +624,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlServerKeyType> ServerKeyType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Uri> Uri { get { throw null; } set { } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlServerKey FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlServerKey FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_01_01;
@@ -697,7 +697,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlServerSecurityAlertPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlServerSecurityAlertPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlServerSecurityAlertPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> DisabledAlerts { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> EmailAddresses { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -709,7 +709,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<string> StorageAccountAccessKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlServerSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlServerSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
@@ -778,7 +778,7 @@ namespace Azure.Provisioning.PostgreSql
     }
     public partial class PostgreSqlVirtualNetworkRule : Azure.Provisioning.Primitives.Resource
     {
-        public PostgreSqlVirtualNetworkRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PostgreSqlVirtualNetworkRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IgnoreMissingVnetServiceEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -786,7 +786,7 @@ namespace Azure.Provisioning.PostgreSql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.PostgreSql.PostgreSqlVirtualNetworkRuleState> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> VirtualNetworkSubnetId { get { throw null; } set { } }
-        public static Azure.Provisioning.PostgreSql.PostgreSqlVirtualNetworkRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.PostgreSql.PostgreSqlVirtualNetworkRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlConfiguration.cs
@@ -80,10 +80,15 @@ public partial class PostgreSqlConfiguration : Resource
     /// <summary>
     /// Creates a new PostgreSqlConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlConfiguration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlConfiguration.</param>
-    public PostgreSqlConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers/configurations", resourceVersion ?? "2017-12-01")
+    public PostgreSqlConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers/configurations", resourceVersion ?? "2017-12-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _source = BicepValue<string>.DefineProperty(this, "Source", ["properties", "source"]);
@@ -116,9 +121,14 @@ public partial class PostgreSqlConfiguration : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlConfiguration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlConfiguration.</param>
     /// <returns>The existing PostgreSqlConfiguration resource.</returns>
-    public static PostgreSqlConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlDatabase.cs
@@ -57,10 +57,15 @@ public partial class PostgreSqlDatabase : Resource
     /// <summary>
     /// Creates a new PostgreSqlDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlDatabase resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlDatabase.</param>
-    public PostgreSqlDatabase(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers/databases", resourceVersion ?? "2017-12-01")
+    public PostgreSqlDatabase(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers/databases", resourceVersion ?? "2017-12-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _charset = BicepValue<string>.DefineProperty(this, "Charset", ["properties", "charset"]);
@@ -89,11 +94,16 @@ public partial class PostgreSqlDatabase : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlDatabase resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlDatabase.</param>
     /// <returns>The existing PostgreSqlDatabase resource.</returns>
-    public static PostgreSqlDatabase FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlDatabase FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this PostgreSqlDatabase resource.

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFirewallRule.cs
@@ -58,10 +58,15 @@ public partial class PostgreSqlFirewallRule : Resource
     /// <summary>
     /// Creates a new PostgreSqlFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlFirewallRule resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFirewallRule.</param>
-    public PostgreSqlFirewallRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers/firewallRules", resourceVersion ?? "2017-12-01")
+    public PostgreSqlFirewallRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers/firewallRules", resourceVersion ?? "2017-12-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _endIPAddress = BicepValue<IPAddress>.DefineProperty(this, "EndIPAddress", ["properties", "endIpAddress"], isRequired: true);
@@ -90,11 +95,16 @@ public partial class PostgreSqlFirewallRule : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlFirewallRule resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFirewallRule.</param>
     /// <returns>The existing PostgreSqlFirewallRule resource.</returns>
-    public static PostgreSqlFirewallRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlFirewallRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this PostgreSqlFirewallRule resource.

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServer.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServer.cs
@@ -193,10 +193,15 @@ public partial class PostgreSqlFlexibleServer : Resource
     /// <summary>
     /// Creates a new PostgreSqlFlexibleServer.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlFlexibleServer resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServer.</param>
-    public PostgreSqlFlexibleServer(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/flexibleServers", resourceVersion ?? "2024-08-01")
+    public PostgreSqlFlexibleServer(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/flexibleServers", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -251,11 +256,16 @@ public partial class PostgreSqlFlexibleServer : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlFlexibleServer.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlFlexibleServer resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServer.</param>
     /// <returns>The existing PostgreSqlFlexibleServer resource.</returns>
-    public static PostgreSqlFlexibleServer FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlFlexibleServer FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this PostgreSqlFlexibleServer resource.

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServerActiveDirectoryAdministrator.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServerActiveDirectoryAdministrator.cs
@@ -69,10 +69,16 @@ public partial class PostgreSqlFlexibleServerActiveDirectoryAdministrator : Reso
     /// <summary>
     /// Creates a new PostgreSqlFlexibleServerActiveDirectoryAdministrator.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServerActiveDirectoryAdministrator.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlFlexibleServerActiveDirectoryAdministrator resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServerActiveDirectoryAdministrator.</param>
-    public PostgreSqlFlexibleServerActiveDirectoryAdministrator(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/flexibleServers/administrators", resourceVersion ?? "2024-08-01")
+    public PostgreSqlFlexibleServerActiveDirectoryAdministrator(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/flexibleServers/administrators", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _objectId = BicepValue<string>.DefineProperty(this, "ObjectId", ["properties", "objectId"], isOutput: true);
@@ -110,9 +116,15 @@ public partial class PostgreSqlFlexibleServerActiveDirectoryAdministrator : Reso
     /// Creates a reference to an existing
     /// PostgreSqlFlexibleServerActiveDirectoryAdministrator.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServerActiveDirectoryAdministrator.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlFlexibleServerActiveDirectoryAdministrator resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServerActiveDirectoryAdministrator.</param>
     /// <returns>The existing PostgreSqlFlexibleServerActiveDirectoryAdministrator resource.</returns>
-    public static PostgreSqlFlexibleServerActiveDirectoryAdministrator FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlFlexibleServerActiveDirectoryAdministrator FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServerConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServerConfiguration.cs
@@ -110,10 +110,15 @@ public partial class PostgreSqlFlexibleServerConfiguration : Resource
     /// <summary>
     /// Creates a new PostgreSqlFlexibleServerConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServerConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlFlexibleServerConfiguration resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServerConfiguration.</param>
-    public PostgreSqlFlexibleServerConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/flexibleServers/configurations", resourceVersion ?? "2024-08-01")
+    public PostgreSqlFlexibleServerConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/flexibleServers/configurations", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _source = BicepValue<string>.DefineProperty(this, "Source", ["properties", "source"]);
@@ -157,9 +162,14 @@ public partial class PostgreSqlFlexibleServerConfiguration : Resource
     /// Creates a reference to an existing
     /// PostgreSqlFlexibleServerConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServerConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlFlexibleServerConfiguration resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServerConfiguration.</param>
     /// <returns>The existing PostgreSqlFlexibleServerConfiguration resource.</returns>
-    public static PostgreSqlFlexibleServerConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlFlexibleServerConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServerDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServerDatabase.cs
@@ -56,10 +56,15 @@ public partial class PostgreSqlFlexibleServerDatabase : Resource
     /// <summary>
     /// Creates a new PostgreSqlFlexibleServerDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServerDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlFlexibleServerDatabase
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServerDatabase.</param>
-    public PostgreSqlFlexibleServerDatabase(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/flexibleServers/databases", resourceVersion ?? "2024-08-01")
+    public PostgreSqlFlexibleServerDatabase(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/flexibleServers/databases", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _charset = BicepValue<string>.DefineProperty(this, "Charset", ["properties", "charset"]);
@@ -93,9 +98,14 @@ public partial class PostgreSqlFlexibleServerDatabase : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlFlexibleServerDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServerDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlFlexibleServerDatabase
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServerDatabase.</param>
     /// <returns>The existing PostgreSqlFlexibleServerDatabase resource.</returns>
-    public static PostgreSqlFlexibleServerDatabase FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlFlexibleServerDatabase FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServerFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFlexibleServerFirewallRule.cs
@@ -57,10 +57,15 @@ public partial class PostgreSqlFlexibleServerFirewallRule : Resource
     /// <summary>
     /// Creates a new PostgreSqlFlexibleServerFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServerFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlFlexibleServerFirewallRule resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServerFirewallRule.</param>
-    public PostgreSqlFlexibleServerFirewallRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules", resourceVersion ?? "2024-08-01")
+    public PostgreSqlFlexibleServerFirewallRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _endIPAddress = BicepValue<IPAddress>.DefineProperty(this, "EndIPAddress", ["properties", "endIpAddress"], isRequired: true);
@@ -94,9 +99,14 @@ public partial class PostgreSqlFlexibleServerFirewallRule : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlFlexibleServerFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlFlexibleServerFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlFlexibleServerFirewallRule resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlFlexibleServerFirewallRule.</param>
     /// <returns>The existing PostgreSqlFlexibleServerFirewallRule resource.</returns>
-    public static PostgreSqlFlexibleServerFirewallRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlFlexibleServerFirewallRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlMigration.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlMigration.cs
@@ -186,10 +186,15 @@ public partial class PostgreSqlMigration : Resource
     /// <summary>
     /// Creates a new PostgreSqlMigration.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlMigration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlMigration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlMigration.</param>
-    public PostgreSqlMigration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/flexibleServers/migrations", resourceVersion ?? "2024-08-01")
+    public PostgreSqlMigration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/flexibleServers/migrations", resourceVersion ?? "2024-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -243,9 +248,14 @@ public partial class PostgreSqlMigration : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlMigration.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlMigration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlMigration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlMigration.</param>
     /// <returns>The existing PostgreSqlMigration resource.</returns>
-    public static PostgreSqlMigration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlMigration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlPrivateEndpointConnection.cs
@@ -62,10 +62,15 @@ public partial class PostgreSqlPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new PostgreSqlPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlPrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlPrivateEndpointConnection.</param>
-    public PostgreSqlPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers/privateEndpointConnections", resourceVersion ?? "2018-06-01")
+    public PostgreSqlPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers/privateEndpointConnections", resourceVersion ?? "2018-06-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<PostgreSqlPrivateLinkServiceConnectionStateProperty>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -95,9 +100,14 @@ public partial class PostgreSqlPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlPrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlPrivateEndpointConnection.</param>
     /// <returns>The existing PostgreSqlPrivateEndpointConnection resource.</returns>
-    public static PostgreSqlPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServer.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServer.cs
@@ -175,10 +175,15 @@ public partial class PostgreSqlServer : Resource
     /// <summary>
     /// Creates a new PostgreSqlServer.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlServer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlServer resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlServer.</param>
-    public PostgreSqlServer(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers", resourceVersion ?? "2017-12-01")
+    public PostgreSqlServer(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers", resourceVersion ?? "2017-12-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -224,11 +229,16 @@ public partial class PostgreSqlServer : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlServer.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlServer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlServer resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlServer.</param>
     /// <returns>The existing PostgreSqlServer resource.</returns>
-    public static PostgreSqlServer FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlServer FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this PostgreSqlServer resource.

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerAdministrator.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerAdministrator.cs
@@ -68,10 +68,15 @@ public partial class PostgreSqlServerAdministrator : Resource
     /// <summary>
     /// Creates a new PostgreSqlServerAdministrator.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlServerAdministrator.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlServerAdministrator
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlServerAdministrator.</param>
-    public PostgreSqlServerAdministrator(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers/administrators", resourceVersion ?? "2017-12-01")
+    public PostgreSqlServerAdministrator(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers/administrators", resourceVersion ?? "2017-12-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _administratorType = BicepValue<PostgreSqlAdministratorType>.DefineProperty(this, "AdministratorType", ["properties", "administratorType"]);
@@ -102,9 +107,14 @@ public partial class PostgreSqlServerAdministrator : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlServerAdministrator.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlServerAdministrator.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlServerAdministrator
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlServerAdministrator.</param>
     /// <returns>The existing PostgreSqlServerAdministrator resource.</returns>
-    public static PostgreSqlServerAdministrator FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlServerAdministrator FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerKey.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerKey.cs
@@ -69,10 +69,15 @@ public partial class PostgreSqlServerKey : Resource
     /// <summary>
     /// Creates a new PostgreSqlServerKey.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlServerKey.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlServerKey resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlServerKey.</param>
-    public PostgreSqlServerKey(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers/keys", resourceVersion ?? "2020-01-01")
+    public PostgreSqlServerKey(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers/keys", resourceVersion ?? "2020-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _serverKeyType = BicepValue<PostgreSqlServerKeyType>.DefineProperty(this, "ServerKeyType", ["properties", "serverKeyType"]);
@@ -103,9 +108,14 @@ public partial class PostgreSqlServerKey : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlServerKey.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlServerKey.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlServerKey resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlServerKey.</param>
     /// <returns>The existing PostgreSqlServerKey resource.</returns>
-    public static PostgreSqlServerKey FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlServerKey FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerSecurityAlertPolicy.cs
@@ -91,10 +91,15 @@ public partial class PostgreSqlServerSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a new PostgreSqlServerSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlServerSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlServerSecurityAlertPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlServerSecurityAlertPolicy.</param>
-    public PostgreSqlServerSecurityAlertPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers/securityAlertPolicies", resourceVersion ?? "2017-12-01")
+    public PostgreSqlServerSecurityAlertPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers/securityAlertPolicies", resourceVersion ?? "2017-12-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _disabledAlerts = BicepList<string>.DefineProperty(this, "DisabledAlerts", ["properties", "disabledAlerts"]);
@@ -128,9 +133,14 @@ public partial class PostgreSqlServerSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlServerSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlServerSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// PostgreSqlServerSecurityAlertPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlServerSecurityAlertPolicy.</param>
     /// <returns>The existing PostgreSqlServerSecurityAlertPolicy resource.</returns>
-    public static PostgreSqlServerSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlServerSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlVirtualNetworkRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlVirtualNetworkRule.cs
@@ -64,10 +64,15 @@ public partial class PostgreSqlVirtualNetworkRule : Resource
     /// <summary>
     /// Creates a new PostgreSqlVirtualNetworkRule.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlVirtualNetworkRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlVirtualNetworkRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlVirtualNetworkRule.</param>
-    public PostgreSqlVirtualNetworkRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules", resourceVersion ?? "2017-12-01")
+    public PostgreSqlVirtualNetworkRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules", resourceVersion ?? "2017-12-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _ignoreMissingVnetServiceEndpoint = BicepValue<bool>.DefineProperty(this, "IgnoreMissingVnetServiceEndpoint", ["properties", "ignoreMissingVnetServiceEndpoint"]);
@@ -97,11 +102,16 @@ public partial class PostgreSqlVirtualNetworkRule : Resource
     /// <summary>
     /// Creates a reference to an existing PostgreSqlVirtualNetworkRule.
     /// </summary>
-    /// <param name="resourceName">Name of the PostgreSqlVirtualNetworkRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PostgreSqlVirtualNetworkRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PostgreSqlVirtualNetworkRule.</param>
     /// <returns>The existing PostgreSqlVirtualNetworkRule resource.</returns>
-    public static PostgreSqlVirtualNetworkRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PostgreSqlVirtualNetworkRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this PostgreSqlVirtualNetworkRule

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/BasicPostgreSqlTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/tests/BasicPostgreSqlTests.cs
@@ -121,7 +121,7 @@ public class BasicPostgreSqlTests(bool async)
             param location string = resourceGroup().location
 
             resource server 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
-              name: take('server${uniqueString(resourceGroup().id)}', 24)
+              name: take('server-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
                 administratorLogin: adminLogin

--- a/sdk/provisioning/Azure.Provisioning.Redis/api/Azure.Provisioning.Redis.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/api/Azure.Provisioning.Redis.netstandard2.0.cs
@@ -52,7 +52,7 @@ namespace Azure.Provisioning.Redis
     }
     public partial class RedisCacheAccessPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public RedisCacheAccessPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RedisCacheAccessPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Redis.RedisResource? Parent { get { throw null; } set { } }
@@ -60,7 +60,7 @@ namespace Azure.Provisioning.Redis
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.AccessPolicyProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.AccessPolicyType> TypePropertiesType { get { throw null; } }
-        public static Azure.Provisioning.Redis.RedisCacheAccessPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Redis.RedisCacheAccessPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -84,7 +84,7 @@ namespace Azure.Provisioning.Redis
     }
     public partial class RedisCacheAccessPolicyAssignment : Azure.Provisioning.Primitives.Resource
     {
-        public RedisCacheAccessPolicyAssignment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RedisCacheAccessPolicyAssignment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AccessPolicyName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -93,7 +93,7 @@ namespace Azure.Provisioning.Redis
         public Azure.Provisioning.Redis.RedisResource? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.AccessPolicyAssignmentProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Redis.RedisCacheAccessPolicyAssignment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Redis.RedisCacheAccessPolicyAssignment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -152,14 +152,14 @@ namespace Azure.Provisioning.Redis
     }
     public partial class RedisFirewallRule : Azure.Provisioning.Primitives.Resource
     {
-        public RedisFirewallRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RedisFirewallRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Net.IPAddress> EndIP { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Redis.RedisResource? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Net.IPAddress> StartIP { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Redis.RedisFirewallRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Redis.RedisFirewallRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -200,7 +200,7 @@ namespace Azure.Provisioning.Redis
     }
     public partial class RedisLinkedServerWithProperty : Azure.Provisioning.Primitives.Resource
     {
-        public RedisLinkedServerWithProperty(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RedisLinkedServerWithProperty(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> GeoReplicatedPrimaryHostName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> LinkedRedisCacheId { get { throw null; } set { } }
@@ -211,7 +211,7 @@ namespace Azure.Provisioning.Redis
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.RedisLinkedServerRole> ServerRole { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Redis.RedisLinkedServerWithProperty FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Redis.RedisLinkedServerWithProperty FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -235,14 +235,14 @@ namespace Azure.Provisioning.Redis
     }
     public partial class RedisPatchSchedule : Azure.Provisioning.Primitives.Resource
     {
-        public RedisPatchSchedule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RedisPatchSchedule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Redis.RedisResource? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Redis.RedisPatchScheduleSetting> ScheduleEntries { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Redis.RedisPatchSchedule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Redis.RedisPatchSchedule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -278,7 +278,7 @@ namespace Azure.Provisioning.Redis
     }
     public partial class RedisPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public RedisPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RedisPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Redis.RedisResource? Parent { get { throw null; } set { } }
@@ -286,7 +286,7 @@ namespace Azure.Provisioning.Redis
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.RedisPrivateLinkServiceConnectionState> RedisPrivateLinkServiceConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.RedisPrivateEndpointConnectionProvisioningState> RedisProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Redis.RedisPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Redis.RedisPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_07_01;
@@ -354,7 +354,7 @@ namespace Azure.Provisioning.Redis
     }
     public partial class RedisResource : Azure.Provisioning.Primitives.Resource
     {
-        public RedisResource(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RedisResource(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.RedisAccessKeys> AccessKeys { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> EnableNonSslPort { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> HostName { get { throw null; } }
@@ -383,9 +383,9 @@ namespace Azure.Provisioning.Redis
         public Azure.Provisioning.BicepDictionary<string> TenantSettings { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Redis.UpdateChannel> UpdateChannel { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> Zones { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Redis.RedisBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Redis.RedisBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Redis.RedisBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.Redis.RedisResource FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Redis.RedisResource FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.Redis.RedisAccessKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisCacheAccessPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisCacheAccessPolicy.cs
@@ -63,10 +63,15 @@ public partial class RedisCacheAccessPolicy : Resource
     /// <summary>
     /// Creates a new RedisCacheAccessPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisCacheAccessPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisCacheAccessPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisCacheAccessPolicy.</param>
-    public RedisCacheAccessPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Cache/redis/accessPolicies", resourceVersion ?? "2024-03-01")
+    public RedisCacheAccessPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Cache/redis/accessPolicies", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _permissions = BicepValue<string>.DefineProperty(this, "Permissions", ["properties", "permissions"]);
@@ -171,9 +176,14 @@ public partial class RedisCacheAccessPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing RedisCacheAccessPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisCacheAccessPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisCacheAccessPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisCacheAccessPolicy.</param>
     /// <returns>The existing RedisCacheAccessPolicy resource.</returns>
-    public static RedisCacheAccessPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RedisCacheAccessPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisCacheAccessPolicyAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisCacheAccessPolicyAssignment.cs
@@ -69,10 +69,15 @@ public partial class RedisCacheAccessPolicyAssignment : Resource
     /// <summary>
     /// Creates a new RedisCacheAccessPolicyAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisCacheAccessPolicyAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisCacheAccessPolicyAssignment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisCacheAccessPolicyAssignment.</param>
-    public RedisCacheAccessPolicyAssignment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Cache/redis/accessPolicyAssignments", resourceVersion ?? "2024-03-01")
+    public RedisCacheAccessPolicyAssignment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Cache/redis/accessPolicyAssignments", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _accessPolicyName = BicepValue<string>.DefineProperty(this, "AccessPolicyName", ["properties", "accessPolicyName"]);
@@ -178,9 +183,14 @@ public partial class RedisCacheAccessPolicyAssignment : Resource
     /// <summary>
     /// Creates a reference to an existing RedisCacheAccessPolicyAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisCacheAccessPolicyAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisCacheAccessPolicyAssignment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisCacheAccessPolicyAssignment.</param>
     /// <returns>The existing RedisCacheAccessPolicyAssignment resource.</returns>
-    public static RedisCacheAccessPolicyAssignment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RedisCacheAccessPolicyAssignment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisFirewallRule.cs
@@ -58,10 +58,15 @@ public partial class RedisFirewallRule : Resource
     /// <summary>
     /// Creates a new RedisFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisFirewallRule resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisFirewallRule.</param>
-    public RedisFirewallRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Cache/redis/firewallRules", resourceVersion ?? "2024-03-01")
+    public RedisFirewallRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Cache/redis/firewallRules", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _endIP = BicepValue<IPAddress>.DefineProperty(this, "EndIP", ["properties", "endIP"], isRequired: true);
@@ -165,11 +170,16 @@ public partial class RedisFirewallRule : Resource
     /// <summary>
     /// Creates a reference to an existing RedisFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisFirewallRule resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisFirewallRule.</param>
     /// <returns>The existing RedisFirewallRule resource.</returns>
-    public static RedisFirewallRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RedisFirewallRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this RedisFirewallRule resource.

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisLinkedServerWithProperty.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisLinkedServerWithProperty.cs
@@ -83,10 +83,15 @@ public partial class RedisLinkedServerWithProperty : Resource
     /// <summary>
     /// Creates a new RedisLinkedServerWithProperty.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisLinkedServerWithProperty.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisLinkedServerWithProperty
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisLinkedServerWithProperty.</param>
-    public RedisLinkedServerWithProperty(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Cache/redis/linkedServers", resourceVersion ?? "2024-03-01")
+    public RedisLinkedServerWithProperty(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Cache/redis/linkedServers", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _linkedRedisCacheId = BicepValue<ResourceIdentifier>.DefineProperty(this, "LinkedRedisCacheId", ["properties", "linkedRedisCacheId"], isRequired: true);
@@ -194,9 +199,14 @@ public partial class RedisLinkedServerWithProperty : Resource
     /// <summary>
     /// Creates a reference to an existing RedisLinkedServerWithProperty.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisLinkedServerWithProperty.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisLinkedServerWithProperty
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisLinkedServerWithProperty.</param>
     /// <returns>The existing RedisLinkedServerWithProperty resource.</returns>
-    public static RedisLinkedServerWithProperty FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RedisLinkedServerWithProperty FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisPatchSchedule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisPatchSchedule.cs
@@ -57,10 +57,15 @@ public partial class RedisPatchSchedule : Resource
     /// <summary>
     /// Creates a new RedisPatchSchedule.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisPatchSchedule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisPatchSchedule resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisPatchSchedule.</param>
-    public RedisPatchSchedule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Cache/redis/patchSchedules", resourceVersion ?? "2024-03-01")
+    public RedisPatchSchedule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Cache/redis/patchSchedules", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _scheduleEntries = BicepList<RedisPatchScheduleSetting>.DefineProperty(this, "ScheduleEntries", ["properties", "scheduleEntries"], isRequired: true);
@@ -164,9 +169,14 @@ public partial class RedisPatchSchedule : Resource
     /// <summary>
     /// Creates a reference to an existing RedisPatchSchedule.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisPatchSchedule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisPatchSchedule resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisPatchSchedule.</param>
     /// <returns>The existing RedisPatchSchedule resource.</returns>
-    public static RedisPatchSchedule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RedisPatchSchedule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisPrivateEndpointConnection.cs
@@ -64,10 +64,15 @@ public partial class RedisPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new RedisPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisPrivateEndpointConnection.</param>
-    public RedisPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Cache/redis/privateEndpointConnections", resourceVersion ?? "2024-03-01")
+    public RedisPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Cache/redis/privateEndpointConnections", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _redisPrivateLinkServiceConnectionState = BicepValue<RedisPrivateLinkServiceConnectionState>.DefineProperty(this, "RedisPrivateLinkServiceConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -137,9 +142,14 @@ public partial class RedisPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing RedisPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisPrivateEndpointConnection.</param>
     /// <returns>The existing RedisPrivateEndpointConnection resource.</returns>
-    public static RedisPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RedisPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
@@ -214,10 +214,15 @@ public partial class RedisResource : Resource
     /// <summary>
     /// Creates a new RedisResource.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisResource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisResource resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisResource.</param>
-    public RedisResource(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Cache/redis", resourceVersion ?? "2024-03-01")
+    public RedisResource(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Cache/redis", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -343,11 +348,16 @@ public partial class RedisResource : Resource
     /// <summary>
     /// Creates a reference to an existing RedisResource.
     /// </summary>
-    /// <param name="resourceName">Name of the RedisResource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RedisResource resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RedisResource.</param>
     /// <returns>The existing RedisResource resource.</returns>
-    public static RedisResource FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RedisResource FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this RedisResource resource.
@@ -363,7 +373,7 @@ public partial class RedisResource : Resource
     /// <returns>The keys for this RedisResource resource.</returns>
     public RedisAccessKeys GetKeys() =>
         RedisAccessKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -373,10 +383,10 @@ public partial class RedisResource : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(RedisBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{RedisBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{RedisBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -389,13 +399,13 @@ public partial class RedisResource : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(RedisBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{RedisBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(RedisBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{RedisBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.Search/api/Azure.Provisioning.Search.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/api/Azure.Provisioning.Search.netstandard2.0.cs
@@ -67,13 +67,13 @@ namespace Azure.Provisioning.Search
     }
     public partial class SearchPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public SearchPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SearchPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Search.SearchService? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Search.SearchServicePrivateEndpointConnectionProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Search.SearchPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Search.SearchPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_07_31_Preview;
@@ -119,7 +119,7 @@ namespace Azure.Provisioning.Search
     }
     public partial class SearchService : Azure.Provisioning.Primitives.Resource
     {
-        public SearchService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SearchService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Search.SearchAadAuthDataPlaneAuthOptions> AuthOptions { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Search.SearchDisabledDataExfiltrationOption> DisabledDataExfiltrationOptions { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Search.SearchEncryptionWithCmk> EncryptionWithCmk { get { throw null; } set { } }
@@ -144,9 +144,9 @@ namespace Azure.Provisioning.Search
         public Azure.Provisioning.BicepValue<string> StatusDetails { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Search.SearchBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Search.SearchBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Search.SearchBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.Search.SearchService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Search.SearchService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -268,13 +268,13 @@ namespace Azure.Provisioning.Search
     }
     public partial class SharedSearchServicePrivateLink : Azure.Provisioning.Primitives.Resource
     {
-        public SharedSearchServicePrivateLink(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SharedSearchServicePrivateLink(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Search.SearchService? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Search.SharedSearchServicePrivateLinkResourceProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Search.SharedSearchServicePrivateLink FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Search.SharedSearchServicePrivateLink FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_07_31_Preview;

--- a/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchPrivateEndpointConnection.cs
@@ -52,10 +52,15 @@ public partial class SearchPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new SearchPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SearchPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SearchPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SearchPrivateEndpointConnection.</param>
-    public SearchPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Search/searchServices/privateEndpointConnections", resourceVersion ?? "2023-11-01")
+    public SearchPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Search/searchServices/privateEndpointConnections", resourceVersion ?? "2023-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _properties = BicepValue<SearchServicePrivateEndpointConnectionProperties>.DefineProperty(this, "Properties", ["properties"]);
@@ -138,9 +143,14 @@ public partial class SearchPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing SearchPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SearchPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SearchPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SearchPrivateEndpointConnection.</param>
     /// <returns>The existing SearchPrivateEndpointConnection resource.</returns>
-    public static SearchPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SearchPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SearchService.cs
@@ -240,10 +240,15 @@ public partial class SearchService : Resource
     /// <summary>
     /// Creates a new SearchService.
     /// </summary>
-    /// <param name="resourceName">Name of the SearchService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SearchService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SearchService.</param>
-    public SearchService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Search/searchServices", resourceVersion ?? "2023-11-01")
+    public SearchService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Search/searchServices", resourceVersion ?? "2023-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -345,11 +350,16 @@ public partial class SearchService : Resource
     /// <summary>
     /// Creates a reference to an existing SearchService.
     /// </summary>
-    /// <param name="resourceName">Name of the SearchService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SearchService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SearchService.</param>
     /// <returns>The existing SearchService resource.</returns>
-    public static SearchService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SearchService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SearchService resource.
@@ -367,10 +377,10 @@ public partial class SearchService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(SearchBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{SearchBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{SearchBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -383,13 +393,13 @@ public partial class SearchService : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(SearchBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{SearchBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(SearchBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{SearchBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SharedSearchServicePrivateLink.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/src/Generated/SharedSearchServicePrivateLink.cs
@@ -52,10 +52,15 @@ public partial class SharedSearchServicePrivateLink : Resource
     /// <summary>
     /// Creates a new SharedSearchServicePrivateLink.
     /// </summary>
-    /// <param name="resourceName">Name of the SharedSearchServicePrivateLink.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SharedSearchServicePrivateLink
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SharedSearchServicePrivateLink.</param>
-    public SharedSearchServicePrivateLink(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Search/searchServices/sharedPrivateLinkResources", resourceVersion ?? "2023-11-01")
+    public SharedSearchServicePrivateLink(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Search/searchServices/sharedPrivateLinkResources", resourceVersion ?? "2023-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _properties = BicepValue<SharedSearchServicePrivateLinkResourceProperties>.DefineProperty(this, "Properties", ["properties"]);
@@ -138,9 +143,14 @@ public partial class SharedSearchServicePrivateLink : Resource
     /// <summary>
     /// Creates a reference to an existing SharedSearchServicePrivateLink.
     /// </summary>
-    /// <param name="resourceName">Name of the SharedSearchServicePrivateLink.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SharedSearchServicePrivateLink
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SharedSearchServicePrivateLink.</param>
     /// <returns>The existing SharedSearchServicePrivateLink resource.</returns>
-    public static SharedSearchServicePrivateLink FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SharedSearchServicePrivateLink FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/api/Azure.Provisioning.ServiceBus.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/api/Azure.Provisioning.ServiceBus.netstandard2.0.cs
@@ -11,7 +11,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class MigrationConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public MigrationConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public MigrationConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> MigrationState { get { throw null; } }
@@ -21,7 +21,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> TargetServiceBusNamespace { get { throw null; } set { } }
-        public static Azure.Provisioning.ServiceBus.MigrationConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.MigrationConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_04_01;
@@ -97,7 +97,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusDisasterRecovery : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusDisasterRecovery(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusDisasterRecovery(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AlternateName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -108,7 +108,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusDisasterRecoveryProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusDisasterRecoveryRole> Role { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusDisasterRecovery FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusDisasterRecovery FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -185,7 +185,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusNamespace : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusNamespace(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusNamespace(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AlternateName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> DisableLocalAuth { get { throw null; } set { } }
@@ -207,9 +207,9 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ServiceBus.ServiceBusBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ServiceBus.ServiceBusBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.ServiceBus.ServiceBusBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.ServiceBus.ServiceBusNamespace FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusNamespace FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -223,14 +223,14 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusNamespaceAuthorizationRule : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusNamespaceAuthorizationRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusNamespaceAuthorizationRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.ServiceBus.ServiceBusNamespace? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ServiceBus.ServiceBusAccessRight> Rights { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusNamespaceAuthorizationRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusNamespaceAuthorizationRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.ServiceBus.ServiceBusAccessKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -247,7 +247,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusNetworkRuleSet : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusNetworkRuleSet(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusNetworkRuleSet(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusNetworkRuleSetDefaultAction> DefaultAction { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ServiceBus.ServiceBusNetworkRuleSetIPRules> IPRules { get { throw null; } set { } }
@@ -258,7 +258,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusPublicNetworkAccessFlag> PublicNetworkAccess { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ServiceBus.ServiceBusNetworkRuleSetVirtualNetworkRules> VirtualNetworkRules { get { throw null; } set { } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusNetworkRuleSet FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusNetworkRuleSet FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_04_01;
@@ -285,7 +285,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusPrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -294,7 +294,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusPrivateEndpointConnectionProvisioningState> ProvisioningState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -347,7 +347,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusQueue : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusQueue(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusQueue(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> AccessedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.TimeSpan> AutoDeleteOnIdle { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.MessageCountDetails> CountDetails { get { throw null; } }
@@ -375,7 +375,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusMessagingEntityStatus> Status { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusQueue FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusQueue FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -387,14 +387,14 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusQueueAuthorizationRule : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusQueueAuthorizationRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusQueueAuthorizationRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.ServiceBus.ServiceBusQueue? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ServiceBus.ServiceBusAccessRight> Rights { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusQueueAuthorizationRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusQueueAuthorizationRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.ServiceBus.ServiceBusAccessKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -407,7 +407,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusRule : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusFilterAction> Action { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusCorrelationFilter> CorrelationFilter { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusFilterType> FilterType { get { throw null; } set { } }
@@ -417,7 +417,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.ServiceBus.ServiceBusSubscription? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusSqlFilter> SqlFilter { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_04_01;
@@ -453,7 +453,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> AccessedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.TimeSpan> AutoDeleteOnIdle { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusClientAffineProperties> ClientAffineProperties { get { throw null; } set { } }
@@ -478,7 +478,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.ServiceBusMessagingEntityStatus> Status { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -490,7 +490,7 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusTopic : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusTopic(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusTopic(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> AccessedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.TimeSpan> AutoDeleteOnIdle { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.ServiceBus.MessageCountDetails> CountDetails { get { throw null; } }
@@ -513,7 +513,7 @@ namespace Azure.Provisioning.ServiceBus
         public Azure.Provisioning.BicepValue<bool> SupportOrdering { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusTopic FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusTopic FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -525,14 +525,14 @@ namespace Azure.Provisioning.ServiceBus
     }
     public partial class ServiceBusTopicAuthorizationRule : Azure.Provisioning.Primitives.Resource
     {
-        public ServiceBusTopicAuthorizationRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServiceBusTopicAuthorizationRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.ServiceBus.ServiceBusTopic? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.ServiceBus.ServiceBusAccessRight> Rights { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.ServiceBus.ServiceBusTopicAuthorizationRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.ServiceBus.ServiceBusTopicAuthorizationRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.ServiceBus.ServiceBusAccessKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/MigrationConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/MigrationConfiguration.cs
@@ -83,10 +83,15 @@ public partial class MigrationConfiguration : Resource
     /// <summary>
     /// Creates a new MigrationConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the MigrationConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MigrationConfiguration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MigrationConfiguration.</param>
-    public MigrationConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/migrationConfigurations", resourceVersion ?? "2024-01-01")
+    public MigrationConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/migrationConfigurations", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true, defaultValue: GetNameDefaultValue());
         _postMigrationName = BicepValue<string>.DefineProperty(this, "PostMigrationName", ["properties", "postMigrationName"]);
@@ -124,9 +129,14 @@ public partial class MigrationConfiguration : Resource
     /// <summary>
     /// Creates a reference to an existing MigrationConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the MigrationConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the MigrationConfiguration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the MigrationConfiguration.</param>
     /// <returns>The existing MigrationConfiguration resource.</returns>
-    public static MigrationConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static MigrationConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusDisasterRecovery.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusDisasterRecovery.cs
@@ -86,10 +86,15 @@ public partial class ServiceBusDisasterRecovery : Resource
     /// <summary>
     /// Creates a new ServiceBusDisasterRecovery.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusDisasterRecovery.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusDisasterRecovery
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusDisasterRecovery.</param>
-    public ServiceBusDisasterRecovery(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs", resourceVersion ?? "2024-01-01")
+    public ServiceBusDisasterRecovery(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _alternateName = BicepValue<string>.DefineProperty(this, "AlternateName", ["properties", "alternateName"]);
@@ -127,11 +132,16 @@ public partial class ServiceBusDisasterRecovery : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusDisasterRecovery.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusDisasterRecovery.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusDisasterRecovery
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusDisasterRecovery.</param>
     /// <returns>The existing ServiceBusDisasterRecovery resource.</returns>
-    public static ServiceBusDisasterRecovery FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusDisasterRecovery FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ServiceBusDisasterRecovery

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespace.cs
@@ -156,10 +156,15 @@ public partial class ServiceBusNamespace : Resource
     /// <summary>
     /// Creates a new ServiceBusNamespace.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusNamespace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusNamespace resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusNamespace.</param>
-    public ServiceBusNamespace(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces", resourceVersion ?? "2024-01-01")
+    public ServiceBusNamespace(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -218,11 +223,16 @@ public partial class ServiceBusNamespace : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusNamespace.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusNamespace.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusNamespace resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusNamespace.</param>
     /// <returns>The existing ServiceBusNamespace resource.</returns>
-    public static ServiceBusNamespace FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusNamespace FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ServiceBusNamespace resource.
@@ -240,10 +250,10 @@ public partial class ServiceBusNamespace : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(ServiceBusBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -256,13 +266,13 @@ public partial class ServiceBusNamespace : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(ServiceBusBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(ServiceBusBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{ServiceBusBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespaceAuthorizationRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNamespaceAuthorizationRule.cs
@@ -59,10 +59,15 @@ public partial class ServiceBusNamespaceAuthorizationRule : Resource
     /// <summary>
     /// Creates a new ServiceBusNamespaceAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusNamespaceAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ServiceBusNamespaceAuthorizationRule resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusNamespaceAuthorizationRule.</param>
-    public ServiceBusNamespaceAuthorizationRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/AuthorizationRules", resourceVersion ?? "2024-01-01")
+    public ServiceBusNamespaceAuthorizationRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/AuthorizationRules", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _rights = BicepList<ServiceBusAccessRight>.DefineProperty(this, "Rights", ["properties", "rights"]);
@@ -96,11 +101,16 @@ public partial class ServiceBusNamespaceAuthorizationRule : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusNamespaceAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusNamespaceAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ServiceBusNamespaceAuthorizationRule resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusNamespaceAuthorizationRule.</param>
     /// <returns>The existing ServiceBusNamespaceAuthorizationRule resource.</returns>
-    public static ServiceBusNamespaceAuthorizationRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusNamespaceAuthorizationRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this
@@ -117,5 +127,5 @@ public partial class ServiceBusNamespaceAuthorizationRule : Resource
     /// <returns>The keys for this ServiceBusNamespaceAuthorizationRule resource.</returns>
     public ServiceBusAccessKeys GetKeys() =>
         ServiceBusAccessKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNetworkRuleSet.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusNetworkRuleSet.cs
@@ -82,10 +82,15 @@ public partial class ServiceBusNetworkRuleSet : Resource
     /// <summary>
     /// Creates a new ServiceBusNetworkRuleSet.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusNetworkRuleSet.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusNetworkRuleSet resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusNetworkRuleSet.</param>
-    public ServiceBusNetworkRuleSet(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/networkRuleSets", resourceVersion ?? "2024-01-01")
+    public ServiceBusNetworkRuleSet(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/networkRuleSets", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _defaultAction = BicepValue<ServiceBusNetworkRuleSetDefaultAction>.DefineProperty(this, "DefaultAction", ["properties", "defaultAction"]);
@@ -123,9 +128,14 @@ public partial class ServiceBusNetworkRuleSet : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusNetworkRuleSet.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusNetworkRuleSet.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusNetworkRuleSet resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusNetworkRuleSet.</param>
     /// <returns>The existing ServiceBusNetworkRuleSet resource.</returns>
-    public static ServiceBusNetworkRuleSet FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusNetworkRuleSet FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusPrivateEndpointConnection.cs
@@ -68,10 +68,15 @@ public partial class ServiceBusPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new ServiceBusPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ServiceBusPrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusPrivateEndpointConnection.</param>
-    public ServiceBusPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/privateEndpointConnections", resourceVersion ?? "2024-01-01")
+    public ServiceBusPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/privateEndpointConnections", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<ServiceBusPrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -102,9 +107,14 @@ public partial class ServiceBusPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ServiceBusPrivateEndpointConnection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusPrivateEndpointConnection.</param>
     /// <returns>The existing ServiceBusPrivateEndpointConnection resource.</returns>
-    public static ServiceBusPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusQueue.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusQueue.cs
@@ -199,10 +199,15 @@ public partial class ServiceBusQueue : Resource
     /// <summary>
     /// Creates a new ServiceBusQueue.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusQueue.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusQueue resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusQueue.</param>
-    public ServiceBusQueue(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/queues", resourceVersion ?? "2024-01-01")
+    public ServiceBusQueue(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/queues", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"]);
@@ -257,11 +262,16 @@ public partial class ServiceBusQueue : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusQueue.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusQueue.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusQueue resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusQueue.</param>
     /// <returns>The existing ServiceBusQueue resource.</returns>
-    public static ServiceBusQueue FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusQueue FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ServiceBusQueue resource.

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusQueueAuthorizationRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusQueueAuthorizationRule.cs
@@ -59,10 +59,15 @@ public partial class ServiceBusQueueAuthorizationRule : Resource
     /// <summary>
     /// Creates a new ServiceBusQueueAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusQueueAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusQueueAuthorizationRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusQueueAuthorizationRule.</param>
-    public ServiceBusQueueAuthorizationRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/queues/authorizationRules", resourceVersion ?? "2024-01-01")
+    public ServiceBusQueueAuthorizationRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/queues/authorizationRules", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _rights = BicepList<ServiceBusAccessRight>.DefineProperty(this, "Rights", ["properties", "rights"]);
@@ -96,11 +101,16 @@ public partial class ServiceBusQueueAuthorizationRule : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusQueueAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusQueueAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusQueueAuthorizationRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusQueueAuthorizationRule.</param>
     /// <returns>The existing ServiceBusQueueAuthorizationRule resource.</returns>
-    public static ServiceBusQueueAuthorizationRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusQueueAuthorizationRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ServiceBusQueueAuthorizationRule
@@ -117,5 +127,5 @@ public partial class ServiceBusQueueAuthorizationRule : Resource
     /// <returns>The keys for this ServiceBusQueueAuthorizationRule resource.</returns>
     public ServiceBusAccessKeys GetKeys() =>
         ServiceBusAccessKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusRule.cs
@@ -76,10 +76,15 @@ public partial class ServiceBusRule : Resource
     /// <summary>
     /// Creates a new ServiceBusRule.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusRule resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusRule.</param>
-    public ServiceBusRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules", resourceVersion ?? "2024-01-01")
+    public ServiceBusRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _action = BicepValue<ServiceBusFilterAction>.DefineProperty(this, "Action", ["properties", "action"]);
@@ -116,9 +121,14 @@ public partial class ServiceBusRule : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusRule.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusRule resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusRule.</param>
     /// <returns>The existing ServiceBusRule resource.</returns>
-    public static ServiceBusRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusSubscription.cs
@@ -174,10 +174,15 @@ public partial class ServiceBusSubscription : Resource
     /// <summary>
     /// Creates a new ServiceBusSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusSubscription resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusSubscription.</param>
-    public ServiceBusSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/topics/subscriptions", resourceVersion ?? "2024-01-01")
+    public ServiceBusSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/topics/subscriptions", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"]);
@@ -229,11 +234,16 @@ public partial class ServiceBusSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusSubscription resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusSubscription.</param>
     /// <returns>The existing ServiceBusSubscription resource.</returns>
-    public static ServiceBusSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ServiceBusSubscription resource.

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusTopic.cs
@@ -164,10 +164,15 @@ public partial class ServiceBusTopic : Resource
     /// <summary>
     /// Creates a new ServiceBusTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusTopic resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusTopic.</param>
-    public ServiceBusTopic(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/topics", resourceVersion ?? "2024-01-01")
+    public ServiceBusTopic(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/topics", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"]);
@@ -217,11 +222,16 @@ public partial class ServiceBusTopic : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusTopic.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusTopic.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusTopic resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusTopic.</param>
     /// <returns>The existing ServiceBusTopic resource.</returns>
-    public static ServiceBusTopic FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusTopic FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ServiceBusTopic resource.

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusTopicAuthorizationRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusTopicAuthorizationRule.cs
@@ -59,10 +59,15 @@ public partial class ServiceBusTopicAuthorizationRule : Resource
     /// <summary>
     /// Creates a new ServiceBusTopicAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusTopicAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusTopicAuthorizationRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusTopicAuthorizationRule.</param>
-    public ServiceBusTopicAuthorizationRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ServiceBus/namespaces/topics/authorizationRules", resourceVersion ?? "2024-01-01")
+    public ServiceBusTopicAuthorizationRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ServiceBus/namespaces/topics/authorizationRules", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _rights = BicepList<ServiceBusAccessRight>.DefineProperty(this, "Rights", ["properties", "rights"]);
@@ -96,11 +101,16 @@ public partial class ServiceBusTopicAuthorizationRule : Resource
     /// <summary>
     /// Creates a reference to an existing ServiceBusTopicAuthorizationRule.
     /// </summary>
-    /// <param name="resourceName">Name of the ServiceBusTopicAuthorizationRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServiceBusTopicAuthorizationRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServiceBusTopicAuthorizationRule.</param>
     /// <returns>The existing ServiceBusTopicAuthorizationRule resource.</returns>
-    public static ServiceBusTopicAuthorizationRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServiceBusTopicAuthorizationRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ServiceBusTopicAuthorizationRule
@@ -117,5 +127,5 @@ public partial class ServiceBusTopicAuthorizationRule : Resource
     /// <returns>The keys for this ServiceBusTopicAuthorizationRule resource.</returns>
     public ServiceBusAccessKeys GetKeys() =>
         ServiceBusAccessKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 }

--- a/sdk/provisioning/Azure.Provisioning.SignalR/api/Azure.Provisioning.SignalR.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/api/Azure.Provisioning.SignalR.netstandard2.0.cs
@@ -33,7 +33,7 @@ namespace Azure.Provisioning.SignalR
     }
     public partial class SignalRCustomCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public SignalRCustomCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SignalRCustomCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Uri> KeyVaultBaseUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> KeyVaultSecretName { get { throw null; } set { } }
@@ -42,7 +42,7 @@ namespace Azure.Provisioning.SignalR
         public Azure.Provisioning.SignalR.SignalRService? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.SignalR.SignalRProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.SignalR.SignalRCustomCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.SignalR.SignalRCustomCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2018_10_01;
@@ -56,7 +56,7 @@ namespace Azure.Provisioning.SignalR
     }
     public partial class SignalRCustomDomain : Azure.Provisioning.Primitives.Resource
     {
-        public SignalRCustomDomain(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SignalRCustomDomain(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> CustomCertificateId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DomainName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -64,7 +64,7 @@ namespace Azure.Provisioning.SignalR
         public Azure.Provisioning.SignalR.SignalRService? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.SignalR.SignalRProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.SignalR.SignalRCustomDomain FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.SignalR.SignalRCustomDomain FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_05_01;
@@ -136,7 +136,7 @@ namespace Azure.Provisioning.SignalR
     }
     public partial class SignalRPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public SignalRPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SignalRPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.SignalR.SignalRPrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> GroupIds { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -145,7 +145,7 @@ namespace Azure.Provisioning.SignalR
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.SignalR.SignalRProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.SignalR.SignalRPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.SignalR.SignalRPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2018_10_01;
@@ -212,7 +212,7 @@ namespace Azure.Provisioning.SignalR
     }
     public partial class SignalRService : Azure.Provisioning.Primitives.Resource
     {
-        public SignalRService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SignalRService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> CorsAllowedOrigins { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> DisableAadAuth { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> DisableLocalAuth { get { throw null; } set { } }
@@ -240,9 +240,9 @@ namespace Azure.Provisioning.SignalR
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.SignalR.SignalRUpstreamTemplate> UpstreamTemplates { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.SignalR.SignalRBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.SignalR.SignalRBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.SignalR.SignalRBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.SignalR.SignalRService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.SignalR.SignalRService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.SignalR.SignalRKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -264,7 +264,7 @@ namespace Azure.Provisioning.SignalR
     }
     public partial class SignalRSharedPrivateLink : Azure.Provisioning.Primitives.Resource
     {
-        public SignalRSharedPrivateLink(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SignalRSharedPrivateLink(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> GroupId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -274,7 +274,7 @@ namespace Azure.Provisioning.SignalR
         public Azure.Provisioning.BicepValue<string> RequestMessage { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.SignalR.SignalRSharedPrivateLinkResourceStatus> Status { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.SignalR.SignalRSharedPrivateLink FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.SignalR.SignalRSharedPrivateLink FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2018_10_01;

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRCustomCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRCustomCertificate.cs
@@ -68,10 +68,15 @@ public partial class SignalRCustomCertificate : Resource
     /// <summary>
     /// Creates a new SignalRCustomCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRCustomCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRCustomCertificate resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRCustomCertificate.</param>
-    public SignalRCustomCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/signalR/customCertificates", resourceVersion ?? "2024-03-01")
+    public SignalRCustomCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/signalR/customCertificates", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _keyVaultBaseUri = BicepValue<Uri>.DefineProperty(this, "KeyVaultBaseUri", ["properties", "keyVaultBaseUri"], isRequired: true);
@@ -127,9 +132,14 @@ public partial class SignalRCustomCertificate : Resource
     /// <summary>
     /// Creates a reference to an existing SignalRCustomCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRCustomCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRCustomCertificate resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRCustomCertificate.</param>
     /// <returns>The existing SignalRCustomCertificate resource.</returns>
-    public static SignalRCustomCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SignalRCustomCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRCustomDomain.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRCustomDomain.cs
@@ -62,10 +62,15 @@ public partial class SignalRCustomDomain : Resource
     /// <summary>
     /// Creates a new SignalRCustomDomain.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRCustomDomain.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRCustomDomain resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRCustomDomain.</param>
-    public SignalRCustomDomain(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/signalR/customDomains", resourceVersion ?? "2024-03-01")
+    public SignalRCustomDomain(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/signalR/customDomains", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _domainName = BicepValue<string>.DefineProperty(this, "DomainName", ["properties", "domainName"], isRequired: true);
@@ -115,9 +120,14 @@ public partial class SignalRCustomDomain : Resource
     /// <summary>
     /// Creates a reference to an existing SignalRCustomDomain.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRCustomDomain.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRCustomDomain resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRCustomDomain.</param>
     /// <returns>The existing SignalRCustomDomain resource.</returns>
-    public static SignalRCustomDomain FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SignalRCustomDomain FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRPrivateEndpointConnection.cs
@@ -69,10 +69,15 @@ public partial class SignalRPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new SignalRPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRPrivateEndpointConnection.</param>
-    public SignalRPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/signalR/privateEndpointConnections", resourceVersion ?? "2024-03-01")
+    public SignalRPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/signalR/privateEndpointConnections", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<SignalRPrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -128,9 +133,14 @@ public partial class SignalRPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing SignalRPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRPrivateEndpointConnection.</param>
     /// <returns>The existing SignalRPrivateEndpointConnection resource.</returns>
-    public static SignalRPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SignalRPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
@@ -207,10 +207,15 @@ public partial class SignalRService : Resource
     /// <summary>
     /// Creates a new SignalRService.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRService.</param>
-    public SignalRService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/signalR", resourceVersion ?? "2024-03-01")
+    public SignalRService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/signalR", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -285,11 +290,16 @@ public partial class SignalRService : Resource
     /// <summary>
     /// Creates a reference to an existing SignalRService.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRService.</param>
     /// <returns>The existing SignalRService resource.</returns>
-    public static SignalRService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SignalRService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SignalRService resource.
@@ -305,7 +315,7 @@ public partial class SignalRService : Resource
     /// <returns>The keys for this SignalRService resource.</returns>
     public SignalRKeys GetKeys() =>
         SignalRKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -315,10 +325,10 @@ public partial class SignalRService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(SignalRBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -331,13 +341,13 @@ public partial class SignalRService : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(SignalRBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(SignalRBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{SignalRBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRSharedPrivateLink.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRSharedPrivateLink.cs
@@ -76,10 +76,15 @@ public partial class SignalRSharedPrivateLink : Resource
     /// <summary>
     /// Creates a new SignalRSharedPrivateLink.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRSharedPrivateLink.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRSharedPrivateLink resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRSharedPrivateLink.</param>
-    public SignalRSharedPrivateLink(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/signalR/sharedPrivateLinkResources", resourceVersion ?? "2024-03-01")
+    public SignalRSharedPrivateLink(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/signalR/sharedPrivateLinkResources", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _groupId = BicepValue<string>.DefineProperty(this, "GroupId", ["properties", "groupId"]);
@@ -136,9 +141,14 @@ public partial class SignalRSharedPrivateLink : Resource
     /// <summary>
     /// Creates a reference to an existing SignalRSharedPrivateLink.
     /// </summary>
-    /// <param name="resourceName">Name of the SignalRSharedPrivateLink.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SignalRSharedPrivateLink resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SignalRSharedPrivateLink.</param>
     /// <returns>The existing SignalRSharedPrivateLink resource.</returns>
-    public static SignalRSharedPrivateLink FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SignalRSharedPrivateLink FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/api/Azure.Provisioning.Sql.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/api/Azure.Provisioning.Sql.netstandard2.0.cs
@@ -16,14 +16,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class BackupShortTermRetentionPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public BackupShortTermRetentionPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public BackupShortTermRetentionPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<int> DiffBackupIntervalInHours { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> RetentionDays { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.BackupShortTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.BackupShortTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -59,14 +59,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class DatabaseAdvancedThreatProtection : Azure.Provisioning.Primitives.Resource
     {
-        public DatabaseAdvancedThreatProtection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public DatabaseAdvancedThreatProtection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.AdvancedThreatProtectionState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.DatabaseAdvancedThreatProtection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.DatabaseAdvancedThreatProtection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -102,7 +102,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class DataMaskingPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public DataMaskingPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public DataMaskingPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ApplicationPrincipals { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.DataMaskingState> DataMaskingState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ExemptPrincipals { get { throw null; } set { } }
@@ -113,7 +113,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.DataMaskingPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.DataMaskingPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -129,7 +129,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class DistributedAvailabilityGroup : Azure.Provisioning.Primitives.Resource
     {
-        public DistributedAvailabilityGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public DistributedAvailabilityGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Guid> DistributedAvailabilityGroupId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> LastHardenedLsn { get { throw null; } }
@@ -144,7 +144,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TargetDatabase { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Guid> TargetReplicaId { get { throw null; } }
-        public static Azure.Provisioning.Sql.DistributedAvailabilityGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.DistributedAvailabilityGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -163,7 +163,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ElasticPool : Azure.Provisioning.Primitives.Resource
     {
-        public ElasticPool(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ElasticPool(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlAvailabilityZoneType> AvailabilityZone { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> HighAvailabilityReplicaCount { get { throw null; } set { } }
@@ -183,7 +183,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ElasticPoolState> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.ElasticPool FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ElasticPool FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -214,7 +214,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class EncryptionProtector : Azure.Provisioning.Primitives.Resource
     {
-        public EncryptionProtector(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EncryptionProtector(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAutoRotationEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } }
@@ -227,7 +227,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Thumbprint { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Uri> Uri { get { throw null; } }
-        public static Azure.Provisioning.Sql.EncryptionProtector FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.EncryptionProtector FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -241,7 +241,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ExtendedDatabaseBlobAuditingPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ExtendedDatabaseBlobAuditingPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ExtendedDatabaseBlobAuditingPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> AuditActionsAndGroups { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAzureMonitorTargetEnabled { get { throw null; } set { } }
@@ -257,7 +257,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<System.Guid> StorageAccountSubscriptionId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ExtendedDatabaseBlobAuditingPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ExtendedDatabaseBlobAuditingPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -269,7 +269,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ExtendedServerBlobAuditingPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ExtendedServerBlobAuditingPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ExtendedServerBlobAuditingPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> AuditActionsAndGroups { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAzureMonitorTargetEnabled { get { throw null; } set { } }
@@ -286,7 +286,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<System.Guid> StorageAccountSubscriptionId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ExtendedServerBlobAuditingPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ExtendedServerBlobAuditingPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -300,7 +300,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class FailoverGroup : Azure.Provisioning.Primitives.Resource
     {
-        public FailoverGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public FailoverGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Core.ResourceIdentifier> FailoverDatabases { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -313,7 +313,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> ReplicationState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.FailoverGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.FailoverGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -346,7 +346,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class GeoBackupPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public GeoBackupPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public GeoBackupPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -355,7 +355,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.GeoBackupPolicyState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageType { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.GeoBackupPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.GeoBackupPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -380,7 +380,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class InstanceFailoverGroup : Azure.Provisioning.Primitives.Resource
     {
-        public InstanceFailoverGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public InstanceFailoverGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Sql.ManagedInstancePairInfo> ManagedInstancePairs { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -391,7 +391,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> ReplicationState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.GeoSecondaryInstanceType> SecondaryType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.InstanceFailoverGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.InstanceFailoverGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -411,7 +411,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class InstancePool : Azure.Provisioning.Primitives.Resource
     {
-        public InstancePool(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public InstancePool(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DnsZone { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.InstancePoolLicenseType> LicenseType { get { throw null; } set { } }
@@ -423,7 +423,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> VCores { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.InstancePool FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.InstancePool FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -437,13 +437,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class IPv6FirewallRule : Azure.Provisioning.Primitives.Resource
     {
-        public IPv6FirewallRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public IPv6FirewallRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> EndIPv6Address { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StartIPv6Address { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.IPv6FirewallRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.IPv6FirewallRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -554,14 +554,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class LedgerDigestUpload : Azure.Provisioning.Primitives.Resource
     {
-        public LedgerDigestUpload(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public LedgerDigestUpload(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DigestStorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.LedgerDigestUploadsState> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.LedgerDigestUpload FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.LedgerDigestUpload FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -580,13 +580,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class LogicalDatabaseTransparentDataEncryption : Azure.Provisioning.Primitives.Resource
     {
-        public LogicalDatabaseTransparentDataEncryption(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public LogicalDatabaseTransparentDataEncryption(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.TransparentDataEncryptionState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.LogicalDatabaseTransparentDataEncryption FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.LogicalDatabaseTransparentDataEncryption FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_04_01;
@@ -596,7 +596,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class LongTermRetentionPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public LongTermRetentionPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public LongTermRetentionPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlBackupStorageAccessTier> BackupStorageAccessTier { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> MakeBackupsImmutable { get { throw null; } set { } }
@@ -607,7 +607,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> WeeklyRetention { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> WeekOfYear { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> YearlyRetention { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.LongTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.LongTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -621,13 +621,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedBackupShortTermRetentionPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedBackupShortTermRetentionPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedBackupShortTermRetentionPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> RetentionDays { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedBackupShortTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedBackupShortTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -636,7 +636,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedDatabase : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedDatabase(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedDatabase(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> AllowAutoCompleteRestore { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.CatalogCollationType> CatalogCollation { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Collation { get { throw null; } set { } }
@@ -665,7 +665,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<System.Uri> StorageContainerUri { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.ManagedDatabase FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedDatabase FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -674,14 +674,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedDatabaseAdvancedThreatProtection : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedDatabaseAdvancedThreatProtection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedDatabaseAdvancedThreatProtection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.AdvancedThreatProtectionState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedDatabaseAdvancedThreatProtection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedDatabaseAdvancedThreatProtection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_05_01_preview;
@@ -697,7 +697,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedDatabaseSecurityAlertPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedDatabaseSecurityAlertPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedDatabaseSecurityAlertPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepList<string> DisabledAlerts { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> EmailAddresses { get { throw null; } set { } }
@@ -710,7 +710,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StorageAccountAccessKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedDatabaseSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedDatabaseSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -719,7 +719,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedDatabaseSensitivityLabel : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedDatabaseSensitivityLabel(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedDatabaseSensitivityLabel(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ColumnName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> InformationType { get { throw null; } set { } }
@@ -733,7 +733,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> SchemaName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TableName { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedDatabaseSensitivityLabel FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedDatabaseSensitivityLabel FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public enum ManagedDatabaseStatus
     {
@@ -754,7 +754,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedDatabaseVulnerabilityAssessment : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedDatabaseVulnerabilityAssessment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedDatabaseVulnerabilityAssessment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedDatabase? Parent { get { throw null; } set { } }
@@ -763,7 +763,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StorageContainerPath { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageContainerSasKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedDatabaseVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedDatabaseVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -772,16 +772,16 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedDatabaseVulnerabilityAssessmentRuleBaseline : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedDatabaseVulnerabilityAssessmentRuleBaseline(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedDatabaseVulnerabilityAssessmentRuleBaseline(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Sql.DatabaseVulnerabilityAssessmentRuleBaselineItem> BaselineResults { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedDatabaseVulnerabilityAssessmentRuleBaseline FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedDatabaseVulnerabilityAssessmentRuleBaseline FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public partial class ManagedInstance : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstance(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstance(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AdministratorLogin { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AdministratorLoginPassword { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ManagedInstanceExternalAdministrator> Administrators { get { throw null; } set { } }
@@ -818,7 +818,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> TimezoneId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> VCores { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.ManagedInstance FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstance FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -829,7 +829,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceAdministrator : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceAdministrator(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceAdministrator(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ManagedInstanceAdministratorType> AdministratorType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Login { get { throw null; } set { } }
@@ -838,7 +838,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<System.Guid> Sid { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Guid> TenantId { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.ManagedInstanceAdministrator FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceAdministrator FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -851,14 +851,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceAdvancedThreatProtection : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceAdvancedThreatProtection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceAdvancedThreatProtection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedInstance? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.AdvancedThreatProtectionState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedInstanceAdvancedThreatProtection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceAdvancedThreatProtection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_05_01_preview;
@@ -866,13 +866,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceAzureADOnlyAuthentication : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceAzureADOnlyAuthentication(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceAzureADOnlyAuthentication(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAzureADOnlyAuthenticationEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedInstance? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedInstanceAzureADOnlyAuthentication FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceAzureADOnlyAuthentication FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -881,7 +881,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceDtc : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceDtc(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceDtc(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> DtcEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DtcHostNameDnsSuffix { get { throw null; } }
         public Azure.Provisioning.BicepList<string> ExternalDnsSuffixSearchList { get { throw null; } set { } }
@@ -891,7 +891,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.JobExecutionProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ManagedInstanceDtcSecuritySettings> SecuritySettings { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedInstanceDtc FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceDtc FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -916,7 +916,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceEncryptionProtector : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceEncryptionProtector(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceEncryptionProtector(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAutoRotationEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } }
@@ -927,7 +927,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Thumbprint { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Uri> Uri { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedInstanceEncryptionProtector FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceEncryptionProtector FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -946,7 +946,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceKey : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceKey(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceKey(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAutoRotationEnabled { get { throw null; } }
@@ -957,7 +957,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Thumbprint { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Uri> Uri { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.ManagedInstanceKey FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceKey FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -971,7 +971,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceLongTermRetentionPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceLongTermRetentionPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceLongTermRetentionPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> MonthlyRetention { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
@@ -980,7 +980,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> WeeklyRetention { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> WeekOfYear { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> YearlyRetention { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.ManagedInstanceLongTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceLongTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1006,7 +1006,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstancePrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstancePrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstancePrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ManagedInstancePrivateLinkServiceConnectionStateProperty> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -1014,7 +1014,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedInstancePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstancePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1061,14 +1061,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceServerConfigurationOption : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceServerConfigurationOption(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceServerConfigurationOption(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedInstance? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.JobExecutionProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> ServerConfigurationOptionValue { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedInstanceServerConfigurationOption FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceServerConfigurationOption FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1082,7 +1082,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceServerTrustCertificate : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceServerTrustCertificate(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceServerTrustCertificate(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> CertificateName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -1090,7 +1090,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> PublicBlob { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Thumbprint { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedInstanceServerTrustCertificate FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceServerTrustCertificate FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1099,7 +1099,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceStartStopSchedule : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceStartStopSchedule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceStartStopSchedule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
@@ -1109,7 +1109,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepList<Azure.Provisioning.Sql.SqlScheduleItem> ScheduleList { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TimeZoneId { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.ManagedInstanceStartStopSchedule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceStartStopSchedule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1123,7 +1123,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedInstanceVulnerabilityAssessment : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedInstanceVulnerabilityAssessment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedInstanceVulnerabilityAssessment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedInstance? Parent { get { throw null; } set { } }
@@ -1132,7 +1132,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StorageContainerPath { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageContainerSasKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedInstanceVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedInstanceVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1141,14 +1141,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedLedgerDigestUpload : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedLedgerDigestUpload(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedLedgerDigestUpload(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DigestStorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ManagedLedgerDigestUploadsState> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedLedgerDigestUpload FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedLedgerDigestUpload FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_05_01_preview;
@@ -1166,12 +1166,12 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedRestorableDroppedDbBackupShortTermRetentionPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedRestorableDroppedDbBackupShortTermRetentionPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedRestorableDroppedDbBackupShortTermRetentionPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> RetentionDays { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedRestorableDroppedDbBackupShortTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedRestorableDroppedDbBackupShortTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public enum ManagedServerCreateMode
     {
@@ -1180,7 +1180,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedServerDnsAlias : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedServerDnsAlias(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedServerDnsAlias(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AzureDnsRecord { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> CreateDnsRecord { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -1188,7 +1188,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.Sql.ManagedInstance? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> PublicAzureDnsRecord { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedServerDnsAlias FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedServerDnsAlias FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1197,7 +1197,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedServerSecurityAlertPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedServerSecurityAlertPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedServerSecurityAlertPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepList<string> DisabledAlerts { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> EmailAddresses { get { throw null; } set { } }
@@ -1210,7 +1210,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StorageAccountAccessKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedServerSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedServerSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1224,13 +1224,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ManagedTransparentDataEncryption : Azure.Provisioning.Primitives.Resource
     {
-        public ManagedTransparentDataEncryption(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagedTransparentDataEncryption(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.TransparentDataEncryptionState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ManagedTransparentDataEncryption FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ManagedTransparentDataEncryption FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1239,13 +1239,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class OutboundFirewallRule : Azure.Provisioning.Primitives.Resource
     {
-        public OutboundFirewallRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public OutboundFirewallRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.OutboundFirewallRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.OutboundFirewallRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -1317,14 +1317,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class ServerAdvancedThreatProtection : Azure.Provisioning.Primitives.Resource
     {
-        public ServerAdvancedThreatProtection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ServerAdvancedThreatProtection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.AdvancedThreatProtectionState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.ServerAdvancedThreatProtection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.ServerAdvancedThreatProtection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1391,13 +1391,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlAgentConfiguration : Azure.Provisioning.Primitives.Resource
     {
-        public SqlAgentConfiguration(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlAgentConfiguration(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.ManagedInstance? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlAgentConfigurationPropertiesState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlAgentConfiguration FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlAgentConfiguration FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2018_06_01;
@@ -1463,7 +1463,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlDatabase : Azure.Provisioning.Primitives.Resource
     {
-        public SqlDatabase(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlDatabase(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<int> AutoPauseDelay { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlAvailabilityZoneType> AvailabilityZone { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.CatalogCollationType> CatalogCollation { get { throw null; } set { } }
@@ -1522,7 +1522,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> UseFreeLimit { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlDatabase FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlDatabase FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1536,7 +1536,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlDatabaseBlobAuditingPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public SqlDatabaseBlobAuditingPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlDatabaseBlobAuditingPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> AuditActionsAndGroups { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAzureMonitorTargetEnabled { get { throw null; } set { } }
@@ -1552,7 +1552,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<System.Guid> StorageAccountSubscriptionId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlDatabaseBlobAuditingPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlDatabaseBlobAuditingPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1586,7 +1586,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlDatabaseSecurityAlertPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public SqlDatabaseSecurityAlertPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlDatabaseSecurityAlertPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepList<string> DisabledAlerts { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> EmailAddresses { get { throw null; } set { } }
@@ -1599,7 +1599,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StorageAccountAccessKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlDatabaseSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlDatabaseSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -1610,7 +1610,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlDatabaseSensitivityLabel : Azure.Provisioning.Primitives.Resource
     {
-        public SqlDatabaseSensitivityLabel(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlDatabaseSensitivityLabel(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ColumnName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> InformationType { get { throw null; } set { } }
@@ -1624,28 +1624,28 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> SchemaName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TableName { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlDatabaseSensitivityLabel FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlDatabaseSensitivityLabel FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public partial class SqlDatabaseSqlVulnerabilityAssessmentBaseline : Azure.Provisioning.Primitives.Resource
     {
-        public SqlDatabaseSqlVulnerabilityAssessmentBaseline(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlDatabaseSqlVulnerabilityAssessmentBaseline(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsLatestScan { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<Azure.Provisioning.BicepList<Azure.Provisioning.BicepList<string>>> Results { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlDatabaseSqlVulnerabilityAssessmentBaseline FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlDatabaseSqlVulnerabilityAssessmentBaseline FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public partial class SqlDatabaseSqlVulnerabilityAssessmentBaselineRule : Azure.Provisioning.Primitives.Resource
     {
-        public SqlDatabaseSqlVulnerabilityAssessmentBaselineRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlDatabaseSqlVulnerabilityAssessmentBaselineRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsLatestScan { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlDatabaseSqlVulnerabilityAssessmentBaseline? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.BicepList<string>> Results { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlDatabaseSqlVulnerabilityAssessmentBaselineRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlDatabaseSqlVulnerabilityAssessmentBaselineRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public enum SqlDatabaseStatus
     {
@@ -1676,7 +1676,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlDatabaseVulnerabilityAssessment : Azure.Provisioning.Primitives.Resource
     {
-        public SqlDatabaseVulnerabilityAssessment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlDatabaseVulnerabilityAssessment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlDatabase? Parent { get { throw null; } set { } }
@@ -1685,7 +1685,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StorageContainerPath { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageContainerSasKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlDatabaseVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlDatabaseVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1694,12 +1694,12 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlDatabaseVulnerabilityAssessmentRuleBaseline : Azure.Provisioning.Primitives.Resource
     {
-        public SqlDatabaseVulnerabilityAssessmentRuleBaseline(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlDatabaseVulnerabilityAssessmentRuleBaseline(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Sql.DatabaseVulnerabilityAssessmentRuleBaselineItem> BaselineResults { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlDatabaseVulnerabilityAssessmentRuleBaseline FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlDatabaseVulnerabilityAssessmentRuleBaseline FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public enum SqlDayOfWeek
     {
@@ -1713,13 +1713,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlFirewallRule : Azure.Provisioning.Primitives.Resource
     {
-        public SqlFirewallRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlFirewallRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> EndIPAddress { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StartIPAddress { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlFirewallRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlFirewallRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1745,7 +1745,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public SqlPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlPrivateLinkServiceConnectionStateProperty> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> GroupIds { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -1754,7 +1754,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlPrivateEndpointProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -1803,7 +1803,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServer : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServer(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServer(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AdministratorLogin { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> AdministratorLoginPassword { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ServerExternalAdministrator> Administrators { get { throw null; } set { } }
@@ -1827,9 +1827,9 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ServerWorkspaceFeature> WorkspaceFeature { get { throw null; } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Sql.SqlBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Sql.SqlBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Sql.SqlBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.Sql.SqlServer FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServer FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1842,7 +1842,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerAzureADAdministrator : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerAzureADAdministrator(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerAzureADAdministrator(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlAdministratorType> AdministratorType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAzureADOnlyAuthenticationEnabled { get { throw null; } }
@@ -1851,7 +1851,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<System.Guid> Sid { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Guid> TenantId { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlServerAzureADAdministrator FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerAzureADAdministrator FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -1862,13 +1862,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerAzureADOnlyAuthentication : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerAzureADOnlyAuthentication(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerAzureADOnlyAuthentication(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAzureADOnlyAuthenticationEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerAzureADOnlyAuthentication FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerAzureADOnlyAuthentication FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -1879,7 +1879,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerBlobAuditingPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerBlobAuditingPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerBlobAuditingPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> AuditActionsAndGroups { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAzureMonitorTargetEnabled { get { throw null; } set { } }
@@ -1895,7 +1895,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<System.Guid> StorageAccountSubscriptionId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerBlobAuditingPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerBlobAuditingPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1904,7 +1904,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerCommunicationLink : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerCommunicationLink(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerCommunicationLink(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -1913,7 +1913,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> PartnerServer { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerCommunicationLink FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerCommunicationLink FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -1923,7 +1923,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerConnectionPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerConnectionPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerConnectionPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.ServerConnectionType> ConnectionType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Kind { get { throw null; } }
@@ -1931,7 +1931,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerConnectionPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerConnectionPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -1942,7 +1942,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerDatabaseRestorePoint : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerDatabaseRestorePoint(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerDatabaseRestorePoint(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> EarliestRestoreOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
@@ -1952,7 +1952,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> RestorePointLabel { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.RestorePointType> RestorePointType { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerDatabaseRestorePoint FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerDatabaseRestorePoint FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2014_01_01;
@@ -1964,7 +1964,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerDevOpsAuditingSetting : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerDevOpsAuditingSetting(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerDevOpsAuditingSetting(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAzureMonitorTargetEnabled { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> IsManagedIdentityInUse { get { throw null; } set { } }
@@ -1975,7 +1975,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<System.Guid> StorageAccountSubscriptionId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerDevOpsAuditingSetting FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerDevOpsAuditingSetting FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1984,13 +1984,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerDnsAlias : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerDnsAlias(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerDnsAlias(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AzureDnsRecord { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerDnsAlias FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerDnsAlias FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -1999,7 +1999,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerJob : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerJob(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerJob(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -2007,7 +2007,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlServerJobSchedule> Schedule { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> Version { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerJob FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerJob FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2016,7 +2016,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerJobAgent : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerJobAgent(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerJobAgent(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> DatabaseId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2026,7 +2026,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.JobAgentState> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlServerJobAgent FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerJobAgent FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2035,14 +2035,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerJobCredential : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerJobCredential(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerJobCredential(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Sql.SqlServerJobAgent? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Password { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Username { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlServerJobCredential FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerJobCredential FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2051,7 +2051,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerJobExecution : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerJobExecution(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerJobExecution(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreateOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<int> CurrentAttempts { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CurrentAttemptStartOn { get { throw null; } }
@@ -2069,7 +2069,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StepName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.JobExecutionTarget> Target { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerJobExecution FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerJobExecution FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2092,7 +2092,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerJobStep : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerJobStep(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerJobStep(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.JobStepAction> Action { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Credential { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.JobStepExecutionOptions> ExecutionOptions { get { throw null; } set { } }
@@ -2103,7 +2103,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<int> StepId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TargetGroup { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlServerJobStep FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerJobStep FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2112,13 +2112,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerJobTargetGroup : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerJobTargetGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerJobTargetGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Sql.JobTarget> Members { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Sql.SqlServerJobAgent? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerJobTargetGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerJobTargetGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2127,7 +2127,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerKey : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerKey(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerKey(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsAutoRotationEnabled { get { throw null; } }
@@ -2140,7 +2140,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Thumbprint { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Uri> Uri { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlServerKey FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerKey FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2166,7 +2166,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerSecurityAlertPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerSecurityAlertPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerSecurityAlertPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepList<string> DisabledAlerts { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> EmailAddresses { get { throw null; } set { } }
@@ -2179,7 +2179,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StorageAccountAccessKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2188,13 +2188,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerSqlVulnerabilityAssessment : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerSqlVulnerabilityAssessment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerSqlVulnerabilityAssessment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlVulnerabilityAssessmentState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_05_01_preview;
@@ -2202,14 +2202,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerSqlVulnerabilityAssessmentBaseline : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerSqlVulnerabilityAssessmentBaseline(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerSqlVulnerabilityAssessmentBaseline(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsLatestScan { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessment? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<Azure.Provisioning.BicepList<Azure.Provisioning.BicepList<string>>> Results { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessmentBaseline FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessmentBaseline FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_05_01_preview;
@@ -2217,14 +2217,14 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerSqlVulnerabilityAssessmentBaselineRule : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerSqlVulnerabilityAssessmentBaselineRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerSqlVulnerabilityAssessmentBaselineRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsLatestScan { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessmentBaseline? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.BicepList<string>> Results { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessmentBaselineRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessmentBaselineRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2024_05_01_preview;
@@ -2232,13 +2232,13 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerTrustGroup : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerTrustGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerTrustGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Sql.ServerTrustGroupServerInfo> GroupMembers { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Sql.ServerTrustGroupPropertiesTrustScopesItem> TrustScopes { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlServerTrustGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerTrustGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2247,7 +2247,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerVirtualNetworkRule : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerVirtualNetworkRule(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerVirtualNetworkRule(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IgnoreMissingVnetServiceEndpoint { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -2255,7 +2255,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SqlServerVirtualNetworkRuleState> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> VirtualNetworkSubnetId { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SqlServerVirtualNetworkRule FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerVirtualNetworkRule FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2273,7 +2273,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SqlServerVulnerabilityAssessment : Azure.Provisioning.Primitives.Resource
     {
-        public SqlServerVulnerabilityAssessment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SqlServerVulnerabilityAssessment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Sql.SqlServer? Parent { get { throw null; } set { } }
@@ -2282,7 +2282,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<string> StorageContainerPath { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StorageContainerSasKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.SqlServerVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SqlServerVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2323,7 +2323,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SyncAgent : Azure.Provisioning.Primitives.Resource
     {
-        public SyncAgent(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SyncAgent(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> ExpireOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> IsUpToDate { get { throw null; } }
@@ -2334,7 +2334,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> SyncDatabaseId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
-        public static Azure.Provisioning.Sql.SyncAgent FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SyncAgent FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2360,7 +2360,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SyncGroup : Azure.Provisioning.Primitives.Resource
     {
-        public SyncGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SyncGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<int> ConflictLoggingRetentionInDays { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SyncConflictResolutionPolicy> ConflictResolutionPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> HubDatabasePassword { get { throw null; } set { } }
@@ -2378,7 +2378,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SyncGroupState> SyncState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> UsePrivateLinkConnection { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SyncGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SyncGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -2416,7 +2416,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class SyncMember : Azure.Provisioning.Primitives.Resource
     {
-        public SyncMember(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SyncMember(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DatabaseName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Sql.SyncMemberDbType> DatabaseType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -2433,7 +2433,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> UsePrivateLinkConnection { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> UserName { get { throw null; } set { } }
-        public static Azure.Provisioning.Sql.SyncMember FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.SyncMember FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2497,7 +2497,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class WorkloadClassifier : Azure.Provisioning.Primitives.Resource
     {
-        public WorkloadClassifier(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WorkloadClassifier(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Context { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> EndTime { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -2508,7 +2508,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.Sql.WorkloadGroup? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> StartTime { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.WorkloadClassifier FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.WorkloadClassifier FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
@@ -2517,7 +2517,7 @@ namespace Azure.Provisioning.Sql
     }
     public partial class WorkloadGroup : Azure.Provisioning.Primitives.Resource
     {
-        public WorkloadGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WorkloadGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Importance { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> MaxResourcePercent { get { throw null; } set { } }
@@ -2528,7 +2528,7 @@ namespace Azure.Provisioning.Sql
         public Azure.Provisioning.Sql.SqlDatabase? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<int> QueryExecutionTimeout { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Sql.WorkloadGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Sql.WorkloadGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/BackupShortTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/BackupShortTermRetentionPolicy.cs
@@ -59,10 +59,15 @@ public partial class BackupShortTermRetentionPolicy : Resource
     /// <summary>
     /// Creates a new BackupShortTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the BackupShortTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the BackupShortTermRetentionPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the BackupShortTermRetentionPolicy.</param>
-    public BackupShortTermRetentionPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies", resourceVersion ?? "2021-11-01")
+    public BackupShortTermRetentionPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _diffBackupIntervalInHours = BicepValue<int>.DefineProperty(this, "DiffBackupIntervalInHours", ["properties", "diffBackupIntervalInHours"]);
@@ -91,9 +96,14 @@ public partial class BackupShortTermRetentionPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing BackupShortTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the BackupShortTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the BackupShortTermRetentionPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the BackupShortTermRetentionPolicy.</param>
     /// <returns>The existing BackupShortTermRetentionPolicy resource.</returns>
-    public static BackupShortTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static BackupShortTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DataMaskingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DataMaskingPolicy.cs
@@ -84,10 +84,15 @@ public partial class DataMaskingPolicy : Resource
     /// <summary>
     /// Creates a new DataMaskingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the DataMaskingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DataMaskingPolicy resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DataMaskingPolicy.</param>
-    public DataMaskingPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/dataMaskingPolicies", resourceVersion ?? "2021-11-01")
+    public DataMaskingPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/dataMaskingPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _dataMaskingState = BicepValue<DataMaskingState>.DefineProperty(this, "DataMaskingState", ["properties", "dataMaskingState"]);
@@ -130,9 +135,14 @@ public partial class DataMaskingPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing DataMaskingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the DataMaskingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DataMaskingPolicy resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DataMaskingPolicy.</param>
     /// <returns>The existing DataMaskingPolicy resource.</returns>
-    public static DataMaskingPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static DataMaskingPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DatabaseAdvancedThreatProtection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DatabaseAdvancedThreatProtection.cs
@@ -58,10 +58,15 @@ public partial class DatabaseAdvancedThreatProtection : Resource
     /// <summary>
     /// Creates a new DatabaseAdvancedThreatProtection.
     /// </summary>
-    /// <param name="resourceName">Name of the DatabaseAdvancedThreatProtection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DatabaseAdvancedThreatProtection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DatabaseAdvancedThreatProtection.</param>
-    public DatabaseAdvancedThreatProtection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/advancedThreatProtectionSettings", resourceVersion ?? "2021-11-01")
+    public DatabaseAdvancedThreatProtection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/advancedThreatProtectionSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<AdvancedThreatProtectionState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -90,9 +95,14 @@ public partial class DatabaseAdvancedThreatProtection : Resource
     /// <summary>
     /// Creates a reference to an existing DatabaseAdvancedThreatProtection.
     /// </summary>
-    /// <param name="resourceName">Name of the DatabaseAdvancedThreatProtection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DatabaseAdvancedThreatProtection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DatabaseAdvancedThreatProtection.</param>
     /// <returns>The existing DatabaseAdvancedThreatProtection resource.</returns>
-    public static DatabaseAdvancedThreatProtection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static DatabaseAdvancedThreatProtection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DistributedAvailabilityGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DistributedAvailabilityGroup.cs
@@ -105,10 +105,15 @@ public partial class DistributedAvailabilityGroup : Resource
     /// <summary>
     /// Creates a new DistributedAvailabilityGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the DistributedAvailabilityGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DistributedAvailabilityGroup
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DistributedAvailabilityGroup.</param>
-    public DistributedAvailabilityGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/distributedAvailabilityGroups", resourceVersion ?? "2021-11-01")
+    public DistributedAvailabilityGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/distributedAvailabilityGroups", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _primaryAvailabilityGroupName = BicepValue<string>.DefineProperty(this, "PrimaryAvailabilityGroupName", ["properties", "primaryAvailabilityGroupName"]);
@@ -145,9 +150,14 @@ public partial class DistributedAvailabilityGroup : Resource
     /// <summary>
     /// Creates a reference to an existing DistributedAvailabilityGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the DistributedAvailabilityGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the DistributedAvailabilityGroup
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the DistributedAvailabilityGroup.</param>
     /// <returns>The existing DistributedAvailabilityGroup resource.</returns>
-    public static DistributedAvailabilityGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static DistributedAvailabilityGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ElasticPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ElasticPool.cs
@@ -151,10 +151,15 @@ public partial class ElasticPool : Resource
     /// <summary>
     /// Creates a new ElasticPool.
     /// </summary>
-    /// <param name="resourceName">Name of the ElasticPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ElasticPool resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ElasticPool.</param>
-    public ElasticPool(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/elasticPools", resourceVersion ?? "2021-11-01")
+    public ElasticPool(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/elasticPools", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -211,11 +216,16 @@ public partial class ElasticPool : Resource
     /// <summary>
     /// Creates a reference to an existing ElasticPool.
     /// </summary>
-    /// <param name="resourceName">Name of the ElasticPool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ElasticPool resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ElasticPool.</param>
     /// <returns>The existing ElasticPool resource.</returns>
-    public static ElasticPool FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ElasticPool FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ElasticPool resource.

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/EncryptionProtector.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/EncryptionProtector.cs
@@ -94,10 +94,15 @@ public partial class EncryptionProtector : Resource
     /// <summary>
     /// Creates a new EncryptionProtector.
     /// </summary>
-    /// <param name="resourceName">Name of the EncryptionProtector.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EncryptionProtector resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EncryptionProtector.</param>
-    public EncryptionProtector(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/encryptionProtector", resourceVersion ?? "2021-11-01")
+    public EncryptionProtector(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/encryptionProtector", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isAutoRotationEnabled = BicepValue<bool>.DefineProperty(this, "IsAutoRotationEnabled", ["properties", "autoRotationEnabled"]);
@@ -132,9 +137,14 @@ public partial class EncryptionProtector : Resource
     /// <summary>
     /// Creates a reference to an existing EncryptionProtector.
     /// </summary>
-    /// <param name="resourceName">Name of the EncryptionProtector.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EncryptionProtector resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EncryptionProtector.</param>
     /// <returns>The existing EncryptionProtector resource.</returns>
-    public static EncryptionProtector FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EncryptionProtector FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ExtendedDatabaseBlobAuditingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ExtendedDatabaseBlobAuditingPolicy.cs
@@ -198,10 +198,15 @@ public partial class ExtendedDatabaseBlobAuditingPolicy : Resource
     /// <summary>
     /// Creates a new ExtendedDatabaseBlobAuditingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ExtendedDatabaseBlobAuditingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ExtendedDatabaseBlobAuditingPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ExtendedDatabaseBlobAuditingPolicy.</param>
-    public ExtendedDatabaseBlobAuditingPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/extendedAuditingSettings", resourceVersion ?? "2021-11-01")
+    public ExtendedDatabaseBlobAuditingPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/extendedAuditingSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _auditActionsAndGroups = BicepList<string>.DefineProperty(this, "AuditActionsAndGroups", ["properties", "auditActionsAndGroups"]);
@@ -254,9 +259,14 @@ public partial class ExtendedDatabaseBlobAuditingPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing ExtendedDatabaseBlobAuditingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ExtendedDatabaseBlobAuditingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ExtendedDatabaseBlobAuditingPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ExtendedDatabaseBlobAuditingPolicy.</param>
     /// <returns>The existing ExtendedDatabaseBlobAuditingPolicy resource.</returns>
-    public static ExtendedDatabaseBlobAuditingPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ExtendedDatabaseBlobAuditingPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ExtendedServerBlobAuditingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ExtendedServerBlobAuditingPolicy.cs
@@ -218,10 +218,15 @@ public partial class ExtendedServerBlobAuditingPolicy : Resource
     /// <summary>
     /// Creates a new ExtendedServerBlobAuditingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ExtendedServerBlobAuditingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ExtendedServerBlobAuditingPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ExtendedServerBlobAuditingPolicy.</param>
-    public ExtendedServerBlobAuditingPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/extendedAuditingSettings", resourceVersion ?? "2021-11-01")
+    public ExtendedServerBlobAuditingPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/extendedAuditingSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _auditActionsAndGroups = BicepList<string>.DefineProperty(this, "AuditActionsAndGroups", ["properties", "auditActionsAndGroups"]);
@@ -260,9 +265,14 @@ public partial class ExtendedServerBlobAuditingPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing ExtendedServerBlobAuditingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ExtendedServerBlobAuditingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ExtendedServerBlobAuditingPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ExtendedServerBlobAuditingPolicy.</param>
     /// <returns>The existing ExtendedServerBlobAuditingPolicy resource.</returns>
-    public static ExtendedServerBlobAuditingPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ExtendedServerBlobAuditingPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/FailoverGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/FailoverGroup.cs
@@ -94,10 +94,15 @@ public partial class FailoverGroup : Resource
     /// <summary>
     /// Creates a new FailoverGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the FailoverGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the FailoverGroup resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the FailoverGroup.</param>
-    public FailoverGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/failoverGroups", resourceVersion ?? "2021-11-01")
+    public FailoverGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/failoverGroups", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _failoverDatabases = BicepList<ResourceIdentifier>.DefineProperty(this, "FailoverDatabases", ["properties", "databases"]);
@@ -132,11 +137,16 @@ public partial class FailoverGroup : Resource
     /// <summary>
     /// Creates a reference to an existing FailoverGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the FailoverGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the FailoverGroup resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the FailoverGroup.</param>
     /// <returns>The existing FailoverGroup resource.</returns>
-    public static FailoverGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static FailoverGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this FailoverGroup resource.

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/GeoBackupPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/GeoBackupPolicy.cs
@@ -69,10 +69,15 @@ public partial class GeoBackupPolicy : Resource
     /// <summary>
     /// Creates a new GeoBackupPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the GeoBackupPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GeoBackupPolicy resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GeoBackupPolicy.</param>
-    public GeoBackupPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/geoBackupPolicies", resourceVersion ?? "2021-11-01")
+    public GeoBackupPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/geoBackupPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<GeoBackupPolicyState>.DefineProperty(this, "State", ["properties", "state"], isRequired: true);
@@ -113,9 +118,14 @@ public partial class GeoBackupPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing GeoBackupPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the GeoBackupPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GeoBackupPolicy resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GeoBackupPolicy.</param>
     /// <returns>The existing GeoBackupPolicy resource.</returns>
-    public static GeoBackupPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static GeoBackupPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/IPv6FirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/IPv6FirewallRule.cs
@@ -50,10 +50,15 @@ public partial class IPv6FirewallRule : Resource
     /// <summary>
     /// Creates a new IPv6FirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the IPv6FirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the IPv6FirewallRule resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the IPv6FirewallRule.</param>
-    public IPv6FirewallRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/ipv6FirewallRules", resourceVersion ?? "2021-11-01")
+    public IPv6FirewallRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/ipv6FirewallRules", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _endIPv6Address = BicepValue<string>.DefineProperty(this, "EndIPv6Address", ["properties", "endIPv6Address"]);
@@ -91,9 +96,14 @@ public partial class IPv6FirewallRule : Resource
     /// <summary>
     /// Creates a reference to an existing IPv6FirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the IPv6FirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the IPv6FirewallRule resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the IPv6FirewallRule.</param>
     /// <returns>The existing IPv6FirewallRule resource.</returns>
-    public static IPv6FirewallRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static IPv6FirewallRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/InstanceFailoverGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/InstanceFailoverGroup.cs
@@ -82,10 +82,15 @@ public partial class InstanceFailoverGroup : Resource
     /// <summary>
     /// Creates a new InstanceFailoverGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the InstanceFailoverGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the InstanceFailoverGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the InstanceFailoverGroup.</param>
-    public InstanceFailoverGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/locations/instanceFailoverGroups", resourceVersion ?? "2021-11-01")
+    public InstanceFailoverGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/locations/instanceFailoverGroups", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _managedInstancePairs = BicepList<ManagedInstancePairInfo>.DefineProperty(this, "ManagedInstancePairs", ["properties", "managedInstancePairs"]);
@@ -118,9 +123,14 @@ public partial class InstanceFailoverGroup : Resource
     /// <summary>
     /// Creates a reference to an existing InstanceFailoverGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the InstanceFailoverGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the InstanceFailoverGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the InstanceFailoverGroup.</param>
     /// <returns>The existing InstanceFailoverGroup resource.</returns>
-    public static InstanceFailoverGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static InstanceFailoverGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/InstancePool.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/InstancePool.cs
@@ -90,10 +90,15 @@ public partial class InstancePool : Resource
     /// <summary>
     /// Creates a new InstancePool.
     /// </summary>
-    /// <param name="resourceName">Name of the InstancePool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the InstancePool resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the InstancePool.</param>
-    public InstancePool(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/instancePools", resourceVersion ?? "2021-11-01")
+    public InstancePool(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/instancePools", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -127,9 +132,14 @@ public partial class InstancePool : Resource
     /// <summary>
     /// Creates a reference to an existing InstancePool.
     /// </summary>
-    /// <param name="resourceName">Name of the InstancePool.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the InstancePool resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the InstancePool.</param>
     /// <returns>The existing InstancePool resource.</returns>
-    public static InstancePool FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static InstancePool FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LedgerDigestUpload.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LedgerDigestUpload.cs
@@ -57,10 +57,15 @@ public partial class LedgerDigestUpload : Resource
     /// <summary>
     /// Creates a new LedgerDigestUpload.
     /// </summary>
-    /// <param name="resourceName">Name of the LedgerDigestUpload.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LedgerDigestUpload resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LedgerDigestUpload.</param>
-    public LedgerDigestUpload(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/ledgerDigestUploads", resourceVersion ?? "2021-11-01")
+    public LedgerDigestUpload(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/ledgerDigestUploads", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _digestStorageEndpoint = BicepValue<string>.DefineProperty(this, "DigestStorageEndpoint", ["properties", "digestStorageEndpoint"]);
@@ -89,9 +94,14 @@ public partial class LedgerDigestUpload : Resource
     /// <summary>
     /// Creates a reference to an existing LedgerDigestUpload.
     /// </summary>
-    /// <param name="resourceName">Name of the LedgerDigestUpload.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LedgerDigestUpload resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LedgerDigestUpload.</param>
     /// <returns>The existing LedgerDigestUpload resource.</returns>
-    public static LedgerDigestUpload FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static LedgerDigestUpload FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LogicalDatabaseTransparentDataEncryption.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LogicalDatabaseTransparentDataEncryption.cs
@@ -50,10 +50,16 @@ public partial class LogicalDatabaseTransparentDataEncryption : Resource
     /// <summary>
     /// Creates a new LogicalDatabaseTransparentDataEncryption.
     /// </summary>
-    /// <param name="resourceName">Name of the LogicalDatabaseTransparentDataEncryption.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// LogicalDatabaseTransparentDataEncryption resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogicalDatabaseTransparentDataEncryption.</param>
-    public LogicalDatabaseTransparentDataEncryption(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/transparentDataEncryption", resourceVersion ?? "2021-11-01")
+    public LogicalDatabaseTransparentDataEncryption(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/transparentDataEncryption", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<TransparentDataEncryptionState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -87,9 +93,15 @@ public partial class LogicalDatabaseTransparentDataEncryption : Resource
     /// Creates a reference to an existing
     /// LogicalDatabaseTransparentDataEncryption.
     /// </summary>
-    /// <param name="resourceName">Name of the LogicalDatabaseTransparentDataEncryption.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// LogicalDatabaseTransparentDataEncryption resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LogicalDatabaseTransparentDataEncryption.</param>
     /// <returns>The existing LogicalDatabaseTransparentDataEncryption resource.</returns>
-    public static LogicalDatabaseTransparentDataEncryption FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static LogicalDatabaseTransparentDataEncryption FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LongTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LongTermRetentionPolicy.cs
@@ -80,10 +80,15 @@ public partial class LongTermRetentionPolicy : Resource
     /// <summary>
     /// Creates a new LongTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the LongTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LongTermRetentionPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LongTermRetentionPolicy.</param>
-    public LongTermRetentionPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies", resourceVersion ?? "2021-11-01")
+    public LongTermRetentionPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _backupStorageAccessTier = BicepValue<SqlBackupStorageAccessTier>.DefineProperty(this, "BackupStorageAccessTier", ["properties", "backupStorageAccessTier"]);
@@ -116,9 +121,14 @@ public partial class LongTermRetentionPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing LongTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the LongTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the LongTermRetentionPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the LongTermRetentionPolicy.</param>
     /// <returns>The existing LongTermRetentionPolicy resource.</returns>
-    public static LongTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static LongTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedBackupShortTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedBackupShortTermRetentionPolicy.cs
@@ -51,10 +51,15 @@ public partial class ManagedBackupShortTermRetentionPolicy : Resource
     /// <summary>
     /// Creates a new ManagedBackupShortTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedBackupShortTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedBackupShortTermRetentionPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedBackupShortTermRetentionPolicy.</param>
-    public ManagedBackupShortTermRetentionPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/backupShortTermRetentionPolicies", resourceVersion ?? "2021-11-01")
+    public ManagedBackupShortTermRetentionPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/backupShortTermRetentionPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _retentionDays = BicepValue<int>.DefineProperty(this, "RetentionDays", ["properties", "retentionDays"]);
@@ -83,9 +88,14 @@ public partial class ManagedBackupShortTermRetentionPolicy : Resource
     /// Creates a reference to an existing
     /// ManagedBackupShortTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedBackupShortTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedBackupShortTermRetentionPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedBackupShortTermRetentionPolicy.</param>
     /// <returns>The existing ManagedBackupShortTermRetentionPolicy resource.</returns>
-    public static ManagedBackupShortTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedBackupShortTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabase.cs
@@ -218,10 +218,15 @@ public partial class ManagedDatabase : Resource
     /// <summary>
     /// Creates a new ManagedDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedDatabase resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabase.</param>
-    public ManagedDatabase(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases", resourceVersion ?? "2021-11-01")
+    public ManagedDatabase(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -272,9 +277,14 @@ public partial class ManagedDatabase : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedDatabase resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabase.</param>
     /// <returns>The existing ManagedDatabase resource.</returns>
-    public static ManagedDatabase FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedDatabase FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseAdvancedThreatProtection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseAdvancedThreatProtection.cs
@@ -58,10 +58,15 @@ public partial class ManagedDatabaseAdvancedThreatProtection : Resource
     /// <summary>
     /// Creates a new ManagedDatabaseAdvancedThreatProtection.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseAdvancedThreatProtection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedDatabaseAdvancedThreatProtection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseAdvancedThreatProtection.</param>
-    public ManagedDatabaseAdvancedThreatProtection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/advancedThreatProtectionSettings", resourceVersion ?? "2024-05-01-preview")
+    public ManagedDatabaseAdvancedThreatProtection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/advancedThreatProtectionSettings", resourceVersion ?? "2024-05-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<AdvancedThreatProtectionState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -86,9 +91,14 @@ public partial class ManagedDatabaseAdvancedThreatProtection : Resource
     /// Creates a reference to an existing
     /// ManagedDatabaseAdvancedThreatProtection.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseAdvancedThreatProtection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedDatabaseAdvancedThreatProtection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseAdvancedThreatProtection.</param>
     /// <returns>The existing ManagedDatabaseAdvancedThreatProtection resource.</returns>
-    public static ManagedDatabaseAdvancedThreatProtection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedDatabaseAdvancedThreatProtection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseSecurityAlertPolicy.cs
@@ -99,10 +99,15 @@ public partial class ManagedDatabaseSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a new ManagedDatabaseSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedDatabaseSecurityAlertPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseSecurityAlertPolicy.</param>
-    public ManagedDatabaseSecurityAlertPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/securityAlertPolicies", resourceVersion ?? "2021-11-01")
+    public ManagedDatabaseSecurityAlertPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/securityAlertPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _disabledAlerts = BicepList<string>.DefineProperty(this, "DisabledAlerts", ["properties", "disabledAlerts"]);
@@ -137,9 +142,14 @@ public partial class ManagedDatabaseSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedDatabaseSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedDatabaseSecurityAlertPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseSecurityAlertPolicy.</param>
     /// <returns>The existing ManagedDatabaseSecurityAlertPolicy resource.</returns>
-    public static ManagedDatabaseSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedDatabaseSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseSensitivityLabel.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseSensitivityLabel.cs
@@ -100,10 +100,15 @@ public partial class ManagedDatabaseSensitivityLabel : Resource
     /// <summary>
     /// Creates a new ManagedDatabaseSensitivityLabel.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseSensitivityLabel.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedDatabaseSensitivityLabel
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseSensitivityLabel.</param>
-    public ManagedDatabaseSensitivityLabel(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels", resourceVersion)
+    public ManagedDatabaseSensitivityLabel(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _informationType = BicepValue<string>.DefineProperty(this, "InformationType", ["properties", "informationType"]);
@@ -123,9 +128,14 @@ public partial class ManagedDatabaseSensitivityLabel : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedDatabaseSensitivityLabel.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseSensitivityLabel.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedDatabaseSensitivityLabel
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseSensitivityLabel.</param>
     /// <returns>The existing ManagedDatabaseSensitivityLabel resource.</returns>
-    public static ManagedDatabaseSensitivityLabel FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedDatabaseSensitivityLabel FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseVulnerabilityAssessment.cs
@@ -76,10 +76,15 @@ public partial class ManagedDatabaseVulnerabilityAssessment : Resource
     /// <summary>
     /// Creates a new ManagedDatabaseVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedDatabaseVulnerabilityAssessment resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseVulnerabilityAssessment.</param>
-    public ManagedDatabaseVulnerabilityAssessment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments", resourceVersion ?? "2021-11-01")
+    public ManagedDatabaseVulnerabilityAssessment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _recurringScans = BicepValue<VulnerabilityAssessmentRecurringScansProperties>.DefineProperty(this, "RecurringScans", ["properties", "recurringScans"]);
@@ -111,9 +116,14 @@ public partial class ManagedDatabaseVulnerabilityAssessment : Resource
     /// Creates a reference to an existing
     /// ManagedDatabaseVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedDatabaseVulnerabilityAssessment resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseVulnerabilityAssessment.</param>
     /// <returns>The existing ManagedDatabaseVulnerabilityAssessment resource.</returns>
-    public static ManagedDatabaseVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedDatabaseVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseVulnerabilityAssessmentRuleBaseline.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseVulnerabilityAssessmentRuleBaseline.cs
@@ -45,10 +45,16 @@ public partial class ManagedDatabaseVulnerabilityAssessmentRuleBaseline : Resour
     /// <summary>
     /// Creates a new ManagedDatabaseVulnerabilityAssessmentRuleBaseline.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseVulnerabilityAssessmentRuleBaseline.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedDatabaseVulnerabilityAssessmentRuleBaseline resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseVulnerabilityAssessmentRuleBaseline.</param>
-    public ManagedDatabaseVulnerabilityAssessmentRuleBaseline(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/rules/baselines", resourceVersion)
+    public ManagedDatabaseVulnerabilityAssessmentRuleBaseline(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/rules/baselines", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _baselineResults = BicepList<DatabaseVulnerabilityAssessmentRuleBaselineItem>.DefineProperty(this, "BaselineResults", ["properties", "baselineResults"]);
@@ -60,9 +66,15 @@ public partial class ManagedDatabaseVulnerabilityAssessmentRuleBaseline : Resour
     /// Creates a reference to an existing
     /// ManagedDatabaseVulnerabilityAssessmentRuleBaseline.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedDatabaseVulnerabilityAssessmentRuleBaseline.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedDatabaseVulnerabilityAssessmentRuleBaseline resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseVulnerabilityAssessmentRuleBaseline.</param>
     /// <returns>The existing ManagedDatabaseVulnerabilityAssessmentRuleBaseline resource.</returns>
-    public static ManagedDatabaseVulnerabilityAssessmentRuleBaseline FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedDatabaseVulnerabilityAssessmentRuleBaseline FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstance.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstance.cs
@@ -274,10 +274,15 @@ public partial class ManagedInstance : Resource
     /// <summary>
     /// Creates a new ManagedInstance.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstance.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstance resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstance.</param>
-    public ManagedInstance(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances", resourceVersion ?? "2021-11-01")
+    public ManagedInstance(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -336,11 +341,16 @@ public partial class ManagedInstance : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedInstance.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstance.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstance resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstance.</param>
     /// <returns>The existing ManagedInstance resource.</returns>
-    public static ManagedInstance FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstance FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ManagedInstance resource.

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAdministrator.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAdministrator.cs
@@ -68,10 +68,15 @@ public partial class ManagedInstanceAdministrator : Resource
     /// <summary>
     /// Creates a new ManagedInstanceAdministrator.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceAdministrator.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceAdministrator
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceAdministrator.</param>
-    public ManagedInstanceAdministrator(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/administrators", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceAdministrator(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/administrators", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _administratorType = BicepValue<ManagedInstanceAdministratorType>.DefineProperty(this, "AdministratorType", ["properties", "administratorType"]);
@@ -102,9 +107,14 @@ public partial class ManagedInstanceAdministrator : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedInstanceAdministrator.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceAdministrator.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceAdministrator
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceAdministrator.</param>
     /// <returns>The existing ManagedInstanceAdministrator resource.</returns>
-    public static ManagedInstanceAdministrator FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceAdministrator FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAdvancedThreatProtection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAdvancedThreatProtection.cs
@@ -58,10 +58,15 @@ public partial class ManagedInstanceAdvancedThreatProtection : Resource
     /// <summary>
     /// Creates a new ManagedInstanceAdvancedThreatProtection.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceAdvancedThreatProtection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceAdvancedThreatProtection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceAdvancedThreatProtection.</param>
-    public ManagedInstanceAdvancedThreatProtection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/advancedThreatProtectionSettings", resourceVersion ?? "2024-05-01-preview")
+    public ManagedInstanceAdvancedThreatProtection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/advancedThreatProtectionSettings", resourceVersion ?? "2024-05-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<AdvancedThreatProtectionState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -86,9 +91,14 @@ public partial class ManagedInstanceAdvancedThreatProtection : Resource
     /// Creates a reference to an existing
     /// ManagedInstanceAdvancedThreatProtection.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceAdvancedThreatProtection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceAdvancedThreatProtection resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceAdvancedThreatProtection.</param>
     /// <returns>The existing ManagedInstanceAdvancedThreatProtection resource.</returns>
-    public static ManagedInstanceAdvancedThreatProtection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceAdvancedThreatProtection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAzureADOnlyAuthentication.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAzureADOnlyAuthentication.cs
@@ -50,10 +50,16 @@ public partial class ManagedInstanceAzureADOnlyAuthentication : Resource
     /// <summary>
     /// Creates a new ManagedInstanceAzureADOnlyAuthentication.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceAzureADOnlyAuthentication.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceAzureADOnlyAuthentication resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceAzureADOnlyAuthentication.</param>
-    public ManagedInstanceAzureADOnlyAuthentication(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/azureADOnlyAuthentications", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceAzureADOnlyAuthentication(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/azureADOnlyAuthentications", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isAzureADOnlyAuthenticationEnabled = BicepValue<bool>.DefineProperty(this, "IsAzureADOnlyAuthenticationEnabled", ["properties", "azureADOnlyAuthentication"]);
@@ -82,9 +88,15 @@ public partial class ManagedInstanceAzureADOnlyAuthentication : Resource
     /// Creates a reference to an existing
     /// ManagedInstanceAzureADOnlyAuthentication.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceAzureADOnlyAuthentication.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceAzureADOnlyAuthentication resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceAzureADOnlyAuthentication.</param>
     /// <returns>The existing ManagedInstanceAzureADOnlyAuthentication resource.</returns>
-    public static ManagedInstanceAzureADOnlyAuthentication FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceAzureADOnlyAuthentication FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceDtc.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceDtc.cs
@@ -75,10 +75,15 @@ public partial class ManagedInstanceDtc : Resource
     /// <summary>
     /// Creates a new ManagedInstanceDtc.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceDtc.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceDtc resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceDtc.</param>
-    public ManagedInstanceDtc(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/dtc", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceDtc(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/dtc", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _dtcEnabled = BicepValue<bool>.DefineProperty(this, "DtcEnabled", ["properties", "dtcEnabled"]);
@@ -110,9 +115,14 @@ public partial class ManagedInstanceDtc : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedInstanceDtc.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceDtc.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceDtc resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceDtc.</param>
     /// <returns>The existing ManagedInstanceDtc resource.</returns>
-    public static ManagedInstanceDtc FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceDtc FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceEncryptionProtector.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceEncryptionProtector.cs
@@ -82,10 +82,15 @@ public partial class ManagedInstanceEncryptionProtector : Resource
     /// <summary>
     /// Creates a new ManagedInstanceEncryptionProtector.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceEncryptionProtector.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceEncryptionProtector
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceEncryptionProtector.</param>
-    public ManagedInstanceEncryptionProtector(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/encryptionProtector", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceEncryptionProtector(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/encryptionProtector", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isAutoRotationEnabled = BicepValue<bool>.DefineProperty(this, "IsAutoRotationEnabled", ["properties", "autoRotationEnabled"]);
@@ -118,9 +123,14 @@ public partial class ManagedInstanceEncryptionProtector : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedInstanceEncryptionProtector.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceEncryptionProtector.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceEncryptionProtector
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceEncryptionProtector.</param>
     /// <returns>The existing ManagedInstanceEncryptionProtector resource.</returns>
-    public static ManagedInstanceEncryptionProtector FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceEncryptionProtector FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceKey.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceKey.cs
@@ -83,10 +83,15 @@ public partial class ManagedInstanceKey : Resource
     /// <summary>
     /// Creates a new ManagedInstanceKey.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceKey.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceKey resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceKey.</param>
-    public ManagedInstanceKey(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/keys", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceKey(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/keys", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _serverKeyType = BicepValue<SqlServerKeyType>.DefineProperty(this, "ServerKeyType", ["properties", "serverKeyType"]);
@@ -119,9 +124,14 @@ public partial class ManagedInstanceKey : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedInstanceKey.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceKey.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceKey resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceKey.</param>
     /// <returns>The existing ManagedInstanceKey resource.</returns>
-    public static ManagedInstanceKey FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceKey FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceLongTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceLongTermRetentionPolicy.cs
@@ -68,10 +68,15 @@ public partial class ManagedInstanceLongTermRetentionPolicy : Resource
     /// <summary>
     /// Creates a new ManagedInstanceLongTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceLongTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceLongTermRetentionPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceLongTermRetentionPolicy.</param>
-    public ManagedInstanceLongTermRetentionPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/backupLongTermRetentionPolicies", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceLongTermRetentionPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/backupLongTermRetentionPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _monthlyRetention = BicepValue<string>.DefineProperty(this, "MonthlyRetention", ["properties", "monthlyRetention"]);
@@ -103,9 +108,14 @@ public partial class ManagedInstanceLongTermRetentionPolicy : Resource
     /// Creates a reference to an existing
     /// ManagedInstanceLongTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceLongTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceLongTermRetentionPolicy resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceLongTermRetentionPolicy.</param>
     /// <returns>The existing ManagedInstanceLongTermRetentionPolicy resource.</returns>
-    public static ManagedInstanceLongTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceLongTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstancePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstancePrivateEndpointConnection.cs
@@ -62,10 +62,16 @@ public partial class ManagedInstancePrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new ManagedInstancePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstancePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstancePrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstancePrivateEndpointConnection.</param>
-    public ManagedInstancePrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/privateEndpointConnections", resourceVersion ?? "2021-11-01")
+    public ManagedInstancePrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/privateEndpointConnections", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<ManagedInstancePrivateLinkServiceConnectionStateProperty>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -96,9 +102,15 @@ public partial class ManagedInstancePrivateEndpointConnection : Resource
     /// Creates a reference to an existing
     /// ManagedInstancePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstancePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstancePrivateEndpointConnection resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstancePrivateEndpointConnection.</param>
     /// <returns>The existing ManagedInstancePrivateEndpointConnection resource.</returns>
-    public static ManagedInstancePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstancePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceServerConfigurationOption.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceServerConfigurationOption.cs
@@ -56,10 +56,16 @@ public partial class ManagedInstanceServerConfigurationOption : Resource
     /// <summary>
     /// Creates a new ManagedInstanceServerConfigurationOption.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceServerConfigurationOption.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceServerConfigurationOption resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceServerConfigurationOption.</param>
-    public ManagedInstanceServerConfigurationOption(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/serverConfigurationOptions", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceServerConfigurationOption(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/serverConfigurationOptions", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _serverConfigurationOptionValue = BicepValue<int>.DefineProperty(this, "ServerConfigurationOptionValue", ["properties", "serverConfigurationOptionValue"]);
@@ -89,9 +95,15 @@ public partial class ManagedInstanceServerConfigurationOption : Resource
     /// Creates a reference to an existing
     /// ManagedInstanceServerConfigurationOption.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceServerConfigurationOption.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceServerConfigurationOption resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceServerConfigurationOption.</param>
     /// <returns>The existing ManagedInstanceServerConfigurationOption resource.</returns>
-    public static ManagedInstanceServerConfigurationOption FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceServerConfigurationOption FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceServerTrustCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceServerTrustCertificate.cs
@@ -62,10 +62,15 @@ public partial class ManagedInstanceServerTrustCertificate : Resource
     /// <summary>
     /// Creates a new ManagedInstanceServerTrustCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceServerTrustCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceServerTrustCertificate resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceServerTrustCertificate.</param>
-    public ManagedInstanceServerTrustCertificate(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/serverTrustCertificates", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceServerTrustCertificate(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/serverTrustCertificates", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _publicBlob = BicepValue<string>.DefineProperty(this, "PublicBlob", ["properties", "publicBlob"]);
@@ -96,9 +101,14 @@ public partial class ManagedInstanceServerTrustCertificate : Resource
     /// Creates a reference to an existing
     /// ManagedInstanceServerTrustCertificate.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceServerTrustCertificate.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceServerTrustCertificate resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceServerTrustCertificate.</param>
     /// <returns>The existing ManagedInstanceServerTrustCertificate resource.</returns>
-    public static ManagedInstanceServerTrustCertificate FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceServerTrustCertificate FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceStartStopSchedule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceStartStopSchedule.cs
@@ -76,10 +76,15 @@ public partial class ManagedInstanceStartStopSchedule : Resource
     /// <summary>
     /// Creates a new ManagedInstanceStartStopSchedule.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceStartStopSchedule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceStartStopSchedule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceStartStopSchedule.</param>
-    public ManagedInstanceStartStopSchedule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/startStopSchedules", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceStartStopSchedule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/startStopSchedules", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -111,9 +116,14 @@ public partial class ManagedInstanceStartStopSchedule : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedInstanceStartStopSchedule.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceStartStopSchedule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedInstanceStartStopSchedule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceStartStopSchedule.</param>
     /// <returns>The existing ManagedInstanceStartStopSchedule resource.</returns>
-    public static ManagedInstanceStartStopSchedule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceStartStopSchedule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceVulnerabilityAssessment.cs
@@ -77,10 +77,15 @@ public partial class ManagedInstanceVulnerabilityAssessment : Resource
     /// <summary>
     /// Creates a new ManagedInstanceVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceVulnerabilityAssessment resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceVulnerabilityAssessment.</param>
-    public ManagedInstanceVulnerabilityAssessment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/vulnerabilityAssessments", resourceVersion ?? "2021-11-01")
+    public ManagedInstanceVulnerabilityAssessment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/vulnerabilityAssessments", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _recurringScans = BicepValue<VulnerabilityAssessmentRecurringScansProperties>.DefineProperty(this, "RecurringScans", ["properties", "recurringScans"]);
@@ -112,9 +117,14 @@ public partial class ManagedInstanceVulnerabilityAssessment : Resource
     /// Creates a reference to an existing
     /// ManagedInstanceVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedInstanceVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedInstanceVulnerabilityAssessment resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceVulnerabilityAssessment.</param>
     /// <returns>The existing ManagedInstanceVulnerabilityAssessment resource.</returns>
-    public static ManagedInstanceVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedInstanceVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedLedgerDigestUpload.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedLedgerDigestUpload.cs
@@ -57,10 +57,15 @@ public partial class ManagedLedgerDigestUpload : Resource
     /// <summary>
     /// Creates a new ManagedLedgerDigestUpload.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedLedgerDigestUpload.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedLedgerDigestUpload
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedLedgerDigestUpload.</param>
-    public ManagedLedgerDigestUpload(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/ledgerDigestUploads", resourceVersion ?? "2024-05-01-preview")
+    public ManagedLedgerDigestUpload(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/ledgerDigestUploads", resourceVersion ?? "2024-05-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _digestStorageEndpoint = BicepValue<string>.DefineProperty(this, "DigestStorageEndpoint", ["properties", "digestStorageEndpoint"]);
@@ -84,9 +89,14 @@ public partial class ManagedLedgerDigestUpload : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedLedgerDigestUpload.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedLedgerDigestUpload.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedLedgerDigestUpload
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedLedgerDigestUpload.</param>
     /// <returns>The existing ManagedLedgerDigestUpload resource.</returns>
-    public static ManagedLedgerDigestUpload FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedLedgerDigestUpload FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedRestorableDroppedDbBackupShortTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedRestorableDroppedDbBackupShortTermRetentionPolicy.cs
@@ -45,10 +45,16 @@ public partial class ManagedRestorableDroppedDbBackupShortTermRetentionPolicy : 
     /// <summary>
     /// Creates a new ManagedRestorableDroppedDbBackupShortTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedRestorableDroppedDbBackupShortTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedRestorableDroppedDbBackupShortTermRetentionPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedRestorableDroppedDbBackupShortTermRetentionPolicy.</param>
-    public ManagedRestorableDroppedDbBackupShortTermRetentionPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/restorableDroppedDatabases/backupShortTermRetentionPolicies", resourceVersion)
+    public ManagedRestorableDroppedDbBackupShortTermRetentionPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/restorableDroppedDatabases/backupShortTermRetentionPolicies", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _retentionDays = BicepValue<int>.DefineProperty(this, "RetentionDays", ["properties", "retentionDays"]);
@@ -60,9 +66,15 @@ public partial class ManagedRestorableDroppedDbBackupShortTermRetentionPolicy : 
     /// Creates a reference to an existing
     /// ManagedRestorableDroppedDbBackupShortTermRetentionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedRestorableDroppedDbBackupShortTermRetentionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// ManagedRestorableDroppedDbBackupShortTermRetentionPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedRestorableDroppedDbBackupShortTermRetentionPolicy.</param>
     /// <returns>The existing ManagedRestorableDroppedDbBackupShortTermRetentionPolicy resource.</returns>
-    public static ManagedRestorableDroppedDbBackupShortTermRetentionPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedRestorableDroppedDbBackupShortTermRetentionPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedServerDnsAlias.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedServerDnsAlias.cs
@@ -62,10 +62,15 @@ public partial class ManagedServerDnsAlias : Resource
     /// <summary>
     /// Creates a new ManagedServerDnsAlias.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedServerDnsAlias.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedServerDnsAlias resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedServerDnsAlias.</param>
-    public ManagedServerDnsAlias(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/dnsAliases", resourceVersion ?? "2021-11-01")
+    public ManagedServerDnsAlias(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/dnsAliases", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _createDnsRecord = BicepValue<bool>.DefineProperty(this, "CreateDnsRecord", ["createDnsRecord"]);
@@ -95,9 +100,14 @@ public partial class ManagedServerDnsAlias : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedServerDnsAlias.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedServerDnsAlias.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedServerDnsAlias resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedServerDnsAlias.</param>
     /// <returns>The existing ManagedServerDnsAlias resource.</returns>
-    public static ManagedServerDnsAlias FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedServerDnsAlias FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedServerSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedServerSecurityAlertPolicy.cs
@@ -99,10 +99,15 @@ public partial class ManagedServerSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a new ManagedServerSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedServerSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedServerSecurityAlertPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedServerSecurityAlertPolicy.</param>
-    public ManagedServerSecurityAlertPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/securityAlertPolicies", resourceVersion ?? "2021-11-01")
+    public ManagedServerSecurityAlertPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/securityAlertPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _disabledAlerts = BicepList<string>.DefineProperty(this, "DisabledAlerts", ["properties", "disabledAlerts"]);
@@ -137,9 +142,14 @@ public partial class ManagedServerSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedServerSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedServerSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedServerSecurityAlertPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedServerSecurityAlertPolicy.</param>
     /// <returns>The existing ManagedServerSecurityAlertPolicy resource.</returns>
-    public static ManagedServerSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedServerSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedTransparentDataEncryption.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedTransparentDataEncryption.cs
@@ -50,10 +50,15 @@ public partial class ManagedTransparentDataEncryption : Resource
     /// <summary>
     /// Creates a new ManagedTransparentDataEncryption.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedTransparentDataEncryption.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedTransparentDataEncryption
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedTransparentDataEncryption.</param>
-    public ManagedTransparentDataEncryption(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/databases/transparentDataEncryption", resourceVersion ?? "2021-11-01")
+    public ManagedTransparentDataEncryption(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/databases/transparentDataEncryption", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<TransparentDataEncryptionState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -81,9 +86,14 @@ public partial class ManagedTransparentDataEncryption : Resource
     /// <summary>
     /// Creates a reference to an existing ManagedTransparentDataEncryption.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagedTransparentDataEncryption.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagedTransparentDataEncryption
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagedTransparentDataEncryption.</param>
     /// <returns>The existing ManagedTransparentDataEncryption resource.</returns>
-    public static ManagedTransparentDataEncryption FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagedTransparentDataEncryption FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/OutboundFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/OutboundFirewallRule.cs
@@ -50,10 +50,15 @@ public partial class OutboundFirewallRule : Resource
     /// <summary>
     /// Creates a new OutboundFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the OutboundFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OutboundFirewallRule resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OutboundFirewallRule.</param>
-    public OutboundFirewallRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/outboundFirewallRules", resourceVersion ?? "2021-11-01")
+    public OutboundFirewallRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/outboundFirewallRules", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _id = BicepValue<ResourceIdentifier>.DefineProperty(this, "Id", ["id"], isOutput: true);
@@ -91,9 +96,14 @@ public partial class OutboundFirewallRule : Resource
     /// <summary>
     /// Creates a reference to an existing OutboundFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the OutboundFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the OutboundFirewallRule resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the OutboundFirewallRule.</param>
     /// <returns>The existing OutboundFirewallRule resource.</returns>
-    public static OutboundFirewallRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static OutboundFirewallRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ServerAdvancedThreatProtection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ServerAdvancedThreatProtection.cs
@@ -58,10 +58,15 @@ public partial class ServerAdvancedThreatProtection : Resource
     /// <summary>
     /// Creates a new ServerAdvancedThreatProtection.
     /// </summary>
-    /// <param name="resourceName">Name of the ServerAdvancedThreatProtection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServerAdvancedThreatProtection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServerAdvancedThreatProtection.</param>
-    public ServerAdvancedThreatProtection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/advancedThreatProtectionSettings", resourceVersion ?? "2021-11-01")
+    public ServerAdvancedThreatProtection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/advancedThreatProtectionSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<AdvancedThreatProtectionState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -90,9 +95,14 @@ public partial class ServerAdvancedThreatProtection : Resource
     /// <summary>
     /// Creates a reference to an existing ServerAdvancedThreatProtection.
     /// </summary>
-    /// <param name="resourceName">Name of the ServerAdvancedThreatProtection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ServerAdvancedThreatProtection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ServerAdvancedThreatProtection.</param>
     /// <returns>The existing ServerAdvancedThreatProtection resource.</returns>
-    public static ServerAdvancedThreatProtection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ServerAdvancedThreatProtection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlAgentConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlAgentConfiguration.cs
@@ -50,10 +50,15 @@ public partial class SqlAgentConfiguration : Resource
     /// <summary>
     /// Creates a new SqlAgentConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlAgentConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlAgentConfiguration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlAgentConfiguration.</param>
-    public SqlAgentConfiguration(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/managedInstances/sqlAgent", resourceVersion ?? "2021-11-01")
+    public SqlAgentConfiguration(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/managedInstances/sqlAgent", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<SqlAgentConfigurationPropertiesState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -86,9 +91,14 @@ public partial class SqlAgentConfiguration : Resource
     /// <summary>
     /// Creates a reference to an existing SqlAgentConfiguration.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlAgentConfiguration.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlAgentConfiguration resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlAgentConfiguration.</param>
     /// <returns>The existing SqlAgentConfiguration resource.</returns>
-    public static SqlAgentConfiguration FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlAgentConfiguration FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabase.cs
@@ -476,10 +476,15 @@ public partial class SqlDatabase : Resource
     /// <summary>
     /// Creates a new SqlDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabase resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabase.</param>
-    public SqlDatabase(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases", resourceVersion ?? "2021-11-01")
+    public SqlDatabase(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -575,11 +580,16 @@ public partial class SqlDatabase : Resource
     /// <summary>
     /// Creates a reference to an existing SqlDatabase.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabase.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabase resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabase.</param>
     /// <returns>The existing SqlDatabase resource.</returns>
-    public static SqlDatabase FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlDatabase FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SqlDatabase resource.

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseBlobAuditingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseBlobAuditingPolicy.cs
@@ -198,10 +198,15 @@ public partial class SqlDatabaseBlobAuditingPolicy : Resource
     /// <summary>
     /// Creates a new SqlDatabaseBlobAuditingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseBlobAuditingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabaseBlobAuditingPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseBlobAuditingPolicy.</param>
-    public SqlDatabaseBlobAuditingPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/auditingSettings", resourceVersion ?? "2021-11-01")
+    public SqlDatabaseBlobAuditingPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/auditingSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _auditActionsAndGroups = BicepList<string>.DefineProperty(this, "AuditActionsAndGroups", ["properties", "auditActionsAndGroups"]);
@@ -239,9 +244,14 @@ public partial class SqlDatabaseBlobAuditingPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing SqlDatabaseBlobAuditingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseBlobAuditingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabaseBlobAuditingPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseBlobAuditingPolicy.</param>
     /// <returns>The existing SqlDatabaseBlobAuditingPolicy resource.</returns>
-    public static SqlDatabaseBlobAuditingPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlDatabaseBlobAuditingPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSecurityAlertPolicy.cs
@@ -99,10 +99,15 @@ public partial class SqlDatabaseSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a new SqlDatabaseSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabaseSecurityAlertPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseSecurityAlertPolicy.</param>
-    public SqlDatabaseSecurityAlertPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/securityAlertPolicies", resourceVersion ?? "2021-11-01")
+    public SqlDatabaseSecurityAlertPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/securityAlertPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _disabledAlerts = BicepList<string>.DefineProperty(this, "DisabledAlerts", ["properties", "disabledAlerts"]);
@@ -147,9 +152,14 @@ public partial class SqlDatabaseSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing SqlDatabaseSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabaseSecurityAlertPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseSecurityAlertPolicy.</param>
     /// <returns>The existing SqlDatabaseSecurityAlertPolicy resource.</returns>
-    public static SqlDatabaseSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlDatabaseSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSensitivityLabel.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSensitivityLabel.cs
@@ -100,10 +100,15 @@ public partial class SqlDatabaseSensitivityLabel : Resource
     /// <summary>
     /// Creates a new SqlDatabaseSensitivityLabel.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseSensitivityLabel.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabaseSensitivityLabel
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseSensitivityLabel.</param>
-    public SqlDatabaseSensitivityLabel(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels", resourceVersion)
+    public SqlDatabaseSensitivityLabel(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _informationType = BicepValue<string>.DefineProperty(this, "InformationType", ["properties", "informationType"]);
@@ -123,9 +128,14 @@ public partial class SqlDatabaseSensitivityLabel : Resource
     /// <summary>
     /// Creates a reference to an existing SqlDatabaseSensitivityLabel.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseSensitivityLabel.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabaseSensitivityLabel
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseSensitivityLabel.</param>
     /// <returns>The existing SqlDatabaseSensitivityLabel resource.</returns>
-    public static SqlDatabaseSensitivityLabel FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlDatabaseSensitivityLabel FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSqlVulnerabilityAssessmentBaseline.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSqlVulnerabilityAssessmentBaseline.cs
@@ -51,10 +51,16 @@ public partial class SqlDatabaseSqlVulnerabilityAssessmentBaseline : Resource
     /// <summary>
     /// Creates a new SqlDatabaseSqlVulnerabilityAssessmentBaseline.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseSqlVulnerabilityAssessmentBaseline.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlDatabaseSqlVulnerabilityAssessmentBaseline resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseSqlVulnerabilityAssessmentBaseline.</param>
-    public SqlDatabaseSqlVulnerabilityAssessmentBaseline(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/baselines", resourceVersion)
+    public SqlDatabaseSqlVulnerabilityAssessmentBaseline(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/baselines", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isLatestScan = BicepValue<bool>.DefineProperty(this, "IsLatestScan", ["properties", "latestScan"]);
@@ -67,9 +73,15 @@ public partial class SqlDatabaseSqlVulnerabilityAssessmentBaseline : Resource
     /// Creates a reference to an existing
     /// SqlDatabaseSqlVulnerabilityAssessmentBaseline.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseSqlVulnerabilityAssessmentBaseline.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlDatabaseSqlVulnerabilityAssessmentBaseline resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseSqlVulnerabilityAssessmentBaseline.</param>
     /// <returns>The existing SqlDatabaseSqlVulnerabilityAssessmentBaseline resource.</returns>
-    public static SqlDatabaseSqlVulnerabilityAssessmentBaseline FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlDatabaseSqlVulnerabilityAssessmentBaseline FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSqlVulnerabilityAssessmentBaselineRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSqlVulnerabilityAssessmentBaselineRule.cs
@@ -57,10 +57,16 @@ public partial class SqlDatabaseSqlVulnerabilityAssessmentBaselineRule : Resourc
     /// <summary>
     /// Creates a new SqlDatabaseSqlVulnerabilityAssessmentBaselineRule.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseSqlVulnerabilityAssessmentBaselineRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlDatabaseSqlVulnerabilityAssessmentBaselineRule resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseSqlVulnerabilityAssessmentBaselineRule.</param>
-    public SqlDatabaseSqlVulnerabilityAssessmentBaselineRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/baselines/rules", resourceVersion)
+    public SqlDatabaseSqlVulnerabilityAssessmentBaselineRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/baselines/rules", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isLatestScan = BicepValue<bool>.DefineProperty(this, "IsLatestScan", ["properties", "latestScan"]);
@@ -74,9 +80,15 @@ public partial class SqlDatabaseSqlVulnerabilityAssessmentBaselineRule : Resourc
     /// Creates a reference to an existing
     /// SqlDatabaseSqlVulnerabilityAssessmentBaselineRule.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseSqlVulnerabilityAssessmentBaselineRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlDatabaseSqlVulnerabilityAssessmentBaselineRule resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseSqlVulnerabilityAssessmentBaselineRule.</param>
     /// <returns>The existing SqlDatabaseSqlVulnerabilityAssessmentBaselineRule resource.</returns>
-    public static SqlDatabaseSqlVulnerabilityAssessmentBaselineRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlDatabaseSqlVulnerabilityAssessmentBaselineRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseVulnerabilityAssessment.cs
@@ -76,10 +76,15 @@ public partial class SqlDatabaseVulnerabilityAssessment : Resource
     /// <summary>
     /// Creates a new SqlDatabaseVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabaseVulnerabilityAssessment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseVulnerabilityAssessment.</param>
-    public SqlDatabaseVulnerabilityAssessment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/vulnerabilityAssessments", resourceVersion ?? "2021-11-01")
+    public SqlDatabaseVulnerabilityAssessment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/vulnerabilityAssessments", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _recurringScans = BicepValue<VulnerabilityAssessmentRecurringScansProperties>.DefineProperty(this, "RecurringScans", ["properties", "recurringScans"]);
@@ -110,9 +115,14 @@ public partial class SqlDatabaseVulnerabilityAssessment : Resource
     /// <summary>
     /// Creates a reference to an existing SqlDatabaseVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlDatabaseVulnerabilityAssessment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseVulnerabilityAssessment.</param>
     /// <returns>The existing SqlDatabaseVulnerabilityAssessment resource.</returns>
-    public static SqlDatabaseVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlDatabaseVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseVulnerabilityAssessmentRuleBaseline.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseVulnerabilityAssessmentRuleBaseline.cs
@@ -45,10 +45,16 @@ public partial class SqlDatabaseVulnerabilityAssessmentRuleBaseline : Resource
     /// <summary>
     /// Creates a new SqlDatabaseVulnerabilityAssessmentRuleBaseline.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseVulnerabilityAssessmentRuleBaseline.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlDatabaseVulnerabilityAssessmentRuleBaseline resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseVulnerabilityAssessmentRuleBaseline.</param>
-    public SqlDatabaseVulnerabilityAssessmentRuleBaseline(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines", resourceVersion)
+    public SqlDatabaseVulnerabilityAssessmentRuleBaseline(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _baselineResults = BicepList<DatabaseVulnerabilityAssessmentRuleBaselineItem>.DefineProperty(this, "BaselineResults", ["properties", "baselineResults"]);
@@ -60,9 +66,15 @@ public partial class SqlDatabaseVulnerabilityAssessmentRuleBaseline : Resource
     /// Creates a reference to an existing
     /// SqlDatabaseVulnerabilityAssessmentRuleBaseline.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlDatabaseVulnerabilityAssessmentRuleBaseline.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlDatabaseVulnerabilityAssessmentRuleBaseline resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlDatabaseVulnerabilityAssessmentRuleBaseline.</param>
     /// <returns>The existing SqlDatabaseVulnerabilityAssessmentRuleBaseline resource.</returns>
-    public static SqlDatabaseVulnerabilityAssessmentRuleBaseline FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlDatabaseVulnerabilityAssessmentRuleBaseline FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlFirewallRule.cs
@@ -53,10 +53,15 @@ public partial class SqlFirewallRule : Resource
     /// <summary>
     /// Creates a new SqlFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlFirewallRule resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlFirewallRule.</param>
-    public SqlFirewallRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/firewallRules", resourceVersion ?? "2021-11-01")
+    public SqlFirewallRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/firewallRules", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _endIPAddress = BicepValue<string>.DefineProperty(this, "EndIPAddress", ["properties", "endIpAddress"]);
@@ -94,11 +99,16 @@ public partial class SqlFirewallRule : Resource
     /// <summary>
     /// Creates a reference to an existing SqlFirewallRule.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlFirewallRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlFirewallRule resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlFirewallRule.</param>
     /// <returns>The existing SqlFirewallRule resource.</returns>
-    public static SqlFirewallRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlFirewallRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SqlFirewallRule resource.

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlPrivateEndpointConnection.cs
@@ -69,10 +69,15 @@ public partial class SqlPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new SqlPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlPrivateEndpointConnection.</param>
-    public SqlPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/privateEndpointConnections", resourceVersion ?? "2021-11-01")
+    public SqlPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/privateEndpointConnections", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<SqlPrivateLinkServiceConnectionStateProperty>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -113,9 +118,14 @@ public partial class SqlPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing SqlPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlPrivateEndpointConnection.</param>
     /// <returns>The existing SqlPrivateEndpointConnection resource.</returns>
-    public static SqlPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
@@ -176,10 +176,15 @@ public partial class SqlServer : Resource
     /// <summary>
     /// Creates a new SqlServer.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServer resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServer.</param>
-    public SqlServer(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers", resourceVersion ?? "2021-11-01")
+    public SqlServer(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -235,11 +240,16 @@ public partial class SqlServer : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServer.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServer resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServer.</param>
     /// <returns>The existing SqlServer resource.</returns>
-    public static SqlServer FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServer FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SqlServer resource.
@@ -257,10 +267,10 @@ public partial class SqlServer : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(SqlBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{SqlBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{SqlBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -273,13 +283,13 @@ public partial class SqlServer : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(SqlBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{SqlBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(SqlBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{SqlBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerAzureADAdministrator.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerAzureADAdministrator.cs
@@ -75,10 +75,15 @@ public partial class SqlServerAzureADAdministrator : Resource
     /// <summary>
     /// Creates a new SqlServerAzureADAdministrator.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerAzureADAdministrator.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerAzureADAdministrator
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerAzureADAdministrator.</param>
-    public SqlServerAzureADAdministrator(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/administrators", resourceVersion ?? "2021-11-01")
+    public SqlServerAzureADAdministrator(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/administrators", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true, defaultValue: GetNameDefaultValue());
         _administratorType = BicepValue<SqlAdministratorType>.DefineProperty(this, "AdministratorType", ["properties", "administratorType"]);
@@ -120,9 +125,14 @@ public partial class SqlServerAzureADAdministrator : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerAzureADAdministrator.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerAzureADAdministrator.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerAzureADAdministrator
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerAzureADAdministrator.</param>
     /// <returns>The existing SqlServerAzureADAdministrator resource.</returns>
-    public static SqlServerAzureADAdministrator FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerAzureADAdministrator FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerAzureADOnlyAuthentication.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerAzureADOnlyAuthentication.cs
@@ -50,10 +50,15 @@ public partial class SqlServerAzureADOnlyAuthentication : Resource
     /// <summary>
     /// Creates a new SqlServerAzureADOnlyAuthentication.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerAzureADOnlyAuthentication.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerAzureADOnlyAuthentication
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerAzureADOnlyAuthentication.</param>
-    public SqlServerAzureADOnlyAuthentication(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/azureADOnlyAuthentications", resourceVersion ?? "2021-11-01")
+    public SqlServerAzureADOnlyAuthentication(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/azureADOnlyAuthentications", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isAzureADOnlyAuthenticationEnabled = BicepValue<bool>.DefineProperty(this, "IsAzureADOnlyAuthenticationEnabled", ["properties", "azureADOnlyAuthentication"]);
@@ -91,9 +96,14 @@ public partial class SqlServerAzureADOnlyAuthentication : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerAzureADOnlyAuthentication.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerAzureADOnlyAuthentication.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerAzureADOnlyAuthentication
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerAzureADOnlyAuthentication.</param>
     /// <returns>The existing SqlServerAzureADOnlyAuthentication resource.</returns>
-    public static SqlServerAzureADOnlyAuthentication FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerAzureADOnlyAuthentication FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerBlobAuditingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerBlobAuditingPolicy.cs
@@ -212,10 +212,15 @@ public partial class SqlServerBlobAuditingPolicy : Resource
     /// <summary>
     /// Creates a new SqlServerBlobAuditingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerBlobAuditingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerBlobAuditingPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerBlobAuditingPolicy.</param>
-    public SqlServerBlobAuditingPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/auditingSettings", resourceVersion ?? "2021-11-01")
+    public SqlServerBlobAuditingPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/auditingSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _auditActionsAndGroups = BicepList<string>.DefineProperty(this, "AuditActionsAndGroups", ["properties", "auditActionsAndGroups"]);
@@ -253,9 +258,14 @@ public partial class SqlServerBlobAuditingPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerBlobAuditingPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerBlobAuditingPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerBlobAuditingPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerBlobAuditingPolicy.</param>
     /// <returns>The existing SqlServerBlobAuditingPolicy resource.</returns>
-    public static SqlServerBlobAuditingPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerBlobAuditingPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerCommunicationLink.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerCommunicationLink.cs
@@ -69,10 +69,15 @@ public partial class SqlServerCommunicationLink : Resource
     /// <summary>
     /// Creates a new SqlServerCommunicationLink.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerCommunicationLink.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerCommunicationLink
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerCommunicationLink.</param>
-    public SqlServerCommunicationLink(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/communicationLinks", resourceVersion ?? "2014-04-01")
+    public SqlServerCommunicationLink(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/communicationLinks", resourceVersion ?? "2014-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _partnerServer = BicepValue<string>.DefineProperty(this, "PartnerServer", ["properties", "partnerServer"]);
@@ -108,9 +113,14 @@ public partial class SqlServerCommunicationLink : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerCommunicationLink.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerCommunicationLink.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerCommunicationLink
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerCommunicationLink.</param>
     /// <returns>The existing SqlServerCommunicationLink resource.</returns>
-    public static SqlServerCommunicationLink FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerCommunicationLink FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerConnectionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerConnectionPolicy.cs
@@ -62,10 +62,15 @@ public partial class SqlServerConnectionPolicy : Resource
     /// <summary>
     /// Creates a new SqlServerConnectionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerConnectionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerConnectionPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerConnectionPolicy.</param>
-    public SqlServerConnectionPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/connectionPolicies", resourceVersion ?? "2021-11-01")
+    public SqlServerConnectionPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/connectionPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _connectionType = BicepValue<ServerConnectionType>.DefineProperty(this, "ConnectionType", ["properties", "connectionType"]);
@@ -105,9 +110,14 @@ public partial class SqlServerConnectionPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerConnectionPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerConnectionPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerConnectionPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerConnectionPolicy.</param>
     /// <returns>The existing SqlServerConnectionPolicy resource.</returns>
-    public static SqlServerConnectionPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerConnectionPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDatabaseRestorePoint.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDatabaseRestorePoint.cs
@@ -74,10 +74,15 @@ public partial class SqlServerDatabaseRestorePoint : Resource
     /// <summary>
     /// Creates a new SqlServerDatabaseRestorePoint.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerDatabaseRestorePoint.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerDatabaseRestorePoint
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerDatabaseRestorePoint.</param>
-    public SqlServerDatabaseRestorePoint(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/restorePoints", resourceVersion ?? "2021-11-01")
+    public SqlServerDatabaseRestorePoint(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/restorePoints", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _earliestRestoreOn = BicepValue<DateTimeOffset>.DefineProperty(this, "EarliestRestoreOn", ["properties", "earliestRestoreDate"], isOutput: true);
@@ -124,9 +129,14 @@ public partial class SqlServerDatabaseRestorePoint : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerDatabaseRestorePoint.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerDatabaseRestorePoint.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerDatabaseRestorePoint
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerDatabaseRestorePoint.</param>
     /// <returns>The existing SqlServerDatabaseRestorePoint resource.</returns>
-    public static SqlServerDatabaseRestorePoint FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerDatabaseRestorePoint FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDevOpsAuditingSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDevOpsAuditingSetting.cs
@@ -106,10 +106,15 @@ public partial class SqlServerDevOpsAuditingSetting : Resource
     /// <summary>
     /// Creates a new SqlServerDevOpsAuditingSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerDevOpsAuditingSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerDevOpsAuditingSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerDevOpsAuditingSetting.</param>
-    public SqlServerDevOpsAuditingSetting(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/devOpsAuditingSettings", resourceVersion ?? "2021-11-01")
+    public SqlServerDevOpsAuditingSetting(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/devOpsAuditingSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _isAzureMonitorTargetEnabled = BicepValue<bool>.DefineProperty(this, "IsAzureMonitorTargetEnabled", ["properties", "isAzureMonitorTargetEnabled"]);
@@ -142,9 +147,14 @@ public partial class SqlServerDevOpsAuditingSetting : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerDevOpsAuditingSetting.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerDevOpsAuditingSetting.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerDevOpsAuditingSetting
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerDevOpsAuditingSetting.</param>
     /// <returns>The existing SqlServerDevOpsAuditingSetting resource.</returns>
-    public static SqlServerDevOpsAuditingSetting FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerDevOpsAuditingSetting FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDnsAlias.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDnsAlias.cs
@@ -50,10 +50,15 @@ public partial class SqlServerDnsAlias : Resource
     /// <summary>
     /// Creates a new SqlServerDnsAlias.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerDnsAlias.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerDnsAlias resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerDnsAlias.</param>
-    public SqlServerDnsAlias(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/dnsAliases", resourceVersion ?? "2021-11-01")
+    public SqlServerDnsAlias(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/dnsAliases", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _azureDnsRecord = BicepValue<string>.DefineProperty(this, "AzureDnsRecord", ["properties", "azureDnsRecord"], isOutput: true);
@@ -81,9 +86,14 @@ public partial class SqlServerDnsAlias : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerDnsAlias.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerDnsAlias.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerDnsAlias resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerDnsAlias.</param>
     /// <returns>The existing SqlServerDnsAlias resource.</returns>
-    public static SqlServerDnsAlias FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerDnsAlias FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJob.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJob.cs
@@ -62,10 +62,15 @@ public partial class SqlServerJob : Resource
     /// <summary>
     /// Creates a new SqlServerJob.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJob.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJob resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJob.</param>
-    public SqlServerJob(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/jobAgents/jobs", resourceVersion ?? "2021-11-01")
+    public SqlServerJob(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/jobAgents/jobs", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -95,9 +100,14 @@ public partial class SqlServerJob : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerJob.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJob.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJob resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJob.</param>
     /// <returns>The existing SqlServerJob resource.</returns>
-    public static SqlServerJob FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerJob FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobAgent.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobAgent.cs
@@ -75,10 +75,15 @@ public partial class SqlServerJobAgent : Resource
     /// <summary>
     /// Creates a new SqlServerJobAgent.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobAgent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobAgent resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobAgent.</param>
-    public SqlServerJobAgent(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/jobAgents", resourceVersion ?? "2021-11-01")
+    public SqlServerJobAgent(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/jobAgents", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -110,9 +115,14 @@ public partial class SqlServerJobAgent : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerJobAgent.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobAgent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobAgent resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobAgent.</param>
     /// <returns>The existing SqlServerJobAgent resource.</returns>
-    public static SqlServerJobAgent FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerJobAgent FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobCredential.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobCredential.cs
@@ -56,10 +56,15 @@ public partial class SqlServerJobCredential : Resource
     /// <summary>
     /// Creates a new SqlServerJobCredential.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobCredential.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobCredential resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobCredential.</param>
-    public SqlServerJobCredential(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/jobAgents/credentials", resourceVersion ?? "2021-11-01")
+    public SqlServerJobCredential(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/jobAgents/credentials", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _password = BicepValue<string>.DefineProperty(this, "Password", ["properties", "password"]);
@@ -88,9 +93,14 @@ public partial class SqlServerJobCredential : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerJobCredential.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobCredential.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobCredential resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobCredential.</param>
     /// <returns>The existing SqlServerJobCredential resource.</returns>
-    public static SqlServerJobCredential FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerJobCredential FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobExecution.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobExecution.cs
@@ -122,10 +122,15 @@ public partial class SqlServerJobExecution : Resource
     /// <summary>
     /// Creates a new SqlServerJobExecution.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobExecution.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobExecution resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobExecution.</param>
-    public SqlServerJobExecution(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/jobAgents/jobs/executions", resourceVersion ?? "2021-11-01")
+    public SqlServerJobExecution(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/jobAgents/jobs/executions", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _createOn = BicepValue<DateTimeOffset>.DefineProperty(this, "CreateOn", ["properties", "createTime"], isOutput: true);
@@ -165,9 +170,14 @@ public partial class SqlServerJobExecution : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerJobExecution.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobExecution.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobExecution resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobExecution.</param>
     /// <returns>The existing SqlServerJobExecution resource.</returns>
-    public static SqlServerJobExecution FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerJobExecution FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobStep.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobStep.cs
@@ -84,10 +84,15 @@ public partial class SqlServerJobStep : Resource
     /// <summary>
     /// Creates a new SqlServerJobStep.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobStep.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobStep resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobStep.</param>
-    public SqlServerJobStep(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/jobAgents/jobs/steps", resourceVersion ?? "2021-11-01")
+    public SqlServerJobStep(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/jobAgents/jobs/steps", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _action = BicepValue<JobStepAction>.DefineProperty(this, "Action", ["properties", "action"]);
@@ -120,9 +125,14 @@ public partial class SqlServerJobStep : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerJobStep.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobStep.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobStep resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobStep.</param>
     /// <returns>The existing SqlServerJobStep resource.</returns>
-    public static SqlServerJobStep FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerJobStep FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobTargetGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobTargetGroup.cs
@@ -51,10 +51,15 @@ public partial class SqlServerJobTargetGroup : Resource
     /// <summary>
     /// Creates a new SqlServerJobTargetGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobTargetGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobTargetGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobTargetGroup.</param>
-    public SqlServerJobTargetGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/jobAgents/targetGroups", resourceVersion ?? "2021-11-01")
+    public SqlServerJobTargetGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/jobAgents/targetGroups", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _members = BicepList<JobTarget>.DefineProperty(this, "Members", ["properties", "members"]);
@@ -82,9 +87,14 @@ public partial class SqlServerJobTargetGroup : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerJobTargetGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerJobTargetGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerJobTargetGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerJobTargetGroup.</param>
     /// <returns>The existing SqlServerJobTargetGroup resource.</returns>
-    public static SqlServerJobTargetGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerJobTargetGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerKey.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerKey.cs
@@ -100,10 +100,15 @@ public partial class SqlServerKey : Resource
     /// <summary>
     /// Creates a new SqlServerKey.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerKey.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerKey resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerKey.</param>
-    public SqlServerKey(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/keys", resourceVersion ?? "2021-11-01")
+    public SqlServerKey(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/keys", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _serverKeyType = BicepValue<SqlServerKeyType>.DefineProperty(this, "ServerKeyType", ["properties", "serverKeyType"]);
@@ -138,9 +143,14 @@ public partial class SqlServerKey : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerKey.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerKey.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerKey resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerKey.</param>
     /// <returns>The existing SqlServerKey resource.</returns>
-    public static SqlServerKey FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerKey FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSecurityAlertPolicy.cs
@@ -99,10 +99,15 @@ public partial class SqlServerSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a new SqlServerSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerSecurityAlertPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSecurityAlertPolicy.</param>
-    public SqlServerSecurityAlertPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/securityAlertPolicies", resourceVersion ?? "2021-11-01")
+    public SqlServerSecurityAlertPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/securityAlertPolicies", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _disabledAlerts = BicepList<string>.DefineProperty(this, "DisabledAlerts", ["properties", "disabledAlerts"]);
@@ -137,9 +142,14 @@ public partial class SqlServerSecurityAlertPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerSecurityAlertPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerSecurityAlertPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerSecurityAlertPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSecurityAlertPolicy.</param>
     /// <returns>The existing SqlServerSecurityAlertPolicy resource.</returns>
-    public static SqlServerSecurityAlertPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerSecurityAlertPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessment.cs
@@ -52,10 +52,15 @@ public partial class SqlServerSqlVulnerabilityAssessment : Resource
     /// <summary>
     /// Creates a new SqlServerSqlVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerSqlVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlServerSqlVulnerabilityAssessment resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessment.</param>
-    public SqlServerSqlVulnerabilityAssessment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/sqlVulnerabilityAssessments", resourceVersion ?? "2024-05-01-preview")
+    public SqlServerSqlVulnerabilityAssessment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/sqlVulnerabilityAssessments", resourceVersion ?? "2024-05-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<SqlVulnerabilityAssessmentState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -78,9 +83,14 @@ public partial class SqlServerSqlVulnerabilityAssessment : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerSqlVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerSqlVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlServerSqlVulnerabilityAssessment resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessment.</param>
     /// <returns>The existing SqlServerSqlVulnerabilityAssessment resource.</returns>
-    public static SqlServerSqlVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerSqlVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessmentBaseline.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessmentBaseline.cs
@@ -57,10 +57,16 @@ public partial class SqlServerSqlVulnerabilityAssessmentBaseline : Resource
     /// <summary>
     /// Creates a new SqlServerSqlVulnerabilityAssessmentBaseline.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerSqlVulnerabilityAssessmentBaseline.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlServerSqlVulnerabilityAssessmentBaseline resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessmentBaseline.</param>
-    public SqlServerSqlVulnerabilityAssessmentBaseline(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines", resourceVersion ?? "2024-05-01-preview")
+    public SqlServerSqlVulnerabilityAssessmentBaseline(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines", resourceVersion ?? "2024-05-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isLatestScan = BicepValue<bool>.DefineProperty(this, "IsLatestScan", ["properties", "latestScan"]);
@@ -85,9 +91,15 @@ public partial class SqlServerSqlVulnerabilityAssessmentBaseline : Resource
     /// Creates a reference to an existing
     /// SqlServerSqlVulnerabilityAssessmentBaseline.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerSqlVulnerabilityAssessmentBaseline.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlServerSqlVulnerabilityAssessmentBaseline resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessmentBaseline.</param>
     /// <returns>The existing SqlServerSqlVulnerabilityAssessmentBaseline resource.</returns>
-    public static SqlServerSqlVulnerabilityAssessmentBaseline FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerSqlVulnerabilityAssessmentBaseline FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessmentBaselineRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessmentBaselineRule.cs
@@ -57,10 +57,16 @@ public partial class SqlServerSqlVulnerabilityAssessmentBaselineRule : Resource
     /// <summary>
     /// Creates a new SqlServerSqlVulnerabilityAssessmentBaselineRule.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerSqlVulnerabilityAssessmentBaselineRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlServerSqlVulnerabilityAssessmentBaselineRule resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessmentBaselineRule.</param>
-    public SqlServerSqlVulnerabilityAssessmentBaselineRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines/rules", resourceVersion ?? "2024-05-01-preview")
+    public SqlServerSqlVulnerabilityAssessmentBaselineRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines/rules", resourceVersion ?? "2024-05-01-preview")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isLatestScan = BicepValue<bool>.DefineProperty(this, "IsLatestScan", ["properties", "latestScan"]);
@@ -86,9 +92,15 @@ public partial class SqlServerSqlVulnerabilityAssessmentBaselineRule : Resource
     /// Creates a reference to an existing
     /// SqlServerSqlVulnerabilityAssessmentBaselineRule.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerSqlVulnerabilityAssessmentBaselineRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the
+    /// SqlServerSqlVulnerabilityAssessmentBaselineRule resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessmentBaselineRule.</param>
     /// <returns>The existing SqlServerSqlVulnerabilityAssessmentBaselineRule resource.</returns>
-    public static SqlServerSqlVulnerabilityAssessmentBaselineRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerSqlVulnerabilityAssessmentBaselineRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerTrustGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerTrustGroup.cs
@@ -51,10 +51,15 @@ public partial class SqlServerTrustGroup : Resource
     /// <summary>
     /// Creates a new SqlServerTrustGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerTrustGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerTrustGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerTrustGroup.</param>
-    public SqlServerTrustGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/locations/serverTrustGroups", resourceVersion ?? "2021-11-01")
+    public SqlServerTrustGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/locations/serverTrustGroups", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _groupMembers = BicepList<ServerTrustGroupServerInfo>.DefineProperty(this, "GroupMembers", ["properties", "groupMembers"]);
@@ -82,9 +87,14 @@ public partial class SqlServerTrustGroup : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerTrustGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerTrustGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerTrustGroup resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerTrustGroup.</param>
     /// <returns>The existing SqlServerTrustGroup resource.</returns>
-    public static SqlServerTrustGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerTrustGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerVirtualNetworkRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerVirtualNetworkRule.cs
@@ -63,10 +63,15 @@ public partial class SqlServerVirtualNetworkRule : Resource
     /// <summary>
     /// Creates a new SqlServerVirtualNetworkRule.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerVirtualNetworkRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerVirtualNetworkRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerVirtualNetworkRule.</param>
-    public SqlServerVirtualNetworkRule(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/virtualNetworkRules", resourceVersion ?? "2021-11-01")
+    public SqlServerVirtualNetworkRule(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/virtualNetworkRules", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _ignoreMissingVnetServiceEndpoint = BicepValue<bool>.DefineProperty(this, "IgnoreMissingVnetServiceEndpoint", ["properties", "ignoreMissingVnetServiceEndpoint"]);
@@ -96,9 +101,14 @@ public partial class SqlServerVirtualNetworkRule : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerVirtualNetworkRule.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerVirtualNetworkRule.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerVirtualNetworkRule
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerVirtualNetworkRule.</param>
     /// <returns>The existing SqlServerVirtualNetworkRule resource.</returns>
-    public static SqlServerVirtualNetworkRule FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerVirtualNetworkRule FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerVulnerabilityAssessment.cs
@@ -77,10 +77,15 @@ public partial class SqlServerVulnerabilityAssessment : Resource
     /// <summary>
     /// Creates a new SqlServerVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerVulnerabilityAssessment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerVulnerabilityAssessment.</param>
-    public SqlServerVulnerabilityAssessment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/vulnerabilityAssessments", resourceVersion ?? "2021-11-01")
+    public SqlServerVulnerabilityAssessment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/vulnerabilityAssessments", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _recurringScans = BicepValue<VulnerabilityAssessmentRecurringScansProperties>.DefineProperty(this, "RecurringScans", ["properties", "recurringScans"]);
@@ -111,9 +116,14 @@ public partial class SqlServerVulnerabilityAssessment : Resource
     /// <summary>
     /// Creates a reference to an existing SqlServerVulnerabilityAssessment.
     /// </summary>
-    /// <param name="resourceName">Name of the SqlServerVulnerabilityAssessment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SqlServerVulnerabilityAssessment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SqlServerVulnerabilityAssessment.</param>
     /// <returns>The existing SqlServerVulnerabilityAssessment resource.</returns>
-    public static SqlServerVulnerabilityAssessment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SqlServerVulnerabilityAssessment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncAgent.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncAgent.cs
@@ -80,10 +80,15 @@ public partial class SyncAgent : Resource
     /// <summary>
     /// Creates a new SyncAgent.
     /// </summary>
-    /// <param name="resourceName">Name of the SyncAgent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SyncAgent resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SyncAgent.</param>
-    public SyncAgent(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/syncAgents", resourceVersion ?? "2021-11-01")
+    public SyncAgent(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/syncAgents", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _syncDatabaseId = BicepValue<ResourceIdentifier>.DefineProperty(this, "SyncDatabaseId", ["properties", "syncDatabaseId"]);
@@ -116,9 +121,14 @@ public partial class SyncAgent : Resource
     /// <summary>
     /// Creates a reference to an existing SyncAgent.
     /// </summary>
-    /// <param name="resourceName">Name of the SyncAgent.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SyncAgent resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SyncAgent.</param>
     /// <returns>The existing SyncAgent resource.</returns>
-    public static SyncAgent FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SyncAgent FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncGroup.cs
@@ -125,10 +125,15 @@ public partial class SyncGroup : Resource
     /// <summary>
     /// Creates a new SyncGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the SyncGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SyncGroup resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SyncGroup.</param>
-    public SyncGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/syncGroups", resourceVersion ?? "2021-11-01")
+    public SyncGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/syncGroups", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _conflictLoggingRetentionInDays = BicepValue<int>.DefineProperty(this, "ConflictLoggingRetentionInDays", ["properties", "conflictLoggingRetentionInDays"]);
@@ -168,11 +173,16 @@ public partial class SyncGroup : Resource
     /// <summary>
     /// Creates a reference to an existing SyncGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the SyncGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SyncGroup resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SyncGroup.</param>
     /// <returns>The existing SyncGroup resource.</returns>
-    public static SyncGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SyncGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SyncGroup resource.

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncMember.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncMember.cs
@@ -118,10 +118,15 @@ public partial class SyncMember : Resource
     /// <summary>
     /// Creates a new SyncMember.
     /// </summary>
-    /// <param name="resourceName">Name of the SyncMember.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SyncMember resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SyncMember.</param>
-    public SyncMember(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/syncGroups/syncMembers", resourceVersion ?? "2021-11-01")
+    public SyncMember(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/syncGroups/syncMembers", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _databaseName = BicepValue<string>.DefineProperty(this, "DatabaseName", ["properties", "databaseName"]);
@@ -160,9 +165,14 @@ public partial class SyncMember : Resource
     /// <summary>
     /// Creates a reference to an existing SyncMember.
     /// </summary>
-    /// <param name="resourceName">Name of the SyncMember.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SyncMember resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SyncMember.</param>
     /// <returns>The existing SyncMember resource.</returns>
-    public static SyncMember FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SyncMember FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/WorkloadClassifier.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/WorkloadClassifier.cs
@@ -80,10 +80,15 @@ public partial class WorkloadClassifier : Resource
     /// <summary>
     /// Creates a new WorkloadClassifier.
     /// </summary>
-    /// <param name="resourceName">Name of the WorkloadClassifier.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WorkloadClassifier resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WorkloadClassifier.</param>
-    public WorkloadClassifier(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/workloadGroups/workloadClassifiers", resourceVersion ?? "2021-11-01")
+    public WorkloadClassifier(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/workloadGroups/workloadClassifiers", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _context = BicepValue<string>.DefineProperty(this, "Context", ["properties", "context"]);
@@ -116,9 +121,14 @@ public partial class WorkloadClassifier : Resource
     /// <summary>
     /// Creates a reference to an existing WorkloadClassifier.
     /// </summary>
-    /// <param name="resourceName">Name of the WorkloadClassifier.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WorkloadClassifier resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WorkloadClassifier.</param>
     /// <returns>The existing WorkloadClassifier resource.</returns>
-    public static WorkloadClassifier FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WorkloadClassifier FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/WorkloadGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/WorkloadGroup.cs
@@ -80,10 +80,15 @@ public partial class WorkloadGroup : Resource
     /// <summary>
     /// Creates a new WorkloadGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the WorkloadGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WorkloadGroup resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WorkloadGroup.</param>
-    public WorkloadGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Sql/servers/databases/workloadGroups", resourceVersion ?? "2021-11-01")
+    public WorkloadGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Sql/servers/databases/workloadGroups", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _importance = BicepValue<string>.DefineProperty(this, "Importance", ["properties", "importance"]);
@@ -116,9 +121,14 @@ public partial class WorkloadGroup : Resource
     /// <summary>
     /// Creates a reference to an existing WorkloadGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the WorkloadGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WorkloadGroup resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WorkloadGroup.</param>
     /// <returns>The existing WorkloadGroup resource.</returns>
-    public static WorkloadGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WorkloadGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.netstandard2.0.cs
@@ -34,7 +34,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class BlobContainer : Azure.Provisioning.Primitives.Resource
     {
-        public BlobContainer(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public BlobContainer(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DefaultEncryptionScope { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> DeletedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<bool> EnableNfsV3AllSquash { get { throw null; } set { } }
@@ -59,7 +59,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<int> RemainingRetentionDays { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
-        public static Azure.Provisioning.Storage.BlobContainer FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.BlobContainer FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -100,14 +100,14 @@ namespace Azure.Provisioning.Storage
     }
     public partial class BlobInventoryPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public BlobInventoryPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public BlobInventoryPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> LastModifiedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Storage.StorageAccount? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.BlobInventoryPolicySchema> PolicySchema { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.BlobInventoryPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.BlobInventoryPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_06_15;
@@ -218,7 +218,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class BlobService : Azure.Provisioning.Primitives.Resource, Azure.Provisioning.Primitives.IClientCreator, Azure.Provisioning.Primitives.IClientCreator<Azure.Storage.Blobs.BlobServiceClient, Azure.Storage.Blobs.BlobClientOptions>
     {
-        public BlobService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public BlobService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.BlobServiceChangeFeed> ChangeFeed { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.DeleteRetentionPolicy> ContainerDeleteRetentionPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.StorageCorsRule> CorsRules { get { throw null; } set { } }
@@ -234,7 +234,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         System.Collections.Generic.IEnumerable<Azure.Provisioning.ProvisioningOutput> Azure.Provisioning.Primitives.IClientCreator.GetOutputs() { throw null; }
         Azure.Storage.Blobs.BlobServiceClient Azure.Provisioning.Primitives.IClientCreator<Azure.Storage.Blobs.BlobServiceClient, Azure.Storage.Blobs.BlobClientOptions>.CreateClient(System.Collections.Generic.IReadOnlyDictionary<string, object?> deploymentOutputs, Azure.Core.TokenCredential credential, Azure.Storage.Blobs.BlobClientOptions? options) { throw null; }
-        public static Azure.Provisioning.Storage.BlobService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.BlobService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2016_05_01;
@@ -328,7 +328,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class EncryptionScope : Azure.Provisioning.Primitives.Resource
     {
-        public EncryptionScope(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public EncryptionScope(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.EncryptionScopeKeyVaultProperties> KeyVaultProperties { get { throw null; } set { } }
@@ -339,7 +339,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.EncryptionScopeSource> Source { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.EncryptionScopeState> State { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.EncryptionScope FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.EncryptionScope FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_06_01;
@@ -383,7 +383,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class FileService : Azure.Provisioning.Primitives.Resource
     {
-        public FileService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public FileService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.StorageCorsRule> CorsRules { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.Storage.StorageAccount? Parent { get { throw null; } set { } }
@@ -391,7 +391,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.DeleteRetentionPolicy> ShareDeleteRetentionPolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.StorageSku> Sku { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.FileService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.FileService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2016_05_01;
@@ -420,7 +420,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class FileShare : Azure.Provisioning.Primitives.Resource
     {
-        public FileShare(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public FileShare(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.FileShareAccessTier> AccessTier { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> AccessTierChangeOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> AccessTierStatus { get { throw null; } }
@@ -444,7 +444,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> SnapshotOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
-        public static Azure.Provisioning.Storage.FileShare FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.FileShare FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -509,7 +509,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class ImmutabilityPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ImmutabilityPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ImmutabilityPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> AllowProtectedAppendWrites { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> AllowProtectedAppendWritesAll { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.ETag> ETag { get { throw null; } }
@@ -519,7 +519,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.Storage.BlobContainer? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.ImmutabilityPolicyState> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.ImmutabilityPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.ImmutabilityPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2016_05_01;
@@ -688,7 +688,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class ObjectReplicationPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public ObjectReplicationPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ObjectReplicationPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DestinationAccount { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> EnabledOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -698,7 +698,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.ObjectReplicationPolicyRule> Rules { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> SourceAccount { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.ObjectReplicationPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.ObjectReplicationPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_06_15;
@@ -749,13 +749,13 @@ namespace Azure.Provisioning.Storage
     }
     public partial class QueueService : Azure.Provisioning.Primitives.Resource
     {
-        public QueueService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public QueueService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.StorageCorsRule> CorsRules { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Storage.StorageAccount? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.QueueService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.QueueService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2016_05_01;
@@ -807,7 +807,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class StorageAccount : Azure.Provisioning.Primitives.Resource
     {
-        public StorageAccount(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StorageAccount(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.StorageAccountAccessTier> AccessTier { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> AllowBlobPublicAccess { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> AllowCrossTenantReplication { get { throw null; } set { } }
@@ -855,9 +855,9 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.StorageAccountSkuConversionStatus> StorageAccountSkuConversionStatus { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Storage.StorageBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Storage.StorageBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.Storage.StorageBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.Storage.StorageAccount FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.StorageAccount FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.StorageAccountKey> GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -984,7 +984,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class StorageAccountLocalUser : Azure.Provisioning.Primitives.Resource
     {
-        public StorageAccountLocalUser(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StorageAccountLocalUser(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<bool> HasSharedKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> HasSshKey { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<bool> HasSshPassword { get { throw null; } set { } }
@@ -996,7 +996,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<string> Sid { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.StorageSshPublicKey> SshAuthorizedKeys { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.StorageAccountLocalUser FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.StorageAccountLocalUser FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.Storage.LocalUserKeys GetKeys() { throw null; }
         public static partial class ResourceVersions
         {
@@ -1028,13 +1028,13 @@ namespace Azure.Provisioning.Storage
     }
     public partial class StorageAccountManagementPolicy : Azure.Provisioning.Primitives.Resource
     {
-        public StorageAccountManagementPolicy(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StorageAccountManagementPolicy(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> LastModifiedOn { get { throw null; } }
         public Azure.Provisioning.Storage.StorageAccount? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.ManagementPolicyRule> Rules { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.StorageAccountManagementPolicy FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.StorageAccountManagementPolicy FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_06_15;
@@ -1272,7 +1272,7 @@ namespace Azure.Provisioning.Storage
     }
     public partial class StoragePrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public StoragePrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StoragePrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.StoragePrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -1280,7 +1280,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.StoragePrivateEndpointConnectionProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.StoragePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.StoragePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_06_15;
@@ -1359,14 +1359,14 @@ namespace Azure.Provisioning.Storage
     }
     public partial class StorageQueue : Azure.Provisioning.Primitives.Resource
     {
-        public StorageQueue(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StorageQueue(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<int> ApproximateMessageCount { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Metadata { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Storage.QueueService? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.StorageQueue FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.StorageQueue FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1458,14 +1458,14 @@ namespace Azure.Provisioning.Storage
     }
     public partial class StorageTable : Azure.Provisioning.Primitives.Resource
     {
-        public StorageTable(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public StorageTable(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.Storage.TableService? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.StorageTableSignedIdentifier> SignedIdentifiers { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> TableName { get { throw null; } }
-        public static Azure.Provisioning.Storage.StorageTable FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.StorageTable FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1509,13 +1509,13 @@ namespace Azure.Provisioning.Storage
     }
     public partial class TableService : Azure.Provisioning.Primitives.Resource
     {
-        public TableService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public TableService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Storage.StorageCorsRule> CorsRules { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.Storage.StorageAccount? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Storage.TableService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Storage.TableService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2016_05_01;

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/BlobService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/BlobService.cs
@@ -24,7 +24,7 @@ public partial class BlobService
     /// <inheritdoc/>
     IEnumerable<ProvisioningOutput> IClientCreator.GetOutputs()
     {
-        yield return new ProvisioningOutput($"{ResourceName}_endpoint", typeof(string))
+        yield return new ProvisioningOutput($"{IdentifierName}_endpoint", typeof(string))
         {
             Value = Parent!.PrimaryEndpoints.Value!.BlobUri
         };
@@ -50,10 +50,10 @@ public partial class BlobService
         BlobClientOptions? options)
     {
         // TODO: Move into a shared helper off ProvCtx's namescoping
-        string qualifiedName = $"{ResourceName}_endpoint";
+        string qualifiedName = $"{IdentifierName}_endpoint";
         string endpoint = (deploymentOutputs.TryGetValue(qualifiedName, out object? raw) && raw is string value) ?
             value :
-            throw new InvalidOperationException($"Could not find output value {qualifiedName} to construct {GetType().Name} resource {ResourceName}.");
+            throw new InvalidOperationException($"Could not find output value {qualifiedName} to construct {GetType().Name} resource {IdentifierName}.");
         return new BlobServiceClient(new Uri(endpoint), credential, options);
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/BlobContainer.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/BlobContainer.cs
@@ -182,10 +182,15 @@ public partial class BlobContainer : Resource
     /// <summary>
     /// Creates a new BlobContainer.
     /// </summary>
-    /// <param name="resourceName">Name of the BlobContainer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the BlobContainer resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the BlobContainer.</param>
-    public BlobContainer(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/blobServices/containers", resourceVersion ?? "2024-01-01")
+    public BlobContainer(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/blobServices/containers", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _defaultEncryptionScope = BicepValue<string>.DefineProperty(this, "DefaultEncryptionScope", ["properties", "defaultEncryptionScope"]);
@@ -332,11 +337,16 @@ public partial class BlobContainer : Resource
     /// <summary>
     /// Creates a reference to an existing BlobContainer.
     /// </summary>
-    /// <param name="resourceName">Name of the BlobContainer.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the BlobContainer resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the BlobContainer.</param>
     /// <returns>The existing BlobContainer resource.</returns>
-    public static BlobContainer FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static BlobContainer FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this BlobContainer resource.

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/BlobInventoryPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/BlobInventoryPolicy.cs
@@ -58,10 +58,15 @@ public partial class BlobInventoryPolicy : Resource
     /// <summary>
     /// Creates a new BlobInventoryPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the BlobInventoryPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the BlobInventoryPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the BlobInventoryPolicy.</param>
-    public BlobInventoryPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/inventoryPolicies", resourceVersion ?? "2024-01-01")
+    public BlobInventoryPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/inventoryPolicies", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _policySchema = BicepValue<BlobInventoryPolicySchema>.DefineProperty(this, "PolicySchema", ["properties", "policy"]);
@@ -200,9 +205,14 @@ public partial class BlobInventoryPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing BlobInventoryPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the BlobInventoryPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the BlobInventoryPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the BlobInventoryPolicy.</param>
     /// <returns>The existing BlobInventoryPolicy resource.</returns>
-    public static BlobInventoryPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static BlobInventoryPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/BlobService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/BlobService.cs
@@ -111,10 +111,15 @@ public partial class BlobService : Resource
     /// <summary>
     /// Creates a new BlobService.
     /// </summary>
-    /// <param name="resourceName">Name of the BlobService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the BlobService resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the BlobService.</param>
-    public BlobService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/blobServices", resourceVersion ?? "2024-01-01")
+    public BlobService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/blobServices", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], defaultValue: GetNameDefaultValue());
         _changeFeed = BicepValue<BlobServiceChangeFeed>.DefineProperty(this, "ChangeFeed", ["properties", "changeFeed"]);
@@ -251,9 +256,14 @@ public partial class BlobService : Resource
     /// <summary>
     /// Creates a reference to an existing BlobService.
     /// </summary>
-    /// <param name="resourceName">Name of the BlobService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the BlobService resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the BlobService.</param>
     /// <returns>The existing BlobService resource.</returns>
-    public static BlobService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static BlobService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/EncryptionScope.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/EncryptionScope.cs
@@ -89,10 +89,15 @@ public partial class EncryptionScope : Resource
     /// <summary>
     /// Creates a new EncryptionScope.
     /// </summary>
-    /// <param name="resourceName">Name of the EncryptionScope.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EncryptionScope resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EncryptionScope.</param>
-    public EncryptionScope(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/encryptionScopes", resourceVersion ?? "2024-01-01")
+    public EncryptionScope(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/encryptionScopes", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _keyVaultProperties = BicepValue<EncryptionScopeKeyVaultProperties>.DefineProperty(this, "KeyVaultProperties", ["properties", "keyVaultProperties"]);
@@ -185,9 +190,14 @@ public partial class EncryptionScope : Resource
     /// <summary>
     /// Creates a reference to an existing EncryptionScope.
     /// </summary>
-    /// <param name="resourceName">Name of the EncryptionScope.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the EncryptionScope resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the EncryptionScope.</param>
     /// <returns>The existing EncryptionScope resource.</returns>
-    public static EncryptionScope FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static EncryptionScope FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/FileService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/FileService.cs
@@ -71,10 +71,15 @@ public partial class FileService : Resource
     /// <summary>
     /// Creates a new FileService.
     /// </summary>
-    /// <param name="resourceName">Name of the FileService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the FileService resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the FileService.</param>
-    public FileService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/fileServices", resourceVersion ?? "2024-01-01")
+    public FileService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/fileServices", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], defaultValue: GetNameDefaultValue());
         _corsRules = BicepList<StorageCorsRule>.DefineProperty(this, "CorsRules", ["properties", "cors", "corsRules"]);
@@ -205,9 +210,14 @@ public partial class FileService : Resource
     /// <summary>
     /// Creates a reference to an existing FileService.
     /// </summary>
-    /// <param name="resourceName">Name of the FileService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the FileService resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the FileService.</param>
     /// <returns>The existing FileService resource.</returns>
-    public static FileService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static FileService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/FileShare.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/FileShare.cs
@@ -173,10 +173,15 @@ public partial class FileShare : Resource
     /// <summary>
     /// Creates a new FileShare.
     /// </summary>
-    /// <param name="resourceName">Name of the FileShare.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the FileShare resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the FileShare.</param>
-    public FileShare(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/fileServices/shares", resourceVersion ?? "2024-01-01")
+    public FileShare(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/fileServices/shares", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _accessTier = BicepValue<FileShareAccessTier>.DefineProperty(this, "AccessTier", ["properties", "accessTier"]);
@@ -322,11 +327,16 @@ public partial class FileShare : Resource
     /// <summary>
     /// Creates a reference to an existing FileShare.
     /// </summary>
-    /// <param name="resourceName">Name of the FileShare.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the FileShare resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the FileShare.</param>
     /// <returns>The existing FileShare resource.</returns>
-    public static FileShare FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static FileShare FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this FileShare resource.

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/ImmutabilityPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/ImmutabilityPolicy.cs
@@ -90,10 +90,15 @@ public partial class ImmutabilityPolicy : Resource
     /// <summary>
     /// Creates a new ImmutabilityPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ImmutabilityPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ImmutabilityPolicy resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ImmutabilityPolicy.</param>
-    public ImmutabilityPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies", resourceVersion ?? "2024-01-01")
+    public ImmutabilityPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _allowProtectedAppendWrites = BicepValue<bool>.DefineProperty(this, "AllowProtectedAppendWrites", ["properties", "allowProtectedAppendWrites"]);
@@ -225,9 +230,14 @@ public partial class ImmutabilityPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing ImmutabilityPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ImmutabilityPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ImmutabilityPolicy resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ImmutabilityPolicy.</param>
     /// <returns>The existing ImmutabilityPolicy resource.</returns>
-    public static ImmutabilityPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ImmutabilityPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/ObjectReplicationPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/ObjectReplicationPolicy.cs
@@ -77,10 +77,15 @@ public partial class ObjectReplicationPolicy : Resource
     /// <summary>
     /// Creates a new ObjectReplicationPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ObjectReplicationPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ObjectReplicationPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ObjectReplicationPolicy.</param>
-    public ObjectReplicationPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/objectReplicationPolicies", resourceVersion ?? "2024-01-01")
+    public ObjectReplicationPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/objectReplicationPolicies", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _destinationAccount = BicepValue<string>.DefineProperty(this, "DestinationAccount", ["properties", "destinationAccount"]);
@@ -222,9 +227,14 @@ public partial class ObjectReplicationPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing ObjectReplicationPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the ObjectReplicationPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ObjectReplicationPolicy resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ObjectReplicationPolicy.</param>
     /// <returns>The existing ObjectReplicationPolicy resource.</returns>
-    public static ObjectReplicationPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ObjectReplicationPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/QueueService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/QueueService.cs
@@ -52,10 +52,15 @@ public partial class QueueService : Resource
     /// <summary>
     /// Creates a new QueueService.
     /// </summary>
-    /// <param name="resourceName">Name of the QueueService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the QueueService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the QueueService.</param>
-    public QueueService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/queueServices", resourceVersion ?? "2024-01-01")
+    public QueueService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/queueServices", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _corsRules = BicepList<StorageCorsRule>.DefineProperty(this, "CorsRules", ["properties", "cors", "corsRules"]);
@@ -183,9 +188,14 @@ public partial class QueueService : Resource
     /// <summary>
     /// Creates a reference to an existing QueueService.
     /// </summary>
-    /// <param name="resourceName">Name of the QueueService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the QueueService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the QueueService.</param>
     /// <returns>The existing QueueService resource.</returns>
-    public static QueueService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static QueueService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccount.cs
@@ -361,10 +361,15 @@ public partial class StorageAccount : Resource
     /// <summary>
     /// Creates a new StorageAccount.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageAccount.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageAccount resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageAccount.</param>
-    public StorageAccount(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts", resourceVersion ?? "2024-01-01")
+    public StorageAccount(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<StorageKind>.DefineProperty(this, "Kind", ["kind"], isRequired: true);
@@ -544,11 +549,16 @@ public partial class StorageAccount : Resource
     /// <summary>
     /// Creates a reference to an existing StorageAccount.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageAccount.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageAccount resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageAccount.</param>
     /// <returns>The existing StorageAccount resource.</returns>
-    public static StorageAccount FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StorageAccount FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this StorageAccount resource.
@@ -565,7 +575,7 @@ public partial class StorageAccount : Resource
     public BicepList<StorageAccountKey> GetKeys() =>
         BicepList<StorageAccountKey>.FromExpression(
             StorageAccountKey.FromExpression,
-            new MemberExpression(new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")), "keys"));
+            new MemberExpression(new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")), "keys"));
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -575,10 +585,10 @@ public partial class StorageAccount : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(StorageBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{StorageBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{StorageBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -591,13 +601,13 @@ public partial class StorageAccount : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(StorageBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{StorageBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(StorageBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{StorageBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccountLocalUser.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccountLocalUser.cs
@@ -93,10 +93,15 @@ public partial class StorageAccountLocalUser : Resource
     /// <summary>
     /// Creates a new StorageAccountLocalUser.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageAccountLocalUser.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageAccountLocalUser resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageAccountLocalUser.</param>
-    public StorageAccountLocalUser(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/localUsers", resourceVersion ?? "2024-01-01")
+    public StorageAccountLocalUser(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/localUsers", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _hasSharedKey = BicepValue<bool>.DefineProperty(this, "HasSharedKey", ["properties", "hasSharedKey"]);
@@ -240,11 +245,16 @@ public partial class StorageAccountLocalUser : Resource
     /// <summary>
     /// Creates a reference to an existing StorageAccountLocalUser.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageAccountLocalUser.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageAccountLocalUser resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageAccountLocalUser.</param>
     /// <returns>The existing StorageAccountLocalUser resource.</returns>
-    public static StorageAccountLocalUser FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StorageAccountLocalUser FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get access keys for this StorageAccountLocalUser resource.
@@ -252,5 +262,5 @@ public partial class StorageAccountLocalUser : Resource
     /// <returns>The keys for this StorageAccountLocalUser resource.</returns>
     public LocalUserKeys GetKeys() =>
         LocalUserKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccountManagementPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageAccountManagementPolicy.cs
@@ -59,10 +59,15 @@ public partial class StorageAccountManagementPolicy : Resource
     /// <summary>
     /// Creates a new StorageAccountManagementPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageAccountManagementPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageAccountManagementPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageAccountManagementPolicy.</param>
-    public StorageAccountManagementPolicy(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/managementPolicies", resourceVersion ?? "2024-01-01")
+    public StorageAccountManagementPolicy(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/managementPolicies", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], defaultValue: GetNameDefaultValue());
         _rules = BicepList<ManagementPolicyRule>.DefineProperty(this, "Rules", ["properties", "policy", "rules"]);
@@ -201,9 +206,14 @@ public partial class StorageAccountManagementPolicy : Resource
     /// <summary>
     /// Creates a reference to an existing StorageAccountManagementPolicy.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageAccountManagementPolicy.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageAccountManagementPolicy
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageAccountManagementPolicy.</param>
     /// <returns>The existing StorageAccountManagementPolicy resource.</returns>
-    public static StorageAccountManagementPolicy FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StorageAccountManagementPolicy FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StoragePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StoragePrivateEndpointConnection.cs
@@ -64,10 +64,15 @@ public partial class StoragePrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new StoragePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the StoragePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StoragePrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StoragePrivateEndpointConnection.</param>
-    public StoragePrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/privateEndpointConnections", resourceVersion ?? "2024-01-01")
+    public StoragePrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/privateEndpointConnections", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<StoragePrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -207,9 +212,14 @@ public partial class StoragePrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing StoragePrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the StoragePrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StoragePrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StoragePrivateEndpointConnection.</param>
     /// <returns>The existing StoragePrivateEndpointConnection resource.</returns>
-    public static StoragePrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StoragePrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageQueue.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageQueue.cs
@@ -64,10 +64,15 @@ public partial class StorageQueue : Resource
     /// <summary>
     /// Creates a new StorageQueue.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageQueue.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageQueue resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageQueue.</param>
-    public StorageQueue(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/queueServices/queues", resourceVersion ?? "2024-01-01")
+    public StorageQueue(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/queueServices/queues", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _metadata = BicepDictionary<string>.DefineProperty(this, "Metadata", ["properties", "metadata"]);
@@ -196,11 +201,16 @@ public partial class StorageQueue : Resource
     /// <summary>
     /// Creates a reference to an existing StorageQueue.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageQueue.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageQueue resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageQueue.</param>
     /// <returns>The existing StorageQueue resource.</returns>
-    public static StorageQueue FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StorageQueue FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this StorageQueue resource.

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageTable.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/StorageTable.cs
@@ -60,10 +60,15 @@ public partial class StorageTable : Resource
     /// <summary>
     /// Creates a new StorageTable.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageTable.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageTable resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageTable.</param>
-    public StorageTable(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/tableServices/tables", resourceVersion ?? "2024-01-01")
+    public StorageTable(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/tableServices/tables", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _signedIdentifiers = BicepList<StorageTableSignedIdentifier>.DefineProperty(this, "SignedIdentifiers", ["properties", "signedIdentifiers"]);
@@ -192,11 +197,16 @@ public partial class StorageTable : Resource
     /// <summary>
     /// Creates a reference to an existing StorageTable.
     /// </summary>
-    /// <param name="resourceName">Name of the StorageTable.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the StorageTable resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the StorageTable.</param>
     /// <returns>The existing StorageTable resource.</returns>
-    public static StorageTable FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static StorageTable FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this StorageTable resource.

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/TableService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Generated/TableService.cs
@@ -52,10 +52,15 @@ public partial class TableService : Resource
     /// <summary>
     /// Creates a new TableService.
     /// </summary>
-    /// <param name="resourceName">Name of the TableService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TableService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TableService.</param>
-    public TableService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Storage/storageAccounts/tableServices", resourceVersion ?? "2024-01-01")
+    public TableService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Storage/storageAccounts/tableServices", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _corsRules = BicepList<StorageCorsRule>.DefineProperty(this, "CorsRules", ["properties", "cors", "corsRules"]);
@@ -183,9 +188,14 @@ public partial class TableService : Resource
     /// <summary>
     /// Creates a reference to an existing TableService.
     /// </summary>
-    /// <param name="resourceName">Name of the TableService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TableService resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TableService.</param>
     /// <returns>The existing TableService resource.</returns>
-    public static TableService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static TableService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/tests/BasicStorageTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/tests/BasicStorageTests.cs
@@ -165,7 +165,7 @@ public class BasicStorageTests(bool async)
                 infra.Add(role);
 
                 role = storage.CreateRoleAssignment(StorageBuiltInRole.StorageBlobDataContributor, RoleManagementPrincipalType.ServicePrincipal, id.PrincipalId);
-                role.ResourceName = "storage_writer";
+                role.IdentifierName = "storage_writer";
                 infra.Add(role);
 
                 return infra;

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/api/Azure.Provisioning.WebPubSub.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/api/Azure.Provisioning.WebPubSub.netstandard2.0.cs
@@ -85,13 +85,13 @@ namespace Azure.Provisioning.WebPubSub
     }
     public partial class WebPubSubHub : Azure.Provisioning.Primitives.Resource
     {
-        public WebPubSubHub(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebPubSubHub(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.WebPubSub.WebPubSubService? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.WebPubSub.WebPubSubHubProperties> Properties { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.WebPubSub.WebPubSubHub FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.WebPubSub.WebPubSubHub FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_05_01;
@@ -126,7 +126,7 @@ namespace Azure.Provisioning.WebPubSub
     }
     public partial class WebPubSubPrivateEndpointConnection : Azure.Provisioning.Primitives.Resource
     {
-        public WebPubSubPrivateEndpointConnection(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebPubSubPrivateEndpointConnection(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.WebPubSub.WebPubSubPrivateLinkServiceConnectionState> ConnectionState { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<string> GroupIds { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -135,7 +135,7 @@ namespace Azure.Provisioning.WebPubSub
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> PrivateEndpointId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.WebPubSub.WebPubSubProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.WebPubSub.WebPubSubPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.WebPubSub.WebPubSubPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_05_01;
@@ -192,7 +192,7 @@ namespace Azure.Provisioning.WebPubSub
     }
     public partial class WebPubSubService : Azure.Provisioning.Primitives.Resource
     {
-        public WebPubSubService(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebPubSubService(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ExternalIP { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> HostName { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> HostNamePrefix { get { throw null; } }
@@ -216,9 +216,9 @@ namespace Azure.Provisioning.WebPubSub
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Version { get { throw null; } }
-        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.WebPubSub.WebPubSubBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? resourceNameSuffix = null) { throw null; }
+        public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.WebPubSub.WebPubSubBuiltInRole role, Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleManagementPrincipalType> principalType, Azure.Provisioning.BicepValue<System.Guid> principalId, string? identifierNameSuffix = null) { throw null; }
         public Azure.Provisioning.Authorization.RoleAssignment CreateRoleAssignment(Azure.Provisioning.WebPubSub.WebPubSubBuiltInRole role, Azure.Provisioning.Roles.UserAssignedIdentity identity) { throw null; }
-        public static Azure.Provisioning.WebPubSub.WebPubSubService FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.WebPubSub.WebPubSubService FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public Azure.Provisioning.WebPubSub.WebPubSubKeys GetKeys() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
@@ -233,7 +233,7 @@ namespace Azure.Provisioning.WebPubSub
     }
     public partial class WebPubSubSharedPrivateLink : Azure.Provisioning.Primitives.Resource
     {
-        public WebPubSubSharedPrivateLink(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public WebPubSubSharedPrivateLink(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> GroupId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -243,7 +243,7 @@ namespace Azure.Provisioning.WebPubSub
         public Azure.Provisioning.BicepValue<string> RequestMessage { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.WebPubSub.WebPubSubSharedPrivateLinkStatus> Status { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.WebPubSub.WebPubSubSharedPrivateLink FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.WebPubSub.WebPubSubSharedPrivateLink FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_05_01;

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubHub.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubHub.cs
@@ -51,10 +51,15 @@ public partial class WebPubSubHub : Resource
     /// <summary>
     /// Creates a new WebPubSubHub.
     /// </summary>
-    /// <param name="resourceName">Name of the WebPubSubHub.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebPubSubHub resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebPubSubHub.</param>
-    public WebPubSubHub(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/webPubSub/hubs", resourceVersion ?? "2024-03-01")
+    public WebPubSubHub(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/webPubSub/hubs", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _properties = BicepValue<WebPubSubHubProperties>.DefineProperty(this, "Properties", ["properties"], isRequired: true);
@@ -97,9 +102,14 @@ public partial class WebPubSubHub : Resource
     /// <summary>
     /// Creates a reference to an existing WebPubSubHub.
     /// </summary>
-    /// <param name="resourceName">Name of the WebPubSubHub.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebPubSubHub resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebPubSubHub.</param>
     /// <returns>The existing WebPubSubHub resource.</returns>
-    public static WebPubSubHub FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebPubSubHub FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubPrivateEndpointConnection.cs
@@ -69,10 +69,15 @@ public partial class WebPubSubPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a new WebPubSubPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the WebPubSubPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebPubSubPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebPubSubPrivateEndpointConnection.</param>
-    public WebPubSubPrivateEndpointConnection(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/webPubSub/privateEndpointConnections", resourceVersion ?? "2024-03-01")
+    public WebPubSubPrivateEndpointConnection(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/webPubSub/privateEndpointConnections", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _connectionState = BicepValue<WebPubSubPrivateLinkServiceConnectionState>.DefineProperty(this, "ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
@@ -118,9 +123,14 @@ public partial class WebPubSubPrivateEndpointConnection : Resource
     /// <summary>
     /// Creates a reference to an existing WebPubSubPrivateEndpointConnection.
     /// </summary>
-    /// <param name="resourceName">Name of the WebPubSubPrivateEndpointConnection.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebPubSubPrivateEndpointConnection
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebPubSubPrivateEndpointConnection.</param>
     /// <returns>The existing WebPubSubPrivateEndpointConnection resource.</returns>
-    public static WebPubSubPrivateEndpointConnection FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebPubSubPrivateEndpointConnection FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubService.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubService.cs
@@ -174,10 +174,15 @@ public partial class WebPubSubService : Resource
     /// <summary>
     /// Creates a new WebPubSubService.
     /// </summary>
-    /// <param name="resourceName">Name of the WebPubSubService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebPubSubService resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebPubSubService.</param>
-    public WebPubSubService(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/webPubSub", resourceVersion ?? "2024-03-01")
+    public WebPubSubService(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/webPubSub", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -238,11 +243,16 @@ public partial class WebPubSubService : Resource
     /// <summary>
     /// Creates a reference to an existing WebPubSubService.
     /// </summary>
-    /// <param name="resourceName">Name of the WebPubSubService.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebPubSubService resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebPubSubService.</param>
     /// <returns>The existing WebPubSubService resource.</returns>
-    public static WebPubSubService FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebPubSubService FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this WebPubSubService resource.
@@ -258,7 +268,7 @@ public partial class WebPubSubService : Resource
     /// <returns>The keys for this WebPubSubService resource.</returns>
     public WebPubSubKeys GetKeys() =>
         WebPubSubKeys.FromExpression(
-            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(ResourceName), "listKeys")));
+            new FunctionCallExpression(new MemberExpression(new IdentifierExpression(IdentifierName), "listKeys")));
 
     /// <summary>
     /// Creates a role assignment for a user-assigned identity that grants
@@ -268,10 +278,10 @@ public partial class WebPubSubService : Resource
     /// <param name="identity">The <see cref="UserAssignedIdentity"/>.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
     public RoleAssignment CreateRoleAssignment(WebPubSubBuiltInRole role, UserAssignedIdentity identity) =>
-        new($"{ResourceName}_{identity.ResourceName}_{WebPubSubBuiltInRole.GetBuiltInRoleName(role)}")
+        new($"{IdentifierName}_{identity.IdentifierName}_{WebPubSubBuiltInRole.GetBuiltInRoleName(role)}")
         {
             Name = BicepFunction.CreateGuid(Id, identity.PrincipalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = identity.PrincipalId
@@ -284,13 +294,13 @@ public partial class WebPubSubService : Resource
     /// <param name="role">The role to grant.</param>
     /// <param name="principalType">The type of the principal to assign to.</param>
     /// <param name="principalId">The principal to assign to.</param>
-    /// <param name="resourceNameSuffix">Optional role assignment resource name suffix.</param>
+    /// <param name="identifierNameSuffix">Optional role assignment identifier name suffix.</param>
     /// <returns>The <see cref="RoleAssignment"/>.</returns>
-    public RoleAssignment CreateRoleAssignment(WebPubSubBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? resourceNameSuffix = default) =>
-        new($"{ResourceName}_{WebPubSubBuiltInRole.GetBuiltInRoleName(role)}{(resourceNameSuffix is null ? "" : "_")}{resourceNameSuffix}")
+    public RoleAssignment CreateRoleAssignment(WebPubSubBuiltInRole role, BicepValue<RoleManagementPrincipalType> principalType, BicepValue<Guid> principalId, string? identifierNameSuffix = default) =>
+        new($"{IdentifierName}_{WebPubSubBuiltInRole.GetBuiltInRoleName(role)}{(identifierNameSuffix is null ? "" : "_")}{identifierNameSuffix}")
         {
             Name = BicepFunction.CreateGuid(Id, principalId, BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString())),
-            Scope = new IdentifierExpression(ResourceName),
+            Scope = new IdentifierExpression(IdentifierName),
             PrincipalType = principalType,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.ToString()),
             PrincipalId = principalId

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubSharedPrivateLink.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubSharedPrivateLink.cs
@@ -76,10 +76,15 @@ public partial class WebPubSubSharedPrivateLink : Resource
     /// <summary>
     /// Creates a new WebPubSubSharedPrivateLink.
     /// </summary>
-    /// <param name="resourceName">Name of the WebPubSubSharedPrivateLink.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebPubSubSharedPrivateLink
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebPubSubSharedPrivateLink.</param>
-    public WebPubSubSharedPrivateLink(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.SignalRService/webPubSub/sharedPrivateLinkResources", resourceVersion ?? "2024-03-01")
+    public WebPubSubSharedPrivateLink(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.SignalRService/webPubSub/sharedPrivateLinkResources", resourceVersion ?? "2024-03-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _groupId = BicepValue<string>.DefineProperty(this, "GroupId", ["properties", "groupId"]);
@@ -126,9 +131,14 @@ public partial class WebPubSubSharedPrivateLink : Resource
     /// <summary>
     /// Creates a reference to an existing WebPubSubSharedPrivateLink.
     /// </summary>
-    /// <param name="resourceName">Name of the WebPubSubSharedPrivateLink.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the WebPubSubSharedPrivateLink
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the WebPubSubSharedPrivateLink.</param>
     /// <returns>The existing WebPubSubSharedPrivateLink resource.</returns>
-    public static WebPubSubSharedPrivateLink FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static WebPubSubSharedPrivateLink FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -145,7 +145,7 @@ namespace Azure.Provisioning.Authorization
 {
     public partial class AuthorizationRoleDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public AuthorizationRoleDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public AuthorizationRoleDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> AssignableScopes { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -154,7 +154,7 @@ namespace Azure.Provisioning.Authorization
         public Azure.Provisioning.BicepValue<string> RoleName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.AuthorizationRoleType> RoleType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Authorization.AuthorizationRoleDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Authorization.AuthorizationRoleDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_06_01;
@@ -194,7 +194,7 @@ namespace Azure.Provisioning.Authorization
     }
     public partial class RoleAssignment : Azure.Provisioning.Primitives.Resource
     {
-        public RoleAssignment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RoleAssignment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Condition { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ConditionVersion { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> CreatedBy { get { throw null; } }
@@ -210,7 +210,7 @@ namespace Azure.Provisioning.Authorization
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> UpdatedBy { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> UpdatedOn { get { throw null; } }
-        public static Azure.Provisioning.Authorization.RoleAssignment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Authorization.RoleAssignment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2015_06_01;
@@ -230,7 +230,7 @@ namespace Azure.Provisioning.Authorization
     }
     public partial class RoleAssignmentScheduleRequest : Azure.Provisioning.Primitives.Resource
     {
-        public RoleAssignmentScheduleRequest(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RoleAssignmentScheduleRequest(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ApprovalId { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Condition { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ConditionVersion { get { throw null; } set { } }
@@ -255,7 +255,7 @@ namespace Azure.Provisioning.Authorization
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> TargetRoleAssignmentScheduleId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> TargetRoleAssignmentScheduleInstanceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleAssignmentScheduleTicketInfo> TicketInfo { get { throw null; } set { } }
-        public static Azure.Provisioning.Authorization.RoleAssignmentScheduleRequest FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Authorization.RoleAssignmentScheduleRequest FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_10_01;
@@ -278,7 +278,7 @@ namespace Azure.Provisioning.Authorization
     }
     public partial class RoleEligibilityScheduleRequest : Azure.Provisioning.Primitives.Resource
     {
-        public RoleEligibilityScheduleRequest(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RoleEligibilityScheduleRequest(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ApprovalId { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Condition { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ConditionVersion { get { throw null; } set { } }
@@ -302,7 +302,7 @@ namespace Azure.Provisioning.Authorization
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> TargetRoleEligibilityScheduleId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> TargetRoleEligibilityScheduleInstanceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Authorization.RoleEligibilityScheduleRequestPropertiesTicketInfo> TicketInfo { get { throw null; } set { } }
-        public static Azure.Provisioning.Authorization.RoleEligibilityScheduleRequest FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Authorization.RoleEligibilityScheduleRequest FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_10_01;
@@ -367,7 +367,7 @@ namespace Azure.Provisioning.Authorization
     }
     public partial class RoleManagementPolicyAssignment : Azure.Provisioning.Primitives.Resource
     {
-        public RoleManagementPolicyAssignment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public RoleManagementPolicyAssignment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Authorization.RoleManagementPolicyRule> EffectiveRules { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
@@ -376,7 +376,7 @@ namespace Azure.Provisioning.Authorization
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> RoleDefinitionId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Scope { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Authorization.RoleManagementPolicyAssignment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Authorization.RoleManagementPolicyAssignment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_10_01;
@@ -808,7 +808,7 @@ namespace Azure.Provisioning.Primitives
     }
     public partial class ModuleImport : Azure.Provisioning.Primitives.NamedProvisioningConstruct
     {
-        public ModuleImport(string resourceName, Azure.Provisioning.BicepValue<string> path) : base (default(string)) { }
+        public ModuleImport(string identifierName, Azure.Provisioning.BicepValue<string> path) : base (default(string)) { }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<object> Parameters { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Path { get { throw null; } set { } }
@@ -818,8 +818,8 @@ namespace Azure.Provisioning.Primitives
     }
     public abstract partial class NamedProvisioningConstruct : Azure.Provisioning.Primitives.ProvisioningConstruct
     {
-        protected NamedProvisioningConstruct(string resourceName) { }
-        public string ResourceName { get { throw null; } set { } }
+        protected NamedProvisioningConstruct(string identifierName) { }
+        public string IdentifierName { get { throw null; } set { } }
     }
     public partial class OrderingInfrastructureResolver : Azure.Provisioning.Primitives.InfrastructureResolver
     {
@@ -918,7 +918,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ArmApplication : Azure.Provisioning.Primitives.Resource
     {
-        public ArmApplication(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ArmApplication(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> ApplicationDefinitionId { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.ArmApplicationArtifact> Artifacts { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.ArmApplicationAuthorization> Authorizations { get { throw null; } }
@@ -944,7 +944,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ArmApplicationDetails> UpdatedBy { get { throw null; } }
-        public static Azure.Provisioning.Resources.ArmApplication FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ArmApplication FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_09_01;
@@ -984,7 +984,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ArmApplicationDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public ArmApplicationDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ArmApplicationDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.ArmApplicationDefinitionArtifact> Artifacts { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.ArmApplicationAuthorization> Authorizations { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.BinaryData> CreateUiDefinition { get { throw null; } set { } }
@@ -1005,7 +1005,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ArmApplicationSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Resources.ArmApplicationDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ArmApplicationDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2017_09_01;
@@ -1162,14 +1162,14 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ArmDeployment : Azure.Provisioning.Primitives.Resource
     {
-        public ArmDeployment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ArmDeployment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ArmDeploymentPropertiesExtended> Properties { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } }
-        public static Azure.Provisioning.Resources.ArmDeployment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ArmDeployment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Provisioning.Resources.ArmDeployment FromExpression(Azure.Provisioning.Expressions.Expression expression) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -1259,14 +1259,14 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ArmDeploymentScript : Azure.Provisioning.Primitives.Resource
     {
-        public ArmDeploymentScript(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ArmDeploymentScript(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ArmDeploymentScriptManagedIdentity> Identity { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Resources.ArmDeploymentScript FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ArmDeploymentScript FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2020_10_01;
@@ -1395,7 +1395,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class GenericResource : Azure.Provisioning.Primitives.Resource
     {
-        public GenericResource(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public GenericResource(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> ChangedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.DateTimeOffset> CreatedOn { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ExtendedAzureLocation> ExtendedLocation { get { throw null; } set { } }
@@ -1411,7 +1411,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ResourcesSku> Sku { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Resources.GenericResource FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.GenericResource FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
     }
     public enum JitApprovalMode
     {
@@ -1441,7 +1441,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class JitRequest : Azure.Provisioning.Primitives.Resource
     {
-        public JitRequest(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public JitRequest(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> ApplicationResourceId { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ArmApplicationDetails> CreatedBy { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -1455,7 +1455,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ArmApplicationDetails> UpdatedBy { get { throw null; } }
-        public static Azure.Provisioning.Resources.JitRequest FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.JitRequest FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2019_07_01;
@@ -1515,7 +1515,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ManagementGroup : Azure.Provisioning.Primitives.Resource
     {
-        public ManagementGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagementGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.ManagementGroupChildOptions> Children { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.CreateManagementGroupDetails> Details { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
@@ -1523,7 +1523,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Guid> TenantId { get { throw null; } }
-        public static Azure.Provisioning.Resources.ManagementGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ManagementGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1588,7 +1588,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ManagementGroupPolicyDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public ManagementGroupPolicyDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagementGroupPolicyDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -1599,7 +1599,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<System.BinaryData> PolicyRule { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.PolicyType> PolicyType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Resources.ManagementGroupPolicyDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ManagementGroupPolicyDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1620,7 +1620,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ManagementGroupPolicySetDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public ManagementGroupPolicySetDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagementGroupPolicySetDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -1631,7 +1631,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.PolicyDefinitionReference> PolicyDefinitions { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.PolicyType> PolicyType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Resources.ManagementGroupPolicySetDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ManagementGroupPolicySetDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1650,7 +1650,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ManagementGroupSubscription : Azure.Provisioning.Primitives.Resource
     {
-        public ManagementGroupSubscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagementGroupSubscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
@@ -1659,7 +1659,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<string> State { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Tenant { get { throw null; } }
-        public static Azure.Provisioning.Resources.ManagementGroupSubscription FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ManagementGroupSubscription FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2018_03_01_beta;
@@ -1673,14 +1673,14 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ManagementLock : Azure.Provisioning.Primitives.Resource
     {
-        public ManagementLock(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ManagementLock(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.ManagementLockLevel> Level { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Notes { get { throw null; } set { } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.ManagementLockOwner> Owners { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Resources.ManagementLock FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ManagementLock FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1727,7 +1727,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class PolicyAssignment : Azure.Provisioning.Primitives.Resource
     {
-        public PolicyAssignment(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public PolicyAssignment(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.EnforcementMode> EnforcementMode { get { throw null; } set { } }
@@ -1744,7 +1744,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.ResourceSelector> ResourceSelectors { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Scope { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Resources.PolicyAssignment FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.PolicyAssignment FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -1831,7 +1831,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class ResourceGroup : Azure.Provisioning.Primitives.Resource
     {
-        public ResourceGroup(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public ResourceGroup(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> ManagedBy { get { throw null; } set { } }
@@ -1839,7 +1839,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<string> ResourceGroupProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
-        public static Azure.Provisioning.Resources.ResourceGroup FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.ResourceGroup FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Provisioning.Resources.ResourceGroup FromExpression(Azure.Provisioning.Expressions.Expression expression) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -2021,7 +2021,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class Subscription : Azure.Provisioning.Primitives.Resource
     {
-        public Subscription(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public Subscription(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> AuthorizationSource { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -2069,7 +2069,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class SubscriptionPolicyDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public SubscriptionPolicyDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SubscriptionPolicyDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -2080,13 +2080,13 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<System.BinaryData> PolicyRule { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.PolicyType> PolicyType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Resources.SubscriptionPolicyDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.SubscriptionPolicyDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
     }
     public partial class SubscriptionPolicySetDefinition : Azure.Provisioning.Primitives.Resource
     {
-        public SubscriptionPolicySetDefinition(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public SubscriptionPolicySetDefinition(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -2097,7 +2097,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.PolicyDefinitionReference> PolicyDefinitions { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.PolicyType> PolicyType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Resources.SubscriptionPolicySetDefinition FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.SubscriptionPolicySetDefinition FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
     }
@@ -2133,12 +2133,12 @@ namespace Azure.Provisioning.Resources
     }
     public partial class TagResource : Azure.Provisioning.Primitives.Resource
     {
-        public TagResource(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public TagResource(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> Name { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> TagValues { get { throw null; } set { } }
-        public static Azure.Provisioning.Resources.TagResource FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.TagResource FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -2154,7 +2154,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class TemplateSpec : Azure.Provisioning.Primitives.Resource
     {
-        public TemplateSpec(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public TemplateSpec(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> DisplayName { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
@@ -2164,7 +2164,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepDictionary<Azure.Provisioning.Resources.TemplateSpecVersionInfo> Versions { get { throw null; } }
-        public static Azure.Provisioning.Resources.TemplateSpec FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.TemplateSpec FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions
@@ -2175,7 +2175,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class TemplateSpecVersion : Azure.Provisioning.Primitives.Resource
     {
-        public TemplateSpecVersion(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public TemplateSpecVersion(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Description { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepList<Azure.Provisioning.Resources.LinkedTemplateArtifact> LinkedTemplates { get { throw null; } set { } }
@@ -2187,7 +2187,7 @@ namespace Azure.Provisioning.Resources
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.BinaryData> UiFormDefinition { get { throw null; } set { } }
-        public static Azure.Provisioning.Resources.TemplateSpecVersion FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Resources.TemplateSpecVersion FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2021_05_01;
@@ -2203,7 +2203,7 @@ namespace Azure.Provisioning.Resources
     }
     public partial class Tenant : Azure.Provisioning.Primitives.Resource
     {
-        public Tenant(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public Tenant(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<string> Country { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> CountryCode { get { throw null; } }
         public Azure.Provisioning.BicepValue<string> DefaultDomain { get { throw null; } }
@@ -2276,7 +2276,7 @@ namespace Azure.Provisioning.Roles
 {
     public partial class FederatedIdentityCredential : Azure.Provisioning.Primitives.Resource
     {
-        public FederatedIdentityCredential(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public FederatedIdentityCredential(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepList<string> Audiences { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<System.Uri> IssuerUri { get { throw null; } set { } }
@@ -2284,7 +2284,7 @@ namespace Azure.Provisioning.Roles
         public Azure.Provisioning.Roles.UserAssignedIdentity? Parent { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<string> Subject { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        public static Azure.Provisioning.Roles.FederatedIdentityCredential FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Roles.FederatedIdentityCredential FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
             public static readonly string V2022_01_31_PREVIEW;
@@ -2294,7 +2294,7 @@ namespace Azure.Provisioning.Roles
     }
     public partial class UserAssignedIdentity : Azure.Provisioning.Primitives.Resource
     {
-        public UserAssignedIdentity(string resourceName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
+        public UserAssignedIdentity(string identifierName, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<System.Guid> ClientId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> Id { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Core.AzureLocation> Location { get { throw null; } set { } }
@@ -2303,7 +2303,7 @@ namespace Azure.Provisioning.Roles
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<System.Guid> TenantId { get { throw null; } }
-        public static Azure.Provisioning.Roles.UserAssignedIdentity FromExisting(string resourceName, string? resourceVersion = null) { throw null; }
+        public static Azure.Provisioning.Roles.UserAssignedIdentity FromExisting(string identifierName, string? resourceVersion = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Provisioning.Primitives.ResourceNameRequirements GetResourceNameRequirements() { throw null; }
         public static partial class ResourceVersions

--- a/sdk/provisioning/Azure.Provisioning/src/Authorization/AuthorizationRoleDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Authorization/AuthorizationRoleDefinition.cs
@@ -12,5 +12,5 @@ public partial class AuthorizationRoleDefinition
     // naming policies won't be able to manage that as cleanly.  Anyone who
     // really wants can override the value though.
     private partial BicepValue<string> GetNameDefaultValue() =>
-        BicepFunction.CreateGuid(BicepFunction.GetResourceGroup().Id, ResourceName);
+        BicepFunction.CreateGuid(BicepFunction.GetResourceGroup().Id, IdentifierName);
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Authorization/RoleAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Authorization/RoleAssignment.cs
@@ -12,5 +12,5 @@ public partial class RoleAssignment
     // won't be able to manage that as cleanly.  Anyone who really wants can
     // override the value though.
     private partial BicepValue<string> GetNameDefaultValue() =>
-        BicepFunction.CreateGuid(BicepFunction.GetResourceGroup().Id, ResourceName);
+        BicepFunction.CreateGuid(BicepFunction.GetResourceGroup().Id, IdentifierName);
 }

--- a/sdk/provisioning/Azure.Provisioning/src/BicepDictionaryOfT.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/BicepDictionaryOfT.cs
@@ -69,7 +69,7 @@ public class BicepDictionary<T> : BicepValue, IDictionary<string, BicepValue<T>>
     /// </summary>
     /// <param name="reference">The variable or parameter.</param>
     public static implicit operator BicepDictionary<T>(ProvisioningVariable reference) =>
-        new(new BicepValueReference(reference, "<value>"), BicepSyntax.Var(reference.ResourceName)) { IsSecure = reference is ProvisioningParameter p && p.IsSecure };
+        new(new BicepValueReference(reference, "<value>"), BicepSyntax.Var(reference.IdentifierName)) { IsSecure = reference is ProvisioningParameter p && p.IsSecure };
 
     // TODO: Make it possible to correctly reference these values (especially
     // across module boundaries)?  Currently we only allow pulling values into

--- a/sdk/provisioning/Azure.Provisioning/src/BicepListOfT.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/BicepListOfT.cs
@@ -66,7 +66,7 @@ public class BicepList<T> : BicepValue, IList<BicepValue<T>>
     public static implicit operator BicepList<T>(ProvisioningVariable reference) =>
         new(
             new BicepValueReference(reference, "<value>"),
-            BicepSyntax.Var(reference.ResourceName))
+            BicepSyntax.Var(reference.IdentifierName))
         {
             IsSecure = reference is ProvisioningParameter p && p.IsSecure
         };

--- a/sdk/provisioning/Azure.Provisioning/src/BicepValueOfT.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/BicepValueOfT.cs
@@ -115,7 +115,7 @@ public class BicepValue<T> : BicepValue
     }
     public static implicit operator BicepValue<T>(Expression expression) => new(expression);
     public static implicit operator BicepValue<T>(ProvisioningVariable reference) =>
-        new(new BicepValueReference(reference, "<value>"), BicepSyntax.Var(reference.ResourceName)) { IsSecure = reference is ProvisioningParameter p && p.IsSecure };
+        new(new BicepValueReference(reference, "<value>"), BicepSyntax.Var(reference.IdentifierName)) { IsSecure = reference is ProvisioningParameter p && p.IsSecure };
 
     // Special case conversions to string for things like Uri, AzureLocation, etc.
     public static implicit operator BicepValue<string>(BicepValue<T> value) =>

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
@@ -313,7 +313,7 @@ public static class BicepFunction
                 text.GetArgument(i) switch
                 {
                     BicepValue v => v,
-                    ProvisioningVariable v => BicepSyntax.Var(v.ResourceName),
+                    ProvisioningVariable v => BicepSyntax.Var(v.IdentifierName),
                     var a => new BicepValue<object>(a?.ToString() ?? "")
                 };
         };

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ArmApplication.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ArmApplication.cs
@@ -201,10 +201,15 @@ public partial class ArmApplication : Resource
     /// <summary>
     /// Creates a new ArmApplication.
     /// </summary>
-    /// <param name="resourceName">Name of the ArmApplication.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ArmApplication resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ArmApplication.</param>
-    public ArmApplication(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Solutions/applications", resourceVersion ?? "2021-07-01")
+    public ArmApplication(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Solutions/applications", resourceVersion ?? "2021-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _kind = BicepValue<string>.DefineProperty(this, "Kind", ["kind"], isRequired: true);
@@ -277,9 +282,14 @@ public partial class ArmApplication : Resource
     /// <summary>
     /// Creates a reference to an existing ArmApplication.
     /// </summary>
-    /// <param name="resourceName">Name of the ArmApplication.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ArmApplication resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ArmApplication.</param>
     /// <returns>The existing ArmApplication resource.</returns>
-    public static ArmApplication FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ArmApplication FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ArmApplicationDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ArmApplicationDefinition.cs
@@ -171,10 +171,15 @@ public partial class ArmApplicationDefinition : Resource
     /// <summary>
     /// Creates a new ArmApplicationDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the ArmApplicationDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ArmApplicationDefinition resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ArmApplicationDefinition.</param>
-    public ArmApplicationDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Solutions/applicationDefinitions", resourceVersion ?? "2021-07-01")
+    public ArmApplicationDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Solutions/applicationDefinitions", resourceVersion ?? "2021-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -242,9 +247,14 @@ public partial class ArmApplicationDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing ArmApplicationDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the ArmApplicationDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ArmApplicationDefinition resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ArmApplicationDefinition.</param>
     /// <returns>The existing ArmApplicationDefinition resource.</returns>
-    public static ArmApplicationDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ArmApplicationDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ArmDeployment.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ArmDeployment.cs
@@ -253,7 +253,7 @@ public partial class ArmDeployment : Resource
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static ArmDeployment FromExpression(Expression expression)
     {
-        ArmDeployment resource = new(expression.ToString());
+        ArmDeployment resource = new(nameof(ArmDeployment));
         resource.OverrideWithExpression(expression);
         return resource;
     }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ArmDeployment.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ArmDeployment.cs
@@ -59,10 +59,15 @@ public partial class ArmDeployment : Resource
     /// <summary>
     /// Creates a new ArmDeployment.
     /// </summary>
-    /// <param name="resourceName">Name of the ArmDeployment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ArmDeployment resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ArmDeployment.</param>
-    public ArmDeployment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Resources/deployments", resourceVersion ?? "2023-07-01")
+    public ArmDeployment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Resources/deployments", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _id = BicepValue<ResourceIdentifier>.DefineProperty(this, "Id", ["id"], isOutput: true);
@@ -226,11 +231,16 @@ public partial class ArmDeployment : Resource
     /// <summary>
     /// Creates a reference to an existing ArmDeployment.
     /// </summary>
-    /// <param name="resourceName">Name of the ArmDeployment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ArmDeployment resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ArmDeployment.</param>
     /// <returns>The existing ArmDeployment resource.</returns>
-    public static ArmDeployment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ArmDeployment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Creates a new ArmDeployment resource from a Bicep expression that

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ArmDeploymentScript.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ArmDeploymentScript.cs
@@ -58,10 +58,15 @@ public partial class ArmDeploymentScript : Resource
     /// <summary>
     /// Creates a new ArmDeploymentScript.
     /// </summary>
-    /// <param name="resourceName">Name of the ArmDeploymentScript.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ArmDeploymentScript resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ArmDeploymentScript.</param>
-    public ArmDeploymentScript(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Resources/deploymentScripts", resourceVersion ?? "2023-08-01")
+    public ArmDeploymentScript(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Resources/deploymentScripts", resourceVersion ?? "2023-08-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -90,9 +95,14 @@ public partial class ArmDeploymentScript : Resource
     /// <summary>
     /// Creates a reference to an existing ArmDeploymentScript.
     /// </summary>
-    /// <param name="resourceName">Name of the ArmDeploymentScript.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ArmDeploymentScript resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ArmDeploymentScript.</param>
     /// <returns>The existing ArmDeploymentScript resource.</returns>
-    public static ArmDeploymentScript FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ArmDeploymentScript FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/AuthorizationRoleDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/AuthorizationRoleDefinition.cs
@@ -74,10 +74,15 @@ public partial class AuthorizationRoleDefinition : Resource
     /// <summary>
     /// Creates a new AuthorizationRoleDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the AuthorizationRoleDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AuthorizationRoleDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AuthorizationRoleDefinition.</param>
-    public AuthorizationRoleDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/roleDefinitions", resourceVersion ?? "2022-04-01")
+    public AuthorizationRoleDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/roleDefinitions", resourceVersion ?? "2022-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true, defaultValue: GetNameDefaultValue());
         _assignableScopes = BicepList<string>.DefineProperty(this, "AssignableScopes", ["properties", "assignableScopes"]);
@@ -138,9 +143,14 @@ public partial class AuthorizationRoleDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing AuthorizationRoleDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the AuthorizationRoleDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the AuthorizationRoleDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the AuthorizationRoleDefinition.</param>
     /// <returns>The existing AuthorizationRoleDefinition resource.</returns>
-    public static AuthorizationRoleDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static AuthorizationRoleDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/FederatedIdentityCredential.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/FederatedIdentityCredential.cs
@@ -63,10 +63,15 @@ public partial class FederatedIdentityCredential : Resource
     /// <summary>
     /// Creates a new FederatedIdentityCredential.
     /// </summary>
-    /// <param name="resourceName">Name of the FederatedIdentityCredential.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the FederatedIdentityCredential
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the FederatedIdentityCredential.</param>
-    public FederatedIdentityCredential(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials", resourceVersion ?? "2023-01-31")
+    public FederatedIdentityCredential(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials", resourceVersion ?? "2023-01-31")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _audiences = BicepList<string>.DefineProperty(this, "Audiences", ["properties", "audiences"]);
@@ -101,9 +106,14 @@ public partial class FederatedIdentityCredential : Resource
     /// <summary>
     /// Creates a reference to an existing FederatedIdentityCredential.
     /// </summary>
-    /// <param name="resourceName">Name of the FederatedIdentityCredential.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the FederatedIdentityCredential
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the FederatedIdentityCredential.</param>
     /// <returns>The existing FederatedIdentityCredential resource.</returns>
-    public static FederatedIdentityCredential FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static FederatedIdentityCredential FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/GenericResource.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/GenericResource.cs
@@ -128,10 +128,15 @@ public partial class GenericResource : Resource
     /// <summary>
     /// Creates a new GenericResource.
     /// </summary>
-    /// <param name="resourceName">Name of the GenericResource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GenericResource resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GenericResource.</param>
-    public GenericResource(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "", resourceVersion)
+    public GenericResource(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -153,9 +158,14 @@ public partial class GenericResource : Resource
     /// <summary>
     /// Creates a reference to an existing GenericResource.
     /// </summary>
-    /// <param name="resourceName">Name of the GenericResource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the GenericResource resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the GenericResource.</param>
     /// <returns>The existing GenericResource resource.</returns>
-    public static GenericResource FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static GenericResource FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/JitRequest.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/JitRequest.cs
@@ -98,10 +98,15 @@ public partial class JitRequest : Resource
     /// <summary>
     /// Creates a new JitRequest.
     /// </summary>
-    /// <param name="resourceName">Name of the JitRequest.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the JitRequest resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the JitRequest.</param>
-    public JitRequest(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Solutions/jitRequests", resourceVersion ?? "2021-07-01")
+    public JitRequest(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Solutions/jitRequests", resourceVersion ?? "2021-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -137,9 +142,14 @@ public partial class JitRequest : Resource
     /// <summary>
     /// Creates a reference to an existing JitRequest.
     /// </summary>
-    /// <param name="resourceName">Name of the JitRequest.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the JitRequest resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the JitRequest.</param>
     /// <returns>The existing JitRequest resource.</returns>
-    public static JitRequest FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static JitRequest FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementGroup.cs
@@ -67,10 +67,15 @@ public partial class ManagementGroup : Resource
     /// <summary>
     /// Creates a new ManagementGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementGroup resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementGroup.</param>
-    public ManagementGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Management/managementGroups", resourceVersion ?? "2023-04-01")
+    public ManagementGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Management/managementGroups", resourceVersion ?? "2023-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"]);
         _details = BicepValue<CreateManagementGroupDetails>.DefineProperty(this, "Details", ["properties", "details"]);
@@ -125,11 +130,16 @@ public partial class ManagementGroup : Resource
     /// <summary>
     /// Creates a reference to an existing ManagementGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementGroup resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementGroup.</param>
     /// <returns>The existing ManagementGroup resource.</returns>
-    public static ManagementGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagementGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ManagementGroup resource.

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementGroupPolicyDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementGroupPolicyDefinition.cs
@@ -113,10 +113,15 @@ public partial class ManagementGroupPolicyDefinition : Resource
     /// <summary>
     /// Creates a new ManagementGroupPolicyDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementGroupPolicyDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementGroupPolicyDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementGroupPolicyDefinition.</param>
-    public ManagementGroupPolicyDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/policyDefinitions", resourceVersion ?? "2023-04-01")
+    public ManagementGroupPolicyDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/policyDefinitions", resourceVersion ?? "2023-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -199,11 +204,16 @@ public partial class ManagementGroupPolicyDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing ManagementGroupPolicyDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementGroupPolicyDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementGroupPolicyDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementGroupPolicyDefinition.</param>
     /// <returns>The existing ManagementGroupPolicyDefinition resource.</returns>
-    public static ManagementGroupPolicyDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagementGroupPolicyDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ManagementGroupPolicyDefinition

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementGroupPolicySetDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementGroupPolicySetDefinition.cs
@@ -100,10 +100,15 @@ public partial class ManagementGroupPolicySetDefinition : Resource
     /// <summary>
     /// Creates a new ManagementGroupPolicySetDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementGroupPolicySetDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementGroupPolicySetDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementGroupPolicySetDefinition.</param>
-    public ManagementGroupPolicySetDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/policySetDefinitions", resourceVersion ?? "2023-04-01")
+    public ManagementGroupPolicySetDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/policySetDefinitions", resourceVersion ?? "2023-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -176,11 +181,16 @@ public partial class ManagementGroupPolicySetDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing ManagementGroupPolicySetDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementGroupPolicySetDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementGroupPolicySetDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementGroupPolicySetDefinition.</param>
     /// <returns>The existing ManagementGroupPolicySetDefinition resource.</returns>
-    public static ManagementGroupPolicySetDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagementGroupPolicySetDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ManagementGroupPolicySetDefinition

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementGroupSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementGroupSubscription.cs
@@ -71,10 +71,15 @@ public partial class ManagementGroupSubscription : Resource
     /// <summary>
     /// Creates a new ManagementGroupSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementGroupSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementGroupSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementGroupSubscription.</param>
-    public ManagementGroupSubscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Management/managementGroups/subscriptions", resourceVersion ?? "2023-04-01")
+    public ManagementGroupSubscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Management/managementGroups/subscriptions", resourceVersion ?? "2023-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _displayName = BicepValue<string>.DefineProperty(this, "DisplayName", ["properties", "displayName"], isOutput: true);
@@ -130,9 +135,14 @@ public partial class ManagementGroupSubscription : Resource
     /// <summary>
     /// Creates a reference to an existing ManagementGroupSubscription.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementGroupSubscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementGroupSubscription
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementGroupSubscription.</param>
     /// <returns>The existing ManagementGroupSubscription resource.</returns>
-    public static ManagementGroupSubscription FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagementGroupSubscription FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementLock.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ManagementLock.cs
@@ -62,10 +62,15 @@ public partial class ManagementLock : Resource
     /// <summary>
     /// Creates a new ManagementLock.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementLock.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementLock resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementLock.</param>
-    public ManagementLock(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/locks", resourceVersion ?? "2020-05-01")
+    public ManagementLock(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/locks", resourceVersion ?? "2020-05-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _level = BicepValue<ManagementLockLevel>.DefineProperty(this, "Level", ["properties", "level"], isRequired: true);
@@ -109,11 +114,16 @@ public partial class ManagementLock : Resource
     /// <summary>
     /// Creates a reference to an existing ManagementLock.
     /// </summary>
-    /// <param name="resourceName">Name of the ManagementLock.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ManagementLock resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ManagementLock.</param>
     /// <returns>The existing ManagementLock resource.</returns>
-    public static ManagementLock FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ManagementLock FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this ManagementLock resource.

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/PolicyAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/PolicyAssignment.cs
@@ -138,10 +138,15 @@ public partial class PolicyAssignment : Resource
     /// <summary>
     /// Creates a new PolicyAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the PolicyAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PolicyAssignment resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PolicyAssignment.</param>
-    public PolicyAssignment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/policyAssignments", resourceVersion ?? "2024-04-01")
+    public PolicyAssignment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/policyAssignments", resourceVersion ?? "2024-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -240,11 +245,16 @@ public partial class PolicyAssignment : Resource
     /// <summary>
     /// Creates a reference to an existing PolicyAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the PolicyAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the PolicyAssignment resource.  This
+    /// can be used to refer to the resource in expressions, but is not the
+    /// Azure name of the resource.  This value can contain letters, numbers,
+    /// and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the PolicyAssignment.</param>
     /// <returns>The existing PolicyAssignment resource.</returns>
-    public static PolicyAssignment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static PolicyAssignment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this PolicyAssignment resource.

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ResourceGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ResourceGroup.cs
@@ -333,7 +333,7 @@ public partial class ResourceGroup : Resource
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static ResourceGroup FromExpression(Expression expression)
     {
-        ResourceGroup resource = new(expression.ToString());
+        ResourceGroup resource = new(nameof(ResourceGroup));
         resource.OverrideWithExpression(expression);
         return resource;
     }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ResourceGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ResourceGroup.cs
@@ -68,10 +68,15 @@ public partial class ResourceGroup : Resource
     /// <summary>
     /// Creates a new ResourceGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the ResourceGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ResourceGroup resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ResourceGroup.</param>
-    public ResourceGroup(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Resources/resourceGroups", resourceVersion ?? "2023-07-01")
+    public ResourceGroup(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Resources/resourceGroups", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -306,11 +311,16 @@ public partial class ResourceGroup : Resource
     /// <summary>
     /// Creates a reference to an existing ResourceGroup.
     /// </summary>
-    /// <param name="resourceName">Name of the ResourceGroup.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the ResourceGroup resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the ResourceGroup.</param>
     /// <returns>The existing ResourceGroup resource.</returns>
-    public static ResourceGroup FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static ResourceGroup FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Creates a new ResourceGroup resource from a Bicep expression that

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/RoleAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/RoleAssignment.cs
@@ -119,10 +119,15 @@ public partial class RoleAssignment : Resource
     /// <summary>
     /// Creates a new RoleAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the RoleAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RoleAssignment resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RoleAssignment.</param>
-    public RoleAssignment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/roleAssignments", resourceVersion ?? "2022-04-01")
+    public RoleAssignment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/roleAssignments", resourceVersion ?? "2022-04-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true, defaultValue: GetNameDefaultValue());
         _principalId = BicepValue<Guid>.DefineProperty(this, "PrincipalId", ["properties", "principalId"], isRequired: true);
@@ -185,9 +190,14 @@ public partial class RoleAssignment : Resource
     /// <summary>
     /// Creates a reference to an existing RoleAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the RoleAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RoleAssignment resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RoleAssignment.</param>
     /// <returns>The existing RoleAssignment resource.</returns>
-    public static RoleAssignment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RoleAssignment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/RoleAssignmentScheduleRequest.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/RoleAssignmentScheduleRequest.cs
@@ -170,10 +170,15 @@ public partial class RoleAssignmentScheduleRequest : Resource
     /// <summary>
     /// Creates a new RoleAssignmentScheduleRequest.
     /// </summary>
-    /// <param name="resourceName">Name of the RoleAssignmentScheduleRequest.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RoleAssignmentScheduleRequest
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RoleAssignmentScheduleRequest.</param>
-    public RoleAssignmentScheduleRequest(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/roleAssignmentScheduleRequests", resourceVersion ?? "2020-10-01")
+    public RoleAssignmentScheduleRequest(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/roleAssignmentScheduleRequests", resourceVersion ?? "2020-10-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _condition = BicepValue<string>.DefineProperty(this, "Condition", ["properties", "condition"]);
@@ -220,9 +225,14 @@ public partial class RoleAssignmentScheduleRequest : Resource
     /// <summary>
     /// Creates a reference to an existing RoleAssignmentScheduleRequest.
     /// </summary>
-    /// <param name="resourceName">Name of the RoleAssignmentScheduleRequest.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RoleAssignmentScheduleRequest
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RoleAssignmentScheduleRequest.</param>
     /// <returns>The existing RoleAssignmentScheduleRequest resource.</returns>
-    public static RoleAssignmentScheduleRequest FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RoleAssignmentScheduleRequest FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/RoleEligibilityScheduleRequest.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/RoleEligibilityScheduleRequest.cs
@@ -163,10 +163,15 @@ public partial class RoleEligibilityScheduleRequest : Resource
     /// <summary>
     /// Creates a new RoleEligibilityScheduleRequest.
     /// </summary>
-    /// <param name="resourceName">Name of the RoleEligibilityScheduleRequest.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RoleEligibilityScheduleRequest
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RoleEligibilityScheduleRequest.</param>
-    public RoleEligibilityScheduleRequest(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/roleEligibilityScheduleRequests", resourceVersion ?? "2020-10-01")
+    public RoleEligibilityScheduleRequest(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/roleEligibilityScheduleRequests", resourceVersion ?? "2020-10-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _condition = BicepValue<string>.DefineProperty(this, "Condition", ["properties", "condition"]);
@@ -212,9 +217,14 @@ public partial class RoleEligibilityScheduleRequest : Resource
     /// <summary>
     /// Creates a reference to an existing RoleEligibilityScheduleRequest.
     /// </summary>
-    /// <param name="resourceName">Name of the RoleEligibilityScheduleRequest.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RoleEligibilityScheduleRequest
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RoleEligibilityScheduleRequest.</param>
     /// <returns>The existing RoleEligibilityScheduleRequest resource.</returns>
-    public static RoleEligibilityScheduleRequest FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RoleEligibilityScheduleRequest FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/RoleManagementPolicyAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/RoleManagementPolicyAssignment.cs
@@ -82,10 +82,15 @@ public partial class RoleManagementPolicyAssignment : Resource
     /// <summary>
     /// Creates a new RoleManagementPolicyAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the RoleManagementPolicyAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RoleManagementPolicyAssignment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RoleManagementPolicyAssignment.</param>
-    public RoleManagementPolicyAssignment(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/roleManagementPolicyAssignments", resourceVersion ?? "2020-10-01")
+    public RoleManagementPolicyAssignment(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/roleManagementPolicyAssignments", resourceVersion ?? "2020-10-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _policyId = BicepValue<ResourceIdentifier>.DefineProperty(this, "PolicyId", ["properties", "policyId"]);
@@ -116,9 +121,14 @@ public partial class RoleManagementPolicyAssignment : Resource
     /// <summary>
     /// Creates a reference to an existing RoleManagementPolicyAssignment.
     /// </summary>
-    /// <param name="resourceName">Name of the RoleManagementPolicyAssignment.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the RoleManagementPolicyAssignment
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the RoleManagementPolicyAssignment.</param>
     /// <returns>The existing RoleManagementPolicyAssignment resource.</returns>
-    public static RoleManagementPolicyAssignment FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static RoleManagementPolicyAssignment FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/Subscription.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/Subscription.cs
@@ -232,7 +232,7 @@ public partial class Subscription : Resource
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Subscription FromExpression(Expression expression)
     {
-        Subscription resource = new(expression.ToString());
+        Subscription resource = new(nameof(Subscription));
         resource.OverrideWithExpression(expression);
         return resource;
     }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/Subscription.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/Subscription.cs
@@ -79,10 +79,15 @@ public partial class Subscription : Resource
     /// <summary>
     /// Creates a new Subscription.
     /// </summary>
-    /// <param name="resourceName">Name of the Subscription.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the Subscription resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the Subscription.</param>
-    public Subscription(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Resources/subscriptions", resourceVersion ?? "2019-10-01")
+    public Subscription(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Resources/subscriptions", resourceVersion ?? "2019-10-01")
     {
         _authorizationSource = BicepValue<string>.DefineProperty(this, "AuthorizationSource", ["authorizationSource"], isOutput: true);
         _displayName = BicepValue<string>.DefineProperty(this, "DisplayName", ["displayName"], isOutput: true);

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/SubscriptionPolicyDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/SubscriptionPolicyDefinition.cs
@@ -113,10 +113,15 @@ public partial class SubscriptionPolicyDefinition : Resource
     /// <summary>
     /// Creates a new SubscriptionPolicyDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the SubscriptionPolicyDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SubscriptionPolicyDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SubscriptionPolicyDefinition.</param>
-    public SubscriptionPolicyDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/policyDefinitions", resourceVersion)
+    public SubscriptionPolicyDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/policyDefinitions", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -133,11 +138,16 @@ public partial class SubscriptionPolicyDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing SubscriptionPolicyDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the SubscriptionPolicyDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SubscriptionPolicyDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SubscriptionPolicyDefinition.</param>
     /// <returns>The existing SubscriptionPolicyDefinition resource.</returns>
-    public static SubscriptionPolicyDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SubscriptionPolicyDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SubscriptionPolicyDefinition

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/SubscriptionPolicySetDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/SubscriptionPolicySetDefinition.cs
@@ -100,10 +100,15 @@ public partial class SubscriptionPolicySetDefinition : Resource
     /// <summary>
     /// Creates a new SubscriptionPolicySetDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the SubscriptionPolicySetDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SubscriptionPolicySetDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SubscriptionPolicySetDefinition.</param>
-    public SubscriptionPolicySetDefinition(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Authorization/policySetDefinitions", resourceVersion)
+    public SubscriptionPolicySetDefinition(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Authorization/policySetDefinitions", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -120,11 +125,16 @@ public partial class SubscriptionPolicySetDefinition : Resource
     /// <summary>
     /// Creates a reference to an existing SubscriptionPolicySetDefinition.
     /// </summary>
-    /// <param name="resourceName">Name of the SubscriptionPolicySetDefinition.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the SubscriptionPolicySetDefinition
+    /// resource.  This can be used to refer to the resource in expressions,
+    /// but is not the Azure name of the resource.  This value can contain
+    /// letters, numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the SubscriptionPolicySetDefinition.</param>
     /// <returns>The existing SubscriptionPolicySetDefinition resource.</returns>
-    public static SubscriptionPolicySetDefinition FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static SubscriptionPolicySetDefinition FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this SubscriptionPolicySetDefinition

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/TagResource.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/TagResource.cs
@@ -47,10 +47,15 @@ public partial class TagResource : Resource
     /// <summary>
     /// Creates a new TagResource.
     /// </summary>
-    /// <param name="resourceName">Name of the TagResource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TagResource resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TagResource.</param>
-    public TagResource(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Resources/tags", resourceVersion ?? "2023-07-01")
+    public TagResource(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Resources/tags", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _tagValues = BicepDictionary<string>.DefineProperty(this, "TagValues", ["properties", "tags"]);
@@ -102,11 +107,16 @@ public partial class TagResource : Resource
     /// <summary>
     /// Creates a reference to an existing TagResource.
     /// </summary>
-    /// <param name="resourceName">Name of the TagResource.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TagResource resource.  This can be
+    /// used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TagResource.</param>
     /// <returns>The existing TagResource resource.</returns>
-    public static TagResource FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static TagResource FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this TagResource resource.

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/TemplateSpec.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/TemplateSpec.cs
@@ -92,10 +92,15 @@ public partial class TemplateSpec : Resource
     /// <summary>
     /// Creates a new TemplateSpec.
     /// </summary>
-    /// <param name="resourceName">Name of the TemplateSpec.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TemplateSpec resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TemplateSpec.</param>
-    public TemplateSpec(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Resources/templateSpecs", resourceVersion ?? "2022-02-01")
+    public TemplateSpec(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Resources/templateSpecs", resourceVersion ?? "2022-02-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -127,11 +132,16 @@ public partial class TemplateSpec : Resource
     /// <summary>
     /// Creates a reference to an existing TemplateSpec.
     /// </summary>
-    /// <param name="resourceName">Name of the TemplateSpec.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TemplateSpec resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TemplateSpec.</param>
     /// <returns>The existing TemplateSpec resource.</returns>
-    public static TemplateSpec FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static TemplateSpec FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this TemplateSpec resource.

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/TemplateSpecVersion.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/TemplateSpecVersion.cs
@@ -127,10 +127,15 @@ public partial class TemplateSpecVersion : Resource
     /// <summary>
     /// Creates a new TemplateSpecVersion.
     /// </summary>
-    /// <param name="resourceName">Name of the TemplateSpecVersion.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TemplateSpecVersion resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TemplateSpecVersion.</param>
-    public TemplateSpecVersion(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Resources/templateSpecs/versions", resourceVersion ?? "2022-02-01")
+    public TemplateSpecVersion(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Resources/templateSpecs/versions", resourceVersion ?? "2022-02-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -164,9 +169,14 @@ public partial class TemplateSpecVersion : Resource
     /// <summary>
     /// Creates a reference to an existing TemplateSpecVersion.
     /// </summary>
-    /// <param name="resourceName">Name of the TemplateSpecVersion.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the TemplateSpecVersion resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the TemplateSpecVersion.</param>
     /// <returns>The existing TemplateSpecVersion resource.</returns>
-    public static TemplateSpecVersion FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static TemplateSpecVersion FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/Tenant.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/Tenant.cs
@@ -83,10 +83,15 @@ public partial class Tenant : Resource
     /// <summary>
     /// Creates a new Tenant.
     /// </summary>
-    /// <param name="resourceName">Name of the Tenant.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the Tenant resource.  This can be used
+    /// to refer to the resource in expressions, but is not the Azure name of
+    /// the resource.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the Tenant.</param>
-    public Tenant(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.Resources/tenants", resourceVersion ?? "2020-01-01")
+    public Tenant(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.Resources/tenants", resourceVersion ?? "2020-01-01")
     {
         _country = BicepValue<string>.DefineProperty(this, "Country", ["country"], isOutput: true);
         _countryCode = BicepValue<string>.DefineProperty(this, "CountryCode", ["countryCode"], isOutput: true);

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/Tenant.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/Tenant.cs
@@ -237,7 +237,7 @@ public partial class Tenant : Resource
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Tenant FromExpression(Expression expression)
     {
-        Tenant resource = new(expression.ToString());
+        Tenant resource = new(nameof(Tenant));
         resource.OverrideWithExpression(expression);
         return resource;
     }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/UserAssignedIdentity.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/UserAssignedIdentity.cs
@@ -72,10 +72,15 @@ public partial class UserAssignedIdentity : Resource
     /// <summary>
     /// Creates a new UserAssignedIdentity.
     /// </summary>
-    /// <param name="resourceName">Name of the UserAssignedIdentity.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the UserAssignedIdentity resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the UserAssignedIdentity.</param>
-    public UserAssignedIdentity(string resourceName, string? resourceVersion = default)
-        : base(resourceName, "Microsoft.ManagedIdentity/userAssignedIdentities", resourceVersion ?? "2023-01-31")
+    public UserAssignedIdentity(string identifierName, string? resourceVersion = default)
+        : base(identifierName, "Microsoft.ManagedIdentity/userAssignedIdentities", resourceVersion ?? "2023-01-31")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -126,11 +131,16 @@ public partial class UserAssignedIdentity : Resource
     /// <summary>
     /// Creates a reference to an existing UserAssignedIdentity.
     /// </summary>
-    /// <param name="resourceName">Name of the UserAssignedIdentity.</param>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the UserAssignedIdentity resource.
+    /// This can be used to refer to the resource in expressions, but is not
+    /// the Azure name of the resource.  This value can contain letters,
+    /// numbers, and underscores.
+    /// </param>
     /// <param name="resourceVersion">Version of the UserAssignedIdentity.</param>
     /// <returns>The existing UserAssignedIdentity resource.</returns>
-    public static UserAssignedIdentity FromExisting(string resourceName, string? resourceVersion = default) =>
-        new(resourceName, resourceVersion) { IsExistingResource = true };
+    public static UserAssignedIdentity FromExisting(string identifierName, string? resourceVersion = default) =>
+        new(identifierName, resourceVersion) { IsExistingResource = true };
 
     /// <summary>
     /// Get the requirements for naming this UserAssignedIdentity resource.

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/BicepValueReference.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/BicepValueReference.cs
@@ -25,7 +25,7 @@ public class BicepValueReference(ProvisioningConstruct construct, string propert
             throw new NotImplementedException("Cannot reference a construct without a name yet.");
         }
 
-        Expression target = BicepSyntax.Var(named.ResourceName);
+        Expression target = BicepSyntax.Var(named.IdentifierName);
         if (BicepPath is not null)
         {
             foreach (string segment in BicepPath)

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/LocationPropertyResolver.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/LocationPropertyResolver.cs
@@ -65,8 +65,8 @@ public class LocationPropertyResolver : PropertyResolver
         IDictionary<string, ProvisioningParameter> existing =
             infra.GetResources()
             .OfType<ProvisioningParameter>()
-            .Where(p => p.ResourceName.StartsWith("location"))
-            .ToDictionary(p => p.ResourceName);
+            .Where(p => p.IdentifierName.StartsWith("location"))
+            .ToDictionary(p => p.IdentifierName);
         foreach (ProvisioningParameter p in existing.Values)
         {
             if (p.BicepType is TypeExpression type &&
@@ -87,7 +87,7 @@ public class LocationPropertyResolver : PropertyResolver
             // Optionally specialize to the resource
             if (construct is NamedProvisioningConstruct resource)
             {
-                name = $"{name}_{resource.ResourceName}";
+                name = $"{name}_{resource.IdentifierName}";
                 increment = existing.ContainsKey(name);
             }
 

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ModuleImport.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ModuleImport.cs
@@ -19,7 +19,7 @@ public class ModuleImport : NamedProvisioningConstruct
 
     public BicepDictionary<object> Parameters { get; }
 
-    public ModuleImport(string resourceName, BicepValue<string> path) : base(resourceName)
+    public ModuleImport(string identifierName, BicepValue<string> path) : base(identifierName)
     {
         _name = BicepValue<string>.DefineProperty(this, nameof(Name), ["name"], isRequired: true);
         _path = BicepValue<string>.DefineProperty(this, nameof(Path), ["path"], defaultValue: path);
@@ -39,7 +39,7 @@ public class ModuleImport : NamedProvisioningConstruct
         Dictionary<string, Expression> properties = new() { { "name", _name.Compile() } };
         if (_scope.Kind != BicepValueKind.Unset) { properties.Add("scope", _scope.Compile()); }
         if (Parameters.Count > 0) { properties.Add("params", Parameters.Compile()); }
-        ModuleStatement module = BicepSyntax.Declare.Module(ResourceName, _path.Compile(), BicepSyntax.Object(properties));
+        ModuleStatement module = BicepSyntax.Declare.Module(IdentifierName, _path.Compile(), BicepSyntax.Object(properties));
         statements.Add(module);
         return statements;
     }

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisioningConstruct.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisioningConstruct.cs
@@ -12,14 +12,15 @@ namespace Azure.Provisioning.Primitives;
 /// <summary>
 /// A named Bicep entity, like a resource or parameter.
 /// </summary>
-public abstract class NamedProvisioningConstruct(string resourceName) : ProvisioningConstruct
+public abstract class NamedProvisioningConstruct(string identifierName) : ProvisioningConstruct
 {
     /// <summary>
-    /// Gets or sets the the Bicep name of the resource.  This can be used to
-    /// refer to the resource in expressions, but isn't the Azure name of the
-    /// resource.  This value can contain letters, numbers, and underscores.
+    /// Gets or sets the the Bicep identifier name of the resource.  This can
+    /// be used to refer to the resource in expressions, but is not the Azure
+    /// name of the resource.  This value can contain letters, numbers, and
+    /// underscores.
     /// </summary>
-    public string ResourceName { get; set; } = resourceName;
+    public string IdentifierName { get; set; } = identifierName;
 }
 
 public abstract class ProvisioningConstruct : Provisionable

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisioningConstruct.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisioningConstruct.cs
@@ -42,6 +42,8 @@ public abstract class NamedProvisioningConstruct : ProvisioningConstruct
     // TODO: Relax this in the future when we make identifier names optional
     private static string ValidateIdentifierName(string identifierName, string paramName)
     {
+        // TODO: Enable when Aspire is ready
+        /*
         if (identifierName is null)
         {
             throw new ArgumentNullException(paramName, $"{nameof(IdentifierName)} cannot be null.");
@@ -58,6 +60,7 @@ public abstract class NamedProvisioningConstruct : ProvisioningConstruct
                 throw new ArgumentException($"{nameof(IdentifierName)} \"{identifierName}\" should only contain letters, numbers, and underscores.", paramName);
             }
         }
+        /**/
         return identifierName;
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisioningConstruct.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisioningConstruct.cs
@@ -12,7 +12,7 @@ namespace Azure.Provisioning.Primitives;
 /// <summary>
 /// A named Bicep entity, like a resource or parameter.
 /// </summary>
-public abstract class NamedProvisioningConstruct(string identifierName) : ProvisioningConstruct
+public abstract class NamedProvisioningConstruct : ProvisioningConstruct
 {
     /// <summary>
     /// Gets or sets the the Bicep identifier name of the resource.  This can
@@ -20,7 +20,46 @@ public abstract class NamedProvisioningConstruct(string identifierName) : Provis
     /// name of the resource.  This value can contain letters, numbers, and
     /// underscores.
     /// </summary>
-    public string IdentifierName { get; set; } = identifierName;
+    public string IdentifierName
+    {
+        get => _identifierName;
+        set => _identifierName = ValidateIdentifierName(value, nameof(value));
+    }
+    private string _identifierName;
+    // TODO: Listen for feedback, but discuss IdentifierName vs. ProvisioningName in the Arch Board
+
+    /// <summary>
+    /// Creates a named Bicep entity, like a resource or parameter.
+    /// </summary>
+    /// <param name="identifierName">
+    /// The the Bicep identifier name of the resource.  This can be used to
+    /// refer to the resource in expressions, but is not the Azure name of the
+    /// resource.  This value can contain letters, numbers, and underscores.
+    /// </param>
+    protected NamedProvisioningConstruct(string identifierName) =>
+        _identifierName = ValidateIdentifierName(identifierName, nameof(identifierName));
+
+    // TODO: Relax this in the future when we make identifier names optional
+    private static string ValidateIdentifierName(string identifierName, string paramName)
+    {
+        if (identifierName is null)
+        {
+            throw new ArgumentNullException(paramName, $"{nameof(IdentifierName)} cannot be null.");
+        }
+        else if (identifierName.Length == 0)
+        {
+            throw new ArgumentException($"{nameof(IdentifierName)} cannot be empty.", paramName);
+        }
+
+        foreach (var ch in identifierName)
+        {
+            if (!char.IsLetterOrDigit(ch) && ch != '_')
+            {
+                throw new ArgumentException($"{nameof(IdentifierName)} \"{identifierName}\" should only contain letters, numbers, and underscores.", paramName);
+            }
+        }
+        return identifierName;
+    }
 }
 
 public abstract class ProvisioningConstruct : Provisionable

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/Resource.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/Resource.cs
@@ -72,7 +72,7 @@ public abstract class Resource(string resourceName, ResourceType resourceType, s
     /// </returns>
     public virtual ProvisioningPlan Build(ProvisioningContext? context = default) =>
         ParentInfrastructure?.Build(context ?? new()) ??
-            throw new InvalidOperationException($"Cannot build a provisioning plan for {GetType().Name} resource {ResourceName} before it has been added to {nameof(Infrastructure)}.");
+            throw new InvalidOperationException($"Cannot build a provisioning plan for {GetType().Name} resource {IdentifierName} before it has been added to {nameof(Infrastructure)}.");
 
     /// <inheritdoc />
     protected internal override void Validate(ProvisioningContext? context = null)
@@ -81,12 +81,12 @@ public abstract class Resource(string resourceName, ResourceType resourceType, s
 
         if (ResourceVersion is null)
         {
-            throw new InvalidOperationException($"{GetType().Name} resource {ResourceName} must have {nameof(ResourceVersion)} specified.");
+            throw new InvalidOperationException($"{GetType().Name} resource {IdentifierName} must have {nameof(ResourceVersion)} specified.");
         }
 
         if (DependsOn.Count > 0 && (IsExistingResource || ExpressionOverride is not null))
         {
-            throw new InvalidOperationException($"{GetType().Name} resource {ResourceName} cannot have dependencies if it's an existing resource or an expression override.");
+            throw new InvalidOperationException($"{GetType().Name} resource {IdentifierName} cannot have dependencies if it's an existing resource or an expression override.");
         }
 
         if (IsExistingResource)
@@ -122,17 +122,17 @@ public abstract class Resource(string resourceName, ResourceType resourceType, s
             // This should be caught by Validate above
             if (body is not ObjectExpression obj)
             {
-                throw new InvalidOperationException($"{GetType().Name} resource {ResourceName} cannot have dependencies if it's an existing resource or an expression override.");
+                throw new InvalidOperationException($"{GetType().Name} resource {IdentifierName} cannot have dependencies if it's an existing resource or an expression override.");
             }
 
             // Add the dependsOn property
-            ArrayExpression dependencies = new(DependsOn.Select(r => BicepSyntax.Var(r.ResourceName)).ToArray());
+            ArrayExpression dependencies = new(DependsOn.Select(r => BicepSyntax.Var(r.IdentifierName)).ToArray());
             body = new ObjectExpression([.. obj.Properties, new PropertyExpression("dependsOn", dependencies)]);
         }
 
         // Create a resource declaration
         ResourceStatement resource = BicepSyntax.Declare.Resource(
-            ResourceName,
+            IdentifierName,
             $"{ResourceType}@{ResourceVersion}",
             body);
         if (IsExistingResource)

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceNamePropertyResolver.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceNamePropertyResolver.cs
@@ -180,7 +180,7 @@ public abstract class ResourceNamePropertyResolver : PropertyResolver
 
 /// <summary>
 /// Generate a unique name for a resource by combining the resource's
-/// <see cref="NamedProvisioningConstruct.ResourceName"/> as a prefix and a
+/// <see cref="NamedProvisioningConstruct.IdentifierName"/> as a prefix and a
 /// unique suffix based on the current resource group's ID.
 /// </summary>
 public class DynamicResourceNamePropertyResolver : ResourceNamePropertyResolver
@@ -191,7 +191,7 @@ public class DynamicResourceNamePropertyResolver : ResourceNamePropertyResolver
 
     /// <summary>
     /// Generate a unique name for a resource by combining the resource's
-    /// <see cref="NamedProvisioningConstruct.ResourceName"/> as a prefix and a
+    /// <see cref="NamedProvisioningConstruct.IdentifierName"/> as a prefix and a
     /// unique suffix based on the current resource group's ID.
     /// </summary>
     /// <param name="context">The provisioning context for this resource.</param>
@@ -203,7 +203,7 @@ public class DynamicResourceNamePropertyResolver : ResourceNamePropertyResolver
         Resource resource,
         ResourceNameRequirements requirements)
     {
-        string prefix = SanitizeText(resource.ResourceName, requirements.ValidCharacters);
+        string prefix = SanitizeText(resource.IdentifierName, requirements.ValidCharacters);
         string separator =
             requirements.ValidCharacters.HasFlag(ResourceNameCharacters.Hyphen) ? "-" :
             requirements.ValidCharacters.HasFlag(ResourceNameCharacters.Underscore) ? "_" :
@@ -233,7 +233,7 @@ public class DynamicResourceNamePropertyResolver : ResourceNamePropertyResolver
 
 /// <summary>
 /// Generate a unique name for a resource by combining the resource's
-/// <see cref="NamedProvisioningConstruct.ResourceName"/> as a prefix and a
+/// <see cref="NamedProvisioningConstruct.IdentifierName"/> as a prefix and a
 /// randomly generated suffix of allowed characters.
 /// </summary>
 public class StaticResourceNamePropertyResolver : ResourceNamePropertyResolver
@@ -247,7 +247,7 @@ public class StaticResourceNamePropertyResolver : ResourceNamePropertyResolver
         StringBuilder name = new(capacity: requirements.MaxLength);
 
         // Start with the sanitized resource name
-        name.Append(SanitizeText(resource.ResourceName, requirements.ValidCharacters));
+        name.Append(SanitizeText(resource.IdentifierName, requirements.ValidCharacters));
         if (name.Length >= requirements.MaxLength)
         {
             return name.ToString(0, requirements.MaxLength);

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceReference.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceReference.cs
@@ -29,7 +29,7 @@ public class ResourceReference<T>(BicepValue<string> reference) where T : Resour
                 // TODO: Consider tracking the source like we do for
                 // BicepValue<T> if that'll improve the overall experience
                 // (debugging/errors/etc.)
-                BicepSyntax.Var(_value.ResourceName);
+                BicepSyntax.Var(_value.IdentifierName);
         }
     }
 

--- a/sdk/provisioning/Azure.Provisioning/src/ProvisioningOutput.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/ProvisioningOutput.cs
@@ -15,7 +15,10 @@ public class ProvisioningOutput : ProvisioningVariable
     /// <summary>
     /// Creates a new ProvisioningOutput.
     /// </summary>
-    /// <param name="name">Name of the output.</param>
+    /// <param name="name">
+    /// Name of the output.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="type">Type of the output.</param>
     public ProvisioningOutput(string name, Expression type)
         : base(name, type, value: null) { }
@@ -23,7 +26,10 @@ public class ProvisioningOutput : ProvisioningVariable
     /// <summary>
     /// Creates a new ProvisioningOutput.
     /// </summary>
-    /// <param name="name">Name of the output.</param>
+    /// <param name="name">
+    /// Name of the output.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="type">Type of the output.</param>
     public ProvisioningOutput(string name, Type type)
         : this(name, new TypeExpression(type)) { }
@@ -31,7 +37,7 @@ public class ProvisioningOutput : ProvisioningVariable
     /// <inheritdoc />
     protected internal override IEnumerable<Statement> Compile()
     {
-        OutputStatement stmt = BicepSyntax.Declare.Output(ResourceName, BicepType, Value.Compile());
+        OutputStatement stmt = BicepSyntax.Declare.Output(IdentifierName, BicepType, Value.Compile());
         if (Description is not null) { stmt = stmt.Decorate("description", BicepSyntax.Value(Description)); }
         yield return stmt;
     }

--- a/sdk/provisioning/Azure.Provisioning/src/ProvisioningParameter.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/ProvisioningParameter.cs
@@ -26,7 +26,10 @@ public class ProvisioningParameter : ProvisioningVariable
     /// <summary>
     /// Creates a new ProvisioningParameter.
     /// </summary>
-    /// <param name="name">Name of the parameter.</param>
+    /// <param name="name">
+    /// Name of the parameter.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="type">Type of the parameter.</param>
     public ProvisioningParameter(string name, Expression type)
         : base(name, type, value: null) { }
@@ -34,7 +37,10 @@ public class ProvisioningParameter : ProvisioningVariable
     /// <summary>
     /// Creates a new ProvisioningParameter.
     /// </summary>
-    /// <param name="name">Name of the parameter.</param>
+    /// <param name="name">
+    /// Name of the parameter.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="type">Type of the parameter.</param>
     public ProvisioningParameter(string name, Type type)
         : this(name, new TypeExpression(type)) { }
@@ -42,7 +48,7 @@ public class ProvisioningParameter : ProvisioningVariable
     /// <inheritdoc />
     protected internal override IEnumerable<Statement> Compile()
     {
-        ParameterStatement stmt = BicepSyntax.Declare.Param(ResourceName, BicepType, Value.Kind == BicepValueKind.Unset ? null : Value.Compile());
+        ParameterStatement stmt = BicepSyntax.Declare.Param(IdentifierName, BicepType, Value.Kind == BicepValueKind.Unset ? null : Value.Compile());
         if (IsSecure) { stmt = stmt.Decorate("secure"); }
         if (Description is not null) { stmt = stmt.Decorate("description", BicepSyntax.Value(Description)); }
         yield return stmt;

--- a/sdk/provisioning/Azure.Provisioning/src/ProvisioningVariable.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/ProvisioningVariable.cs
@@ -34,7 +34,10 @@ public class ProvisioningVariable : NamedProvisioningConstruct
     /// <summary>
     /// Creates a new ProvisioningVariable.
     /// </summary>
-    /// <param name="name">Name of the variable.</param>
+    /// <param name="name">
+    /// Name of the variable.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="type">Type of the variable.</param>
     /// <param name="value">Default value of the variable.</param>
     protected ProvisioningVariable(string name, Expression type, BicepValue<object>? value)
@@ -47,7 +50,10 @@ public class ProvisioningVariable : NamedProvisioningConstruct
     /// <summary>
     /// Creates a new ProvisioningVariable.
     /// </summary>
-    /// <param name="name">Name of the variable.</param>
+    /// <param name="name">
+    /// Name of the variable.  This value can contain letters, numbers, and
+    /// underscores.
+    /// </param>
     /// <param name="type">Type of the variable.</param>
     public ProvisioningVariable(string name, Type type)
         : this(name, new TypeExpression(type), value: null) { }
@@ -56,7 +62,7 @@ public class ProvisioningVariable : NamedProvisioningConstruct
     protected internal override IEnumerable<Statement> Compile()
     {
         // TODO: add the rest of https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameters#use-decorators?
-        VariableStatement stmt = BicepSyntax.Declare.Var(ResourceName, Value.Compile());
+        VariableStatement stmt = BicepSyntax.Declare.Var(IdentifierName, Value.Compile());
         if (Description is not null) { stmt = stmt.Decorate("description", BicepSyntax.Value(Description)); }
         yield return stmt;
     }

--- a/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
@@ -179,7 +179,7 @@ internal class SampleTests(bool async)
                             new StringLiteral("Microsoft.App/managedEnvironments/dotNetComponents@2024-02-02-preview"),
                             new ObjectExpression(
                                 new PropertyExpression("name", "aspire-dashboard"),
-                                new PropertyExpression("parent", new IdentifierExpression(cae.ResourceName)),
+                                new PropertyExpression("parent", new IdentifierExpression(cae.IdentifierName)),
                                 new PropertyExpression("properties",
                                     new ObjectExpression(
                                         new PropertyExpression("componentType", new StringLiteral("AspireDashboard")))))));

--- a/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
@@ -324,7 +324,7 @@ internal class SampleTests(bool async)
                 // the resource group
                 Infrastructure infra = new() { TargetScope = "subscription" };
 
-                ResourceGroup rg = new("rg-test", "2024-03-01");
+                ResourceGroup rg = new("rg_test", "2024-03-01");
                 infra.Add(rg);
 
                 return infra;
@@ -336,8 +336,8 @@ internal class SampleTests(bool async)
             @description('The location for the resource(s) to be deployed.')
             param location string = deployment().location
 
-            resource rg-test 'Microsoft.Resources/resourceGroups@2024-03-01' = {
-              name: take('rg-test-${uniqueString(deployment().id)}', 90)
+            resource rg_test 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+              name: take('rg_test-${uniqueString(deployment().id)}', 90)
               location: location
             }
             """)

--- a/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
@@ -342,5 +343,17 @@ internal class SampleTests(bool async)
             """)
         .Lint()
         .ValidateAndDeployAsync();
+    }
+
+    [Test]
+    public void ValidNames()
+    {
+        Assert.Throws<ArgumentNullException>(() => new StorageAccount(null!));
+        Assert.Throws<ArgumentException>(() => new StorageAccount(""));
+        Assert.Throws<ArgumentException>(() => new StorageAccount("my-storage"));
+        Assert.Throws<ArgumentException>(() => new StorageAccount("my storage"));
+        Assert.Throws<ArgumentException>(() => new StorageAccount("my:storage"));
+        Assert.Throws<ArgumentException>(() => new StorageAccount("storage$"));
+        _ = new StorageAccount("ABCdef123_");
     }
 }

--- a/sdk/provisioning/Generator/src/Model/Resource.cs
+++ b/sdk/provisioning/Generator/src/Model/Resource.cs
@@ -206,7 +206,7 @@ public class Resource(Specification spec, Type armType)
                         writer.WriteLine($"public static {Name} FromExpression(Expression expression)");
                         using (writer.Scope("{", "}"))
                         {
-                            writer.WriteLine($"{Name} resource = new(expression.ToString());");
+                            writer.WriteLine($"{Name} resource = new(nameof({Name}));");
                             writer.WriteLine($"resource.OverrideWithExpression(expression);");
                             writer.WriteLine($"return resource;");
                         }


### PR DESCRIPTION
There are two commits.  The first is tiny with the actual rename.  The second is a regeneration of the world to use it.  Only the first commit needs to be reviewed closely.