### PR TITLE
Fix deserialization bug

### DIFF
--- a/sdk/maps/Azure.Maps.Routing/assets.json
+++ b/sdk/maps/Azure.Maps.Routing/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/maps/Azure.Maps.Routing",
-  "Tag": "net/maps/Azure.Maps.Routing_54064ae0c1"
+  "Tag": "net/maps/Azure.Maps.Routing_0755b0a67d"
 }

--- a/sdk/maps/Azure.Maps.Routing/src/Generated/Models/RouteMatrix.Serialization.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Generated/Models/RouteMatrix.Serialization.cs
@@ -11,44 +11,5 @@ namespace Azure.Maps.Routing.Models
 {
     public partial class RouteMatrix
     {
-        internal static RouteMatrix DeserializeRouteMatrix(JsonElement element)
-        {
-            if (element.ValueKind == JsonValueKind.Null)
-            {
-                return null;
-            }
-            int? statusCode = default;
-            RouteMatrixResultResponse response = default;
-            foreach (var property in element.EnumerateObject())
-            {
-                if (property.NameEquals("statusCode"u8))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
-                    statusCode = property.Value.GetInt32();
-                    continue;
-                }
-                if (property.NameEquals("response"u8))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
-                    response = RouteMatrixResultResponse.DeserializeRouteMatrixResultResponse(property.Value);
-                    continue;
-                }
-            }
-            return new RouteMatrix(statusCode, response);
-        }
-
-        /// <summary> Deserializes the model from a raw response. </summary>
-        /// <param name="response"> The response to deserialize the model from. </param>
-        internal static RouteMatrix FromResponse(Response response)
-        {
-            using var document = JsonDocument.Parse(response.Content);
-            return DeserializeRouteMatrix(document.RootElement);
-        }
     }
 }

--- a/sdk/maps/Azure.Maps.Routing/src/Models/Operation/GetRouteMatrixOperation.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Models/Operation/GetRouteMatrixOperation.cs
@@ -110,8 +110,7 @@ namespace Azure.Maps.Routing.Models
                 _id = paths[paths.Length - 1];
             }
 
-            RouteMatrixResult result = null;
-            return Response.FromValue(result, response);
+            return await WaitForCompletionAsync(async, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/maps/Azure.Maps.Routing/src/Models/RouteMatrix.Serialization.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Models/RouteMatrix.Serialization.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System.Text.Json;
+
+namespace Azure.Maps.Routing.Models
+{
+    public partial class RouteMatrix
+    {
+        internal static RouteMatrix DeserializeRouteMatrix(JsonElement element)
+        {
+            if (element.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+            int? statusCode = default;
+            RouteMatrixResultResponse response = default;
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("statusCode"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    statusCode = property.Value.GetInt32();
+                    continue;
+                }
+                if (property.NameEquals("response"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    if (statusCode == 200) {
+                        response = RouteMatrixResultResponse.DeserializeRouteMatrixResultResponse(property.Value);
+                    } else {
+                        response = new RouteMatrixResultResponse(null);
+                    }
+                    continue;
+                }
+            }
+            return new RouteMatrix(statusCode, response);
+        }
+
+        /// <summary> Deserializes the model from a raw response. </summary>
+        /// <param name="response"> The response to deserialize the model from. </param>
+        internal static RouteMatrix FromResponse(Response response)
+        {
+            using var document = JsonDocument.Parse(response.Content);
+            return DeserializeRouteMatrix(document.RootElement);
+        }
+    }
+}

--- a/sdk/maps/Azure.Maps.Routing/tests/RouteMatrixTests.cs
+++ b/sdk/maps/Azure.Maps.Routing/tests/RouteMatrixTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,15 +28,19 @@ namespace Azure.Maps.Routing.Tests
                     new GeoPosition(123.751, 45.9375),
                     new GeoPosition(123.791, 45.96875)
                 },
-                Destinations = new List<GeoPosition>() { new GeoPosition(123.767, 45.90625) },
+                Destinations = new List<GeoPosition>()
+                {
+                    new GeoPosition(1, 13.5471),
+                    new GeoPosition(123.767, 45.90625),
+                },
             };
             var result = await client.GetImmediateRouteMatrixAsync(routeMatrixQuery);
 
             Assert.AreEqual("0.0.1", result.Value.FormatVersion);
             Assert.AreEqual(2, result.Value.Matrix.Count);
-            Assert.AreEqual(1, result.Value.Matrix[0].Count);
+            Assert.AreEqual(2, result.Value.Matrix[0].Count);
             Assert.AreEqual(2, result.Value.Summary.SuccessfulRoutes);
-            Assert.AreEqual(2, result.Value.Summary.TotalRoutes);
+            Assert.AreEqual(4, result.Value.Summary.TotalRoutes);
         }
 
         [RecordedTest]


### PR DESCRIPTION
Fix for #45643
* If the `statusCode` in `RouteMatrix` is not `200`, it returns a null response.
* Updated test cases to make sure it works as expected.