### PR TITLE
[EngSys] Bump package versions

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -325,7 +325,7 @@
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.10" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Update="Microsoft.Extensions.Logging.Configuration" Version="8.0.0-rc.1.23419.4" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.32" />
     <PackageReference Update="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />

--- a/samples/linecounter/LineCounter.csproj
+++ b/samples/linecounter/LineCounter.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.21.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.10.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.10.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.5" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.11.5" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0-rc.2.23479.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.8" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/aspnet-hosted-service/Directory.Build.targets
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/aspnet-hosted-service/Directory.Build.targets
@@ -6,9 +6,9 @@
 
   <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
   <ItemGroup Condition="'$(IsSamplesProject)' == '' OR '$(IsTestProject)' == ''">
-    <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.10.0" />
+    <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.11.5" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump packages that were flagged by component governance this week related to the STJ 8.0.4 CVE.  Some older Event Hubs and RC-based references were also bumped.