### PR TITLE
[EngSys] Update central Service Bus version

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -115,7 +115,7 @@
     <PackageReference Update="Azure.Data.Tables" Version="12.8.0" />
     <PackageReference Update="Azure.Messaging.EventHubs" Version="5.11.5" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.21.0" />
-    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.18.2" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.4.0" />
     <PackageReference Update="Azure.MixedReality.Authentication" version= "1.2.0" />
     <PackageReference Update="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0-beta.1" />
@@ -255,7 +255,7 @@
     <PackageReference Update="Azure.Identity" Version="1.12.0" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.17.0" />
     <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.11.3" />
-    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.18.2" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.2.0" />
     <PackageReference Update="Azure.ResourceManager.CognitiveServices" Version="1.3.0" />
     <PackageReference Update="Azure.ResourceManager.KeyVault" Version="1.1.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to update the central version for the `Azure.Messaging.ServiceBus` package to use the latest release.