### PR TITLE
[Storage][DataMovement] Fix perf test cleanup + other minor fixes

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/perf/Azure.Storage.DataMovement.Blobs.Perf/Infrastructure/DirectoryTransferTest.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/perf/Azure.Storage.DataMovement.Blobs.Perf/Infrastructure/DirectoryTransferTest.cs
@@ -18,6 +18,7 @@ namespace Azure.Storage.DataMovement.Blobs.Perf
         protected BlobServiceClient BlobServiceClient { get; }
         protected LocalFilesStorageResourceProvider LocalFileResourceProvider { get; }
         protected BlobsStorageResourceProvider BlobResourceProvider { get; }
+        private TimeSpan _transferTimeout;
 
         public DirectoryTransferTest(TOptions options) : base(options)
         {
@@ -25,6 +26,7 @@ namespace Azure.Storage.DataMovement.Blobs.Perf
             BlobServiceClient = new BlobServiceClient(PerfTestEnvironment.Instance.BlobStorageEndpoint, PerfTestEnvironment.Instance.Credential);
             LocalFileResourceProvider = new LocalFilesStorageResourceProvider();
             BlobResourceProvider = new BlobsStorageResourceProvider(PerfTestEnvironment.Instance.Credential);
+            _transferTimeout = TimeSpan.FromSeconds(5 + (Options.Count * Options.Size) / (1 * 1024 * 1024));
         }
 
         protected string CreateLocalDirectory(bool populate = false)
@@ -92,14 +94,20 @@ namespace Azure.Storage.DataMovement.Blobs.Perf
                 source, destination, options, cancellationToken);
 
             // The test runs for a specified duration and then cancels the token.
-            // When canceled, pause the currently running transfer so it can be
-            // cleaned up.
+            // When canceled, pause the currently running transfer so it can be cleaned up.
             cancellationToken.Register(async () =>
             {
                 // Don't pass cancellation token since its already cancelled.
                 await transfer.PauseAsync();
             });
-            await transfer.WaitForCompletionAsync();
+
+            // The cancellation token we specify for WaitForCompletion should not
+            // be the one passed to the test as we don't want this code to exit until
+            // the transfer is complete or paused so it can be properly cleaned up.
+            // However, we pass a token with a generous time to prevent the transfer
+            // from hanging forever if there is an issue.
+            CancellationTokenSource ctx = new(_transferTimeout);
+            await transfer.WaitForCompletionAsync(ctx.Token);
 
             if (!transfer.TransferStatus.HasCompletedSuccessfully &&
                 transfer.TransferStatus.State != DataTransferState.Paused)

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
@@ -379,6 +379,7 @@ namespace Azure.Storage.DataMovement
         {
             if (ex is not OperationCanceledException &&
                 ex is not TaskCanceledException &&
+                ex.InnerException is not TaskCanceledException &&
                 !ex.Message.Contains("The request was canceled."))
             {
                 if (ex is RequestFailedException requestFailedException)

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
@@ -84,6 +84,7 @@ namespace Azure.Storage.DataMovement
             long? length = default,
             CancellationToken cancellationToken = default)
         {
+            CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
             FileStream stream = new FileStream(_uri.LocalPath, FileMode.Open, FileAccess.Read);
             stream.Position = position;
             return Task.FromResult(new StorageResourceReadStreamResult(stream));


### PR DESCRIPTION
This change includes a fix for cleanup during an UploadDirectory perf test as well as a couple of other small changes to stream handling that were found along the way.

- Fix perf test cleanup by not passing the cancellation to `WaitForCompletionAsync` and instead pausing the transfer when the test is cancelled.
- Ignore exceptions with inner Task Cancelled exceptions when processing exceptions
- Minor changes to stream disposal during Upload job.