### PR TITLE
[AzureMonitorDistro] prep release 1.3.0 beta2 (again) - fix package dependency

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -23,10 +23,10 @@
     <!-- Depending on monthly deliverables, we may switch between PackageReference or ProjectReference. Keeping both here to make the switch easier. -->
 
     <!-- FOR PUBLIC RELEASES, MUST USE PackageReference. THIS REQUIRES A STAGGERED RELEASE IF SHIPPING A NEW EXPORTER. -->
-    <!--<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />-->
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
 
     <!-- FOR LOCAL DEV, ProjectReference IS PREFERRED. -->
-    <ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
+    <!--<ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />-->
   </ItemGroup>
 
   <!-- Shared sources from Azure.Core -->


### PR DESCRIPTION
Follow up to #46572.

Need to use the package dependency to unblock the release.