### PR TITLE
[Storage] [Blobs] Updated Changelog to include disposing stream made from wrapping BinaryData on Upload

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed bug where BlobClient.Upload(BinaryData content, ..) did not properly dispose stream after wrapping the BinaryData passed.
 
 ### Other Changes
 


### PR DESCRIPTION
Updating Changelog to reflect changes in this PR https://github.com/Azure/azure-sdk-for-net/pull/44510