### PR TITLE
Update version of System.Text.Json

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -98,7 +98,7 @@
     <PackageReference Update="System.Security.Cryptography.Cose" Version="7.0.0" />
     <PackageReference Update="System.Threading.Channels" Version="6.0.0" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Update="System.Text.Json" Version="6.0.9" />
+    <PackageReference Update="System.Text.Json" Version="6.0.10" />
     <PackageReference Update="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />


### PR DESCRIPTION
Per security vulnerability in 6.0.9 - https://github.com/advisories/GHSA-8g4q-xg66-9fp4
