### PR TITLE
[DocumentIntelligence] Reenabling ignored test after service fix

### DIFF
--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/assets.json
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/documentintelligence/Azure.AI.DocumentIntelligence",
-  "Tag": "net/documentintelligence/Azure.AI.DocumentIntelligence_0e2741b29e"
+  "Tag": "net/documentintelligence/Azure.AI.DocumentIntelligence_76280009cf"
 }

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentAssert.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentAssert.cs
@@ -50,6 +50,7 @@ namespace Azure.AI.DocumentIntelligence.Tests
         public static void AreEqual(DocumentClassifierDetails expected, DocumentClassifierDetails actual)
         {
             Assert.AreEqual(expected.ClassifierId, actual.ClassifierId);
+            Assert.AreEqual(expected.BaseClassifierId, actual.BaseClassifierId);
             Assert.AreEqual(expected.Description, actual.Description);
             Assert.AreEqual(expected.ApiVersion, actual.ApiVersion);
             Assert.AreEqual(expected.CreatedOn, actual.CreatedOn);

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/DocumentClassifierAdministrationLiveTests.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/DocumentClassifierAdministrationLiveTests.cs
@@ -63,6 +63,7 @@ namespace Azure.AI.DocumentIntelligence.Tests
             DocumentClassifierDetails classifier = operation.Value;
 
             Assert.That(classifier.ClassifierId, Is.EqualTo(classifierId));
+            Assert.That(classifier.BaseClassifierId, Is.Null);
             Assert.That(classifier.Description, Is.EqualTo(description));
             Assert.That(classifier.ApiVersion, Is.EqualTo(ServiceVersionString));
             Assert.That(classifier.CreatedOn, Is.GreaterThan(startTime));
@@ -139,7 +140,6 @@ namespace Azure.AI.DocumentIntelligence.Tests
         #region Copy
 
         [RecordedTest]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/45476")]
         public async Task CopyClassifierTo()
         {
             var client = CreateDocumentIntelligenceAdministrationClient();
@@ -183,7 +183,7 @@ namespace Azure.AI.DocumentIntelligence.Tests
             DocumentClassifierDetails classifier = operation.Value;
 
             Assert.That(classifier.ClassifierId, Is.EqualTo(classifierId));
-            Assert.That(classifier.BaseClassifierId, Is.EqualTo(sourceClassifier.ClassifierId));
+            Assert.That(classifier.BaseClassifierId, Is.Null);
             Assert.That(classifier.Description, Is.EqualTo(description));
             Assert.That(classifier.ApiVersion, Is.EqualTo(ServiceVersionString));
 
@@ -191,8 +191,7 @@ namespace Azure.AI.DocumentIntelligence.Tests
             Assert.That(classifier.CreatedOn, Is.GreaterThan(startTime - TimeSpan.FromHours(4)));
             Assert.That(classifier.ExpiresOn, Is.GreaterThan(classifier.CreatedOn));
 
-            // TODO: reenable validation once the following service issue has been fixed: https://github.com/Azure/azure-sdk-for-net/issues/37172
-            // DocumentAssert.AreEquivalent(sourceClassifier.DocTypes, classifier.DocTypes);
+            DocumentAssert.AreEquivalent(sourceClassifier.DocTypes, classifier.DocTypes);
 
             foreach (var docType in classifier.DocTypes.Values)
             {
@@ -304,7 +303,6 @@ namespace Azure.AI.DocumentIntelligence.Tests
         #endregion Delete
 
         [RecordedTest]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/45476")]
         public async Task AuthorizeClassifierCopy()
         {
             var client = CreateDocumentIntelligenceAdministrationClient();
@@ -314,12 +312,12 @@ namespace Azure.AI.DocumentIntelligence.Tests
             ClassifierCopyAuthorization copyAuthorization = await client.AuthorizeClassifierCopyAsync(content);
 
             Assert.That(copyAuthorization.TargetClassifierId, Is.EqualTo(classifierId));
+            Assert.That(copyAuthorization.TargetClassifierLocation.AbsoluteUri, Does.StartWith(TestEnvironment.Endpoint));
             Assert.That(copyAuthorization.TargetResourceId, Is.EqualTo(TestEnvironment.ResourceId));
             Assert.That(copyAuthorization.TargetResourceRegion, Is.EqualTo(TestEnvironment.ResourceRegion));
             Assert.That(copyAuthorization.AccessToken, Is.Not.Null);
             Assert.That(copyAuthorization.AccessToken, Is.Not.Empty);
             Assert.That(copyAuthorization.ExpirationDateTime, Is.GreaterThan(Recording.UtcNow));
-            // TODO: Check targetclassifierlocation and same for model test.
         }
     }
 }

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/DocumentModelAdministrationLiveTests.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/DocumentModelAdministrationLiveTests.cs
@@ -427,6 +427,7 @@ namespace Azure.AI.DocumentIntelligence.Tests
             CopyAuthorization copyAuthorization = await client.AuthorizeModelCopyAsync(content);
 
             Assert.That(copyAuthorization.TargetModelId, Is.EqualTo(modelId));
+            Assert.That(copyAuthorization.TargetModelLocation.AbsoluteUri, Does.StartWith(TestEnvironment.Endpoint));
             Assert.That(copyAuthorization.TargetResourceId, Is.EqualTo(TestEnvironment.ResourceId));
             Assert.That(copyAuthorization.TargetResourceRegion, Is.EqualTo(TestEnvironment.ResourceRegion));
             Assert.That(copyAuthorization.AccessToken, Is.Not.Null);

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/OperationWithIdLiveTests.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceAdministrationClient/OperationWithIdLiveTests.cs
@@ -198,7 +198,6 @@ namespace Azure.AI.DocumentIntelligence.Tests
         [RecordedTest]
         [TestCase(WaitUntil.Started)]
         [TestCase(WaitUntil.Completed)]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/45476")]
         public async Task CopyClassifierToOperationCanParseOperationId(WaitUntil waitUntil)
         {
             var client = CreateDocumentIntelligenceAdministrationClient();


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/45476