### PR TITLE
[Event Hubs] Resilient management link creation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Querying runtime data and other management operations will now correctly guards against the race condition where an AMQP link is in the process of closing as the operation attempts to use it.  These errors will now properly be classified as retriable as they are for producer and consumer operations.
+
 ### Other Changes
 
 ## 5.11.5 (2024-07-31)


### PR DESCRIPTION
# Summary

The focus of these changes is to correctly handle the scenario where the management AMQP link is in the process of closing (such as for an idle timeout) as a new operation attempts to use it.  This error should be detected as a special case and retried as it is with producer and consumer operations.

## References and related

- [EventHubConsumerClient.GetPartitionPropertiesAsync throws InvalidOperationException from AMQP library instead of retrying (#46525)](https://github.com/Azure/azure-sdk-for-net/issues/46525)
