### PR TITLE
Fix storage tests-weekly matrix

### DIFF
--- a/sdk/storage/platform-matrix-all-versions.json
+++ b/sdk/storage/platform-matrix-all-versions.json
@@ -3,11 +3,11 @@
     "Agent": {
       "ubuntu-20.04": {
           "OSVmImage": "env:LINUXVMIMAGE",
-          "Pool": "azsdk-pool-mms-ubuntu-2004-storage"
+          "Pool": "env:LINUXPOOL"
       },
       "windows-2022": {
           "OSVmImage": "env:WINDOWSVMIMAGE",
-          "Pool": "azsdk-pool-mms-win-2022-storage"
+          "Pool": "env:WINDOWSPOOL"
       }
     },
     "TestTargetFramework": [

--- a/sdk/storage/tests.datamovement.yml
+++ b/sdk/storage/tests.datamovement.yml
@@ -10,9 +10,9 @@ extends:
     Location: canadacentral
     CloudConfig:
       Public:
-      PrivatePreview:
-        SubscriptionConfiguration: $(sub-config-storage-test-resources)
-    SupportedClouds: Public, PrivatePreview
+      # PrivatePreview:
+      #  SubscriptionConfiguration: $(sub-config-storage-test-resources)
+    SupportedClouds: Public #, PrivatePreview
     MatrixReplace:
       # Use dedicated storage pool in canadacentral with higher memory capacity
       - Pool=.*LINUXPOOL.*/azsdk-pool-mms-ubuntu-2004-storage

--- a/sdk/storage/tests.functions.yml
+++ b/sdk/storage/tests.functions.yml
@@ -10,9 +10,9 @@ extends:
     Location: canadacentral
     CloudConfig:
       Public:
-      PrivatePreview:
-        SubscriptionConfiguration: $(sub-config-storage-test-resources)
-    SupportedClouds: Public, PrivatePreview
+      # PrivatePreview:
+      #   SubscriptionConfiguration: $(sub-config-storage-test-resources)
+    SupportedClouds: Public #, PrivatePreview
     MatrixReplace:
       # Use dedicated storage pool in canadacentral with higher memory capacity
       - Pool=.*LINUXPOOL.*/azsdk-pool-mms-ubuntu-2004-storage

--- a/sdk/storage/tests.mgmt.yml
+++ b/sdk/storage/tests.mgmt.yml
@@ -10,9 +10,9 @@ extends:
     Location: canadacentral
     CloudConfig:
       Public:
-      PrivatePreview:
-        SubscriptionConfiguration: $(sub-config-storage-test-resources)
-    SupportedClouds: Public, PrivatePreview
+      # PrivatePreview:
+      #  SubscriptionConfiguration: $(sub-config-storage-test-resources)
+    SupportedClouds: Public #, PrivatePreview
     MatrixReplace:
       # Use dedicated storage pool in canadacentral with higher memory capacity
       - Pool=.*LINUXPOOL.*/azsdk-pool-mms-ubuntu-2004-storage

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -10,9 +10,9 @@ extends:
     Location: canadacentral
     CloudConfig:
       Public:
-      PrivatePreview:
-        SubscriptionConfiguration: $(sub-config-storage-test-resources)
-    SupportedClouds: Public, PrivatePreview
+      #PrivatePreview:
+      #  SubscriptionConfiguration: $(sub-config-storage-test-resources)
+    SupportedClouds: Public #, PrivatePreview
     MatrixReplace:
       # Use dedicated storage pool in canadacentral with higher memory capacity
       - Pool=.*LINUXPOOL.*/azsdk-pool-mms-ubuntu-2004-storage

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -7,7 +7,7 @@ extends:
     ServiceDirectory: storage
     BuildInParallel: true
     TimeoutInMinutes: 180
-    Location: canadacentral
+    Location: westus2
     CloudConfig:
       Public:
       #PrivatePreview:


### PR DESCRIPTION
Fix the tests-weekly matrix which has been failing to generate a matrix because the pool names weren't correct.

I also disabled the PrivatePreview configurations because they do not work currently and will require support from the storage team if we want to setup again. 