### PR TITLE
[CODEOWNERS] Removing invalid owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,10 +187,10 @@
 # ServiceOwners:                                                   @quentinRobinson @bidisha-c
 
 # PRLabel: %Cognitive - Content Safety
-/sdk/contentsafety/                                                @bowgong @mengaims @JieZhou000
+/sdk/contentsafety/                                                @bowgong @mengaims
 
 # ServiceLabel: %Cognitive - Content Safety
-# ServiceOwners:                     	                           @bowgong @mengaims @JieZhou000
+# ServiceOwners:                     	                           @bowgong @mengaims
 
 # PRLabel: %Cognitive - Custom Vision
 /sdk/cognitiveservices/Vision.CustomVision*/                       @areddish @tburns10
@@ -843,7 +843,7 @@
 /sdk/signalr/                                                      @chenkennt @vicancy @JialinXin @Y-Sindo
 
 # ServiceLabel: %SignalR
-# ServiceOwners:                                                   @sffamily @chenkennt @vicancy @JialinXin @Y-Sindo
+# ServiceOwners:                                                   @chenkennt @vicancy @JialinXin @Y-Sindo
 
 # ServiceLabel: %SQL
 # ServiceOwners:                                                   @azureSQLGitHub
@@ -1064,10 +1064,7 @@
 # ServiceOwners:                                                   @Daya-Patil
 
 # PRLabel: %Self Help
-/sdk/selfhelp/Azure.ResourceManager.*/                             @siddiavinashmsft @archerzz @ArcturusZhang @ArthurMa1978
-
-# ServiceLabel: %Self Help %Mgmt
-# ServiceOwners:                                                   @siddiavinashmsft
+/sdk/selfhelp/Azure.ResourceManager.*/                             @archerzz @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %Spring App Discovery
 /sdk/springappdiscovery/Azure.ResourceManager.*/                   @sunkun99 @archerzz @ArcturusZhang @ArthurMa1978


### PR DESCRIPTION
# Summary

The focus of these changes is to remove accounts that have recently become invalid for CODEOWNER inclusion and are being flagged by the linter.

## References and Resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4246560&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=8c98ab76-57b2-59d0-3d3a-18dce788f3ba) _(Microsoft internal)_