### PR TITLE
[Storage][DataMovement] Record some tests that could not be previously recorded

### DIFF
--- a/eng/nunit.runsettings
+++ b/eng/nunit.runsettings
@@ -19,7 +19,7 @@
 		<!-- <Parameter name="DisableAutoRecording" value="true" /> -->
 
 		<!-- Change the test mode -->
-    <!-- <Parameter name="TestMode" value="Record" /> -->
+		<!-- <Parameter name="TestMode" value="Record" /> -->
 
 		<!-- Enable running Fiddler -->
 		<!-- <Parameter name="EnableFiddler" value="true" /> -->

--- a/eng/nunit.runsettings
+++ b/eng/nunit.runsettings
@@ -19,7 +19,7 @@
 		<!-- <Parameter name="DisableAutoRecording" value="true" /> -->
 
 		<!-- Change the test mode -->
-		<!-- <Parameter name="TestMode" value="Record" /> -->
+		<Parameter name="TestMode" value="Playback" />
 
 		<!-- Enable running Fiddler -->
 		<!-- <Parameter name="EnableFiddler" value="true" /> -->

--- a/eng/nunit.runsettings
+++ b/eng/nunit.runsettings
@@ -19,7 +19,7 @@
 		<!-- <Parameter name="DisableAutoRecording" value="true" /> -->
 
 		<!-- Change the test mode -->
-		<Parameter name="TestMode" value="Playback" />
+    <!-- <Parameter name="TestMode" value="Record" /> -->
 
 		<!-- Enable running Fiddler -->
 		<!-- <Parameter name="EnableFiddler" value="true" /> -->

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_e796f456ff"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_c66f15b319"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/ProgressHandlerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/ProgressHandlerTests.cs
@@ -8,15 +8,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core.TestFramework;
-using Azure.Storage.Blobs.Tests;
-using Azure.Storage.DataMovement.Blobs.Tests;
+using Azure.Storage.DataMovement.Tests;
 using BaseBlobs::Azure.Storage.Blobs;
-using BaseBlobs::Azure.Storage.Blobs.Models;
 using DMBlobs::Azure.Storage.DataMovement.Blobs;
 using NUnit.Framework;
 
-namespace Azure.Storage.DataMovement.Tests
+namespace Azure.Storage.DataMovement.Blobs.Tests
 {
     public class ProgressHandlerTests : DataMovementBlobTestBase
     {
@@ -144,7 +141,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task ProgressHandler_DownloadDirectory()
         {
             // Arrange
@@ -167,7 +163,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task ProgressHandler_DirectoryUpload()
         {
             // Arrange
@@ -190,7 +185,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task ProgressHandler_Copy()
         {
             // Arrange
@@ -214,7 +208,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         [TestCase(StorageResourceCreationPreference.SkipIfExists)]
         [TestCase(StorageResourceCreationPreference.FailIfExists)]
         public async Task ProgressHandler_Conflict(StorageResourceCreationPreference createMode)
@@ -246,7 +239,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         [TestCase(TransferDirection.Upload)]
         [TestCase(TransferDirection.Download)]
         [TestCase(TransferDirection.Copy)]
@@ -308,7 +300,6 @@ namespace Azure.Storage.DataMovement.Tests
 
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35558")]
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         [TestCase(0)]
         [TestCase(150)]
         public async Task ProgressHandler_PauseResume(int delayInMs)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_4eaa88bc73"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_44f04e1278"
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
-using Azure.Storage.Common;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
 
@@ -276,7 +275,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         [TestCase(0, 10)]
         [TestCase(DataMovementTestConstants.KB / 2, 10)]
         [TestCase(DataMovementTestConstants.KB, 10)]
@@ -357,7 +355,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DirectoryToDirectory_EmptyFolder()
         {
             // Arrange
@@ -398,7 +395,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DirectoryToDirectory_SingleFile()
         {
             // Arrange
@@ -423,7 +419,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DirectoryToDirectory_ManySubDirectories()
         {
             // Arrange
@@ -458,7 +453,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         [TestCase(1)]
         [TestCase(2)]
         [TestCase(3)]
@@ -493,7 +487,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DirectoryToDirectory_OverwriteExists()
         {
             // Arrange
@@ -543,7 +536,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DirectoryToDirectory_OverwriteNotExists()
         {
             // Arrange
@@ -589,7 +581,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public virtual async Task DirectoryToDirectory_OAuth()
         {
             // Arrange
@@ -698,7 +689,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_AwaitCompletion()
         {
             // Arrange
@@ -729,7 +719,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_AwaitCompletion_Failed()
         {
             // Arrange
@@ -767,7 +756,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_AwaitCompletion_Skipped()
         {
             // Arrange
@@ -805,7 +793,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_EnsureCompleted()
         {
             // Arrange
@@ -837,7 +824,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_EnsureCompleted_Failed()
         {
             // Arrange
@@ -875,7 +861,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_EnsureCompleted_Skipped()
         {
             // Arrange
@@ -913,7 +898,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_EnsureCompleted_Failed_SmallChunks()
         {
             // Arrange
@@ -1025,7 +1009,6 @@ namespace Azure.Storage.DataMovement.Tests
         [TestCase((int) TransferPropertiesTestType.Preserve)]
         [TestCase((int) TransferPropertiesTestType.NoPreserve)]
         [TestCase((int) TransferPropertiesTestType.NewProperties)]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task CopyRemoteObjects_VerifyProperties(int propertiesType)
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
@@ -719,6 +719,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/46717
         public async Task StartTransfer_AwaitCompletion_Failed()
         {
             // Arrange
@@ -824,6 +825,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/46717
         public async Task StartTransfer_EnsureCompleted_Failed()
         {
             // Arrange
@@ -898,6 +900,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/46717
         public async Task StartTransfer_EnsureCompleted_Failed_SmallChunks()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryDownloadTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryDownloadTestBase.cs
@@ -475,6 +475,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/46717
         public async Task StartTransfer_AwaitCompletion_Failed()
         {
             // Arrange
@@ -590,6 +591,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/46717
         public async Task StartTransfer_EnsureCompleted_Failed()
         {
             // Arrange
@@ -672,6 +674,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/46717
         public async Task StartTransfer_EnsureCompleted_Failed_SmallChunks()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryDownloadTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryDownloadTestBase.cs
@@ -170,7 +170,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         [TestCase(0, 10)]
         [TestCase(100, 10)]
         [TestCase(Constants.KB, 10)]
@@ -228,7 +227,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DownloadDirectoryAsync_Empty()
         {
             // Arrange
@@ -266,7 +264,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DownloadDirectoryAsync_SingleFile()
         {
             // Arrange
@@ -280,7 +277,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DownloadDirectoryAsync_ManySubDirectories()
         {
             // Arrange
@@ -304,7 +300,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         [TestCase(1)]
         [TestCase(2)]
         [TestCase(3)]
@@ -332,7 +327,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DownloadDirectoryAsync_SmallChunks_ManyFiles()
         {
             // Arrange
@@ -379,7 +373,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task DownloadDirectoryAsync_Root()
         {
             // Arrange
@@ -450,7 +443,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_AwaitCompletion()
         {
             // Arrange
@@ -483,7 +475,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_AwaitCompletion_Failed()
         {
             // Arrange
@@ -525,7 +516,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_AwaitCompletion_Skipped()
         {
             // Arrange
@@ -567,7 +557,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_EnsureCompleted()
         {
             // Arrange
@@ -601,7 +590,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_EnsureCompleted_Failed()
         {
             // Arrange
@@ -643,7 +631,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_EnsureCompleted_Skipped()
         {
             // Arrange
@@ -685,7 +672,6 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public async Task StartTransfer_EnsureCompleted_Failed_SmallChunks()
         {
             // Arrange


### PR DESCRIPTION
This issue preventing these tests from being recorded was resolved a while back so these tests can now be recorded. This change simply removes the LiveOnly and adds the new recordings (approximately 450recordings).

TODO: There are still some more tests to record but they need to be converted to use test base classes first. Will do those in a follow-up PR.