### PR TITLE
fix(digitaltwins): bump System.Text.Json to 6.0.10

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
 
-    <PackageReference Include="System.Text.Json" Version="6.0.9" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We need to bump the `System.Text.Json` to `6.0.10` to unblock our pipelines. See one of the errors: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4217246&view=logs&j=997896c9-acda-580e-e180-6ae890cb75c8&t=c50282b0-2acb-55bb-3103-b9a0c36c4a74&l=614

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
