### PR TITLE
chore(playwrighttesting): removed fallback authentication logic

### DIFF
--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/Constants.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/Constants.cs
@@ -199,6 +199,8 @@ internal class Constants
     internal static readonly string s_invalid_mpt_pat_error = "The Access Token provided in the environment variable is invalid.";
     internal static readonly string s_expired_mpt_pat_error = "The Access Token you are using is expired. Create a new token.";
     internal static readonly string s_invalid_os_error = "Invalid operating system, supported values are 'linux' and 'windows'.";
+    internal static readonly string s_workspace_mismatch_error = "The provided access token does not match the specified workspace URL. Please verify that both values are correct.";
+    internal static readonly string s_invalid_service_endpoint_error_message = "The service endpoint provided is invalid. Please verify the endpoint URL and try again.";
 
     internal static readonly string s_playwright_service_disable_scalable_execution_environment_variable = "PLAYWRIGHT_SERVICE_DISABLE_SCALABLE_EXECUTION";
     internal static readonly string s_playwright_service_reporting_url_environment_variable = "PLAYWRIGHT_SERVICE_REPORTING_URL";

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/EntraLifecycle.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/EntraLifecycle.cs
@@ -24,7 +24,7 @@ internal class EntraLifecycle
         SetEntraIdAccessTokenFromEnvironment();
     }
 
-    internal async Task<bool> FetchEntraIdAccessTokenAsync(CancellationToken cancellationToken = default)
+    internal async Task FetchEntraIdAccessTokenAsync(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -33,12 +33,12 @@ internal class EntraLifecycle
             _entraIdAccessToken = accessToken.Token;
             _entraIdAccessTokenExpiry = accessToken.ExpiresOn.ToUnixTimeSeconds();
             Environment.SetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceAccessToken, _entraIdAccessToken);
-            return true;
+            return;
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine(ex);
-            return false;
+            throw new Exception(Constants.s_no_auth_error);
         }
     }
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/PlaywrightService.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/PlaywrightService.cs
@@ -108,7 +108,7 @@ public class PlaywrightService
         // fetch Entra id access token if required
         // 1. Entra id access token has been fetched once via global functions
         // 2. Not close to expiry
-        if (!string.IsNullOrEmpty(_entraLifecycle!._entraIdAccessToken) && _entraLifecycle!.DoesEntraIdAccessTokenRequireRotation() && ServiceAuth == ServiceAuthType.EntraId)
+        if (!string.IsNullOrEmpty(_entraLifecycle!._entraIdAccessToken) && _entraLifecycle!.DoesEntraIdAccessTokenRequireRotation())
         {
             await _entraLifecycle.FetchEntraIdAccessTokenAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -243,8 +243,6 @@ public class PlaywrightService
 
     private void ValidateMptPAT()
     {
-        try
-        {
             string authToken = GetAuthToken()!;
             if (string.IsNullOrEmpty(authToken))
                 throw new Exception(Constants.s_no_auth_error);
@@ -253,17 +251,12 @@ public class PlaywrightService
             Match match = Regex.Match(ServiceEndpoint, @"wss://(?<region>[\w-]+)\.api\.(?<domain>playwright(?:-test|-int)?\.io|playwright\.microsoft\.com)/accounts/(?<workspaceId>[\w-]+)/");
             if (!match.Success)
                 throw new Exception(Constants.s_invalid_service_endpoint_error_message);
-            var serviceEndpointworkspaceId = match.Groups["workspaceId"].Value;
-            if (tokenaWorkspaceId != serviceEndpointworkspaceId)
+            var serviceEndpointWorkspaceId = match.Groups["workspaceId"].Value;
+            if (tokenaWorkspaceId != serviceEndpointWorkspaceId)
                 throw new Exception(Constants.s_workspace_mismatch_error);
             var expiry = (long)(jsonWebToken.ValidTo - new DateTime(1970, 1, 1)).TotalSeconds;
             if (expiry <= DateTimeOffset.UtcNow.ToUnixTimeSeconds())
                 throw new Exception(Constants.s_expired_mpt_pat_error);
-        }
-        catch (Exception)
-        {
-            throw;
-        }
     }
 
     private string? getServiceCompatibleOs(OSPlatform? oSPlatform)

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/PlaywrightService.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/PlaywrightService.cs
@@ -7,6 +7,7 @@ using Azure.Developer.MicrosoftPlaywrightTesting.TestLogger.Utility;
 using Microsoft.IdentityModel.JsonWebTokens;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -107,9 +108,9 @@ public class PlaywrightService
         // fetch Entra id access token if required
         // 1. Entra id access token has been fetched once via global functions
         // 2. Not close to expiry
-        if (!string.IsNullOrEmpty(_entraLifecycle!._entraIdAccessToken) && _entraLifecycle!.DoesEntraIdAccessTokenRequireRotation())
+        if (!string.IsNullOrEmpty(_entraLifecycle!._entraIdAccessToken) && _entraLifecycle!.DoesEntraIdAccessTokenRequireRotation() && ServiceAuth == ServiceAuthType.EntraId)
         {
-            _ = await _entraLifecycle.FetchEntraIdAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+            await _entraLifecycle.FetchEntraIdAccessTokenAsync(cancellationToken).ConfigureAwait(false);
         }
         if (string.IsNullOrEmpty(GetAuthToken()))
         {
@@ -146,23 +147,14 @@ public class PlaywrightService
             Environment.SetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceUri, null);
         }
         // If default auth mechanism is Access token and token is available in the environment variable, no need to setup rotation handler
-        if (ServiceAuth == ServiceAuthType.AccessToken && !string.IsNullOrEmpty(GetAuthToken()))
+        if (ServiceAuth == ServiceAuthType.AccessToken)
         {
             ValidateMptPAT();
             return;
         }
-        var operationStatus = await _entraLifecycle!.FetchEntraIdAccessTokenAsync(cancellationToken).ConfigureAwait(false);
-        if (!operationStatus)
-        {
-            if (!string.IsNullOrEmpty(GetAuthToken()))
-            {
-                ValidateMptPAT(); // throws exception if token is invalid
-            }
-            return; // no need to setup rotation handler. If token is not available, it will fallback to local browser launch
+            await _entraLifecycle!.FetchEntraIdAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+            RotationTimer = new Timer(RotationHandlerAsync, null, TimeSpan.FromMinutes(Constants.s_entra_access_token_rotation_interval_period_in_minutes), TimeSpan.FromMinutes(Constants.s_entra_access_token_rotation_interval_period_in_minutes));
         }
-
-        RotationTimer = new Timer(RotationHandlerAsync, null, TimeSpan.FromMinutes(Constants.s_entra_access_token_rotation_interval_period_in_minutes), TimeSpan.FromMinutes(Constants.s_entra_access_token_rotation_interval_period_in_minutes));
-    }
 
     /// <summary>
     /// Cleans up the resources used to setup entra id authentication.
@@ -254,14 +246,23 @@ public class PlaywrightService
         try
         {
             string authToken = GetAuthToken()!;
+            if (string.IsNullOrEmpty(authToken))
+                throw new Exception(Constants.s_no_auth_error);
             JsonWebToken jsonWebToken = _jsonWebTokenHandler!.ReadJsonWebToken(authToken) ?? throw new Exception(Constants.s_invalid_mpt_pat_error);
+            var tokenaWorkspaceId = jsonWebToken.Claims.FirstOrDefault(c => c.Type == "aid")?.Value;
+            Match match = Regex.Match(ServiceEndpoint, @"wss://(?<region>[\w-]+)\.api\.(?<domain>playwright(?:-test|-int)?\.io|playwright\.microsoft\.com)/accounts/(?<workspaceId>[\w-]+)/");
+            if (!match.Success)
+                throw new Exception(Constants.s_invalid_service_endpoint_error_message);
+            var serviceEndpointworkspaceId = match.Groups["workspaceId"].Value;
+            if (tokenaWorkspaceId != serviceEndpointworkspaceId)
+                throw new Exception(Constants.s_workspace_mismatch_error);
             var expiry = (long)(jsonWebToken.ValidTo - new DateTime(1970, 1, 1)).TotalSeconds;
             if (expiry <= DateTimeOffset.UtcNow.ToUnixTimeSeconds())
                 throw new Exception(Constants.s_expired_mpt_pat_error);
         }
         catch (Exception)
         {
-            throw new Exception(Constants.s_invalid_mpt_pat_error);
+            throw;
         }
     }
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/PlaywrightServiceOptions.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/PlaywrightServiceOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Runtime.InteropServices;
 using Azure.Core;
 using Azure.Identity;

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/EntraLifecycleTests.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/EntraLifecycleTests.cs
@@ -132,7 +132,7 @@ public class EntraLifecycleTests
     }
 
     [Test]
-    public async Task FetchEntraIdAccessTokenAsync_WhenTokenIsFetched_ReturnsTrue()
+    public async Task FetchEntraIdAccessTokenAsync_WhenTokenIsFetched_ReturnVoid()
     {
         var defaultAzureCredentialMock = new Mock<DefaultAzureCredential>();
         var token = "valid_token";
@@ -141,20 +141,23 @@ public class EntraLifecycleTests
             .Setup(x => x.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AccessToken(token, expiry));
         EntraLifecycle entraLifecycle = new(defaultAzureCredentialMock.Object);
-        Assert.That(await entraLifecycle.FetchEntraIdAccessTokenAsync(), Is.True);
+        await entraLifecycle.FetchEntraIdAccessTokenAsync();
 
         Environment.SetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceAccessToken, null);
     }
 
     [Test]
-    public async Task FetchEntraIdAccessTokenAsync_WhenThrowsError_ReturnsFalse()
+    public void FetchEntraIdAccessTokenAsync_WhenThrowsError()
     {
         var defaultAzureCredentialMock = new Mock<DefaultAzureCredential>();
         defaultAzureCredentialMock
             .Setup(x => x.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("sample exception"));
         EntraLifecycle entraLifecycle = new(defaultAzureCredentialMock.Object);
-        Assert.That(await entraLifecycle.FetchEntraIdAccessTokenAsync(), Is.False);
+          Exception? ex = Assert.ThrowsAsync<Exception>(async () =>
+        await entraLifecycle.FetchEntraIdAccessTokenAsync());
+
+    Assert.That(ex!.Message, Is.EqualTo(Constants.s_no_auth_error));
     }
 
     [Test]

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/PlaywrightServiceTests.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/PlaywrightServiceTests.cs
@@ -229,7 +229,7 @@ public class PlaywrightServiceTests
     }
 
     [Test]
-    public void Initialize_WhenFailsToFetchEntraIdAccessToken_DoesNotSetUpRotationHandler()
+    public void Initialize_WhenFailsToFetchEntraIdAccessToken_ThrowsException()
     {
         var defaultAzureCredentialMock = new Mock<DefaultAzureCredential>();
         var jsonWebTokenHandlerMock = new Mock<JsonWebTokenHandler>();
@@ -238,13 +238,12 @@ public class PlaywrightServiceTests
             .ThrowsAsync(new Exception());
         var entraLifecycleMock = new Mock<EntraLifecycle>(defaultAzureCredentialMock.Object, jsonWebTokenHandlerMock.Object);
         PlaywrightService service = new(entraLifecycle: entraLifecycleMock.Object);
-        service.InitializeAsync().Wait();
-        defaultAzureCredentialMock.Verify(x => x.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
-        Assert.That(service.RotationTimer, Is.Null);
+        Exception? ex = Assert.ThrowsAsync<Exception>(async () => await service.InitializeAsync());
+        Assert.That(ex!.Message, Is.EqualTo(Constants.s_no_auth_error));
     }
 
     [Test]
-    public void Initialize_WhenEntraIdAccessTokenFailsAndMptPatIsSet_DoesNotSetUpRotationHandler()
+    public void Initialize_WhenEntraIdAccessTokenFailsAndMptPatIsSet_ThrowsException()
     {
         var token = GetToken(new Dictionary<string, object>
         {
@@ -257,12 +256,12 @@ public class PlaywrightServiceTests
             .ThrowsAsync(new Exception());
         var entraLifecycleMock = new Mock<EntraLifecycle>(defaultAzureCredentialMock.Object, new JsonWebTokenHandler());
         PlaywrightService service = new(entraLifecycle: entraLifecycleMock.Object, jsonWebTokenHandler: new JsonWebTokenHandler());
-        service.InitializeAsync().Wait();
-        Assert.That(service.RotationTimer, Is.Null);
+        Exception? ex = Assert.ThrowsAsync<Exception>(async () => await service.InitializeAsync());
+        Assert.That(ex!.Message, Is.EqualTo(Constants.s_no_auth_error));
     }
 
     [Test]
-    public void Initialize_WhenEntraIdAccessTokenFailsAndMptPatIsNotSet_DoesNotSetUpRotationHandler()
+    public void Initialize_WhenEntraIdAccessTokenFailsAndMptPatIsNotSet_ThrowsException()
     {
         var token = GetToken(new Dictionary<string, object>
         {
@@ -274,8 +273,8 @@ public class PlaywrightServiceTests
             .ThrowsAsync(new Exception());
         var entraLifecycleMock = new Mock<EntraLifecycle>(defaultAzureCredentialMock.Object, new JsonWebTokenHandler());
         PlaywrightService service = new(entraLifecycle: entraLifecycleMock.Object, jsonWebTokenHandler: new JsonWebTokenHandler());
-        service.InitializeAsync().Wait();
-        Assert.That(service.RotationTimer, Is.Null);
+        Exception? ex = Assert.ThrowsAsync<Exception>(async () => await service.InitializeAsync());
+        Assert.That(ex!.Message, Is.EqualTo(Constants.s_no_auth_error));
     }
 
     [Test]
@@ -335,9 +334,17 @@ public class PlaywrightServiceTests
     {
         var token = GetToken(new Dictionary<string, object>
         {
-            {"aid", "account-id-guid"},
+            {"aid", "eastus_bd830e63-6120-40cb-8cd7-f0739502d888"},
         });
         Environment.SetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceAccessToken, token);
+        var testRubric = new Dictionary<string, string>
+        {
+            { "url", "wss://eastus.api.playwright.microsoft.com/accounts/eastus_bd830e63-6120-40cb-8cd7-f0739502d888/browsers" },
+            { "workspaceId", "eastus_bd830e63-6120-40cb-8cd7-f0739502d888" },
+            { "region", "eastus" },
+            { "domain", "playwright.microsoft.com" }
+        };
+        Environment.SetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceUri, $"{testRubric["url"]}");
         var defaultAzureCredentialMock = new Mock<DefaultAzureCredential>();
         var entraLifecycleMock = new Mock<EntraLifecycle>(defaultAzureCredentialMock.Object, new JsonWebTokenHandler());
         PlaywrightService service = new(entraLifecycle: entraLifecycleMock.Object, jsonWebTokenHandler: new JsonWebTokenHandler(), serviceAuth: ServiceAuthType.AccessToken);


### PR DESCRIPTION
### Packages impacted by this PR

@azure/microsoft-playwright-testing

### Issues associated with this PR

Remove fallback logic in authentication
Improved validation of Pat token.

### Describe the problem that is addressed by this PR

Earlier, we used to have fallback logic in authentication. Entra -> PAT
or PAT -> Entra. This PR removes the fallback logic.