### PR TITLE
Fix missing HybridSearch in copy method of SearchOptions

### DIFF
--- a/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
@@ -428,6 +428,7 @@ namespace Azure.Search.Documents
             destination.QuerySpeller = source.QuerySpeller;
             destination.SemanticSearch = source.SemanticSearch;
             destination.VectorSearch = source.VectorSearch;
+            destination.HybridSearch  = source.HybridSearch;
         }
 
         /// <summary>

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
@@ -1028,6 +1028,11 @@ namespace Azure.Search.Documents.Tests
                 Queries = { new VectorizedQuery(VectorSearchEmbeddings.SearchVectorizeDescription) { KNearestNeighborsCount = 3, Fields = { "DescriptionVector", "CategoryVector" } } },
                 FilterMode = VectorFilterMode.PostFilter
             };
+            source.HybridSearch = new HybridSearch()
+            {
+                MaxTextRecallSize = 50,
+                CountAndFacetMode = HybridCountAndFacetMode.CountRetrievableResults
+            };
             SearchOptions clonedSearchOptions = source.Clone();
 
             CollectionAssert.AreEquivalent(source.Facets, clonedSearchOptions.Facets); // A non-null collection with multiple items
@@ -1048,6 +1053,8 @@ namespace Azure.Search.Documents.Tests
             Assert.AreEqual(source.SemanticSearch.MaxWait, clonedSearchOptions.SemanticSearch.MaxWait);
             Assert.AreEqual(source.VectorSearch.Queries, clonedSearchOptions.VectorSearch.Queries);
             Assert.AreEqual(source.VectorSearch.FilterMode, clonedSearchOptions.VectorSearch.FilterMode);
+            Assert.AreEqual(source.HybridSearch.MaxTextRecallSize, clonedSearchOptions.HybridSearch.MaxTextRecallSize);
+            Assert.AreEqual(source.HybridSearch.CountAndFacetMode, clonedSearchOptions.HybridSearch.CountAndFacetMode);
         }
 
         /* TODO: Enable these Track 1 tests when we have support for index creation


### PR DESCRIPTION
The query parameters to configure hybrid search behaviors are not send to the API because they are not copied when cloning the search options. 

---
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
