### PR TITLE
[CODEOWNERS] Adjust baseline errors

### DIFF
--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -253,7 +253,6 @@ EldertGrootenboer is not a public member of Azure.
 QingChenmsft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 vaishnavk is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 juhacket is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
-sffamily is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 chenkennt is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 azureSQLGitHub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 xgithubtriage is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.


### PR DESCRIPTION
The focus of these changes is to remove an account from the baseline errors, as the CODEOWNERS file has been updated to remove them.