### PR TITLE
[Storage] [DataMovement] [API-Change] Changed ShareFilesStorageResourceProvider.FromFile/Directory to take a Uri over string

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 ### Breaking Changes
+- Changed `FromDirectory(string directoryUri, ShareFileStorageResourceOptions options = default)` to `FromDirectory(Uri directoryUri, ShareFileStorageResourceOptions options = default)`
+- Changed `FromFile(string fileUri, ShareFileStorageResourceOptions options = default)` to `FromFile(Uri fileUri, ShareFileStorageResourceOptions options = default)`
 
 ### Bugs Fixed
 - Fixed bug where copying a Azure Storage Blob to a Share File would not be able to convert Content Language and Content Encoding to the `string[]` type.

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/README.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/README.md
@@ -84,11 +84,11 @@ To create a share `StorageResource`, use the methods `FromFile` or `FromDirector
 
 ```C# Snippet:ResourceConstruction_Shares
 StorageResource directory = shares.FromDirectory(
-    "http://myaccount.files.core.windows.net/share/path/to/directory");
+    new Uri("http://myaccount.files.core.windows.net/share/path/to/directory"));
 StorageResource rootDirectory = shares.FromDirectory(
-    "http://myaccount.files.core.windows.net/share");
+    new Uri("http://myaccount.files.core.windows.net/share"));
 StorageResource file = shares.FromFile(
-    "http://myaccount.files.core.windows.net/share/path/to/file.txt");
+    new Uri("http://myaccount.files.core.windows.net/share/path/to/file.txt"));
 ```
 
 Storage resources can also be initialized with the appropriate client object from Azure.Storage.Files.Shares. Since these resources will use the credential already present in the client object, no credential is required in the provider when using `FromClient()`. **However**, a `ShareFilesStorageResourceProvider` must still have a credential if it is to be used in `TransferManagerOptions` for resuming a transfer.

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
@@ -19,12 +19,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Files.Shares.ShareDirectoryClient client, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Files.Shares.ShareFileClient client, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromDestinationAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public Azure.Storage.DataMovement.StorageResource FromDirectory(string directoryUri, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
-        public Azure.Storage.DataMovement.StorageResource FromFile(string fileUri, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
+        public Azure.Storage.DataMovement.StorageResource FromDirectory(System.Uri directoryUri, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
+        public Azure.Storage.DataMovement.StorageResource FromFile(System.Uri fileUri, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromSourceAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public delegate Azure.AzureSasCredential GetAzureSasCredential(string uri, bool readOnly);
-        public delegate Azure.Storage.StorageSharedKeyCredential GetStorageSharedKeyCredential(string uri, bool readOnly);
-        public delegate Azure.Core.TokenCredential GetTokenCredential(string uri, bool readOnly);
+        public delegate Azure.AzureSasCredential GetAzureSasCredential(System.Uri uri, bool readOnly);
+        public delegate Azure.Storage.StorageSharedKeyCredential GetStorageSharedKeyCredential(System.Uri uri, bool readOnly);
+        public delegate Azure.Core.TokenCredential GetTokenCredential(System.Uri uri, bool readOnly);
     }
     public partial class ShareFileStorageResourceOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
@@ -19,12 +19,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Files.Shares.ShareDirectoryClient client, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
         public Azure.Storage.DataMovement.StorageResource FromClient(Azure.Storage.Files.Shares.ShareFileClient client, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromDestinationAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public Azure.Storage.DataMovement.StorageResource FromDirectory(string directoryUri, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
-        public Azure.Storage.DataMovement.StorageResource FromFile(string fileUri, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
+        public Azure.Storage.DataMovement.StorageResource FromDirectory(System.Uri directoryUri, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
+        public Azure.Storage.DataMovement.StorageResource FromFile(System.Uri fileUri, Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions options = null) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromSourceAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public delegate Azure.AzureSasCredential GetAzureSasCredential(string uri, bool readOnly);
-        public delegate Azure.Storage.StorageSharedKeyCredential GetStorageSharedKeyCredential(string uri, bool readOnly);
-        public delegate Azure.Core.TokenCredential GetTokenCredential(string uri, bool readOnly);
+        public delegate Azure.AzureSasCredential GetAzureSasCredential(System.Uri uri, bool readOnly);
+        public delegate Azure.Storage.StorageSharedKeyCredential GetStorageSharedKeyCredential(System.Uri uri, bool readOnly);
+        public delegate Azure.Core.TokenCredential GetTokenCredential(System.Uri uri, bool readOnly);
     }
     public partial class ShareFileStorageResourceOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/samples/Sample01b_HelloWorldAsync.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/samples/Sample01b_HelloWorldAsync.cs
@@ -52,11 +52,11 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                     // Construct simple blob resources for data movement
                     #region Snippet:ResourceConstruction_Shares
                     StorageResource directory = shares.FromDirectory(
-                        "http://myaccount.files.core.windows.net/share/path/to/directory");
+                        new Uri("http://myaccount.files.core.windows.net/share/path/to/directory"));
                     StorageResource rootDirectory = shares.FromDirectory(
-                        "http://myaccount.files.core.windows.net/share");
+                        new Uri("http://myaccount.files.core.windows.net/share"));
                     StorageResource file = shares.FromFile(
-                        "http://myaccount.files.core.windows.net/share/path/to/file.txt");
+                        new Uri("http://myaccount.files.core.windows.net/share/path/to/file.txt"));
                     #endregion
                 }
                 {
@@ -71,11 +71,11 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 {
                     StorageSharedKeyCredential sharedKeyCredential = new(StorageAccountName, StorageAccountKey);
                     // Get blobs provider with credential
-                    AzureSasCredential GenerateSas(string uri, bool readOnly)
+                    AzureSasCredential GenerateSas(Uri uri, bool readOnly)
                     {
                         // Quick sample demonstrating minimal steps
                         // Construct your SAS according to your needs
-                        ShareUriBuilder pathUri = new(new Uri(uri));
+                        ShareUriBuilder pathUri = new(uri);
                         ShareSasBuilder sas = new(ShareSasPermissions.All, DateTimeOffset.Now.AddHours(1))
                         {
                             ShareName = pathUri.ShareName,
@@ -110,8 +110,8 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 LocalFilesStorageResourceProvider files = new();
 
                 // Get a reference to a destination blobs
-                string destinationFolderUri = share.GetDirectoryClient("sample-directory").Uri.ToString();
-                string destinationFileUri = share.GetRootDirectoryClient().GetFileClient("sample-file").Uri.ToString();
+                Uri destinationFolderUri = share.GetDirectoryClient("sample-directory").Uri;
+                Uri destinationFileUri = share.GetRootDirectoryClient().GetFileClient("sample-file").Uri;
                 TransferManager transferManager = new TransferManager(new TransferManagerOptions());
 
                 // Create simple transfer single blob upload job
@@ -153,8 +153,8 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 LocalFilesStorageResourceProvider files = new();
 
                 // Get a reference to a destination blobs
-                string sourceDirectoryUri = share.GetDirectoryClient("sample-directory").Uri.ToString();
-                string sourceFileUri = share.GetRootDirectoryClient().GetFileClient("sample-file").Uri.ToString();
+                Uri sourceDirectoryUri = share.GetDirectoryClient("sample-directory").Uri;
+                Uri sourceFileUri = share.GetRootDirectoryClient().GetFileClient("sample-file").Uri;
                 TransferManager transferManager = new TransferManager(new TransferManagerOptions());
 
                 // Create simple transfer single blob upload job
@@ -192,10 +192,10 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 ShareFilesStorageResourceProvider shares = new(new StorageSharedKeyCredential(StorageAccountName, StorageAccountKey));
 
                 // Get a reference to a destination blobs
-                string sourceDirectoryUri = share.GetDirectoryClient("sample-directory-1").Uri.ToString();
-                string destinationDirectoryUri = share.GetDirectoryClient("sample-directory-2").Uri.ToString();
-                string sourceFileUri = share.GetRootDirectoryClient().GetFileClient("sample-file-1").Uri.ToString();
-                string destinationFileUri = share.GetRootDirectoryClient().GetFileClient("sample-file-2").Uri.ToString();
+                Uri sourceDirectoryUri = share.GetDirectoryClient("sample-directory-1").Uri;
+                Uri destinationDirectoryUri = share.GetDirectoryClient("sample-directory-2").Uri;
+                Uri sourceFileUri = share.GetRootDirectoryClient().GetFileClient("sample-file-1").Uri;
+                Uri destinationFileUri = share.GetRootDirectoryClient().GetFileClient("sample-file-2").Uri;
                 TransferManager transferManager = new TransferManager(new TransferManagerOptions());
 
                 // Create simple transfer single blob upload job

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFilesStorageResourceProvider.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFilesStorageResourceProvider.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// <param name="readOnly">
         /// Whether the permission can be read-only.
         /// </param>
-        public delegate StorageSharedKeyCredential GetStorageSharedKeyCredential(string uri, bool readOnly);
+        public delegate StorageSharedKeyCredential GetStorageSharedKeyCredential(Uri uri, bool readOnly);
 
         /// <summary>
         /// Delegate for fetching a token credential for a given URI.
@@ -36,7 +36,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// <param name="readOnly">
         /// Whether the permission can be read-only.
         /// </param>
-        public delegate TokenCredential GetTokenCredential(string uri, bool readOnly);
+        public delegate TokenCredential GetTokenCredential(Uri uri, bool readOnly);
 
         /// <summary>
         /// Delegate for fetching a SAS credential for a given URI.
@@ -47,7 +47,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// <param name="readOnly">
         /// Whether the permission can be read-only.
         /// </param>
-        public delegate AzureSasCredential GetAzureSasCredential(string uri, bool readOnly);
+        public delegate AzureSasCredential GetAzureSasCredential(Uri uri, bool readOnly);
 
         private enum ResourceType
         {
@@ -229,8 +229,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             // Source share file data currently empty, so no specific properties to grab
 
             return Task.FromResult(properties.IsContainer
-                ? FromDirectory(properties.SourceUri.AbsoluteUri)
-                : FromFile(properties.SourceUri.AbsoluteUri));
+                ? FromDirectory(properties.SourceUri)
+                : FromFile(properties.SourceUri));
         }
 
         /// <inheritdoc/>
@@ -258,8 +258,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 FileMetadata = checkpointData.FileMetadata,
             };
             return Task.FromResult(properties.IsContainer
-                ? FromDirectory(properties.DestinationUri.AbsoluteUri, options)
-                : FromFile(properties.DestinationUri.AbsoluteUri, options));
+                ? FromDirectory(properties.DestinationUri, options)
+                : FromFile(properties.DestinationUri, options));
         }
 
         /// <summary>
@@ -294,14 +294,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// <returns>
         /// The configured storage resource.
         /// </returns>
-        public StorageResource FromDirectory(string directoryUri, ShareFileStorageResourceOptions options = default)
+        public StorageResource FromDirectory(Uri directoryUri, ShareFileStorageResourceOptions options = default)
         {
             ShareDirectoryClient client = _credentialType switch
             {
-                CredentialType.None => new ShareDirectoryClient(new Uri(directoryUri)),
-                CredentialType.SharedKey => new ShareDirectoryClient(new Uri(directoryUri), _getStorageSharedKeyCredential(directoryUri, false)),
-                CredentialType.Token => new ShareDirectoryClient(new Uri(directoryUri), _getTokenCredential(directoryUri, false)),
-                CredentialType.Sas => new ShareDirectoryClient(new Uri(directoryUri), _getAzureSasCredential(directoryUri, false)),
+                CredentialType.None => new ShareDirectoryClient(directoryUri),
+                CredentialType.SharedKey => new ShareDirectoryClient(directoryUri, _getStorageSharedKeyCredential(directoryUri, false)),
+                CredentialType.Token => new ShareDirectoryClient(directoryUri, _getTokenCredential(directoryUri, false)),
+                CredentialType.Sas => new ShareDirectoryClient(directoryUri, _getAzureSasCredential(directoryUri, false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };
             return new ShareDirectoryStorageResourceContainer(client, options);
@@ -320,15 +320,15 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// The configured storage resource.
         /// </returns>
         public StorageResource FromFile(
-            string fileUri,
+            Uri fileUri,
             ShareFileStorageResourceOptions options = default)
         {
             ShareFileClient client = _credentialType switch
             {
-                CredentialType.None => new ShareFileClient(new Uri(fileUri)),
-                CredentialType.SharedKey => new ShareFileClient(new Uri(fileUri), _getStorageSharedKeyCredential(fileUri, false)),
-                CredentialType.Token => new ShareFileClient(new Uri(fileUri), _getTokenCredential(fileUri, false)),
-                CredentialType.Sas => new ShareFileClient(new Uri(fileUri), _getAzureSasCredential(fileUri, false)),
+                CredentialType.None => new ShareFileClient(fileUri),
+                CredentialType.SharedKey => new ShareFileClient(fileUri, _getStorageSharedKeyCredential(fileUri, false)),
+                CredentialType.Token => new ShareFileClient(fileUri, _getTokenCredential(fileUri, false)),
+                CredentialType.Sas => new ShareFileClient(fileUri, _getAzureSasCredential(fileUri, false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };
             return new ShareFileStorageResource(client, options);


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net-pr/issues/2138
