### PR TITLE
Let DAC chain continue for 400 responses with 'Identity not found'

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## 1.13.0 (2024-10-14)
 
+### Breaking Changes
+- Previously, if a clientID or ResourceID was specified for Cloud Shell managed identity, which is not supported, the clientID or resourceID would be silently ignored. Now, an exception will be thrown if a clientID or resourceID is specified for Cloud Shell managed identity.
+- Previously, if a clientID or ResourceID was specified for Service Fabric managed identity, which is not supported, the clientID or resourceID would be silently ignored. Now, an exception will be thrown if a clientID or resourceID is specified for Service Fabric managed identity.
+
 ### Features Added
 - `ManagedIdentityCredential` now supports specifying a user-assigned managed identity by object ID.
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Fixed an issue that prevented ManagedIdentityCredential from attempting to detect if Workload Identity is enabled in the current environment. [#46653](https://github.com/Azure/azure-sdk-for-net/issues/46653)
+- Fixed an issue that prevented `ManagedIdentityCredential` from attempting to detect if Workload Identity is enabled in the current environment. [#46653](https://github.com/Azure/azure-sdk-for-net/issues/46653)
+- Fixed an issue that prevented `DefaultAzureCredential` from progressing past `ManagedIdentityCredential` in some scenarios where the identity was not available. [#46709](https://github.com/Azure/azure-sdk-for-net/issues/46709)
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity/src/ImdsManagedIdentityProbeSource.cs
+++ b/sdk/identity/Azure.Identity/src/ImdsManagedIdentityProbeSource.cs
@@ -144,7 +144,7 @@ namespace Azure.Identity
             // handle error status codes indicating managed identity is not available
             string baseMessage = response.Status switch
             {
-                400 when IsProbeRequest(message) => throw new ProbeRequestResponseException(),
+                400 when IsRetriableProbeRequest(message) => throw new ProbeRequestResponseException(),
                 400 => IdentityUnavailableError,
                 502 => GatewayError,
                 504 => GatewayError,
@@ -169,10 +169,11 @@ namespace Azure.Identity
             return token;
         }
 
-        public static bool IsProbeRequest(HttpMessage message)
+        public static bool IsRetriableProbeRequest(HttpMessage message)
             => message.Request.Uri.Host == s_imdsEndpoint.Host &&
                 message.Request.Uri.Path == s_imdsEndpoint.AbsolutePath &&
-                !message.Request.Headers.TryGetValue(metadataHeaderName, out _);
+                !message.Request.Headers.TryGetValue(metadataHeaderName, out _) &&
+                !(message.Response.Content?.ToString().Contains("Identity not found") ?? false);
 
         private class ImdsRequestFailedDetailsParser : RequestFailedDetailsParser
         {

--- a/sdk/identity/Azure.Identity/src/ImdsManagedIdentityProbeSource.cs
+++ b/sdk/identity/Azure.Identity/src/ImdsManagedIdentityProbeSource.cs
@@ -173,7 +173,7 @@ namespace Azure.Identity
             => message.Request.Uri.Host == s_imdsEndpoint.Host &&
                 message.Request.Uri.Path == s_imdsEndpoint.AbsolutePath &&
                 !message.Request.Headers.TryGetValue(metadataHeaderName, out _) &&
-                !(message.Response.Content?.ToString().Contains("Identity not found") ?? false);
+                (message.Response.Content?.ToString().IndexOf("Identity not found", StringComparison.InvariantCulture) < 0);
 
         private class ImdsRequestFailedDetailsParser : RequestFailedDetailsParser
         {

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -390,7 +390,7 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var expectedMessage = $"connecting to 169.254.169.254:80: connecting to 169.254.169.254:80: dial tcp 169.254.169.254:80: connectex: A socket operation was attempted to an unreachable {error}.";
+            var expectedMessage = error;
             var response = CreateInvalidJsonResponse(403, expectedMessage);
             var mockTransport = new MockTransport(response);
             var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = true };
@@ -420,6 +420,31 @@ namespace Azure.Identity.Tests
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
             Assert.That(ex.Message, Does.Contain(expectedMessage));
+        }
+
+        [NonParallelizable]
+        [Test]
+        [TestCase("""{"error":"invalid_request","error_description":"Identity not found"}""")]
+        [TestCase(null)]
+        public void VerifyImdsRequestFailureWithValidJsonIdentityNotFoundErrorThrowsCUE(string content)
+        {
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
+
+            var response = CreateResponse(400, content);
+            var mockTransport = new MockTransport(req => response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = true };
+            var pipeline = CredentialPipeline.GetInstance(options);
+
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", pipeline, options));
+            if (content != null)
+            {
+                var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+                Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.IdentityUnavailableError));
+            }
+            else
+            {
+                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            }
         }
 
         [NonParallelizable]
@@ -1126,6 +1151,16 @@ namespace Azure.Identity.Tests
         {
             var response = new MockResponse(status);
             response.SetContent(message);
+            return response;
+        }
+
+        private static MockResponse CreateResponse(int status, string message)
+        {
+            var response = new MockResponse(status);
+            if (message != null)
+            {
+                response.SetContent(message);
+            }
             return response;
         }
     }


### PR DESCRIPTION
fixes #46709
#46679