### PR TITLE
Use common OIDC token env vars for identity live tests

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -57,6 +57,9 @@ parameters:
   - name: UseFederatedAuth
     type: boolean
     default: true
+  - name: PersistOidcToken
+    type: boolean
+    default: false
 
 jobs:
   - job:
@@ -142,6 +145,7 @@ jobs:
               SubscriptionConfiguration: $(SubscriptionConfiguration)
               ArmTemplateParameters: $(ArmTemplateParameters)
               UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+              PersistOidcToken: ${{ parameters.PersistOidcToken }}
               ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
               SubscriptionConfigurationFilePaths: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePaths }}
               EnvVars:

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -226,6 +226,8 @@ jobs:
           displayName: "Build & Test (all tests for $(TestTargetFramework)) - Client Secret Auth"
           env:
             AZURE_TEST_MODE: $(TestMode)
+            ${{ if parameters.PersistOidcToken }}:
+              ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
             ${{ each var in parameters.EnvVars }}:
               ${{ var.key }}: ${{ var.value }}
 

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -103,6 +103,9 @@ parameters:
   - name: UseFederatedAuth
     type: boolean
     default: true
+  - name: PersistOidcToken
+    type: boolean
+    default: false
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -143,6 +146,7 @@ extends:
                       TestSetupSteps: ${{ parameters.TestSetupSteps }}
                       DeployTestResources: ${{ parameters.DeployTestResources }}
                       UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+                      PersistOidcToken: ${{ parameters.PersistOidcToken }}
                     MatrixConfigs:
                       # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).
                       - ${{ each config in parameters.MatrixConfigs }}:

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityAKSIntegrationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityAKSIntegrationTests.cs
@@ -21,8 +21,8 @@ namespace Azure.Identity.Tests
 
         public void SetupKubernetesEnvironment()
         {
-            string sp = Environment.GetEnvironmentVariable("ARM_CLIENT_ID");
-            string tenant = Environment.GetEnvironmentVariable("ARM_TENANT_ID");
+            string sp = Environment.GetEnvironmentVariable("IDENTITY_CLIENT_ID");
+            string tenant = Environment.GetEnvironmentVariable("IDENTITY_TENANT_ID");
             string oidc = Environment.GetEnvironmentVariable("ARM_OIDC_TOKEN");
             string rg = Environment.GetEnvironmentVariable("IDENTITY_RESOURCE_GROUP");
             string aks = Environment.GetEnvironmentVariable("IDENTITY_AKS_CLUSTER_NAME");

--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -4,14 +4,19 @@ param (
     [Parameter(ValueFromRemainingArguments = $true)]
     $RemainingArguments,
 
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $Location,
+
     [Parameter()]
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
     [string] $TestApplicationId,
 
-    [Parameter()]
-    [string] $TestApplicationSecret,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $Environment,
 
-    [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
+    [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string] $TenantId
 )
@@ -23,9 +28,10 @@ $sshKey = Get-Content $PSScriptRoot/sshKey.pub
 
 $templateFileParameters['sshPubKey'] = $sshKey
 
-# Get the max version that is not preview and then get the name of the patch version with the max value
+az cloud set --name $Environment
 az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
-$versions = az aks get-versions -l westus -o json | ConvertFrom-Json
+# Get the max version that is not preview and then get the name of the patch version with the max value
+$versions = az aks get-versions -l $Location -o json | ConvertFrom-Json
 Write-Host "AKS versions: $($versions | ConvertTo-Json -Depth 100)"
 $patchVersions = $versions.values | Where-Object { $_.isPreview -eq $null } | Select-Object -ExpandProperty patchVersions
 Write-Host "AKS patch versions: $($patchVersions | ConvertTo-Json -Depth 100)"

--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -4,10 +4,6 @@ param (
     [Parameter(ValueFromRemainingArguments = $true)]
     $RemainingArguments,
 
-    [Parameter(Mandatory = $true)]
-    [ValidateNotNullOrEmpty()]
-    [string] $Location,
-
     [Parameter()]
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
     [string] $TestApplicationId,
@@ -31,7 +27,8 @@ $templateFileParameters['sshPubKey'] = $sshKey
 az cloud set --name $Environment
 az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
 # Get the max version that is not preview and then get the name of the patch version with the max value
-$versions = az aks get-versions -l $Location -o json | ConvertFrom-Json
+$region = if ($Environment -eq 'AzureUSGovernment') { 'usgovvirginia' } elseif ($Environment -eq 'AzureChinaCloud') { 'chinanorth3' } else { 'westus' }
+$versions = az aks get-versions -l $region -o json | ConvertFrom-Json
 Write-Host "AKS versions: $($versions | ConvertTo-Json -Depth 100)"
 $patchVersions = $versions.values | Where-Object { $_.isPreview -eq $null } | Select-Object -ExpandProperty patchVersions
 Write-Host "AKS patch versions: $($patchVersions | ConvertTo-Json -Depth 100)"

--- a/sdk/identity/test-resources.bicep
+++ b/sdk/identity/test-resources.bicep
@@ -235,7 +235,7 @@ resource newCluster 'Microsoft.ContainerService/managedClusters@2023-06-01' = {
       {
         name: 'agentpool'
         count: 1
-        vmSize: 'Standard_D2s_v3'
+        vmSize: 'Standard_D2s_v5'
         osDiskSizeGB: 128
         osDiskType: 'Managed'
         kubeletDiskType: 'OS'

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -3,23 +3,8 @@ trigger: none
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
-    PreSteps:
-      - task: AzureCLI@2
-        displayName: Set OIDC variables
-        env:
-          ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
-          ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-          ARM_TENANT_ID: $(ARM_TENANT_ID)
-        inputs:
-          azureSubscription: azure-sdk-tests
-          scriptType: pscore
-          scriptLocation: inlineScript
-          addSpnToEnvironment: true
-          inlineScript: |
-            Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
-            Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
-            Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
     TimeoutInMinutes: 120
+    PersistOidcToken: true
     AdditionalMatrixConfigs:
       - Name: identity_msi
         Path: sdk/identity/platform-matrix.json
@@ -31,7 +16,3 @@ extends:
         SubscriptionConfigurations:
           # Contains alternate tenant, AAD app and cert info for testing
           - $(sub-config-identity-test-resources)
-    EnvVars:
-      ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
-      ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-      ARM_TENANT_ID: $(ARM_TENANT_ID)


### PR DESCRIPTION
Support oidc az cli login in post deploy scripts for multi-cloud. Requires https://github.com/Azure/azure-sdk-tools/pull/9099