### PR TITLE
Azure.Provisioning: API cleanup

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.netstandard2.0.cs
@@ -60,7 +60,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public enum ContainerAppAccessMode
@@ -112,7 +111,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppAuthPlatform : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -228,7 +226,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppConnectedEnvironmentCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -247,7 +244,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppConnectedEnvironmentDaprComponent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -271,7 +267,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public enum ContainerAppConnectedEnvironmentProvisioningState
@@ -299,7 +294,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppContainer : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -632,7 +626,6 @@ namespace Azure.Provisioning.AppContainers
         {
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppJobConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -733,7 +726,6 @@ namespace Azure.Provisioning.AppContainers
         {
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppManagedEnvironment : Azure.Provisioning.Primitives.ProvisionableResource
@@ -771,7 +763,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppManagedEnvironmentCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -791,7 +782,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppManagedEnvironmentDaprComponent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -816,7 +806,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public enum ContainerAppManagedEnvironmentOutBoundType
@@ -839,7 +828,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerAppOpenIdConnectClientCredential : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -990,7 +978,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2022_10_01;
             public static readonly string V2023_05_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public enum ContainerAppSourceControlOperationState

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerApp.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerApp.cs
@@ -186,11 +186,6 @@ public partial class ContainerApp : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppAuthConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppAuthConfig.cs
@@ -116,11 +116,6 @@ public partial class ContainerAppAuthConfig : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironment.cs
@@ -125,11 +125,6 @@ public partial class ContainerAppConnectedEnvironment : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentCertificate.cs
@@ -89,11 +89,6 @@ public partial class ContainerAppConnectedEnvironmentCertificate : Provisionable
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentDaprComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentDaprComponent.cs
@@ -125,11 +125,6 @@ public partial class ContainerAppConnectedEnvironmentDaprComponent : Provisionab
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentStorage.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentStorage.cs
@@ -73,11 +73,6 @@ public partial class ContainerAppConnectedEnvironmentStorage : ProvisionableReso
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppJob.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppJob.cs
@@ -131,11 +131,6 @@ public partial class ContainerAppJob : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedCertificate.cs
@@ -88,11 +88,6 @@ public partial class ContainerAppManagedCertificate : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
@@ -211,11 +211,6 @@ public partial class ContainerAppManagedEnvironment : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentCertificate.cs
@@ -89,11 +89,6 @@ public partial class ContainerAppManagedEnvironmentCertificate : ProvisionableRe
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentDaprComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentDaprComponent.cs
@@ -124,11 +124,6 @@ public partial class ContainerAppManagedEnvironmentDaprComponent : Provisionable
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentStorage.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentStorage.cs
@@ -73,11 +73,6 @@ public partial class ContainerAppManagedEnvironmentStorage : ProvisionableResour
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppSourceControl.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppSourceControl.cs
@@ -96,11 +96,6 @@ public partial class ContainerAppSourceControl : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/api/Azure.Provisioning.ApplicationInsights.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/api/Azure.Provisioning.ApplicationInsights.netstandard2.0.cs
@@ -78,7 +78,6 @@ namespace Azure.Provisioning.ApplicationInsights
             public static readonly string V2014_08_01;
             public static readonly string V2015_05_01;
             public static readonly string V2020_02_02;
-            public static readonly string V2020_02_02_preview;
         }
     }
     public enum ApplicationInsightsPublicNetworkAccessType

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Generated/ApplicationInsightsComponent.cs
@@ -290,11 +290,6 @@ public partial class ApplicationInsightsComponent : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2020-02-02-preview.
-        /// </summary>
-        public static readonly string V2020_02_02_preview = "2020-02-02-preview";
-
-        /// <summary>
         /// 2020-02-02.
         /// </summary>
         public static readonly string V2020_02_02 = "2020-02-02";

--- a/sdk/provisioning/Azure.Provisioning.CloudMachine/src/CDKLevel3/Azd.cs
+++ b/sdk/provisioning/Azure.Provisioning.CloudMachine/src/CDKLevel3/Azd.cs
@@ -37,7 +37,7 @@ internal static class Azd
 
         Infrastructure mainBicep = new("main")
         {
-            TargetScope = "subscription"
+            TargetScope = DeploymentScope.Subscription
         };
         ModuleImport import = new("cm", $"cm.bicep")
         {

--- a/sdk/provisioning/Azure.Provisioning.CloudMachine/src/CDKLevel3/CloudMachineInfrastructure.cs
+++ b/sdk/provisioning/Azure.Provisioning.CloudMachine/src/CDKLevel3/CloudMachineInfrastructure.cs
@@ -77,7 +77,14 @@ public class CloudMachineInfrastructure
             UserAssignedIdentities = { { BicepFunction.Interpolate($"{Identity.Id}").Compile().ToString(), new UserAssignedIdentityDetails() } }
         };
 
-        _storage = StorageResources.CreateAccount("cm_storage");
+        _storage =
+            new StorageAccount("cm_storage", StorageAccount.ResourceVersions.V2023_01_01)
+            {
+                Kind = StorageKind.StorageV2,
+                Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                IsHnsEnabled = true,
+                AllowBlobPublicAccess = false
+            };
         _storage.Identity = managedServiceIdentity;
         _storage.Name = _cmid;
 
@@ -110,7 +117,7 @@ public class CloudMachineInfrastructure
             Name = "cm_servicebus_topic_private",
             Parent = _serviceBusNamespace,
             MaxMessageSizeInKilobytes = 256,
-            DefaultMessageTimeToLive = new StringLiteralExpression("P14D"),
+            DefaultMessageTimeToLive = TimeSpan.FromDays(14),
             RequiresDuplicateDetection = false,
             EnableBatchedOperations = true,
             SupportOrdering = true,
@@ -121,9 +128,9 @@ public class CloudMachineInfrastructure
             Name = SB_PRIVATE_SUB,
             Parent = _serviceBusTopic_private,
             IsClientAffine = false,
-            LockDuration = new StringLiteralExpression("PT30S"),
+            LockDuration = TimeSpan.FromSeconds(30),
             RequiresSession = false,
-            DefaultMessageTimeToLive = new StringLiteralExpression("P14D"),
+            DefaultMessageTimeToLive = TimeSpan.FromDays(14),
             DeadLetteringOnFilterEvaluationExceptions = true,
             DeadLetteringOnMessageExpiration = true,
             MaxDeliveryCount = 10,
@@ -135,7 +142,7 @@ public class CloudMachineInfrastructure
             Name = "cm_servicebus_default_topic",
             Parent = _serviceBusNamespace,
             MaxMessageSizeInKilobytes = 256,
-            DefaultMessageTimeToLive = new StringLiteralExpression("P14D"),
+            DefaultMessageTimeToLive = TimeSpan.FromDays(14),
             RequiresDuplicateDetection = false,
             EnableBatchedOperations = true,
             SupportOrdering = true,
@@ -146,9 +153,9 @@ public class CloudMachineInfrastructure
             Name = "cm_servicebus_subscription_default",
             Parent = _serviceBusTopic_default,
             IsClientAffine = false,
-            LockDuration = new StringLiteralExpression("PT30S"),
+            LockDuration = TimeSpan.FromSeconds(30),
             RequiresSession = false,
-            DefaultMessageTimeToLive = new StringLiteralExpression("P14D"),
+            DefaultMessageTimeToLive = TimeSpan.FromDays(14),
             DeadLetteringOnFilterEvaluationExceptions = true,
             DeadLetteringOnMessageExpiration = true,
             MaxDeliveryCount = 10,

--- a/sdk/provisioning/Azure.Provisioning.Communication/api/Azure.Provisioning.Communication.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/api/Azure.Provisioning.Communication.netstandard2.0.cs
@@ -22,7 +22,6 @@ namespace Azure.Provisioning.Communication
         {
             public static readonly string V2023_03_31;
             public static readonly string V2023_04_01;
-            public static readonly string V2023_06_01_preview;
         }
     }
     public partial class CommunicationService : Azure.Provisioning.Primitives.ProvisionableResource
@@ -50,7 +49,6 @@ namespace Azure.Provisioning.Communication
             public static readonly string V2020_08_20;
             public static readonly string V2023_03_31;
             public static readonly string V2023_04_01;
-            public static readonly string V2023_06_01_preview;
         }
     }
     public partial class CommunicationServiceKeys : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -153,7 +151,6 @@ namespace Azure.Provisioning.Communication
         {
             public static readonly string V2023_03_31;
             public static readonly string V2023_04_01;
-            public static readonly string V2023_06_01_preview;
         }
     }
     public enum EmailServicesProvisioningState
@@ -184,7 +181,6 @@ namespace Azure.Provisioning.Communication
         {
             public static readonly string V2023_03_31;
             public static readonly string V2023_04_01;
-            public static readonly string V2023_06_01_preview;
         }
     }
     public enum UserEngagementTracking

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/CommunicationDomain.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/CommunicationDomain.cs
@@ -137,11 +137,6 @@ public partial class CommunicationDomain : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-06-01-preview.
-        /// </summary>
-        public static readonly string V2023_06_01_preview = "2023-06-01-preview";
-
-        /// <summary>
         /// 2023-04-01.
         /// </summary>
         public static readonly string V2023_04_01 = "2023-04-01";

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/CommunicationService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/CommunicationService.cs
@@ -134,11 +134,6 @@ public partial class CommunicationService : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-06-01-preview.
-        /// </summary>
-        public static readonly string V2023_06_01_preview = "2023-06-01-preview";
-
-        /// <summary>
         /// 2023-04-01.
         /// </summary>
         public static readonly string V2023_04_01 = "2023-04-01";

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/EmailService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/EmailService.cs
@@ -88,11 +88,6 @@ public partial class EmailService : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-06-01-preview.
-        /// </summary>
-        public static readonly string V2023_06_01_preview = "2023-06-01-preview";
-
-        /// <summary>
         /// 2023-04-01.
         /// </summary>
         public static readonly string V2023_04_01 = "2023-04-01";

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/SenderUsername.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Generated/SenderUsername.cs
@@ -95,11 +95,6 @@ public partial class SenderUsername : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-06-01-preview.
-        /// </summary>
-        public static readonly string V2023_06_01_preview = "2023-06-01-preview";
-
-        /// <summary>
         /// 2023-04-01.
         /// </summary>
         public static readonly string V2023_04_01 = "2023-04-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/api/Azure.Provisioning.ContainerRegistry.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/api/Azure.Provisioning.ContainerRegistry.netstandard2.0.cs
@@ -22,7 +22,12 @@ namespace Azure.Provisioning.ContainerRegistry
         public static Azure.Provisioning.ContainerRegistry.ContainerRegistryAgentPool FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2019_06_01_preview;
+            public static readonly string V2017_03_01;
+            public static readonly string V2017_10_01;
+            public static readonly string V2019_05_01;
+            public static readonly string V2021_09_01;
+            public static readonly string V2022_12_01;
+            public static readonly string V2023_07_01;
         }
     }
     public partial class ContainerRegistryBaseImageDependency : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -291,7 +296,6 @@ namespace Azure.Provisioning.ContainerRegistry
             public static readonly string V2021_09_01;
             public static readonly string V2022_12_01;
             public static readonly string V2023_07_01;
-            public static readonly string V2023_11_01_preview;
         }
     }
     public partial class ContainerRegistryPrivateEndpointConnectionData : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -355,7 +359,6 @@ namespace Azure.Provisioning.ContainerRegistry
             public static readonly string V2021_09_01;
             public static readonly string V2022_12_01;
             public static readonly string V2023_07_01;
-            public static readonly string V2023_11_01_preview;
         }
     }
     public partial class ContainerRegistryResourceStatus : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -482,7 +485,6 @@ namespace Azure.Provisioning.ContainerRegistry
             public static readonly string V2021_09_01;
             public static readonly string V2022_12_01;
             public static readonly string V2023_07_01;
-            public static readonly string V2023_11_01_preview;
         }
     }
     public partial class ContainerRegistrySku : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -560,7 +562,6 @@ namespace Azure.Provisioning.ContainerRegistry
         {
             public static readonly string V2018_09_01;
             public static readonly string V2019_04_01;
-            public static readonly string V2019_06_01_preview;
         }
     }
     public partial class ContainerRegistryTaskOverridableValue : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -586,7 +587,12 @@ namespace Azure.Provisioning.ContainerRegistry
         public static Azure.Provisioning.ContainerRegistry.ContainerRegistryTaskRun FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2019_06_01_preview;
+            public static readonly string V2017_03_01;
+            public static readonly string V2017_10_01;
+            public static readonly string V2019_05_01;
+            public static readonly string V2021_09_01;
+            public static readonly string V2022_12_01;
+            public static readonly string V2023_07_01;
         }
     }
     public partial class ContainerRegistryTaskRunContent : Azure.Provisioning.ContainerRegistry.ContainerRegistryRunContent
@@ -639,7 +645,6 @@ namespace Azure.Provisioning.ContainerRegistry
         {
             public static readonly string V2022_12_01;
             public static readonly string V2023_07_01;
-            public static readonly string V2023_11_01_preview;
         }
     }
     public partial class ContainerRegistryTokenCertificate : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -737,7 +742,6 @@ namespace Azure.Provisioning.ContainerRegistry
             public static readonly string V2021_09_01;
             public static readonly string V2022_12_01;
             public static readonly string V2023_07_01;
-            public static readonly string V2023_11_01_preview;
         }
     }
     public enum ContainerRegistryWebhookAction
@@ -791,7 +795,6 @@ namespace Azure.Provisioning.ContainerRegistry
         {
             public static readonly string V2022_12_01;
             public static readonly string V2023_07_01;
-            public static readonly string V2023_11_01_preview;
         }
     }
     public partial class SourceCodeRepoAuthInfo : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryAgentPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryAgentPool.cs
@@ -95,7 +95,7 @@ public partial class ContainerRegistryAgentPool : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryAgentPool.</param>
     public ContainerRegistryAgentPool(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.ContainerRegistry/registries/agentPools", resourceVersion ?? "2019-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.ContainerRegistry/registries/agentPools", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -116,9 +116,34 @@ public partial class ContainerRegistryAgentPool : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2019-06-01-preview.
+        /// 2023-07-01.
         /// </summary>
-        public static readonly string V2019_06_01_preview = "2019-06-01-preview";
+        public static readonly string V2023_07_01 = "2023-07-01";
+
+        /// <summary>
+        /// 2022-12-01.
+        /// </summary>
+        public static readonly string V2022_12_01 = "2022-12-01";
+
+        /// <summary>
+        /// 2021-09-01.
+        /// </summary>
+        public static readonly string V2021_09_01 = "2021-09-01";
+
+        /// <summary>
+        /// 2019-05-01.
+        /// </summary>
+        public static readonly string V2019_05_01 = "2019-05-01";
+
+        /// <summary>
+        /// 2017-10-01.
+        /// </summary>
+        public static readonly string V2017_10_01 = "2017-10-01";
+
+        /// <summary>
+        /// 2017-03-01.
+        /// </summary>
+        public static readonly string V2017_03_01 = "2017-03-01";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryPrivateEndpointConnection.cs
@@ -89,11 +89,6 @@ public partial class ContainerRegistryPrivateEndpointConnection : ProvisionableR
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-11-01-preview.
-        /// </summary>
-        public static readonly string V2023_11_01_preview = "2023-11-01-preview";
-
-        /// <summary>
         /// 2023-07-01.
         /// </summary>
         public static readonly string V2023_07_01 = "2023-07-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryReplication.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryReplication.cs
@@ -115,11 +115,6 @@ public partial class ContainerRegistryReplication : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-11-01-preview.
-        /// </summary>
-        public static readonly string V2023_11_01_preview = "2023-11-01-preview";
-
-        /// <summary>
         /// 2023-07-01.
         /// </summary>
         public static readonly string V2023_07_01 = "2023-07-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryService.cs
@@ -195,11 +195,6 @@ public partial class ContainerRegistryService : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-11-01-preview.
-        /// </summary>
-        public static readonly string V2023_11_01_preview = "2023-11-01-preview";
-
-        /// <summary>
         /// 2023-07-01.
         /// </summary>
         public static readonly string V2023_07_01 = "2023-07-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryTask.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryTask.cs
@@ -185,11 +185,6 @@ public partial class ContainerRegistryTask : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2019-06-01-preview.
-        /// </summary>
-        public static readonly string V2019_06_01_preview = "2019-06-01-preview";
-
-        /// <summary>
         /// 2019-04-01.
         /// </summary>
         public static readonly string V2019_04_01 = "2019-04-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryTaskRun.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryTaskRun.cs
@@ -100,7 +100,7 @@ public partial class ContainerRegistryTaskRun : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerRegistryTaskRun.</param>
     public ContainerRegistryTaskRun(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.ContainerRegistry/registries/taskRuns", resourceVersion ?? "2019-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.ContainerRegistry/registries/taskRuns", resourceVersion ?? "2023-07-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _forceUpdateTag = BicepValue<string>.DefineProperty(this, "ForceUpdateTag", ["properties", "forceUpdateTag"]);
@@ -120,9 +120,34 @@ public partial class ContainerRegistryTaskRun : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2019-06-01-preview.
+        /// 2023-07-01.
         /// </summary>
-        public static readonly string V2019_06_01_preview = "2019-06-01-preview";
+        public static readonly string V2023_07_01 = "2023-07-01";
+
+        /// <summary>
+        /// 2022-12-01.
+        /// </summary>
+        public static readonly string V2022_12_01 = "2022-12-01";
+
+        /// <summary>
+        /// 2021-09-01.
+        /// </summary>
+        public static readonly string V2021_09_01 = "2021-09-01";
+
+        /// <summary>
+        /// 2019-05-01.
+        /// </summary>
+        public static readonly string V2019_05_01 = "2019-05-01";
+
+        /// <summary>
+        /// 2017-10-01.
+        /// </summary>
+        public static readonly string V2017_10_01 = "2017-10-01";
+
+        /// <summary>
+        /// 2017-03-01.
+        /// </summary>
+        public static readonly string V2017_03_01 = "2017-03-01";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryToken.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryToken.cs
@@ -104,11 +104,6 @@ public partial class ContainerRegistryToken : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-11-01-preview.
-        /// </summary>
-        public static readonly string V2023_11_01_preview = "2023-11-01-preview";
-
-        /// <summary>
         /// 2023-07-01.
         /// </summary>
         public static readonly string V2023_07_01 = "2023-07-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryWebhook.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ContainerRegistryWebhook.cs
@@ -130,11 +130,6 @@ public partial class ContainerRegistryWebhook : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-11-01-preview.
-        /// </summary>
-        public static readonly string V2023_11_01_preview = "2023-11-01-preview";
-
-        /// <summary>
         /// 2023-07-01.
         /// </summary>
         public static readonly string V2023_07_01 = "2023-07-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ScopeMap.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Generated/ScopeMap.cs
@@ -105,11 +105,6 @@ public partial class ScopeMap : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-11-01-preview.
-        /// </summary>
-        public static readonly string V2023_11_01_preview = "2023-11-01-preview";
-
-        /// <summary>
         /// 2023-07-01.
         /// </summary>
         public static readonly string V2023_07_01 = "2023-07-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/api/Azure.Provisioning.ContainerService.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/api/Azure.Provisioning.ContainerService.netstandard2.0.cs
@@ -74,7 +74,6 @@ namespace Azure.Provisioning.ContainerService
             public static readonly string V2024_06_01;
             public static readonly string V2024_07_01;
             public static readonly string V2024_08_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public enum AgentPoolType
@@ -204,7 +203,6 @@ namespace Azure.Provisioning.ContainerService
             public static readonly string V2024_06_01;
             public static readonly string V2024_07_01;
             public static readonly string V2024_08_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -327,7 +325,6 @@ namespace Azure.Provisioning.ContainerService
             public static readonly string V2024_06_01;
             public static readonly string V2024_07_01;
             public static readonly string V2024_08_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public partial class ContainerServiceMaintenanceRelativeMonthlySchedule : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -476,7 +473,6 @@ namespace Azure.Provisioning.ContainerService
             public static readonly string V2024_06_01;
             public static readonly string V2024_07_01;
             public static readonly string V2024_08_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public enum ContainerServiceNetworkMode
@@ -621,7 +617,6 @@ namespace Azure.Provisioning.ContainerService
             public static readonly string V2024_06_01;
             public static readonly string V2024_07_01;
             public static readonly string V2024_08_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public enum ContainerServicePrivateEndpointConnectionProvisioningState
@@ -745,7 +740,6 @@ namespace Azure.Provisioning.ContainerService
             public static readonly string V2024_06_01;
             public static readonly string V2024_07_01;
             public static readonly string V2024_08_01;
-            public static readonly string V2024_08_02_preview;
         }
     }
     public enum ContainerServiceTrustedAccessRoleBindingProvisioningState

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/AgentPoolSnapshot.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/AgentPoolSnapshot.cs
@@ -133,11 +133,6 @@ public partial class AgentPoolSnapshot : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-08-01.
         /// </summary>
         public static readonly string V2024_08_01 = "2024-08-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceAgentPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceAgentPool.cs
@@ -432,11 +432,6 @@ public partial class ContainerServiceAgentPool : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-08-01.
         /// </summary>
         public static readonly string V2024_08_01 = "2024-08-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceMaintenanceConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceMaintenanceConfiguration.cs
@@ -90,11 +90,6 @@ public partial class ContainerServiceMaintenanceConfiguration : ProvisionableRes
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-08-01.
         /// </summary>
         public static readonly string V2024_08_01 = "2024-08-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceManagedCluster.cs
@@ -406,11 +406,6 @@ public partial class ContainerServiceManagedCluster : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-08-01.
         /// </summary>
         public static readonly string V2024_08_01 = "2024-08-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServicePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServicePrivateEndpointConnection.cs
@@ -89,11 +89,6 @@ public partial class ContainerServicePrivateEndpointConnection : ProvisionableRe
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-08-01.
         /// </summary>
         public static readonly string V2024_08_01 = "2024-08-01";

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceTrustedAccessRoleBinding.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Generated/ContainerServiceTrustedAccessRoleBinding.cs
@@ -92,11 +92,6 @@ public partial class ContainerServiceTrustedAccessRoleBinding : ProvisionableRes
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-08-02-preview.
-        /// </summary>
-        public static readonly string V2024_08_02_preview = "2024-08-02-preview";
-
-        /// <summary>
         /// 2024-08-01.
         /// </summary>
         public static readonly string V2024_08_01 = "2024-08-01";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/api/Azure.Provisioning.CosmosDB.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/api/Azure.Provisioning.CosmosDB.netstandard2.0.cs
@@ -94,7 +94,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CassandraClusterBackupSchedule : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -172,7 +171,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CassandraDataCenterProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -249,7 +247,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CassandraKeyspacePropertiesConfig : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -297,7 +294,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CassandraPartitionKey : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -361,7 +357,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CassandraTablePropertiesConfig : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -417,7 +412,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CassandraViewGetPropertiesOptions : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -473,7 +467,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CassandraViewResource : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -521,7 +514,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public enum CompositePathSortOrder
@@ -663,7 +655,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBAccountBackupPolicy : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -939,7 +930,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBPrivateEndpointConnectionData : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1025,7 +1015,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBServiceProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1106,7 +1095,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBSqlClientEncryptionKeyProperties : Azure.Provisioning.CosmosDB.CosmosDBSqlClientEncryptionKeyResourceInfo
@@ -1164,7 +1152,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBSqlContainerPropertiesConfig : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1228,7 +1215,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBSqlDatabase : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1271,7 +1257,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBSqlDatabasePropertiesConfig : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1326,7 +1311,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBSqlRoleAssignment : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1367,7 +1351,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBSqlRoleDefinition : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1409,7 +1392,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public enum CosmosDBSqlRoleDefinitionType
@@ -1463,7 +1445,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBSqlStoredProcedureResourceInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1512,7 +1493,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public enum CosmosDBSqlTriggerOperation
@@ -1576,7 +1556,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBSqlUserDefinedFunctionResourceInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1637,7 +1616,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class CosmosDBTablePropertiesOptions : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1671,10 +1649,6 @@ namespace Azure.Provisioning.CosmosDB
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public static Azure.Provisioning.CosmosDB.CosmosDBThroughputPool FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
-        public static partial class ResourceVersions
-        {
-            public static readonly string V2024_02_15_preview;
-        }
     }
     public partial class CosmosDBThroughputPoolAccount : Azure.Provisioning.Primitives.ProvisionableResource
     {
@@ -1690,7 +1664,6 @@ namespace Azure.Provisioning.CosmosDB
         public static Azure.Provisioning.CosmosDB.CosmosDBThroughputPoolAccount FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_02_15_preview;
         }
     }
     public partial class CosmosDBUniqueKey : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1755,7 +1728,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class DatabaseAccountKeysMetadata : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1823,7 +1795,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public enum DataTransferJobMode
@@ -2030,7 +2001,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class GremlinDatabase : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2073,7 +2043,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class GremlinDatabasePropertiesConfig : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2134,7 +2103,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class GremlinGraph : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2177,7 +2145,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class GremlinGraphPropertiesConfig : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2238,7 +2205,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class MaterializedViewDefinition : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2340,7 +2306,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class MongoDBCollectionPropertiesConfig : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2398,7 +2363,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class MongoDBDatabase : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2441,7 +2405,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class MongoDBDatabasePropertiesConfig : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2496,7 +2459,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class MongoDBIndex : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2569,7 +2531,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public enum MongoDBRoleDefinitionType
@@ -2618,7 +2579,6 @@ namespace Azure.Provisioning.CosmosDB
             public static readonly string V2023_11_15;
             public static readonly string V2024_05_15;
             public static readonly string V2024_08_15;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public enum NetworkAclBypass

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraCluster.cs
@@ -89,11 +89,6 @@ public partial class CassandraCluster : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraDataCenter.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraDataCenter.cs
@@ -74,11 +74,6 @@ public partial class CassandraDataCenter : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraKeyspace.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraKeyspace.cs
@@ -111,11 +111,6 @@ public partial class CassandraKeyspace : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraKeyspaceThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraKeyspaceThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class CassandraKeyspaceThroughputSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraTable.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraTable.cs
@@ -103,11 +103,6 @@ public partial class CassandraTable : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraTableThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraTableThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class CassandraTableThroughputSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraViewGetResult.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraViewGetResult.cs
@@ -103,11 +103,6 @@ public partial class CassandraViewGetResult : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraViewThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CassandraViewThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class CassandraViewThroughputSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBAccount.cs
@@ -447,11 +447,6 @@ public partial class CosmosDBAccount : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBPrivateEndpointConnection.cs
@@ -94,11 +94,6 @@ public partial class CosmosDBPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBService.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBService.cs
@@ -105,11 +105,6 @@ public partial class CosmosDBService : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlClientEncryptionKey.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlClientEncryptionKey.cs
@@ -73,11 +73,6 @@ public partial class CosmosDBSqlClientEncryptionKey : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlContainer.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlContainer.cs
@@ -103,11 +103,6 @@ public partial class CosmosDBSqlContainer : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlContainerThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlContainerThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class CosmosDBSqlContainerThroughputSetting : ProvisionableResour
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlDatabase.cs
@@ -103,11 +103,6 @@ public partial class CosmosDBSqlDatabase : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlDatabaseThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlDatabaseThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class CosmosDBSqlDatabaseThroughputSetting : ProvisionableResourc
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlRoleAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlRoleAssignment.cs
@@ -91,11 +91,6 @@ public partial class CosmosDBSqlRoleAssignment : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlRoleDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlRoleDefinition.cs
@@ -101,11 +101,6 @@ public partial class CosmosDBSqlRoleDefinition : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlStoredProcedure.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlStoredProcedure.cs
@@ -103,11 +103,6 @@ public partial class CosmosDBSqlStoredProcedure : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlTrigger.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlTrigger.cs
@@ -103,11 +103,6 @@ public partial class CosmosDBSqlTrigger : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlUserDefinedFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBSqlUserDefinedFunction.cs
@@ -103,11 +103,6 @@ public partial class CosmosDBSqlUserDefinedFunction : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBTable.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBTable.cs
@@ -103,11 +103,6 @@ public partial class CosmosDBTable : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBThroughputPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBThroughputPool.cs
@@ -71,7 +71,7 @@ public partial class CosmosDBThroughputPool : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBThroughputPool.</param>
     public CosmosDBThroughputPool(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.DocumentDB/throughputPools", resourceVersion ?? "2024-02-15-preview")
+        : base(bicepIdentifier, "Microsoft.DocumentDB/throughputPools", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -80,17 +80,6 @@ public partial class CosmosDBThroughputPool : ProvisionableResource
         _tags = BicepDictionary<string>.DefineProperty(this, "Tags", ["tags"]);
         _id = BicepValue<ResourceIdentifier>.DefineProperty(this, "Id", ["id"], isOutput: true);
         _systemData = BicepValue<SystemData>.DefineProperty(this, "SystemData", ["systemData"], isOutput: true);
-    }
-
-    /// <summary>
-    /// Supported CosmosDBThroughputPool resource versions.
-    /// </summary>
-    public static class ResourceVersions
-    {
-        /// <summary>
-        /// 2024-02-15-preview.
-        /// </summary>
-        public static readonly string V2024_02_15_preview = "2024-02-15-preview";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBThroughputPoolAccount.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosDBThroughputPoolAccount.cs
@@ -77,7 +77,7 @@ public partial class CosmosDBThroughputPoolAccount : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the CosmosDBThroughputPoolAccount.</param>
     public CosmosDBThroughputPoolAccount(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.DocumentDB/throughputPools/throughputPoolAccounts", resourceVersion ?? "2024-02-15-preview")
+        : base(bicepIdentifier, "Microsoft.DocumentDB/throughputPools/throughputPoolAccounts", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _accountLocation = BicepValue<AzureLocation>.DefineProperty(this, "AccountLocation", ["properties", "accountLocation"]);
@@ -94,12 +94,7 @@ public partial class CosmosDBThroughputPoolAccount : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2024-02-15-preview.
-        /// </summary>
-        public static readonly string V2024_02_15_preview = "2024-02-15-preview";
     }
-
     /// <summary>
     /// Creates a reference to an existing CosmosDBThroughputPoolAccount.
     /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosTableThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/CosmosTableThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class CosmosTableThroughputSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/DataTransferJobGetResult.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/DataTransferJobGetResult.cs
@@ -172,11 +172,6 @@ public partial class DataTransferJobGetResult : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GraphResourceGetResult.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GraphResourceGetResult.cs
@@ -103,11 +103,6 @@ public partial class GraphResourceGetResult : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinDatabase.cs
@@ -103,11 +103,6 @@ public partial class GremlinDatabase : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinDatabaseThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinDatabaseThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class GremlinDatabaseThroughputSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinGraph.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinGraph.cs
@@ -103,11 +103,6 @@ public partial class GremlinGraph : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinGraphThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/GremlinGraphThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class GremlinGraphThroughputSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBCollection.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBCollection.cs
@@ -103,11 +103,6 @@ public partial class MongoDBCollection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBCollectionThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBCollectionThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class MongoDBCollectionThroughputSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBDatabase.cs
@@ -103,11 +103,6 @@ public partial class MongoDBDatabase : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBDatabaseThroughputSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBDatabaseThroughputSetting.cs
@@ -95,11 +95,6 @@ public partial class MongoDBDatabaseThroughputSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBRoleDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBRoleDefinition.cs
@@ -107,11 +107,6 @@ public partial class MongoDBRoleDefinition : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBUserDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Generated/MongoDBUserDefinition.cs
@@ -112,11 +112,6 @@ public partial class MongoDBUserDefinition : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2024-08-15.
         /// </summary>
         public static readonly string V2024_08_15 = "2024-08-15";

--- a/sdk/provisioning/Azure.Provisioning.Deployment/api/Azure.Provisioning.Deployment.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/api/Azure.Provisioning.Deployment.netstandard2.0.cs
@@ -7,13 +7,11 @@ namespace Azure.Provisioning
         public Azure.ResponseError? Error { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Outputs { get { throw null; } }
         public Azure.ResourceManager.Resources.Models.ResourcesProvisioningState? ProvisioningState { get { throw null; } }
-        public TClient CreateClient<TClient, TOptions>(Azure.Provisioning.Primitives.IClientCreator<TClient, TOptions> resource, Azure.Core.TokenCredential? credential = null, TOptions? options = null) where TOptions : Azure.Core.ClientOptions { throw null; }
     }
     public partial class ProvisioningDeploymentOptions
     {
         public ProvisioningDeploymentOptions() { }
         public Azure.ResourceManager.ArmClient ArmClient { get { throw null; } set { } }
-        public System.Action<Azure.Core.ClientOptions>? ConfigureClientOptionsCallback { get { throw null; } set { } }
         public Azure.Core.TokenCredential DefaultArmCredential { get { throw null; } set { } }
         public Azure.Core.TokenCredential DefaultClientCredential { get { throw null; } set { } }
         public Azure.Core.TokenCredential? DefaultCredential { get { throw null; } set { } }

--- a/sdk/provisioning/Azure.Provisioning.Deployment/src/ProvisioningDeployment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/src/ProvisioningDeployment.cs
@@ -88,6 +88,7 @@ public class ProvisioningDeployment
         Outputs = outputs;
     }
 
+#if EXPERIMENTAL_PROVISIONING
     /// <summary>
     /// Create a data-plane client for a specific Azure resource.
     /// </summary>
@@ -120,4 +121,5 @@ public class ProvisioningDeployment
         if (options is not null) { DeploymentOptions.ConfigureClientOptionsCallback?.Invoke(options); }
         return resource.CreateClient(Outputs, credential, options);
     }
+#endif
 }

--- a/sdk/provisioning/Azure.Provisioning.Deployment/src/ProvisioningDeploymentOptions.cs
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/src/ProvisioningDeploymentOptions.cs
@@ -31,7 +31,9 @@ public class ProvisioningDeploymentOptions
             {
                 // TODO: Hook into IConfig story for constructing ArmClient too
                 ArmClientOptions options = new();
+#if EXPERIMENTAL_PROVISIONING
                 ConfigureClientOptionsCallback?.Invoke(options);
+#endif
                 _armClient = new ArmClient(DefaultArmCredential, DefaultSubscriptionId, options);
             }
             return _armClient;
@@ -133,6 +135,7 @@ public class ProvisioningDeploymentOptions
     }
     private TokenCredential? _defaultClientCredential;
 
+#if EXPERIMENTAL_PROVISIONING
     /// <summary>
     /// Optional callback used to configure any <see cref="ClientOptions"/>
     /// instance used for creating <see cref="ArmClient"/> or
@@ -142,6 +145,7 @@ public class ProvisioningDeploymentOptions
     /// Azure client.
     /// </summary>
     public Action<ClientOptions>? ConfigureClientOptionsCallback { get; set; }
+#endif
 
     // TODO: Default CancellationToken to link to all async operations?
 }

--- a/sdk/provisioning/Azure.Provisioning.Deployment/tests/ExtensionTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/tests/ExtensionTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Azure.Provisioning.Primitives;
 using Azure.Provisioning.Storage;
 using Azure.Provisioning.Tests;
+using Microsoft.Identity.Client.Extensions.Msal;
 using NUnit.Framework;
 
 namespace Azure.Provisioning.Deployment.Tests;
@@ -19,7 +20,14 @@ internal class ExtensionTests(bool async)
         if (SkipTools) { return; }
 
         Infrastructure infra = new();
-        StorageAccount resource = StorageResources.CreateAccount("storage");
+        StorageAccount resource =
+            new("storage", StorageAccount.ResourceVersions.V2023_01_01)
+            {
+                Kind = StorageKind.StorageV2,
+                Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                IsHnsEnabled = true,
+                AllowBlobPublicAccess = false
+            };
         infra.Add(resource);
 
         // Lint
@@ -74,7 +82,14 @@ internal class ExtensionTests(bool async)
         if (SkipTools) { return; }
 
         Infrastructure infra = new();
-        StorageAccount resource = StorageResources.CreateAccount("storage");
+        StorageAccount resource =
+            new("storage", StorageAccount.ResourceVersions.V2023_01_01)
+            {
+                Kind = StorageKind.StorageV2,
+                Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                IsHnsEnabled = true,
+                AllowBlobPublicAccess = false
+            };
         infra.Add(resource);
 
         ProvisioningPlan plan = infra.Build();

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/api/Azure.Provisioning.EventGrid.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/api/Azure.Provisioning.EventGrid.netstandard2.0.cs
@@ -53,7 +53,6 @@ namespace Azure.Provisioning.EventGrid
         public static Azure.Provisioning.EventGrid.CaCertificate FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum CaCertificateProvisioningState
@@ -210,7 +209,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class DomainTopic : Azure.Provisioning.Primitives.ProvisionableResource
@@ -230,7 +228,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class DomainTopicEventSubscription : Azure.Provisioning.Primitives.ProvisionableResource
@@ -258,7 +255,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum DomainTopicProvisioningState
@@ -346,7 +342,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class EventGridDomainPrivateEndpointConnection : Azure.Provisioning.Primitives.ProvisionableResource
@@ -367,7 +362,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum EventGridDomainProvisioningState
@@ -433,10 +427,6 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.TopicsConfiguration> TopicsConfiguration { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.TopicSpacesConfiguration> TopicSpacesConfiguration { get { throw null; } set { } }
         public static Azure.Provisioning.EventGrid.EventGridNamespace FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
-        public static partial class ResourceVersions
-        {
-            public static readonly string V2024_06_01_preview;
-        }
     }
     public partial class EventGridNamespaceClientGroup : Azure.Provisioning.Primitives.ProvisionableResource
     {
@@ -451,7 +441,6 @@ namespace Azure.Provisioning.EventGrid
         public static Azure.Provisioning.EventGrid.EventGridNamespaceClientGroup FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum EventGridNamespaceClientProvisioningState
@@ -480,7 +469,6 @@ namespace Azure.Provisioning.EventGrid
         public static Azure.Provisioning.EventGrid.EventGridNamespaceClientResource FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum EventGridNamespaceClientState
@@ -503,7 +491,6 @@ namespace Azure.Provisioning.EventGrid
         public static Azure.Provisioning.EventGrid.EventGridNamespacePermissionBinding FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class EventGridPartnerContent : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -528,7 +515,6 @@ namespace Azure.Provisioning.EventGrid
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class EventGridPrivateEndpointConnectionData : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -615,7 +601,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class EventGridTopicPrivateEndpointConnection : Azure.Provisioning.Primitives.ProvisionableResource
@@ -638,7 +623,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum EventGridTopicProvisioningState
@@ -689,7 +673,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class EventSubscriptionDestination : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -827,10 +810,6 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.PublisherType> PublisherType { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public static Azure.Provisioning.EventGrid.NamespaceTopic FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
-        public static partial class ResourceVersions
-        {
-            public static readonly string V2024_06_01_preview;
-        }
     }
     public partial class NamespaceTopicEventSubscription : Azure.Provisioning.Primitives.ProvisionableResource
     {
@@ -845,10 +824,6 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.EventGrid.SubscriptionProvisioningState> ProvisioningState { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public static Azure.Provisioning.EventGrid.NamespaceTopicEventSubscription FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
-        public static partial class ResourceVersions
-        {
-            public static readonly string V2024_06_01_preview;
-        }
     }
     public partial class NamespaceTopicEventSubscriptionDestination : Azure.Provisioning.EventGrid.EventSubscriptionDestination
     {
@@ -972,7 +947,6 @@ namespace Azure.Provisioning.EventGrid
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum PartnerConfigurationProvisioningState
@@ -1000,10 +974,6 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepDictionary<string> Tags { get { throw null; } set { } }
         public static Azure.Provisioning.EventGrid.PartnerDestination FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
-        public static partial class ResourceVersions
-        {
-            public static readonly string V2024_06_01_preview;
-        }
     }
     public enum PartnerDestinationActivationState
     {
@@ -1055,7 +1025,6 @@ namespace Azure.Provisioning.EventGrid
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class PartnerNamespaceChannel : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1076,7 +1045,6 @@ namespace Azure.Provisioning.EventGrid
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum PartnerNamespaceChannelProvisioningState
@@ -1118,7 +1086,6 @@ namespace Azure.Provisioning.EventGrid
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum PartnerRegistrationProvisioningState
@@ -1151,7 +1118,6 @@ namespace Azure.Provisioning.EventGrid
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum PartnerTopicActivationState
@@ -1182,7 +1148,6 @@ namespace Azure.Provisioning.EventGrid
         public static partial class ResourceVersions
         {
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class PartnerTopicEventTypeInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1439,7 +1404,6 @@ namespace Azure.Provisioning.EventGrid
         {
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class SystemTopicEventSubscription : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1465,7 +1429,6 @@ namespace Azure.Provisioning.EventGrid
         {
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public enum TlsVersion
@@ -1504,7 +1467,6 @@ namespace Azure.Provisioning.EventGrid
             public static readonly string V2020_06_01;
             public static readonly string V2021_12_01;
             public static readonly string V2022_06_15;
-            public static readonly string V2024_06_01_preview;
         }
     }
     public partial class TopicsConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1524,10 +1486,6 @@ namespace Azure.Provisioning.EventGrid
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
         public Azure.Provisioning.BicepList<string> TopicTemplates { get { throw null; } set { } }
         public static Azure.Provisioning.EventGrid.TopicSpace FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
-        public static partial class ResourceVersions
-        {
-            public static readonly string V2024_06_01_preview;
-        }
     }
     public enum TopicSpaceProvisioningState
     {

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/CaCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/CaCertificate.cs
@@ -82,7 +82,7 @@ public partial class CaCertificate : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the CaCertificate.</param>
     public CaCertificate(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/caCertificates", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/caCertificates", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -100,12 +100,7 @@ public partial class CaCertificate : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
-
     /// <summary>
     /// Creates a reference to an existing CaCertificate.
     /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainEventSubscription.cs
@@ -183,11 +183,6 @@ public partial class DomainEventSubscription : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainTopic.cs
@@ -74,11 +74,6 @@ public partial class DomainTopic : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainTopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/DomainTopicEventSubscription.cs
@@ -183,11 +183,6 @@ public partial class DomainTopicEventSubscription : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridDomain.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridDomain.cs
@@ -234,11 +234,6 @@ public partial class EventGridDomain : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridDomainPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridDomainPrivateEndpointConnection.cs
@@ -96,11 +96,6 @@ public partial class EventGridDomainPrivateEndpointConnection : ProvisionableRes
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespace.cs
@@ -132,7 +132,7 @@ public partial class EventGridNamespace : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespace.</param>
     public EventGridNamespace(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -149,17 +149,6 @@ public partial class EventGridNamespace : ProvisionableResource
         _id = BicepValue<ResourceIdentifier>.DefineProperty(this, "Id", ["id"], isOutput: true);
         _provisioningState = BicepValue<NamespaceProvisioningState>.DefineProperty(this, "ProvisioningState", ["properties", "provisioningState"], isOutput: true);
         _systemData = BicepValue<SystemData>.DefineProperty(this, "SystemData", ["systemData"], isOutput: true);
-    }
-
-    /// <summary>
-    /// Supported EventGridNamespace resource versions.
-    /// </summary>
-    public static class ResourceVersions
-    {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespaceClientGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespaceClientGroup.cs
@@ -71,7 +71,7 @@ public partial class EventGridNamespaceClientGroup : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespaceClientGroup.</param>
     public EventGridNamespaceClientGroup(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/clientGroups", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/clientGroups", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -87,12 +87,7 @@ public partial class EventGridNamespaceClientGroup : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
-
     /// <summary>
     /// Creates a reference to an existing EventGridNamespaceClientGroup.
     /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespaceClientResource.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespaceClientResource.cs
@@ -107,7 +107,7 @@ public partial class EventGridNamespaceClientResource : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespaceClientResource.</param>
     public EventGridNamespaceClientResource(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/clients", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/clients", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _attributes = BicepDictionary<BinaryData>.DefineProperty(this, "Attributes", ["properties", "attributes"]);
@@ -126,12 +126,7 @@ public partial class EventGridNamespaceClientResource : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
-
     /// <summary>
     /// Creates a reference to an existing EventGridNamespaceClientResource.
     /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespacePermissionBinding.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridNamespacePermissionBinding.cs
@@ -86,7 +86,7 @@ public partial class EventGridNamespacePermissionBinding : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the EventGridNamespacePermissionBinding.</param>
     public EventGridNamespacePermissionBinding(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/permissionBindings", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/permissionBindings", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _clientGroupName = BicepValue<string>.DefineProperty(this, "ClientGroupName", ["properties", "clientGroupName"]);
@@ -104,12 +104,7 @@ public partial class EventGridNamespacePermissionBinding : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
-
     /// <summary>
     /// Creates a reference to an existing EventGridNamespacePermissionBinding.
     /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridPartnerNamespacePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridPartnerNamespacePrivateEndpointConnection.cs
@@ -97,11 +97,6 @@ public partial class EventGridPartnerNamespacePrivateEndpointConnection : Provis
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridTopic.cs
@@ -206,11 +206,6 @@ public partial class EventGridTopic : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridTopicPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventGridTopicPrivateEndpointConnection.cs
@@ -95,11 +95,6 @@ public partial class EventGridTopicPrivateEndpointConnection : ProvisionableReso
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/EventSubscription.cs
@@ -177,11 +177,6 @@ public partial class EventSubscription : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/Models/QueueInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/Models/QueueInfo.cs
@@ -80,6 +80,6 @@ public partial class QueueInfo : ProvisionableConstruct
         _receiveLockDurationInSeconds = BicepValue<int>.DefineProperty(this, "ReceiveLockDurationInSeconds", ["receiveLockDurationInSeconds"]);
         _maxDeliveryCount = BicepValue<int>.DefineProperty(this, "MaxDeliveryCount", ["maxDeliveryCount"]);
         _deadLetterDestinationWithResourceIdentity = BicepValue<DeadLetterWithResourceIdentity>.DefineProperty(this, "DeadLetterDestinationWithResourceIdentity", ["deadLetterDestinationWithResourceIdentity"]);
-        _eventTimeToLive = BicepValue<TimeSpan>.DefineProperty(this, "EventTimeToLive", ["eventTimeToLive"]);
+        _eventTimeToLive = BicepValue<TimeSpan>.DefineProperty(this, "EventTimeToLive", ["eventTimeToLive"], format: "P");
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/NamespaceTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/NamespaceTopic.cs
@@ -79,7 +79,7 @@ public partial class NamespaceTopic : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the NamespaceTopic.</param>
     public NamespaceTopic(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/topics", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/topics", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _eventRetentionInDays = BicepValue<int>.DefineProperty(this, "EventRetentionInDays", ["properties", "eventRetentionInDays"]);
@@ -89,17 +89,6 @@ public partial class NamespaceTopic : ProvisionableResource
         _provisioningState = BicepValue<NamespaceTopicProvisioningState>.DefineProperty(this, "ProvisioningState", ["properties", "provisioningState"], isOutput: true);
         _systemData = BicepValue<SystemData>.DefineProperty(this, "SystemData", ["systemData"], isOutput: true);
         _parent = ResourceReference<EventGridNamespace>.DefineResource(this, "Parent", ["parent"], isRequired: true);
-    }
-
-    /// <summary>
-    /// Supported NamespaceTopic resource versions.
-    /// </summary>
-    public static class ResourceVersions
-    {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/NamespaceTopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/NamespaceTopicEventSubscription.cs
@@ -85,7 +85,7 @@ public partial class NamespaceTopicEventSubscription : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the NamespaceTopicEventSubscription.</param>
     public NamespaceTopicEventSubscription(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/topics/eventSubscriptions", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/topics/eventSubscriptions", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _deliveryConfiguration = BicepValue<DeliveryConfiguration>.DefineProperty(this, "DeliveryConfiguration", ["properties", "deliveryConfiguration"]);
@@ -96,17 +96,6 @@ public partial class NamespaceTopicEventSubscription : ProvisionableResource
         _provisioningState = BicepValue<SubscriptionProvisioningState>.DefineProperty(this, "ProvisioningState", ["properties", "provisioningState"], isOutput: true);
         _systemData = BicepValue<SystemData>.DefineProperty(this, "SystemData", ["systemData"], isOutput: true);
         _parent = ResourceReference<NamespaceTopic>.DefineResource(this, "Parent", ["parent"], isRequired: true);
-    }
-
-    /// <summary>
-    /// Supported NamespaceTopicEventSubscription resource versions.
-    /// </summary>
-    public static class ResourceVersions
-    {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerConfiguration.cs
@@ -88,11 +88,6 @@ public partial class PartnerConfiguration : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerDestination.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerDestination.cs
@@ -103,7 +103,7 @@ public partial class PartnerDestination : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the PartnerDestination.</param>
     public PartnerDestination(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/partnerDestinations", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/partnerDestinations", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _location = BicepValue<AzureLocation>.DefineProperty(this, "Location", ["location"], isRequired: true);
@@ -117,17 +117,6 @@ public partial class PartnerDestination : ProvisionableResource
         _id = BicepValue<ResourceIdentifier>.DefineProperty(this, "Id", ["id"], isOutput: true);
         _provisioningState = BicepValue<PartnerDestinationProvisioningState>.DefineProperty(this, "ProvisioningState", ["properties", "provisioningState"], isOutput: true);
         _systemData = BicepValue<SystemData>.DefineProperty(this, "SystemData", ["systemData"], isOutput: true);
-    }
-
-    /// <summary>
-    /// Supported PartnerDestination resource versions.
-    /// </summary>
-    public static class ResourceVersions
-    {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerNamespace.cs
@@ -152,11 +152,6 @@ public partial class PartnerNamespace : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerNamespaceChannel.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerNamespaceChannel.cs
@@ -130,11 +130,6 @@ public partial class PartnerNamespaceChannel : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerRegistration.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerRegistration.cs
@@ -90,11 +90,6 @@ public partial class PartnerRegistration : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerTopic.cs
@@ -144,11 +144,6 @@ public partial class PartnerTopic : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerTopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/PartnerTopicEventSubscription.cs
@@ -183,11 +183,6 @@ public partial class PartnerTopicEventSubscription : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/SystemTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/SystemTopic.cs
@@ -109,11 +109,6 @@ public partial class SystemTopic : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/SystemTopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/SystemTopicEventSubscription.cs
@@ -183,11 +183,6 @@ public partial class SystemTopicEventSubscription : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/TopicEventSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/TopicEventSubscription.cs
@@ -183,11 +183,6 @@ public partial class TopicEventSubscription : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
-
-        /// <summary>
         /// 2022-06-15.
         /// </summary>
         public static readonly string V2022_06_15 = "2022-06-15";

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/TopicSpace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Generated/TopicSpace.cs
@@ -76,7 +76,7 @@ public partial class TopicSpace : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the TopicSpace.</param>
     public TopicSpace(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/topicSpaces", resourceVersion ?? "2024-06-01-preview")
+        : base(bicepIdentifier, "Microsoft.EventGrid/namespaces/topicSpaces", resourceVersion)
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _description = BicepValue<string>.DefineProperty(this, "Description", ["properties", "description"]);
@@ -85,17 +85,6 @@ public partial class TopicSpace : ProvisionableResource
         _provisioningState = BicepValue<TopicSpaceProvisioningState>.DefineProperty(this, "ProvisioningState", ["properties", "provisioningState"], isOutput: true);
         _systemData = BicepValue<SystemData>.DefineProperty(this, "SystemData", ["systemData"], isOutput: true);
         _parent = ResourceReference<EventGridNamespace>.DefineResource(this, "Parent", ["parent"], isRequired: true);
-    }
-
-    /// <summary>
-    /// Supported TopicSpace resource versions.
-    /// </summary>
-    public static class ResourceVersions
-    {
-        /// <summary>
-        /// 2024-06-01-preview.
-        /// </summary>
-        public static readonly string V2024_06_01_preview = "2024-06-01-preview";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/api/Azure.Provisioning.EventHubs.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/api/Azure.Provisioning.EventHubs.netstandard2.0.cs
@@ -42,7 +42,6 @@ namespace Azure.Provisioning.EventHubs
             public static readonly string V2017_04_01;
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class EventHubAuthorizationRule : Azure.Provisioning.Primitives.ProvisionableResource
@@ -63,7 +62,6 @@ namespace Azure.Provisioning.EventHubs
             public static readonly string V2017_04_01;
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class EventHubDestination : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -124,7 +122,6 @@ namespace Azure.Provisioning.EventHubs
         public static partial class ResourceVersions
         {
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class EventHubsApplicationGroupPolicy : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -190,7 +187,6 @@ namespace Azure.Provisioning.EventHubs
         {
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum EventHubsClusterProvisioningState
@@ -233,7 +229,6 @@ namespace Azure.Provisioning.EventHubs
             public static readonly string V2017_04_01;
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class EventHubsDisasterRecovery : Azure.Provisioning.Primitives.ProvisionableResource
@@ -257,7 +252,6 @@ namespace Azure.Provisioning.EventHubs
             public static readonly string V2017_04_01;
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum EventHubsDisasterRecoveryProvisioningState
@@ -339,7 +333,6 @@ namespace Azure.Provisioning.EventHubs
             public static readonly string V2017_04_01;
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class EventHubsNamespaceAuthorizationRule : Azure.Provisioning.Primitives.ProvisionableResource
@@ -360,7 +353,6 @@ namespace Azure.Provisioning.EventHubs
             public static readonly string V2017_04_01;
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum EventHubsNetworkRuleIPAction
@@ -386,7 +378,6 @@ namespace Azure.Provisioning.EventHubs
             public static readonly string V2017_04_01;
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum EventHubsNetworkRuleSetDefaultAction
@@ -422,7 +413,6 @@ namespace Azure.Provisioning.EventHubs
         {
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class EventHubsPrivateEndpointConnectionData : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -498,7 +488,6 @@ namespace Azure.Provisioning.EventHubs
             public static readonly string V2017_04_01;
             public static readonly string V2021_11_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum EventHubsSchemaType

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHub.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHub.cs
@@ -124,11 +124,6 @@ public partial class EventHub : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubAuthorizationRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubAuthorizationRule.cs
@@ -83,11 +83,6 @@ public partial class EventHubAuthorizationRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsApplicationGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsApplicationGroup.cs
@@ -107,11 +107,6 @@ public partial class EventHubsApplicationGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsCluster.cs
@@ -128,11 +128,6 @@ public partial class EventHubsCluster : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsConsumerGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsConsumerGroup.cs
@@ -98,11 +98,6 @@ public partial class EventHubsConsumerGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsDisasterRecovery.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsDisasterRecovery.cs
@@ -113,11 +113,6 @@ public partial class EventHubsDisasterRecovery : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespace.cs
@@ -224,11 +224,6 @@ public partial class EventHubsNamespace : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespaceAuthorizationRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNamespaceAuthorizationRule.cs
@@ -83,11 +83,6 @@ public partial class EventHubsNamespaceAuthorizationRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNetworkRuleSet.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsNetworkRuleSet.cs
@@ -112,11 +112,6 @@ public partial class EventHubsNetworkRuleSet : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsPrivateEndpointConnection.cs
@@ -94,11 +94,6 @@ public partial class EventHubsPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsSchemaGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Generated/EventHubsSchemaGroup.cs
@@ -117,11 +117,6 @@ public partial class EventHubsSchemaGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/api/Azure.Provisioning.KeyVault.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/api/Azure.Provisioning.KeyVault.netstandard2.0.cs
@@ -243,7 +243,6 @@ namespace Azure.Provisioning.KeyVault
             public static readonly string V2023_02_01;
             public static readonly string V2023_07_01;
             public static readonly string V2023_08_01_PREVIEW;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class KeyVaultPrivateEndpointConnectionItemData : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -329,7 +328,6 @@ namespace Azure.Provisioning.KeyVault
             public static readonly string V2023_02_01;
             public static readonly string V2023_07_01;
             public static readonly string V2023_08_01_PREVIEW;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class KeyVaultService : Azure.Provisioning.Primitives.ProvisionableResource
@@ -358,7 +356,6 @@ namespace Azure.Provisioning.KeyVault
             public static readonly string V2023_02_01;
             public static readonly string V2023_07_01;
             public static readonly string V2023_08_01_PREVIEW;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class KeyVaultSku : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -403,7 +400,6 @@ namespace Azure.Provisioning.KeyVault
             public static readonly string V2023_02_01;
             public static readonly string V2023_07_01;
             public static readonly string V2023_08_01_PREVIEW;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public enum ManagedHsmActionsRequiredMessage
@@ -479,7 +475,6 @@ namespace Azure.Provisioning.KeyVault
             public static readonly string V2023_02_01;
             public static readonly string V2023_07_01;
             public static readonly string V2023_08_01_PREVIEW;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class ManagedHsmPrivateEndpointConnectionItemData : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultPrivateEndpointConnection.cs
@@ -111,11 +111,6 @@ public partial class KeyVaultPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2023-08-01-PREVIEW.
         /// </summary>
         public static readonly string V2023_08_01_PREVIEW = "2023-08-01-PREVIEW";

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultSecret.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultSecret.cs
@@ -91,11 +91,6 @@ public partial class KeyVaultSecret : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2023-08-01-PREVIEW.
         /// </summary>
         public static readonly string V2023_08_01_PREVIEW = "2023-08-01-PREVIEW";

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/KeyVaultService.cs
@@ -86,11 +86,6 @@ public partial class KeyVaultService : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2023-08-01-PREVIEW.
         /// </summary>
         public static readonly string V2023_08_01_PREVIEW = "2023-08-01-PREVIEW";

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/ManagedHsm.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/ManagedHsm.cs
@@ -89,11 +89,6 @@ public partial class ManagedHsm : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2023-08-01-PREVIEW.
         /// </summary>
         public static readonly string V2023_08_01_PREVIEW = "2023-08-01-PREVIEW";

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/ManagedHsmPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Generated/ManagedHsmPrivateEndpointConnection.cs
@@ -119,11 +119,6 @@ public partial class ManagedHsmPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2023-08-01-PREVIEW.
         /// </summary>
         public static readonly string V2023_08_01_PREVIEW = "2023-08-01-PREVIEW";

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/api/Azure.Provisioning.Kubernetes.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/api/Azure.Provisioning.Kubernetes.netstandard2.0.cs
@@ -33,7 +33,6 @@ namespace Azure.Provisioning.Kubernetes
             public static readonly string V2021_03_01;
             public static readonly string V2021_10_01;
             public static readonly string V2024_01_01;
-            public static readonly string V2024_07_15_preview;
         }
     }
     public enum ConnectivityStatus

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Generated/ConnectedCluster.cs
@@ -189,11 +189,6 @@ public partial class ConnectedCluster : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-07-15-preview.
-        /// </summary>
-        public static readonly string V2024_07_15_preview = "2024-07-15-preview";
-
-        /// <summary>
         /// 2024-01-01.
         /// </summary>
         public static readonly string V2024_01_01 = "2024-01-01";

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/api/Azure.Provisioning.KubernetesConfiguration.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/api/Azure.Provisioning.KubernetesConfiguration.netstandard2.0.cs
@@ -209,7 +209,6 @@ namespace Azure.Provisioning.KubernetesConfiguration
             public static readonly string V2022_07_01;
             public static readonly string V2022_11_01;
             public static readonly string V2023_05_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class KubernetesGitRepository : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Generated/KubernetesFluxConfiguration.cs
@@ -191,11 +191,6 @@ public partial class KubernetesFluxConfiguration : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2023-05-01.
         /// </summary>
         public static readonly string V2023_05_01 = "2023-05-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.netstandard2.0.cs
@@ -21,7 +21,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
-            public static readonly string V2017_12_01_preview;
         }
     }
     public partial class PostgreSqlDatabase : Azure.Provisioning.Primitives.ProvisionableResource
@@ -39,7 +38,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
-            public static readonly string V2017_12_01_preview;
         }
     }
     public partial class PostgreSqlFirewallRule : Azure.Provisioning.Primitives.ProvisionableResource
@@ -57,7 +55,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
-            public static readonly string V2017_12_01_preview;
         }
     }
     public partial class PostgreSqlFlexibleServer : Azure.Provisioning.Primitives.ProvisionableResource
@@ -522,7 +519,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2018_06_01;
-            public static readonly string V2018_06_01_privatepreview;
         }
     }
     public enum PostgreSqlPrivateEndpointProvisioningState
@@ -592,7 +588,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
-            public static readonly string V2017_12_01_preview;
         }
     }
     public partial class PostgreSqlServerAdministrator : Azure.Provisioning.Primitives.ProvisionableResource
@@ -610,7 +605,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
-            public static readonly string V2017_12_01_preview;
         }
     }
     public partial class PostgreSqlServerKey : Azure.Provisioning.Primitives.ProvisionableResource
@@ -628,7 +622,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2020_01_01;
-            public static readonly string V2020_01_01_privatepreview;
         }
     }
     public enum PostgreSqlServerKeyType
@@ -713,7 +706,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
-            public static readonly string V2017_12_01_preview;
         }
     }
     public enum PostgreSqlServerSecurityAlertPolicyState
@@ -792,7 +784,6 @@ namespace Azure.Provisioning.PostgreSql
         public static partial class ResourceVersions
         {
             public static readonly string V2017_12_01;
-            public static readonly string V2017_12_01_preview;
         }
     }
     public enum PostgreSqlVirtualNetworkRuleState

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlConfiguration.cs
@@ -108,11 +108,6 @@ public partial class PostgreSqlConfiguration : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2017-12-01-preview.
-        /// </summary>
-        public static readonly string V2017_12_01_preview = "2017-12-01-preview";
-
-        /// <summary>
         /// 2017-12-01.
         /// </summary>
         public static readonly string V2017_12_01 = "2017-12-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlDatabase.cs
@@ -81,11 +81,6 @@ public partial class PostgreSqlDatabase : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2017-12-01-preview.
-        /// </summary>
-        public static readonly string V2017_12_01_preview = "2017-12-01-preview";
-
-        /// <summary>
         /// 2017-12-01.
         /// </summary>
         public static readonly string V2017_12_01 = "2017-12-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlFirewallRule.cs
@@ -82,11 +82,6 @@ public partial class PostgreSqlFirewallRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2017-12-01-preview.
-        /// </summary>
-        public static readonly string V2017_12_01_preview = "2017-12-01-preview";
-
-        /// <summary>
         /// 2017-12-01.
         /// </summary>
         public static readonly string V2017_12_01 = "2017-12-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlPrivateEndpointConnection.cs
@@ -87,11 +87,6 @@ public partial class PostgreSqlPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2018-06-01-privatepreview.
-        /// </summary>
-        public static readonly string V2018_06_01_privatepreview = "2018-06-01-privatepreview";
-
-        /// <summary>
         /// 2018-06-01.
         /// </summary>
         public static readonly string V2018_06_01 = "2018-06-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServer.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServer.cs
@@ -216,11 +216,6 @@ public partial class PostgreSqlServer : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2017-12-01-preview.
-        /// </summary>
-        public static readonly string V2017_12_01_preview = "2017-12-01-preview";
-
-        /// <summary>
         /// 2017-12-01.
         /// </summary>
         public static readonly string V2017_12_01 = "2017-12-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerAdministrator.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerAdministrator.cs
@@ -94,11 +94,6 @@ public partial class PostgreSqlServerAdministrator : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2017-12-01-preview.
-        /// </summary>
-        public static readonly string V2017_12_01_preview = "2017-12-01-preview";
-
-        /// <summary>
         /// 2017-12-01.
         /// </summary>
         public static readonly string V2017_12_01 = "2017-12-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerKey.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerKey.cs
@@ -95,11 +95,6 @@ public partial class PostgreSqlServerKey : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2020-01-01-privatepreview.
-        /// </summary>
-        public static readonly string V2020_01_01_privatepreview = "2020-01-01-privatepreview";
-
-        /// <summary>
         /// 2020-01-01.
         /// </summary>
         public static readonly string V2020_01_01 = "2020-01-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlServerSecurityAlertPolicy.cs
@@ -120,11 +120,6 @@ public partial class PostgreSqlServerSecurityAlertPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2017-12-01-preview.
-        /// </summary>
-        public static readonly string V2017_12_01_preview = "2017-12-01-preview";
-
-        /// <summary>
         /// 2017-12-01.
         /// </summary>
         public static readonly string V2017_12_01 = "2017-12-01";

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlVirtualNetworkRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Generated/PostgreSqlVirtualNetworkRule.cs
@@ -89,11 +89,6 @@ public partial class PostgreSqlVirtualNetworkRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2017-12-01-preview.
-        /// </summary>
-        public static readonly string V2017_12_01_preview = "2017-12-01-preview";
-
-        /// <summary>
         /// 2017-12-01.
         /// </summary>
         public static readonly string V2017_12_01 = "2017-12-01";

--- a/sdk/provisioning/Azure.Provisioning.Redis/api/Azure.Provisioning.Redis.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/api/Azure.Provisioning.Redis.netstandard2.0.cs
@@ -79,7 +79,6 @@ namespace Azure.Provisioning.Redis
             public static readonly string V2023_04_01;
             public static readonly string V2023_08_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class RedisCacheAccessPolicyAssignment : Azure.Provisioning.Primitives.ProvisionableResource
@@ -112,7 +111,6 @@ namespace Azure.Provisioning.Redis
             public static readonly string V2023_04_01;
             public static readonly string V2023_08_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class RedisCommonConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -181,7 +179,6 @@ namespace Azure.Provisioning.Redis
             public static readonly string V2023_04_01;
             public static readonly string V2023_08_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class RedisInstanceDetails : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -231,7 +228,6 @@ namespace Azure.Provisioning.Redis
             public static readonly string V2023_04_01;
             public static readonly string V2023_08_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class RedisPatchSchedule : Azure.Provisioning.Primitives.ProvisionableResource
@@ -262,7 +258,6 @@ namespace Azure.Provisioning.Redis
             public static readonly string V2023_04_01;
             public static readonly string V2023_08_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public enum RedisPatchScheduleDefaultName
@@ -299,7 +294,6 @@ namespace Azure.Provisioning.Redis
             public static readonly string V2023_04_01;
             public static readonly string V2023_08_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class RedisPrivateEndpointConnectionData : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -409,7 +403,6 @@ namespace Azure.Provisioning.Redis
             public static readonly string V2023_04_01;
             public static readonly string V2023_08_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class RedisSku : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/Models/RedisPatchScheduleSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/Models/RedisPatchScheduleSetting.cs
@@ -38,6 +38,6 @@ public partial class RedisPatchScheduleSetting : ProvisionableConstruct
     {
         _dayOfWeek = BicepValue<RedisDayOfWeek>.DefineProperty(this, "DayOfWeek", ["dayOfWeek"]);
         _startHourUtc = BicepValue<int>.DefineProperty(this, "StartHourUtc", ["startHourUtc"]);
-        _maintenanceWindow = BicepValue<TimeSpan>.DefineProperty(this, "MaintenanceWindow", ["maintenanceWindow"]);
+        _maintenanceWindow = BicepValue<TimeSpan>.DefineProperty(this, "MaintenanceWindow", ["maintenanceWindow"], format: "P");
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisCacheAccessPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisCacheAccessPolicy.cs
@@ -88,11 +88,6 @@ public partial class RedisCacheAccessPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisCacheAccessPolicyAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisCacheAccessPolicyAssignment.cs
@@ -95,11 +95,6 @@ public partial class RedisCacheAccessPolicyAssignment : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisFirewallRule.cs
@@ -82,11 +82,6 @@ public partial class RedisFirewallRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisLinkedServerWithProperty.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisLinkedServerWithProperty.cs
@@ -111,11 +111,6 @@ public partial class RedisLinkedServerWithProperty : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisPatchSchedule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisPatchSchedule.cs
@@ -81,11 +81,6 @@ public partial class RedisPatchSchedule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisPrivateEndpointConnection.cs
@@ -89,11 +89,6 @@ public partial class RedisPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Generated/RedisResource.cs
@@ -269,11 +269,6 @@ public partial class RedisResource : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusQueue.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusQueue.cs
@@ -210,16 +210,16 @@ public partial class ServiceBusQueue : ProvisionableResource
         : base(bicepIdentifier, "Microsoft.ServiceBus/namespaces/queues", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
-        _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"]);
+        _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"], format: "P");
         _deadLetteringOnMessageExpiration = BicepValue<bool>.DefineProperty(this, "DeadLetteringOnMessageExpiration", ["properties", "deadLetteringOnMessageExpiration"]);
-        _defaultMessageTimeToLive = BicepValue<TimeSpan>.DefineProperty(this, "DefaultMessageTimeToLive", ["properties", "defaultMessageTimeToLive"]);
-        _duplicateDetectionHistoryTimeWindow = BicepValue<TimeSpan>.DefineProperty(this, "DuplicateDetectionHistoryTimeWindow", ["properties", "duplicateDetectionHistoryTimeWindow"]);
+        _defaultMessageTimeToLive = BicepValue<TimeSpan>.DefineProperty(this, "DefaultMessageTimeToLive", ["properties", "defaultMessageTimeToLive"], format: "P");
+        _duplicateDetectionHistoryTimeWindow = BicepValue<TimeSpan>.DefineProperty(this, "DuplicateDetectionHistoryTimeWindow", ["properties", "duplicateDetectionHistoryTimeWindow"], format: "P");
         _enableBatchedOperations = BicepValue<bool>.DefineProperty(this, "EnableBatchedOperations", ["properties", "enableBatchedOperations"]);
         _enableExpress = BicepValue<bool>.DefineProperty(this, "EnableExpress", ["properties", "enableExpress"]);
         _enablePartitioning = BicepValue<bool>.DefineProperty(this, "EnablePartitioning", ["properties", "enablePartitioning"]);
         _forwardDeadLetteredMessagesTo = BicepValue<string>.DefineProperty(this, "ForwardDeadLetteredMessagesTo", ["properties", "forwardDeadLetteredMessagesTo"]);
         _forwardTo = BicepValue<string>.DefineProperty(this, "ForwardTo", ["properties", "forwardTo"]);
-        _lockDuration = BicepValue<TimeSpan>.DefineProperty(this, "LockDuration", ["properties", "lockDuration"]);
+        _lockDuration = BicepValue<TimeSpan>.DefineProperty(this, "LockDuration", ["properties", "lockDuration"], format: "P");
         _maxDeliveryCount = BicepValue<int>.DefineProperty(this, "MaxDeliveryCount", ["properties", "maxDeliveryCount"]);
         _maxMessageSizeInKilobytes = BicepValue<long>.DefineProperty(this, "MaxMessageSizeInKilobytes", ["properties", "maxMessageSizeInKilobytes"]);
         _maxSizeInMegabytes = BicepValue<int>.DefineProperty(this, "MaxSizeInMegabytes", ["properties", "maxSizeInMegabytes"]);

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusSubscription.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusSubscription.cs
@@ -185,17 +185,17 @@ public partial class ServiceBusSubscription : ProvisionableResource
         : base(bicepIdentifier, "Microsoft.ServiceBus/namespaces/topics/subscriptions", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
-        _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"]);
+        _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"], format: "P");
         _clientAffineProperties = BicepValue<ServiceBusClientAffineProperties>.DefineProperty(this, "ClientAffineProperties", ["properties", "clientAffineProperties"]);
         _deadLetteringOnFilterEvaluationExceptions = BicepValue<bool>.DefineProperty(this, "DeadLetteringOnFilterEvaluationExceptions", ["properties", "deadLetteringOnFilterEvaluationExceptions"]);
         _deadLetteringOnMessageExpiration = BicepValue<bool>.DefineProperty(this, "DeadLetteringOnMessageExpiration", ["properties", "deadLetteringOnMessageExpiration"]);
-        _defaultMessageTimeToLive = BicepValue<TimeSpan>.DefineProperty(this, "DefaultMessageTimeToLive", ["properties", "defaultMessageTimeToLive"]);
-        _duplicateDetectionHistoryTimeWindow = BicepValue<TimeSpan>.DefineProperty(this, "DuplicateDetectionHistoryTimeWindow", ["properties", "duplicateDetectionHistoryTimeWindow"]);
+        _defaultMessageTimeToLive = BicepValue<TimeSpan>.DefineProperty(this, "DefaultMessageTimeToLive", ["properties", "defaultMessageTimeToLive"], format: "P");
+        _duplicateDetectionHistoryTimeWindow = BicepValue<TimeSpan>.DefineProperty(this, "DuplicateDetectionHistoryTimeWindow", ["properties", "duplicateDetectionHistoryTimeWindow"], format: "P");
         _enableBatchedOperations = BicepValue<bool>.DefineProperty(this, "EnableBatchedOperations", ["properties", "enableBatchedOperations"]);
         _forwardDeadLetteredMessagesTo = BicepValue<string>.DefineProperty(this, "ForwardDeadLetteredMessagesTo", ["properties", "forwardDeadLetteredMessagesTo"]);
         _forwardTo = BicepValue<string>.DefineProperty(this, "ForwardTo", ["properties", "forwardTo"]);
         _isClientAffine = BicepValue<bool>.DefineProperty(this, "IsClientAffine", ["properties", "isClientAffine"]);
-        _lockDuration = BicepValue<TimeSpan>.DefineProperty(this, "LockDuration", ["properties", "lockDuration"]);
+        _lockDuration = BicepValue<TimeSpan>.DefineProperty(this, "LockDuration", ["properties", "lockDuration"], format: "P");
         _maxDeliveryCount = BicepValue<int>.DefineProperty(this, "MaxDeliveryCount", ["properties", "maxDeliveryCount"]);
         _requiresSession = BicepValue<bool>.DefineProperty(this, "RequiresSession", ["properties", "requiresSession"]);
         _status = BicepValue<ServiceBusMessagingEntityStatus>.DefineProperty(this, "Status", ["properties", "status"]);

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusTopic.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Generated/ServiceBusTopic.cs
@@ -175,9 +175,9 @@ public partial class ServiceBusTopic : ProvisionableResource
         : base(bicepIdentifier, "Microsoft.ServiceBus/namespaces/topics", resourceVersion ?? "2024-01-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
-        _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"]);
-        _defaultMessageTimeToLive = BicepValue<TimeSpan>.DefineProperty(this, "DefaultMessageTimeToLive", ["properties", "defaultMessageTimeToLive"]);
-        _duplicateDetectionHistoryTimeWindow = BicepValue<TimeSpan>.DefineProperty(this, "DuplicateDetectionHistoryTimeWindow", ["properties", "duplicateDetectionHistoryTimeWindow"]);
+        _autoDeleteOnIdle = BicepValue<TimeSpan>.DefineProperty(this, "AutoDeleteOnIdle", ["properties", "autoDeleteOnIdle"], format: "P");
+        _defaultMessageTimeToLive = BicepValue<TimeSpan>.DefineProperty(this, "DefaultMessageTimeToLive", ["properties", "defaultMessageTimeToLive"], format: "P");
+        _duplicateDetectionHistoryTimeWindow = BicepValue<TimeSpan>.DefineProperty(this, "DuplicateDetectionHistoryTimeWindow", ["properties", "duplicateDetectionHistoryTimeWindow"], format: "P");
         _enableBatchedOperations = BicepValue<bool>.DefineProperty(this, "EnableBatchedOperations", ["properties", "enableBatchedOperations"]);
         _enableExpress = BicepValue<bool>.DefineProperty(this, "EnableExpress", ["properties", "enableExpress"]);
         _enablePartitioning = BicepValue<bool>.DefineProperty(this, "EnablePartitioning", ["properties", "enablePartitioning"]);

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/tests/BasicServiceBusTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/tests/BasicServiceBusTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Provisioning.Expressions;
@@ -42,18 +43,15 @@ public class BasicServiceBusTests(bool async)
                     {
                         Parent = sb,
                         Name = queueName,
-                        // Hack around TimeSpan not serializing ISO durations
-                        // correctly using a Bicep string literal expression.
-                        // TODO: Change these to regular strings when patched.
-                        LockDuration = new StringLiteralExpression("PT5M"),
+                        LockDuration = TimeSpan.FromMinutes(5),
                         MaxSizeInMegabytes = 1024,
                         RequiresDuplicateDetection = false,
                         RequiresSession = false,
-                        DefaultMessageTimeToLive = new StringLiteralExpression("P10675199DT2H48M5.4775807S"),
+                        DefaultMessageTimeToLive = TimeSpan.MaxValue,
                         DeadLetteringOnMessageExpiration = false,
-                        DuplicateDetectionHistoryTimeWindow = new StringLiteralExpression("PT10M"),
+                        DuplicateDetectionHistoryTimeWindow = TimeSpan.FromMinutes(10),
                         MaxDeliveryCount = 10,
-                        AutoDeleteOnIdle = new StringLiteralExpression("P10675199DT2H48M5.4775807S"),
+                        AutoDeleteOnIdle = TimeSpan.MaxValue,
                         EnablePartitioning = false,
                         EnableExpress = false
                     };

--- a/sdk/provisioning/Azure.Provisioning.SignalR/api/Azure.Provisioning.SignalR.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/api/Azure.Provisioning.SignalR.netstandard2.0.cs
@@ -51,7 +51,6 @@ namespace Azure.Provisioning.SignalR
             public static readonly string V2022_02_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class SignalRCustomDomain : Azure.Provisioning.Primitives.ProvisionableResource
@@ -72,7 +71,6 @@ namespace Azure.Provisioning.SignalR
             public static readonly string V2022_02_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class SignalRFeature : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -154,7 +152,6 @@ namespace Azure.Provisioning.SignalR
             public static readonly string V2022_02_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class SignalRPrivateEndpointConnectionData : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -254,7 +251,6 @@ namespace Azure.Provisioning.SignalR
             public static readonly string V2022_02_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public enum SignalRServiceKind
@@ -283,7 +279,6 @@ namespace Azure.Provisioning.SignalR
             public static readonly string V2022_02_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class SignalRSharedPrivateLinkResourceData : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRCustomCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRCustomCertificate.cs
@@ -94,11 +94,6 @@ public partial class SignalRCustomCertificate : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRCustomDomain.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRCustomDomain.cs
@@ -87,11 +87,6 @@ public partial class SignalRCustomDomain : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRPrivateEndpointConnection.cs
@@ -95,11 +95,6 @@ public partial class SignalRPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRService.cs
@@ -252,11 +252,6 @@ public partial class SignalRService : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRSharedPrivateLink.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Generated/SignalRSharedPrivateLink.cs
@@ -103,11 +103,6 @@ public partial class SignalRSharedPrivateLink : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/api/Azure.Provisioning.Sql.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/api/Azure.Provisioning.Sql.netstandard2.0.cs
@@ -27,7 +27,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum BlobAuditingPolicyName
@@ -70,7 +69,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class DatabaseIdentity : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -119,7 +117,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum DataMaskingState
@@ -148,7 +145,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum DistributedAvailabilityGroupReplicationMode
@@ -192,7 +188,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_04_01;
             public static readonly string V2015_05_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ElasticPoolLicenseType
@@ -231,7 +226,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum EncryptionProtectorName
@@ -264,7 +258,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_04_01;
             public static readonly string V2015_01_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ExtendedServerBlobAuditingPolicy : Azure.Provisioning.Primitives.ProvisionableResource
@@ -290,7 +283,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ExternalGovernanceStatus
@@ -319,7 +311,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class FailoverGroupReadOnlyEndpoint : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -361,7 +352,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum GeoBackupPolicyName
@@ -395,7 +385,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class InstanceFailoverGroupReadWriteEndpoint : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -427,7 +416,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum InstancePoolLicenseType
@@ -449,7 +437,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum JobAgentState
@@ -565,7 +552,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum LedgerDigestUploadsName
@@ -591,7 +577,6 @@ namespace Azure.Provisioning.Sql
         {
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class LongTermRetentionPolicy : Azure.Provisioning.Primitives.ProvisionableResource
@@ -611,7 +596,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum LongTermRetentionPolicyName
@@ -631,7 +615,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedDatabase : Azure.Provisioning.Primitives.ProvisionableResource
@@ -669,7 +652,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedDatabaseAdvancedThreatProtection : Azure.Provisioning.Primitives.ProvisionableResource
@@ -684,7 +666,7 @@ namespace Azure.Provisioning.Sql
         public static Azure.Provisioning.Sql.ManagedDatabaseAdvancedThreatProtection FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_05_01_preview;
+            public static readonly string V2021_11_01;
         }
     }
     public enum ManagedDatabaseCreateMode
@@ -714,7 +696,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedDatabaseSensitivityLabel : Azure.Provisioning.Primitives.ProvisionableResource
@@ -767,7 +748,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedDatabaseVulnerabilityAssessmentRuleBaseline : Azure.Provisioning.Primitives.ProvisionableResource
@@ -824,7 +804,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedInstanceAdministrator : Azure.Provisioning.Primitives.ProvisionableResource
@@ -842,7 +821,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ManagedInstanceAdministratorType
@@ -861,7 +839,7 @@ namespace Azure.Provisioning.Sql
         public static Azure.Provisioning.Sql.ManagedInstanceAdvancedThreatProtection FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_05_01_preview;
+            public static readonly string V2021_11_01;
         }
     }
     public partial class ManagedInstanceAzureADOnlyAuthentication : Azure.Provisioning.Primitives.ProvisionableResource
@@ -876,7 +854,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedInstanceDtc : Azure.Provisioning.Primitives.ProvisionableResource
@@ -895,7 +872,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedInstanceDtcSecuritySettings : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -931,7 +907,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedInstanceExternalAdministrator : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -961,7 +936,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ManagedInstanceLicenseType
@@ -984,7 +958,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ManagedInstanceLongTermRetentionPolicyName
@@ -1018,7 +991,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedInstancePrivateEndpointConnectionProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1072,7 +1044,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ManagedInstanceServerConfigurationOptionName
@@ -1094,7 +1065,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedInstanceStartStopSchedule : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1113,7 +1083,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ManagedInstanceStartStopScheduleName
@@ -1136,7 +1105,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedLedgerDigestUpload : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1151,7 +1119,7 @@ namespace Azure.Provisioning.Sql
         public static Azure.Provisioning.Sql.ManagedLedgerDigestUpload FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_05_01_preview;
+            public static readonly string V2021_11_01;
         }
     }
     public enum ManagedLedgerDigestUploadsName
@@ -1192,7 +1160,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class ManagedServerSecurityAlertPolicy : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1214,7 +1181,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ManagedShortTermRetentionPolicyName
@@ -1234,7 +1200,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class OutboundFirewallRule : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1251,7 +1216,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class PartnerRegionInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1328,7 +1292,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum ServerConnectionType
@@ -1402,7 +1365,6 @@ namespace Azure.Provisioning.Sql
         {
             public static readonly string V2018_06_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum SqlAgentConfigurationPropertiesState
@@ -1531,7 +1493,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_04_01;
             public static readonly string V2015_01_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlDatabaseBlobAuditingPolicy : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1556,7 +1517,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum SqlDatabaseCreateMode
@@ -1605,7 +1565,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlDatabaseSensitivityLabel : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1689,7 +1648,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlDatabaseVulnerabilityAssessmentRuleBaseline : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1727,7 +1685,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum SqlMinimalTlsVersion
@@ -1760,7 +1717,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum SqlPrivateEndpointProvisioningState
@@ -1837,7 +1793,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerAzureADAdministrator : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1857,7 +1812,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerAzureADOnlyAuthentication : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1874,7 +1828,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerBlobAuditingPolicy : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1899,7 +1852,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerCommunicationLink : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1918,7 +1870,6 @@ namespace Azure.Provisioning.Sql
         {
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
-            public static readonly string V2014_04_01_preview;
         }
     }
     public partial class SqlServerConnectionPolicy : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1937,7 +1888,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_01_01;
             public static readonly string V2014_04_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerDatabaseRestorePoint : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1959,7 +1909,6 @@ namespace Azure.Provisioning.Sql
             public static readonly string V2014_04_01;
             public static readonly string V2015_01_01;
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerDevOpsAuditingSetting : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1979,7 +1928,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerDnsAlias : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1994,7 +1942,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerJob : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2011,7 +1958,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerJobAgent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2030,7 +1976,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerJobCredential : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2046,7 +1991,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerJobExecution : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2073,7 +2017,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerJobSchedule : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2107,7 +2050,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerJobTargetGroup : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2122,7 +2064,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerKey : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2144,7 +2085,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum SqlServerKeyType
@@ -2183,7 +2123,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerSqlVulnerabilityAssessment : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2197,7 +2136,9 @@ namespace Azure.Provisioning.Sql
         public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessment FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_05_01_preview;
+            public static readonly string V2014_01_01;
+            public static readonly string V2014_04_01;
+            public static readonly string V2021_11_01;
         }
     }
     public partial class SqlServerSqlVulnerabilityAssessmentBaseline : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2212,7 +2153,9 @@ namespace Azure.Provisioning.Sql
         public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessmentBaseline FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_05_01_preview;
+            public static readonly string V2014_01_01;
+            public static readonly string V2014_04_01;
+            public static readonly string V2021_11_01;
         }
     }
     public partial class SqlServerSqlVulnerabilityAssessmentBaselineRule : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2227,7 +2170,9 @@ namespace Azure.Provisioning.Sql
         public static Azure.Provisioning.Sql.SqlServerSqlVulnerabilityAssessmentBaselineRule FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {
-            public static readonly string V2024_05_01_preview;
+            public static readonly string V2014_01_01;
+            public static readonly string V2014_04_01;
+            public static readonly string V2021_11_01;
         }
     }
     public partial class SqlServerTrustGroup : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2242,7 +2187,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServerVirtualNetworkRule : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2259,7 +2203,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum SqlServerVirtualNetworkRuleState
@@ -2286,7 +2229,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SqlServicePrincipal : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2338,7 +2280,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum SyncAgentState
@@ -2384,7 +2325,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class SyncGroupSchema : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -2437,7 +2377,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public enum SyncMemberDbType
@@ -2512,7 +2451,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
     public partial class WorkloadGroup : Azure.Provisioning.Primitives.ProvisionableResource
@@ -2532,7 +2470,6 @@ namespace Azure.Provisioning.Sql
         public static partial class ResourceVersions
         {
             public static readonly string V2021_11_01;
-            public static readonly string V2024_05_01_preview;
         }
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/BackupShortTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/BackupShortTermRetentionPolicy.cs
@@ -83,11 +83,6 @@ public partial class BackupShortTermRetentionPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DataMaskingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DataMaskingPolicy.cs
@@ -112,11 +112,6 @@ public partial class DataMaskingPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DatabaseAdvancedThreatProtection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DatabaseAdvancedThreatProtection.cs
@@ -82,11 +82,6 @@ public partial class DatabaseAdvancedThreatProtection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DistributedAvailabilityGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/DistributedAvailabilityGroup.cs
@@ -137,11 +137,6 @@ public partial class DistributedAvailabilityGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ElasticPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ElasticPool.cs
@@ -188,11 +188,6 @@ public partial class ElasticPool : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/EncryptionProtector.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/EncryptionProtector.cs
@@ -124,11 +124,6 @@ public partial class EncryptionProtector : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ExtendedDatabaseBlobAuditingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ExtendedDatabaseBlobAuditingPolicy.cs
@@ -231,11 +231,6 @@ public partial class ExtendedDatabaseBlobAuditingPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ExtendedServerBlobAuditingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ExtendedServerBlobAuditingPolicy.cs
@@ -252,11 +252,6 @@ public partial class ExtendedServerBlobAuditingPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/FailoverGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/FailoverGroup.cs
@@ -124,11 +124,6 @@ public partial class FailoverGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/GeoBackupPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/GeoBackupPolicy.cs
@@ -95,11 +95,6 @@ public partial class GeoBackupPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/IPv6FirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/IPv6FirewallRule.cs
@@ -73,11 +73,6 @@ public partial class IPv6FirewallRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/InstanceFailoverGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/InstanceFailoverGroup.cs
@@ -110,11 +110,6 @@ public partial class InstanceFailoverGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/InstancePool.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/InstancePool.cs
@@ -119,11 +119,6 @@ public partial class InstancePool : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LedgerDigestUpload.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LedgerDigestUpload.cs
@@ -81,11 +81,6 @@ public partial class LedgerDigestUpload : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LogicalDatabaseTransparentDataEncryption.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LogicalDatabaseTransparentDataEncryption.cs
@@ -74,11 +74,6 @@ public partial class LogicalDatabaseTransparentDataEncryption : ProvisionableRes
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LongTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/LongTermRetentionPolicy.cs
@@ -108,11 +108,6 @@ public partial class LongTermRetentionPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedBackupShortTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedBackupShortTermRetentionPolicy.cs
@@ -74,11 +74,6 @@ public partial class ManagedBackupShortTermRetentionPolicy : ProvisionableResour
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabase.cs
@@ -264,11 +264,6 @@ public partial class ManagedDatabase : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseAdvancedThreatProtection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseAdvancedThreatProtection.cs
@@ -66,7 +66,7 @@ public partial class ManagedDatabaseAdvancedThreatProtection : ProvisionableReso
     /// </param>
     /// <param name="resourceVersion">Version of the ManagedDatabaseAdvancedThreatProtection.</param>
     public ManagedDatabaseAdvancedThreatProtection(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.Sql/managedInstances/databases/advancedThreatProtectionSettings", resourceVersion ?? "2024-05-01-preview")
+        : base(bicepIdentifier, "Microsoft.Sql/managedInstances/databases/advancedThreatProtectionSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<AdvancedThreatProtectionState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -82,9 +82,9 @@ public partial class ManagedDatabaseAdvancedThreatProtection : ProvisionableReso
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
+        /// 2021-11-01.
         /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
+        public static readonly string V2021_11_01 = "2021-11-01";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseSecurityAlertPolicy.cs
@@ -129,11 +129,6 @@ public partial class ManagedDatabaseSecurityAlertPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedDatabaseVulnerabilityAssessment.cs
@@ -102,11 +102,6 @@ public partial class ManagedDatabaseVulnerabilityAssessment : ProvisionableResou
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstance.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstance.cs
@@ -328,11 +328,6 @@ public partial class ManagedInstance : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAdministrator.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAdministrator.cs
@@ -94,11 +94,6 @@ public partial class ManagedInstanceAdministrator : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAdvancedThreatProtection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAdvancedThreatProtection.cs
@@ -66,7 +66,7 @@ public partial class ManagedInstanceAdvancedThreatProtection : ProvisionableReso
     /// </param>
     /// <param name="resourceVersion">Version of the ManagedInstanceAdvancedThreatProtection.</param>
     public ManagedInstanceAdvancedThreatProtection(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.Sql/managedInstances/advancedThreatProtectionSettings", resourceVersion ?? "2024-05-01-preview")
+        : base(bicepIdentifier, "Microsoft.Sql/managedInstances/advancedThreatProtectionSettings", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<AdvancedThreatProtectionState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -82,9 +82,9 @@ public partial class ManagedInstanceAdvancedThreatProtection : ProvisionableReso
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
+        /// 2021-11-01.
         /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
+        public static readonly string V2021_11_01 = "2021-11-01";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAzureADOnlyAuthentication.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceAzureADOnlyAuthentication.cs
@@ -74,11 +74,6 @@ public partial class ManagedInstanceAzureADOnlyAuthentication : ProvisionableRes
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceDtc.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceDtc.cs
@@ -102,11 +102,6 @@ public partial class ManagedInstanceDtc : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceEncryptionProtector.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceEncryptionProtector.cs
@@ -110,11 +110,6 @@ public partial class ManagedInstanceEncryptionProtector : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceKey.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceKey.cs
@@ -111,11 +111,6 @@ public partial class ManagedInstanceKey : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceLongTermRetentionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceLongTermRetentionPolicy.cs
@@ -94,11 +94,6 @@ public partial class ManagedInstanceLongTermRetentionPolicy : ProvisionableResou
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstancePrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstancePrivateEndpointConnection.cs
@@ -88,11 +88,6 @@ public partial class ManagedInstancePrivateEndpointConnection : ProvisionableRes
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceServerConfigurationOption.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceServerConfigurationOption.cs
@@ -81,11 +81,6 @@ public partial class ManagedInstanceServerConfigurationOption : ProvisionableRes
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceServerTrustCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceServerTrustCertificate.cs
@@ -87,11 +87,6 @@ public partial class ManagedInstanceServerTrustCertificate : ProvisionableResour
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceStartStopSchedule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceStartStopSchedule.cs
@@ -103,11 +103,6 @@ public partial class ManagedInstanceStartStopSchedule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedInstanceVulnerabilityAssessment.cs
@@ -103,11 +103,6 @@ public partial class ManagedInstanceVulnerabilityAssessment : ProvisionableResou
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedLedgerDigestUpload.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedLedgerDigestUpload.cs
@@ -65,7 +65,7 @@ public partial class ManagedLedgerDigestUpload : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ManagedLedgerDigestUpload.</param>
     public ManagedLedgerDigestUpload(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.Sql/managedInstances/databases/ledgerDigestUploads", resourceVersion ?? "2024-05-01-preview")
+        : base(bicepIdentifier, "Microsoft.Sql/managedInstances/databases/ledgerDigestUploads", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _digestStorageEndpoint = BicepValue<string>.DefineProperty(this, "DigestStorageEndpoint", ["properties", "digestStorageEndpoint"]);
@@ -81,9 +81,9 @@ public partial class ManagedLedgerDigestUpload : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
+        /// 2021-11-01.
         /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
+        public static readonly string V2021_11_01 = "2021-11-01";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedServerDnsAlias.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedServerDnsAlias.cs
@@ -87,11 +87,6 @@ public partial class ManagedServerDnsAlias : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedServerSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedServerSecurityAlertPolicy.cs
@@ -129,11 +129,6 @@ public partial class ManagedServerSecurityAlertPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedTransparentDataEncryption.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ManagedTransparentDataEncryption.cs
@@ -73,11 +73,6 @@ public partial class ManagedTransparentDataEncryption : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/Models/SqlServerJobSchedule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/Models/SqlServerJobSchedule.cs
@@ -53,6 +53,6 @@ public partial class SqlServerJobSchedule : ProvisionableConstruct
         _endOn = BicepValue<DateTimeOffset>.DefineProperty(this, "EndOn", ["endTime"]);
         _scheduleType = BicepValue<SqlServerJobScheduleType>.DefineProperty(this, "ScheduleType", ["type"]);
         _isEnabled = BicepValue<bool>.DefineProperty(this, "IsEnabled", ["enabled"]);
-        _interval = BicepValue<TimeSpan>.DefineProperty(this, "Interval", ["interval"]);
+        _interval = BicepValue<TimeSpan>.DefineProperty(this, "Interval", ["interval"], format: "P");
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/OutboundFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/OutboundFirewallRule.cs
@@ -73,11 +73,6 @@ public partial class OutboundFirewallRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ServerAdvancedThreatProtection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/ServerAdvancedThreatProtection.cs
@@ -82,11 +82,6 @@ public partial class ServerAdvancedThreatProtection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlAgentConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlAgentConfiguration.cs
@@ -73,11 +73,6 @@ public partial class SqlAgentConfiguration : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabase.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabase.cs
@@ -552,11 +552,6 @@ public partial class SqlDatabase : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseBlobAuditingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseBlobAuditingPolicy.cs
@@ -231,11 +231,6 @@ public partial class SqlDatabaseBlobAuditingPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseSecurityAlertPolicy.cs
@@ -129,11 +129,6 @@ public partial class SqlDatabaseSecurityAlertPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlDatabaseVulnerabilityAssessment.cs
@@ -102,11 +102,6 @@ public partial class SqlDatabaseVulnerabilityAssessment : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlFirewallRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlFirewallRule.cs
@@ -76,11 +76,6 @@ public partial class SqlFirewallRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlPrivateEndpointConnection.cs
@@ -95,11 +95,6 @@ public partial class SqlPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServer.cs
@@ -217,11 +217,6 @@ public partial class SqlServer : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerAzureADAdministrator.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerAzureADAdministrator.cs
@@ -102,11 +102,6 @@ public partial class SqlServerAzureADAdministrator : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerAzureADOnlyAuthentication.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerAzureADOnlyAuthentication.cs
@@ -73,11 +73,6 @@ public partial class SqlServerAzureADOnlyAuthentication : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerBlobAuditingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerBlobAuditingPolicy.cs
@@ -245,11 +245,6 @@ public partial class SqlServerBlobAuditingPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerCommunicationLink.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerCommunicationLink.cs
@@ -95,11 +95,6 @@ public partial class SqlServerCommunicationLink : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2014-04-01-preview.
-        /// </summary>
-        public static readonly string V2014_04_01_preview = "2014-04-01-preview";
-
-        /// <summary>
         /// 2014-04-01.
         /// </summary>
         public static readonly string V2014_04_01 = "2014-04-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerConnectionPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerConnectionPolicy.cs
@@ -87,11 +87,6 @@ public partial class SqlServerConnectionPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDatabaseRestorePoint.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDatabaseRestorePoint.cs
@@ -101,11 +101,6 @@ public partial class SqlServerDatabaseRestorePoint : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDevOpsAuditingSetting.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDevOpsAuditingSetting.cs
@@ -134,11 +134,6 @@ public partial class SqlServerDevOpsAuditingSetting : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDnsAlias.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerDnsAlias.cs
@@ -73,11 +73,6 @@ public partial class SqlServerDnsAlias : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJob.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJob.cs
@@ -87,11 +87,6 @@ public partial class SqlServerJob : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobAgent.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobAgent.cs
@@ -102,11 +102,6 @@ public partial class SqlServerJobAgent : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobCredential.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobCredential.cs
@@ -80,11 +80,6 @@ public partial class SqlServerJobCredential : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobExecution.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobExecution.cs
@@ -157,11 +157,6 @@ public partial class SqlServerJobExecution : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobStep.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobStep.cs
@@ -112,11 +112,6 @@ public partial class SqlServerJobStep : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobTargetGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerJobTargetGroup.cs
@@ -74,11 +74,6 @@ public partial class SqlServerJobTargetGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerKey.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerKey.cs
@@ -130,11 +130,6 @@ public partial class SqlServerKey : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSecurityAlertPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSecurityAlertPolicy.cs
@@ -129,11 +129,6 @@ public partial class SqlServerSecurityAlertPolicy : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessment.cs
@@ -60,7 +60,7 @@ public partial class SqlServerSqlVulnerabilityAssessment : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessment.</param>
     public SqlServerSqlVulnerabilityAssessment(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.Sql/servers/sqlVulnerabilityAssessments", resourceVersion ?? "2024-05-01-preview")
+        : base(bicepIdentifier, "Microsoft.Sql/servers/sqlVulnerabilityAssessments", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _state = BicepValue<SqlVulnerabilityAssessmentState>.DefineProperty(this, "State", ["properties", "state"]);
@@ -75,9 +75,19 @@ public partial class SqlServerSqlVulnerabilityAssessment : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
+        /// 2021-11-01.
         /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
+        public static readonly string V2021_11_01 = "2021-11-01";
+
+        /// <summary>
+        /// 2014-04-01.
+        /// </summary>
+        public static readonly string V2014_04_01 = "2014-04-01";
+
+        /// <summary>
+        /// 2014-01-01.
+        /// </summary>
+        public static readonly string V2014_01_01 = "2014-01-01";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessmentBaseline.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessmentBaseline.cs
@@ -66,7 +66,7 @@ public partial class SqlServerSqlVulnerabilityAssessmentBaseline : Provisionable
     /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessmentBaseline.</param>
     public SqlServerSqlVulnerabilityAssessmentBaseline(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines", resourceVersion ?? "2024-05-01-preview")
+        : base(bicepIdentifier, "Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isLatestScan = BicepValue<bool>.DefineProperty(this, "IsLatestScan", ["properties", "latestScan"]);
@@ -82,9 +82,19 @@ public partial class SqlServerSqlVulnerabilityAssessmentBaseline : Provisionable
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
+        /// 2021-11-01.
         /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
+        public static readonly string V2021_11_01 = "2021-11-01";
+
+        /// <summary>
+        /// 2014-04-01.
+        /// </summary>
+        public static readonly string V2014_04_01 = "2014-04-01";
+
+        /// <summary>
+        /// 2014-01-01.
+        /// </summary>
+        public static readonly string V2014_01_01 = "2014-01-01";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessmentBaselineRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerSqlVulnerabilityAssessmentBaselineRule.cs
@@ -66,7 +66,7 @@ public partial class SqlServerSqlVulnerabilityAssessmentBaselineRule : Provision
     /// </param>
     /// <param name="resourceVersion">Version of the SqlServerSqlVulnerabilityAssessmentBaselineRule.</param>
     public SqlServerSqlVulnerabilityAssessmentBaselineRule(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines/rules", resourceVersion ?? "2024-05-01-preview")
+        : base(bicepIdentifier, "Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines/rules", resourceVersion ?? "2021-11-01")
     {
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isOutput: true);
         _isLatestScan = BicepValue<bool>.DefineProperty(this, "IsLatestScan", ["properties", "latestScan"]);
@@ -83,9 +83,19 @@ public partial class SqlServerSqlVulnerabilityAssessmentBaselineRule : Provision
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
+        /// 2021-11-01.
         /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
+        public static readonly string V2021_11_01 = "2021-11-01";
+
+        /// <summary>
+        /// 2014-04-01.
+        /// </summary>
+        public static readonly string V2014_04_01 = "2014-04-01";
+
+        /// <summary>
+        /// 2014-01-01.
+        /// </summary>
+        public static readonly string V2014_01_01 = "2014-01-01";
     }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerTrustGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerTrustGroup.cs
@@ -74,11 +74,6 @@ public partial class SqlServerTrustGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerVirtualNetworkRule.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerVirtualNetworkRule.cs
@@ -88,11 +88,6 @@ public partial class SqlServerVirtualNetworkRule : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerVulnerabilityAssessment.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SqlServerVulnerabilityAssessment.cs
@@ -103,11 +103,6 @@ public partial class SqlServerVulnerabilityAssessment : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncAgent.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncAgent.cs
@@ -108,11 +108,6 @@ public partial class SyncAgent : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncGroup.cs
@@ -160,11 +160,6 @@ public partial class SyncGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncMember.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/SyncMember.cs
@@ -152,11 +152,6 @@ public partial class SyncMember : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/WorkloadClassifier.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/WorkloadClassifier.cs
@@ -108,11 +108,6 @@ public partial class WorkloadClassifier : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/WorkloadGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Generated/WorkloadGroup.cs
@@ -108,11 +108,6 @@ public partial class WorkloadGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-05-01-preview.
-        /// </summary>
-        public static readonly string V2024_05_01_preview = "2024-05-01-preview";
-
-        /// <summary>
         /// 2021-11-01.
         /// </summary>
         public static readonly string V2021_11_01 = "2021-11-01";

--- a/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.netstandard2.0.cs
@@ -1,11 +1,3 @@
-namespace Azure.Provisioning
-{
-    public partial class StorageResources
-    {
-        public StorageResources() { }
-        public static Azure.Provisioning.Storage.StorageAccount CreateAccount(string resourceName, int? infrastructureVersion = 2) { throw null; }
-    }
-}
 namespace Azure.Provisioning.Storage
 {
     public partial class AccountImmutabilityPolicy : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -216,7 +208,7 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<string> RestoreId { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.BlobRestoreProgressStatus> Status { get { throw null; } }
     }
-    public partial class BlobService : Azure.Provisioning.Primitives.ProvisionableResource, Azure.Provisioning.Primitives.IClientCreator, Azure.Provisioning.Primitives.IClientCreator<Azure.Storage.Blobs.BlobServiceClient, Azure.Storage.Blobs.BlobClientOptions>
+    public partial class BlobService : Azure.Provisioning.Primitives.ProvisionableResource
     {
         public BlobService(string bicepIdentifier, string? resourceVersion = null) : base (default(string), default(Azure.Core.ResourceType), default(string)) { }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.BlobServiceChangeFeed> ChangeFeed { get { throw null; } set { } }
@@ -232,8 +224,6 @@ namespace Azure.Provisioning.Storage
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.RestorePolicy> RestorePolicy { get { throw null; } set { } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Storage.StorageSku> Sku { get { throw null; } }
         public Azure.Provisioning.BicepValue<Azure.Provisioning.Resources.SystemData> SystemData { get { throw null; } }
-        System.Collections.Generic.IEnumerable<Azure.Provisioning.ProvisioningOutput> Azure.Provisioning.Primitives.IClientCreator.GetOutputs() { throw null; }
-        Azure.Storage.Blobs.BlobServiceClient Azure.Provisioning.Primitives.IClientCreator<Azure.Storage.Blobs.BlobServiceClient, Azure.Storage.Blobs.BlobClientOptions>.CreateClient(System.Collections.Generic.IReadOnlyDictionary<string, object?> deploymentOutputs, Azure.Core.TokenCredential credential, Azure.Storage.Blobs.BlobClientOptions? options) { throw null; }
         public static Azure.Provisioning.Storage.BlobService FromExisting(string bicepIdentifier, string? resourceVersion = null) { throw null; }
         public static partial class ResourceVersions
         {

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/BlobService.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/BlobService.cs
@@ -13,7 +13,9 @@ namespace Azure.Provisioning.Storage;
 
 // Customize the generated BlobService resource.
 public partial class BlobService
+#if EXPERIMENTAL_PROVISIONING
     : IClientCreator<BlobServiceClient, BlobClientOptions>
+#endif
 {
     /// <summary>
     /// Get the default value for the Name property.
@@ -21,6 +23,7 @@ public partial class BlobService
     private partial BicepValue<string> GetNameDefaultValue() =>
         new StringLiteralExpression("default");
 
+#if EXPERIMENTAL_PROVISIONING
     /// <inheritdoc/>
     IEnumerable<ProvisioningOutput> IClientCreator.GetOutputs()
     {
@@ -56,4 +59,5 @@ public partial class BlobService
             throw new InvalidOperationException($"Could not find output value {qualifiedName} to construct {GetType().Name} resource {BicepIdentifier}.");
         return new BlobServiceClient(new Uri(endpoint), credential, options);
     }
+#endif
 }

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/StorageResources.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/StorageResources.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#if EXPERIMENTAL_PROVISIONING
+
 using System;
 using Azure.Core;
 using Azure.Provisioning.Storage;
@@ -54,3 +56,5 @@ public class StorageResources
             } :
         throw new ArgumentOutOfRangeException(nameof(infrastructureVersion), $"Expected a value between 1 and 2 inclusive, not {infrastructureVersion}.");
 }
+
+#endif

--- a/sdk/provisioning/Azure.Provisioning.Storage/tests/BasicStorageTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/tests/BasicStorageTests.cs
@@ -19,7 +19,14 @@ public class BasicStorageTests(bool async)
     public async Task CreateDefault()
     {
         await using Trycep test = CreateBicepTest();
-        await test.Define(StorageResources.CreateAccount("storage"))
+        await test.Define(
+            new StorageAccount("storage", StorageAccount.ResourceVersions.V2023_01_01)
+            {
+                Kind = StorageKind.StorageV2,
+                Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                IsHnsEnabled = true,
+                AllowBlobPublicAccess = false
+            })
         .Compare(
             """
             @description('The location for the resource(s) to be deployed.')
@@ -51,7 +58,14 @@ public class BasicStorageTests(bool async)
             {
                 Infrastructure infra = new();
 
-                StorageAccount storage = StorageResources.CreateAccount(nameof(storage));
+                StorageAccount storage =
+                    new(nameof(storage), StorageAccount.ResourceVersions.V2023_01_01)
+                    {
+                        Kind = StorageKind.StorageV2,
+                        Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                        IsHnsEnabled = true,
+                        AllowBlobPublicAccess = false
+                    };
                 infra.Add(storage);
 
                 BlobService blobs = new(nameof(blobs)) { Parent = storage, DependsOn = { storage } };
@@ -98,7 +112,14 @@ public class BasicStorageTests(bool async)
             {
                 Infrastructure infra = new();
 
-                StorageAccount storage = StorageResources.CreateAccount(nameof(storage));
+                StorageAccount storage =
+                    new(nameof(storage), StorageAccount.ResourceVersions.V2023_01_01)
+                    {
+                        Kind = StorageKind.StorageV2,
+                        Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                        IsHnsEnabled = true,
+                        AllowBlobPublicAccess = false
+                    };
                 infra.Add(storage);
 
                 UserAssignedIdentity id = new(nameof(id));
@@ -155,7 +176,14 @@ public class BasicStorageTests(bool async)
             {
                 Infrastructure infra = new();
 
-                StorageAccount storage = StorageResources.CreateAccount(nameof(storage));
+                StorageAccount storage =
+                    new(nameof(storage), StorageAccount.ResourceVersions.V2023_01_01)
+                    {
+                        Kind = StorageKind.StorageV2,
+                        Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                        IsHnsEnabled = true,
+                        AllowBlobPublicAccess = false
+                    };
                 infra.Add(storage);
 
                 UserAssignedIdentity id = new(nameof(id));
@@ -226,7 +254,14 @@ public class BasicStorageTests(bool async)
             {
                 Infrastructure infra = new();
 
-                StorageAccount storage = StorageResources.CreateAccount(nameof(storage));
+                StorageAccount storage =
+                    new(nameof(storage), StorageAccount.ResourceVersions.V2023_01_01)
+                    {
+                        Kind = StorageKind.StorageV2,
+                        Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                        IsHnsEnabled = true,
+                        AllowBlobPublicAccess = false
+                    };
                 infra.Add(storage);
 
                 BlobService blobs = new(nameof(blobs)) { Parent = storage };

--- a/sdk/provisioning/Azure.Provisioning.Storage/tests/BasicStorageTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/tests/BasicStorageTests.cs
@@ -269,6 +269,71 @@ public class BasicStorageTests(bool async)
 
                 infra.Add(new ProvisioningOutput("blobs_endpoint", typeof(string)) { Value = storage.PrimaryEndpoints.Value!.BlobUri });
 
+                // Manually compute the public Azure endpoint
+                BicepValue<string> computed =
+                    new BicepStringBuilder()
+                    .Append("https://")
+                    .Append($"{storage.Name}")
+                    .Append(".blob.core.windows.net");
+                infra.Add(new ProvisioningOutput("computed_endpoint", typeof(string)) { Value = computed });
+
+                return infra;
+            })
+        .Compare(
+            """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+              name: take('storage${uniqueString(resourceGroup().id)}', 24)
+              kind: 'StorageV2'
+              location: location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              properties: {
+                allowBlobPublicAccess: false
+                isHnsEnabled: true
+              }
+            }
+
+            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
+              name: 'default'
+              parent: storage
+            }
+
+            output blobs_endpoint string = storage.properties.primaryEndpoints.blob
+
+            output computed_endpoint string = 'https://${storage.name}.blob.core.windows.net'
+            """)
+        .Lint()
+        .ValidateAndDeployAsync();
+    }
+
+    [Test]
+    public async Task SimpleConnStr()
+    {
+        await using Trycep test = CreateBicepTest();
+        await test.Define(
+            ctx =>
+            {
+                Infrastructure infra = new();
+
+                StorageAccount storage =
+                    new(nameof(storage), StorageAccount.ResourceVersions.V2023_01_01)
+                    {
+                        Kind = StorageKind.StorageV2,
+                        Sku = new StorageSku { Name = StorageSkuName.StandardLrs },
+                        IsHnsEnabled = true,
+                        AllowBlobPublicAccess = false
+                    };
+                infra.Add(storage);
+
+                BlobService blobs = new(nameof(blobs)) { Parent = storage };
+                infra.Add(blobs);
+
+                infra.Add(new ProvisioningOutput("blobs_endpoint", typeof(string)) { Value = storage.PrimaryEndpoints.Value!.BlobUri });
+
                 return infra;
             })
         .Compare(

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/api/Azure.Provisioning.WebPubSub.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/api/Azure.Provisioning.WebPubSub.netstandard2.0.cs
@@ -98,7 +98,6 @@ namespace Azure.Provisioning.WebPubSub
             public static readonly string V2021_10_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class WebPubSubHubProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -142,7 +141,6 @@ namespace Azure.Provisioning.WebPubSub
             public static readonly string V2021_10_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class WebPubSubPrivateEndpointConnectionData : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -228,7 +226,6 @@ namespace Azure.Provisioning.WebPubSub
             public static readonly string V2021_10_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class WebPubSubSharedPrivateLink : Azure.Provisioning.Primitives.ProvisionableResource
@@ -250,7 +247,6 @@ namespace Azure.Provisioning.WebPubSub
             public static readonly string V2021_10_01;
             public static readonly string V2023_02_01;
             public static readonly string V2024_03_01;
-            public static readonly string V2024_04_01_preview;
         }
     }
     public partial class WebPubSubSharedPrivateLinkData : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubHub.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubHub.cs
@@ -74,11 +74,6 @@ public partial class WebPubSubHub : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubPrivateEndpointConnection.cs
@@ -95,11 +95,6 @@ public partial class WebPubSubPrivateEndpointConnection : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubService.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubService.cs
@@ -215,11 +215,6 @@ public partial class WebPubSubService : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubSharedPrivateLink.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Generated/WebPubSubSharedPrivateLink.cs
@@ -103,11 +103,6 @@ public partial class WebPubSubSharedPrivateLink : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-04-01-preview.
-        /// </summary>
-        public static readonly string V2024_04_01_preview = "2024-04-01-preview";
-
-        /// <summary>
         /// 2024-03-01.
         /// </summary>
         public static readonly string V2024_03_01 = "2024-03-01";

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -92,7 +92,7 @@ namespace Azure.Provisioning
     {
         public Infrastructure(string bicepName = "main") { }
         public string BicepName { get { throw null; } }
-        public string? TargetScope { get { throw null; } set { } }
+        public Azure.Provisioning.Primitives.DeploymentScope? TargetScope { get { throw null; } set { } }
         public virtual void Add(Azure.Provisioning.Primitives.Provisionable resource) { }
         public virtual Azure.Provisioning.ProvisioningPlan Build(Azure.Provisioning.ProvisioningBuildOptions? options = null) { throw null; }
         protected internal override System.Collections.Generic.IEnumerable<Azure.Provisioning.Expressions.BicepStatement> Compile() { throw null; }
@@ -771,6 +771,13 @@ namespace Azure.Provisioning.Primitives
         public Azure.Provisioning.Primitives.ProvisionableConstruct Construct { get { throw null; } }
         public string PropertyName { get { throw null; } }
         public override string ToString() { throw null; }
+    }
+    public enum DeploymentScope
+    {
+        ResourceGroup = 0,
+        Subscription = 1,
+        ManagementGroup = 2,
+        Tenant = 3,
     }
     public partial class DynamicResourceNamePropertyResolver : Azure.Provisioning.Primitives.ResourceNamePropertyResolver
     {

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -82,7 +82,7 @@ namespace Azure.Provisioning
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void Assign(Azure.Provisioning.BicepValue<T> source) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static Azure.Provisioning.BicepValue<T> DefineProperty(Azure.Provisioning.Primitives.ProvisionableConstruct construct, string propertyName, string[]? bicepPath, bool isOutput = false, bool isRequired = false, bool isSecure = false, Azure.Provisioning.BicepValue<T>? defaultValue = null) { throw null; }
+        public static Azure.Provisioning.BicepValue<T> DefineProperty(Azure.Provisioning.Primitives.ProvisionableConstruct construct, string propertyName, string[]? bicepPath, bool isOutput = false, bool isRequired = false, bool isSecure = false, Azure.Provisioning.BicepValue<T>? defaultValue = null, string? format = null) { throw null; }
         public static implicit operator Azure.Provisioning.BicepValue<System.String> (Azure.Provisioning.BicepValue<T> value) { throw null; }
         public static implicit operator Azure.Provisioning.BicepValue<T> (Azure.Provisioning.Expressions.BicepExpression expression) { throw null; }
         public static implicit operator Azure.Provisioning.BicepValue<T> (Azure.Provisioning.ProvisioningVariable reference) { throw null; }
@@ -166,7 +166,6 @@ namespace Azure.Provisioning.Authorization
             public static readonly string V2017_09_01;
             public static readonly string V2018_07_01;
             public static readonly string V2022_04_01;
-            public static readonly string V2023_07_01_preview;
         }
     }
     public enum AuthorizationRoleType
@@ -261,7 +260,6 @@ namespace Azure.Provisioning.Authorization
         public static partial class ResourceVersions
         {
             public static readonly string V2020_10_01;
-            public static readonly string V2022_04_01_preview;
         }
     }
     public partial class RoleAssignmentScheduleTicketInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -308,7 +306,6 @@ namespace Azure.Provisioning.Authorization
         public static partial class ResourceVersions
         {
             public static readonly string V2020_10_01;
-            public static readonly string V2022_04_01_preview;
         }
     }
     public partial class RoleEligibilityScheduleRequestPropertiesTicketInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -382,7 +379,6 @@ namespace Azure.Provisioning.Authorization
         public static partial class ResourceVersions
         {
             public static readonly string V2020_10_01;
-            public static readonly string V2024_09_01_preview;
         }
     }
     public partial class RoleManagementPolicyAuthenticationContextRule : Azure.Provisioning.Authorization.RoleManagementPolicyRule
@@ -776,24 +772,11 @@ namespace Azure.Provisioning.Primitives
         public string PropertyName { get { throw null; } }
         public override string ToString() { throw null; }
     }
-    public partial class ClientCreatorOutputResolver : Azure.Provisioning.Primitives.InfrastructureResolver
-    {
-        public ClientCreatorOutputResolver() { }
-        public override System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> ResolveResources(System.Collections.Generic.IEnumerable<Azure.Provisioning.Primitives.Provisionable> resources, Azure.Provisioning.ProvisioningBuildOptions options) { throw null; }
-    }
     public partial class DynamicResourceNamePropertyResolver : Azure.Provisioning.Primitives.ResourceNamePropertyResolver
     {
         public DynamicResourceNamePropertyResolver() { }
         protected virtual Azure.Provisioning.BicepValue<string> GetUniqueSuffix(Azure.Provisioning.ProvisioningBuildOptions options, Azure.Provisioning.Primitives.ProvisionableResource resource) { throw null; }
         public override Azure.Provisioning.BicepValue<string>? ResolveName(Azure.Provisioning.ProvisioningBuildOptions options, Azure.Provisioning.Primitives.ProvisionableResource resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements) { throw null; }
-    }
-    public partial interface IClientCreator
-    {
-        System.Collections.Generic.IEnumerable<Azure.Provisioning.ProvisioningOutput> GetOutputs();
-    }
-    public partial interface IClientCreator<TClient, TOptions> : Azure.Provisioning.Primitives.IClientCreator where TOptions : Azure.Core.ClientOptions
-    {
-        TClient CreateClient(System.Collections.Generic.IReadOnlyDictionary<string, object?> deploymentOutputs, Azure.Core.TokenCredential credential, TOptions? options = null);
     }
     public abstract partial class InfrastructureResolver
     {
@@ -1886,7 +1869,6 @@ namespace Azure.Provisioning.Resources
             public static readonly string V2022_09_01;
             public static readonly string V2022_12_01;
             public static readonly string V2023_07_01;
-            public static readonly string V2023_07_01_preview;
         }
     }
     public partial class ResourceProviderData : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -544,11 +544,20 @@ namespace Azure.Provisioning.Expressions
         public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetSubscriptionResourceId(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.Tenant GetTenant() { throw null; }
         public static Azure.Provisioning.BicepValue<string> GetUniqueString(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
-        public static Azure.Provisioning.BicepValue<string> Interpolate(System.FormattableString text) { throw null; }
+        public static Azure.Provisioning.BicepValue<string> Interpolate(Azure.Provisioning.Expressions.BicepInterpolatedStringHandler handler) { throw null; }
         public static Azure.Provisioning.BicepValue<object> ParseJson(Azure.Provisioning.BicepValue<object> value) { throw null; }
         public static Azure.Provisioning.BicepValue<string> Take(Azure.Provisioning.BicepValue<string> text, Azure.Provisioning.BicepValue<int> size) { throw null; }
         public static Azure.Provisioning.BicepValue<string> ToLower(Azure.Provisioning.BicepValue<object> value) { throw null; }
         public static Azure.Provisioning.BicepValue<string> ToUpper(Azure.Provisioning.BicepValue<object> value) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public ref partial struct BicepInterpolatedStringHandler
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public BicepInterpolatedStringHandler(int literalLength, int formattedCount) { throw null; }
+        public void AppendFormatted<T>(T t) { }
+        public void AppendLiteral(string text) { }
     }
     public partial class BicepProgram
     {
@@ -562,6 +571,15 @@ namespace Azure.Provisioning.Expressions
         protected BicepStatement() { }
         public override string ToString() { throw null; }
         internal abstract Azure.Provisioning.Expressions.BicepWriter Write(Azure.Provisioning.Expressions.BicepWriter writer);
+    }
+    public partial class BicepStringBuilder
+    {
+        public BicepStringBuilder() { }
+        public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepExpression expression) { throw null; }
+        public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepInterpolatedStringHandler handler) { throw null; }
+        public Azure.Provisioning.Expressions.BicepStringBuilder Append(string text) { throw null; }
+        public Azure.Provisioning.BicepValue<string> Build() { throw null; }
+        public static implicit operator Azure.Provisioning.BicepValue<string> (Azure.Provisioning.Expressions.BicepStringBuilder value) { throw null; }
     }
     public enum BinaryBicepOperator
     {
@@ -635,8 +653,7 @@ namespace Azure.Provisioning.Expressions
     }
     public partial class InterpolatedStringExpression : Azure.Provisioning.Expressions.BicepExpression
     {
-        public InterpolatedStringExpression(string format, Azure.Provisioning.Expressions.BicepExpression[] values) { }
-        public string Format { get { throw null; } }
+        public InterpolatedStringExpression(Azure.Provisioning.Expressions.BicepExpression[] values) { }
         public Azure.Provisioning.Expressions.BicepExpression[] Values { get { throw null; } }
     }
     public partial class IntLiteralExpression : Azure.Provisioning.Expressions.LiteralExpression
@@ -758,9 +775,9 @@ namespace Azure.Provisioning.Expressions
 }
 namespace Azure.Provisioning.Primitives
 {
-    public partial class BicepLiteral : Azure.Provisioning.Primitives.NamedProvisionableConstruct
+    public partial class BicepLiteral : Azure.Provisioning.Primitives.ProvisionableConstruct
     {
-        public BicepLiteral(string bicepIdentifier, params Azure.Provisioning.Expressions.BicepStatement[] statements) : base (default(string)) { }
+        public BicepLiteral(params Azure.Provisioning.Expressions.BicepStatement[] statements) { }
         public System.Collections.Generic.IList<Azure.Provisioning.Expressions.BicepStatement> Statements { get { throw null; } }
         protected internal override System.Collections.Generic.IEnumerable<Azure.Provisioning.Expressions.BicepStatement> Compile() { throw null; }
     }

--- a/sdk/provisioning/Azure.Provisioning/src/BicepValue.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/BicepValue.cs
@@ -48,6 +48,9 @@ public abstract class BicepValue
     // and test sanitization.
     internal bool IsSecure { get; set; } = false;
 
+    // Optional format defining how values should be serialized
+    internal string? Format { get; set; } = null;
+
     // Indicate whether this value is empty or should be included in output
     internal virtual bool IsEmpty => Kind == BicepValueKind.Unset;
 
@@ -97,7 +100,7 @@ public abstract class BicepValue
             _ =>                      $"<{nameof(BicepValue)}: {Compile()}>",
         };
 
-    public BicepExpression Compile() => BicepTypeMapping.ToBicep(this);
+    public BicepExpression Compile() => BicepTypeMapping.ToBicep(this, Format);
 }
 
 /// <summary>

--- a/sdk/provisioning/Azure.Provisioning/src/BicepValueOfT.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/BicepValueOfT.cs
@@ -123,7 +123,7 @@ public class BicepValue<T> : BicepValue
         {
             BicepValueKind.Unset => new(value.Self),
             BicepValueKind.Expression => new(value.Self, value.Expression!),
-            BicepValueKind.Literal => new(value.Self, BicepTypeMapping.ToLiteralString(value.Value!)),
+            BicepValueKind.Literal => new(value.Self, BicepTypeMapping.ToLiteralString(value.Value!, value.Format)),
             _ => throw new InvalidOperationException($"Unknown {nameof(BicepValueKind)}!")
         };
 
@@ -135,14 +135,16 @@ public class BicepValue<T> : BicepValue
         bool isOutput = false,
         bool isRequired = false,
         bool isSecure = false,
-        BicepValue<T>? defaultValue = null)
+        BicepValue<T>? defaultValue = null,
+        string? format = null)
     {
         BicepValue<T> val =
             new(new BicepValueReference(construct, propertyName, bicepPath))
             {
                 IsOutput = isOutput,
                 IsRequired = isRequired,
-                IsSecure = isSecure
+                IsSecure = isSecure,
+                Format = format
             };
         if (defaultValue is not null) { val.Assign(defaultValue); }
         construct.ProvisioningProperties[propertyName] = val;

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
@@ -297,36 +297,8 @@ public static class BicepFunction
     /// Convert a formattable string with literal text, C# expressions, and
     /// Bicep expressions into an interpolated Bicep string.
     /// </summary>
-    /// <param name="text">The formattable string.</param>
+    /// <param name="handler">A bicep interpolated string handler.</param>
     /// <returns>An interpolated string.</returns>
-    public static BicepValue<string> Interpolate(FormattableString text)
-    {
-        // TODO: Use the more efficient interpolated string handler rather than FormattableString
-
-        if (text == null) { return BicepSyntax.Null(); }
-
-        // Turn everything into BicepValues
-        BicepValue<object>[] values = new BicepValue<object>[text.ArgumentCount];
-        for (int i = 0; i < text.ArgumentCount; i++)
-        {
-            values[i] =
-                text.GetArgument(i) switch
-                {
-                    BicepValue v => v,
-                    ProvisioningVariable v => BicepSyntax.Var(v.BicepIdentifier),
-                    var a => new BicepValue<object>(a?.ToString() ?? "")
-                };
-        };
-
-        // Create an interpolated string expression
-        BicepValue<string> result = BicepSyntax.Interpolate(
-            text.Format,
-            [.. values.Select(v => v.Compile())]);
-
-        // Make the entire expression "secure" if any of the values are
-        result.IsSecure = values.Any(v => v.IsSecure);
-        // TODO: Link values to result to validate anything crossing module boundaries?
-
-        return result;
-    }
+    public static BicepValue<string> Interpolate(BicepInterpolatedStringHandler handler) =>
+        handler.Build();
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepStringBuilder.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepStringBuilder.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Azure.Provisioning.Expressions;
+
+// In addition to whether things are secure, also consider tracking
+// dependencies across boundaries for automatic module splitting in
+// the future
+
+/// <summary>
+/// Utility to construct complex interpolated Bicep strings.
+/// </summary>
+public class BicepStringBuilder
+{
+    private readonly List<BicepExpression> _expressions = [];
+    private bool _isSecure = false;
+
+    /// <summary>
+    /// Append literal text.
+    /// </summary>
+    /// <param name="text">Literal text.</param>
+    /// <returns>This BicepStringBuilder.</returns>
+    public BicepStringBuilder Append(string text)
+    {
+        _expressions.Add(BicepSyntax.Value(text));
+        return this;
+    }
+
+    /// <summary>
+    /// Append a bicep expression.
+    /// </summary>
+    /// <param name="expression">Bicep expression.</param>
+    /// <returns>This BicepStringBuilder.</returns>
+    public BicepStringBuilder Append(BicepExpression expression)
+    {
+        _expressions.Add(expression);
+        return this;
+    }
+
+    /// <summary>
+    /// Append an interpolated string composed of literals, expressions,
+    /// BicepValues, and ProvisioningParameters.
+    /// </summary>
+    /// <param name="handler">Bicep interpolated string builder.</param>
+    /// <returns>This BicepStringBuilder.</returns>
+    public BicepStringBuilder Append(BicepInterpolatedStringHandler handler)
+    {
+        _expressions.AddRange(handler._expressions);
+        _isSecure = _isSecure || handler._isSecure;
+        return this;
+    }
+
+    /// <summary>
+    /// Combine all the subexpressions into a single interpolated string.
+    /// </summary>
+    /// <returns>The composed <see cref="BicepValue{String}"/> value.</returns>
+    public BicepValue<string> Build() =>
+        new(new InterpolatedStringExpression([.. _expressions])) { IsSecure = _isSecure };
+
+    /// <summary>
+    /// Implicitly convert a builder to a <see cref="BicepValue{String}"/> so
+    /// users aren't required to explicitly call <see cref="Build"/>.
+    /// </summary>
+    /// <param name="value">The builder.</param>
+    public static implicit operator BicepValue<string>(BicepStringBuilder value) =>
+        value.Build();
+}
+
+/// <summary>
+/// Interpolated string handler for building interpolated Bicep string
+/// expressions.  This is an implementation detail for the C# compiler.  Users
+/// should prefer either <see cref="BicepFunction.Interpolate"/> or
+/// <see cref="BicepStringBuilder"/> for constructing interpolated strings.
+/// </summary>
+/// <param name="literalLength">Combined length of all literal segments.</param>
+/// <param name="formattedCount">Number of formatted segments.</param>
+[InterpolatedStringHandler]
+#pragma warning disable CS9113 // Parameter is unread - literalLength is required for compiler pattern
+public ref struct BicepInterpolatedStringHandler(int literalLength, int formattedCount)
+#pragma warning restore CS9113 // Parameter is unread.
+{
+    internal readonly List<BicepExpression> _expressions = new(capacity: 2 * formattedCount + 1);
+    internal bool _isSecure = false;
+
+    public void AppendLiteral(string text) =>
+        _expressions.Add(BicepSyntax.Value(text));
+
+    public void AppendFormatted<T>(T t)
+    {
+        if (t is BicepValue b)
+        {
+            _expressions.Add(b.Compile());
+            _isSecure = _isSecure || b.IsSecure;
+        }
+        else if (t is ProvisioningVariable v)
+        {
+            _expressions.Add(BicepSyntax.Var(v.BicepIdentifier));
+            _isSecure = _isSecure || v.Value.IsSecure;
+        }
+        else
+        {
+            _expressions.Add(
+                t is null ?
+                    BicepSyntax.Null() :
+                    BicepSyntax.Value(t.ToString() ?? ""));
+        }
+    }
+
+    internal readonly BicepValue<string> Build() =>
+        new(new InterpolatedStringExpression([.. _expressions])) { IsSecure = _isSecure };
+}

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepSyntax.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepSyntax.cs
@@ -49,7 +49,7 @@ internal static class BicepSyntax
     public static FunctionCallExpression Call(BicepExpression func, params BicepExpression[] args) => new(func, args);
     public static FunctionCallExpression Call(string func, params BicepExpression[] args) => Call(Var(func), args);
 
-    public static InterpolatedStringExpression Interpolate(string format, params BicepExpression[] values) => new(format, values);
+    public static InterpolatedStringExpression Interpolate(params BicepExpression[] values) => new(values);
 
     public static MemberExpression Get(this BicepExpression value, string name) => new(value, name);
     public static IndexExpression Index(this BicepExpression value, BicepExpression index) => new(value, index);

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepTypeMapping.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepTypeMapping.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Xml;
 using Azure.Core;
 using Azure.Provisioning.Primitives;
 
@@ -27,6 +28,7 @@ internal static class BicepTypeMapping
     public static string? GetBicepTypeName(Type type) =>
         type == typeof(bool) ? "bool" :
         type == typeof(int) ? "int" :
+        type == typeof(long) ? "int" :
         type == typeof(string) ? "string" :
         type == typeof(object) ? "object" :
         type == typeof(Uri) ? "string" :
@@ -47,19 +49,22 @@ internal static class BicepTypeMapping
     /// Convert a .NET object into a literal Bicep string.
     /// </summary>
     /// <param name="value">The .NET value.</param>
+    /// <param name="format">Optional format.</param>
     /// <returns>The corresponding Bicep literal string.</returns>
     /// <exception cref="InvalidOperationException">
     /// Thrown when we cannot convert a value to a literal Bicep string.
     /// </exception>
-    public static string ToLiteralString(object value) =>
+    public static string ToLiteralString(object value, string? format) =>
         value switch
         {
             bool b => b.ToString(),
             int i => i.ToString(),
+            long i => i.ToString(),
             string s => s,
             Uri u => u.AbsoluteUri,
             DateTimeOffset d => d.ToString("o"),
-            TimeSpan t => t.ToString(), // This eventually needs to carry along a format in BicepValue
+            TimeSpan t when format == "P" => XmlConvert.ToString(t),
+            TimeSpan t => t.ToString(),
             Guid g => g.ToString(),
             IPAddress a => a.ToString(),
             ETag e => e.ToString(),
@@ -75,51 +80,56 @@ internal static class BicepTypeMapping
     /// Convert a .NET object into a Bicep expression.
     /// </summary>
     /// <param name="value">The .NET value.</param>
+    /// <param name="format">Optional format.</param>
     /// <returns>The corresponding Bicep expression.</returns>
     /// <exception cref="InvalidOperationException">
     /// Thrown when we cannot convert a value to a Bicep expression.
     /// </exception>
-    public static BicepExpression ToBicep(object? value)
+    public static BicepExpression ToBicep(object? value, string? format)
     {
         return value switch
         {
             null => BicepSyntax.Null(),
             bool b => BicepSyntax.Value(b),
             int i => BicepSyntax.Value(i),
+            // Note: below cast is valid because bicep limits to int.Min/MaxValue
+            // in bicep source and you need to use a parameter file for larger
+            // values
+            long i => BicepSyntax.Value((int)i),
             string s => BicepSyntax.Value(s),
-            Uri u => BicepSyntax.Value(ToLiteralString(u)),
-            DateTimeOffset d => BicepSyntax.Value(ToLiteralString(d)),
-            TimeSpan t => BicepSyntax.Value(ToLiteralString(t)),
-            Guid g => BicepSyntax.Value(ToLiteralString(g)),
-            IPAddress a => BicepSyntax.Value(ToLiteralString(a)),
-            ETag e => BicepSyntax.Value(ToLiteralString(e)),
-            ResourceIdentifier i => BicepSyntax.Value(ToLiteralString(i)),
-            Enum e => BicepSyntax.Value(ToLiteralString(e)),
+            Uri u => BicepSyntax.Value(ToLiteralString(u, format)),
+            DateTimeOffset d => BicepSyntax.Value(ToLiteralString(d, format)),
+            TimeSpan t => BicepSyntax.Value(ToLiteralString(t, format)),
+            Guid g => BicepSyntax.Value(ToLiteralString(g, format)),
+            IPAddress a => BicepSyntax.Value(ToLiteralString(a, format)),
+            ETag e => BicepSyntax.Value(ToLiteralString(e, format)),
+            ResourceIdentifier i => BicepSyntax.Value(ToLiteralString(i, format)),
+            Enum e => BicepSyntax.Value(ToLiteralString(e, format)),
             ProvisionableConstruct c => CompileNestedConstruct(c),
             IDictionary<string, BicepValue> d =>
                 d is BicepValue b && b.Kind == BicepValueKind.Expression ? b.Expression! : ToObject(d),
             IEnumerable seq =>
                 seq is BicepValue b && b.Kind == BicepValueKind.Expression ? b.Expression! : ToArray(seq.OfType<object>()),
             // Extensible enums like Azure.Location
-            ValueType ee => BicepSyntax.Value(ToLiteralString(ee)),
+            ValueType ee => BicepSyntax.Value(ToLiteralString(ee, format)),
             // Unwrap BicepValue after collections so it doesn't loop forever
             BicepValue v when (v.Kind == BicepValueKind.Expression) => v.Expression!,
             BicepValue v when (v.Source is not null) => v.Source.GetReference(),
-            BicepValue v when (v.Kind == BicepValueKind.Literal) => ToBicep(v.GetLiteralValue()),
+            BicepValue v when (v.Kind == BicepValueKind.Literal) => ToBicep(v.GetLiteralValue(), format),
             BicepValue v when (v.Self is not null) => v.Self.GetReference(),
             BicepValue v when (v.Kind == BicepValueKind.Unset) => BicepSyntax.Null(),
             _ => throw new InvalidOperationException($"Cannot convert {value} to a Bicep expression.")
         };
 
         ArrayExpression ToArray(IEnumerable<object> seq) =>
-            BicepSyntax.Array([.. seq.Select(ToBicep)]);
+            BicepSyntax.Array([.. seq.Select(v => ToBicep(v, v is BicepValue b ? b.Format : null))]);
 
         ObjectExpression ToObject(IDictionary<string, BicepValue> dict)
         {
             Dictionary<string, BicepExpression> values = [];
             foreach (KeyValuePair<string, BicepValue> pair in dict)
             {
-                values[pair.Key] = ToBicep(pair.Value);
+                values[pair.Key] = ToBicep(pair.Value, pair.Value.Format);
             }
             return BicepSyntax.Object(values);
         }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/InterpolatedStringHandlerAttribute.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/InterpolatedStringHandlerAttribute.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace System.Runtime.CompilerServices;
+
+#if !NET6_0_OR_GREATER
+/// <summary>Indicates the attributed type is to be used as an interpolated string handler.</summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+internal sealed class InterpolatedStringHandlerAttribute : Attribute { }
+#endif

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/AuthorizationRoleDefinition.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/AuthorizationRoleDefinition.cs
@@ -100,11 +100,6 @@ public partial class AuthorizationRoleDefinition : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-07-01-preview.
-        /// </summary>
-        public static readonly string V2023_07_01_preview = "2023-07-01-preview";
-
-        /// <summary>
         /// 2022-04-01.
         /// </summary>
         public static readonly string V2022_04_01 = "2022-04-01";

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/Models/ArmApplicationJitAccessPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/Models/ArmApplicationJitAccessPolicy.cs
@@ -47,6 +47,6 @@ public partial class ArmApplicationJitAccessPolicy : ProvisionableConstruct
         _jitAccessEnabled = BicepValue<bool>.DefineProperty(this, "JitAccessEnabled", ["jitAccessEnabled"]);
         _jitApprovalMode = BicepValue<JitApprovalMode>.DefineProperty(this, "JitApprovalMode", ["jitApprovalMode"]);
         _jitApprovers = BicepList<JitApprover>.DefineProperty(this, "JitApprovers", ["jitApprovers"]);
-        _maximumJitAccessDuration = BicepValue<TimeSpan>.DefineProperty(this, "MaximumJitAccessDuration", ["maximumJitAccessDuration"]);
+        _maximumJitAccessDuration = BicepValue<TimeSpan>.DefineProperty(this, "MaximumJitAccessDuration", ["maximumJitAccessDuration"], format: "P");
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/Models/ArmDeploymentPropertiesExtended.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/Models/ArmDeploymentPropertiesExtended.cs
@@ -146,7 +146,7 @@ public partial class ArmDeploymentPropertiesExtended : ProvisionableConstruct
         _provisioningState = BicepValue<ResourcesProvisioningState>.DefineProperty(this, "ProvisioningState", ["provisioningState"], isOutput: true);
         _correlationId = BicepValue<string>.DefineProperty(this, "CorrelationId", ["correlationId"], isOutput: true);
         _timestamp = BicepValue<DateTimeOffset>.DefineProperty(this, "Timestamp", ["timestamp"], isOutput: true);
-        _duration = BicepValue<TimeSpan>.DefineProperty(this, "Duration", ["duration"], isOutput: true);
+        _duration = BicepValue<TimeSpan>.DefineProperty(this, "Duration", ["duration"], isOutput: true, format: "P");
         _outputs = BicepValue<BinaryData>.DefineProperty(this, "Outputs", ["outputs"], isOutput: true);
         _providers = BicepList<ResourceProviderData>.DefineProperty(this, "Providers", ["providers"], isOutput: true);
         _dependencies = BicepList<ArmDependency>.DefineProperty(this, "Dependencies", ["dependencies"], isOutput: true);

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/Models/JitSchedulingPolicy.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/Models/JitSchedulingPolicy.cs
@@ -37,7 +37,7 @@ public partial class JitSchedulingPolicy : ProvisionableConstruct
     public JitSchedulingPolicy()
     {
         _schedulingType = BicepValue<JitSchedulingType>.DefineProperty(this, "SchedulingType", ["type"], isOutput: true);
-        _duration = BicepValue<TimeSpan>.DefineProperty(this, "Duration", ["duration"]);
+        _duration = BicepValue<TimeSpan>.DefineProperty(this, "Duration", ["duration"], format: "P");
         _startOn = BicepValue<DateTimeOffset>.DefineProperty(this, "StartOn", ["startTime"]);
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/Models/RoleManagementPolicyExpirationRule.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/Models/RoleManagementPolicyExpirationRule.cs
@@ -32,6 +32,6 @@ public partial class RoleManagementPolicyExpirationRule : RoleManagementPolicyRu
     {
         BicepValue<string>.DefineProperty(this, "ruleType", ["ruleType"], defaultValue: "RoleManagementPolicyExpirationRule");
         _isExpirationRequired = BicepValue<bool>.DefineProperty(this, "IsExpirationRequired", ["isExpirationRequired"]);
-        _maximumDuration = BicepValue<TimeSpan>.DefineProperty(this, "MaximumDuration", ["maximumDuration"]);
+        _maximumDuration = BicepValue<TimeSpan>.DefineProperty(this, "MaximumDuration", ["maximumDuration"], format: "P");
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/ResourceGroup.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/ResourceGroup.cs
@@ -93,11 +93,6 @@ public partial class ResourceGroup : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2023-07-01-preview.
-        /// </summary>
-        public static readonly string V2023_07_01_preview = "2023-07-01-preview";
-
-        /// <summary>
         /// 2023-07-01.
         /// </summary>
         public static readonly string V2023_07_01 = "2023-07-01";

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/RoleAssignmentScheduleRequest.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/RoleAssignmentScheduleRequest.cs
@@ -183,7 +183,7 @@ public partial class RoleAssignmentScheduleRequest : ProvisionableResource
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _condition = BicepValue<string>.DefineProperty(this, "Condition", ["properties", "condition"]);
         _conditionVersion = BicepValue<string>.DefineProperty(this, "ConditionVersion", ["properties", "conditionVersion"]);
-        _duration = BicepValue<TimeSpan>.DefineProperty(this, "Duration", ["properties", "duration"]);
+        _duration = BicepValue<TimeSpan>.DefineProperty(this, "Duration", ["properties", "duration"], format: "P");
         _endOn = BicepValue<DateTimeOffset>.DefineProperty(this, "EndOn", ["properties", "endDateTime"]);
         _expirationType = BicepValue<RoleManagementScheduleExpirationType>.DefineProperty(this, "ExpirationType", ["properties", "type"]);
         _justification = BicepValue<string>.DefineProperty(this, "Justification", ["properties", "justification"]);
@@ -211,11 +211,6 @@ public partial class RoleAssignmentScheduleRequest : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2022-04-01-preview.
-        /// </summary>
-        public static readonly string V2022_04_01_preview = "2022-04-01-preview";
-
         /// <summary>
         /// 2020-10-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/RoleEligibilityScheduleRequest.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/RoleEligibilityScheduleRequest.cs
@@ -176,7 +176,7 @@ public partial class RoleEligibilityScheduleRequest : ProvisionableResource
         _name = BicepValue<string>.DefineProperty(this, "Name", ["name"], isRequired: true);
         _condition = BicepValue<string>.DefineProperty(this, "Condition", ["properties", "condition"]);
         _conditionVersion = BicepValue<string>.DefineProperty(this, "ConditionVersion", ["properties", "conditionVersion"]);
-        _duration = BicepValue<TimeSpan>.DefineProperty(this, "Duration", ["properties", "duration"]);
+        _duration = BicepValue<TimeSpan>.DefineProperty(this, "Duration", ["properties", "duration"], format: "P");
         _endOn = BicepValue<DateTimeOffset>.DefineProperty(this, "EndOn", ["properties", "endDateTime"]);
         _expirationType = BicepValue<RoleManagementScheduleExpirationType>.DefineProperty(this, "ExpirationType", ["properties", "type"]);
         _justification = BicepValue<string>.DefineProperty(this, "Justification", ["properties", "justification"]);
@@ -203,11 +203,6 @@ public partial class RoleEligibilityScheduleRequest : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2022-04-01-preview.
-        /// </summary>
-        public static readonly string V2022_04_01_preview = "2022-04-01-preview";
-
         /// <summary>
         /// 2020-10-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning/src/Generated/RoleManagementPolicyAssignment.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Generated/RoleManagementPolicyAssignment.cs
@@ -108,11 +108,6 @@ public partial class RoleManagementPolicyAssignment : ProvisionableResource
     public static class ResourceVersions
     {
         /// <summary>
-        /// 2024-09-01-preview.
-        /// </summary>
-        public static readonly string V2024_09_01_preview = "2024-09-01-preview";
-
-        /// <summary>
         /// 2020-10-01.
         /// </summary>
         public static readonly string V2020_10_01 = "2020-10-01";

--- a/sdk/provisioning/Azure.Provisioning/src/Infrastructure.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Infrastructure.cs
@@ -27,9 +27,9 @@ public class Infrastructure(string bicepName = "main") : Provisionable
 
     /// <summary>
     /// Optional target scope for the infrastructure.  If left empty, then
-    /// <c>resourcegroup</c> is assumed.
+    /// <see cref="DeploymentScope.ResourceGroup"/> is assumed.
     /// </summary>
-    public string? TargetScope { get; set; }
+    public DeploymentScope? TargetScope { get; set; }
 
     // Placeholder until we get module splitting handled
     private Infrastructure? _parent = null;
@@ -226,9 +226,6 @@ public class Infrastructure(string bicepName = "main") : Provisionable
 
     /// <inheritdoc/>
     protected internal override IEnumerable<BicepStatement> Compile() =>
-        // TODO: For now I'm letting this through in case someone calls Compile
-        // before Build while debugging.  We could also make it a little less
-        // friendly and more predictable by throwing here.
         CompileInternal(options: null);
 
     /// <summary>
@@ -264,7 +261,16 @@ public class Infrastructure(string bicepName = "main") : Provisionable
         List<BicepStatement> statements = [];
         if (TargetScope is not null)
         {
-            statements.Add(new TargetScopeStatement(TargetScope));
+            statements.Add(
+                new TargetScopeStatement(
+                    TargetScope switch
+                    {
+                        DeploymentScope.ResourceGroup => "resourceGroup",
+                        DeploymentScope.Subscription => "subscription",
+                        DeploymentScope.ManagementGroup => "managementGroup",
+                        DeploymentScope.Tenant => "tenant",
+                        _ => throw new InvalidOperationException($"Unknown deployment scope: {TargetScope}")
+                    }));
         }
 
         IEnumerable<Provisionable> resources = GetProvisionableResources();

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/BicepLiteral.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/BicepLiteral.cs
@@ -13,10 +13,9 @@ namespace Azure.Provisioning.Primitives;
 /// <summary>
 /// Inject literal bicep statements.
 /// </summary>
-public class BicepLiteral(string bicepIdentifier, params BicepStatement[] statements)
-    : NamedProvisionableConstruct(bicepIdentifier)
+public class BicepLiteral(params BicepStatement[] statements)
+    : ProvisionableConstruct()
 {
     public IList<BicepStatement> Statements { get; } = statements;
-
     protected internal override IEnumerable<BicepStatement> Compile() => Statements;
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/DeploymentScope.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/DeploymentScope.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Provisioning.Primitives;
+
+/// <summary>
+/// Target scope to use when deploying resources.
+/// </summary>
+public enum DeploymentScope
+{
+    /// <summary>
+    /// Scope to a resource group.
+    /// </summary>
+    ResourceGroup = 0,
+
+    /// <summary>
+    /// Scope to a subscription.
+    /// </summary>
+    Subscription,
+
+    /// <summary>
+    /// Scope to a management group.
+    /// </summary>
+    ManagementGroup,
+
+    /// <summary>
+    /// Scope to a tenant.
+    /// </summary>
+    Tenant
+}

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/IClientCreator.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/IClientCreator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#if EXPERIMENTAL_PROVISIONING
+
 using System.Collections.Generic;
 using Azure.Core;
 
@@ -89,3 +91,5 @@ public class ClientCreatorOutputResolver : InfrastructureResolver
         }
     }
 }
+
+#endif

--- a/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
@@ -187,7 +187,7 @@ internal class SampleTests(bool async)
                 // Hack in the Aspire Dashboard as a literal since there's no
                 // management plane library support for dotNetComponents yet
                 BicepLiteral aspireDashboard =
-                    new("aspireDashboard",
+                    new(
                         new ResourceStatement(
                             "aspireDashboard",
                             new StringLiteralExpression("Microsoft.App/managedEnvironments/dotNetComponents@2024-02-02-preview"),

--- a/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/SampleTests.cs
@@ -335,7 +335,7 @@ internal class SampleTests(bool async)
             {
                 // Create a new infra group scoped to our subscription and add
                 // the resource group
-                Infrastructure infra = new() { TargetScope = "subscription" };
+                Infrastructure infra = new() { TargetScope = DeploymentScope.Subscription };
 
                 ResourceGroup rg = new("rg_test", "2024-03-01");
                 infra.Add(rg);

--- a/sdk/provisioning/Directory.Build.props
+++ b/sdk/provisioning/Directory.Build.props
@@ -1,6 +1,12 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
+  <!-- Feature flag to enable/disable experimental features end-to-end -->
+  <PropertyGroup>
+    <ExperimentalProvisioning Condition="'$(ExperimentalProvisioning)' == ''">false</ExperimentalProvisioning>
+    <DefineConstants Condition="'$(ExperimentalProvisioning)' == 'true'">EXPERIMENTAL_PROVISIONING;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(AssemblyName)' != 'Generator'">
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>

--- a/sdk/provisioning/Generator/src/Model/Property.cs
+++ b/sdk/provisioning/Generator/src/Model/Property.cs
@@ -29,6 +29,7 @@ public class Property(TypeModel parent, ModelBase propertyType, PropertyInfo? ar
     public bool IsReadOnly { get; set; } = false;
     public bool IsRequired { get; set; } = false;
     public bool IsSecure { get; set; } = false;
+    public string? Format { get; set; } = null;
 
     public bool GenerateDefaultValue { get; set; } = false;
     public bool HideAccessors { get; set; } = false;

--- a/sdk/provisioning/Generator/src/Model/Resource.cs
+++ b/sdk/provisioning/Generator/src/Model/Resource.cs
@@ -138,6 +138,7 @@ public class Resource(Specification spec, Type armType)
                             if (property.IsReadOnly) { writer.Write($", isOutput: true"); }
                             if (property.IsSecure) { writer.Write($", isSecure: true"); }
                             if (property.GenerateDefaultValue) { writer.Write($", defaultValue: Get{property.Name}DefaultValue()"); }
+                            if (property.Format is not null) { writer.Write($", format: \"{property.Format}\""); }
                             writer.WriteLine($");");
                         }
                         if (ParentResource is not null)

--- a/sdk/provisioning/Generator/src/Model/SimpleModel.cs
+++ b/sdk/provisioning/Generator/src/Model/SimpleModel.cs
@@ -103,6 +103,7 @@ public class SimpleModel(Specification spec, Type armType, string name, string? 
                             if (property.IsReadOnly) { writer.Write($", isOutput: true"); }
                             if (property.IsSecure) { writer.Write($", isSecure: true"); }
                             if (property.GenerateDefaultValue) { writer.Write($", defaultValue: Get{property.Name}DefaultValue()"); }
+                            if (property.Format is not null) { writer.Write($", format: \"{property.Format}\""); }
                             writer.WriteLine($");");
                         }
                     }

--- a/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
@@ -104,11 +104,16 @@ public abstract partial class Specification
                         Resource? resource = Resources.FirstOrDefault(r => string.Compare(r.ResourceType?.ToString(), type.ToString(), StringComparison.OrdinalIgnoreCase) == 0);
                         if (resource is null) { continue; }
 
-                        // Only keep the very latest preview if it's the most
-                        // recent release - otherwise people should use a GAed version
+                        // Filter out preview releases
                         resource.ResourceVersions =
                             [.. data.ApiVersions.OrderDescending().Where((v, i) =>
-                            !v.EndsWith("preview") || i == 0)];
+                                !v.EndsWith("preview")
+#if EXPERIMENTAL_PROVISIONING
+                                // Only keep the very latest preview if it's the most
+                                // recent release - otherwise people should use a GAed version
+                                || i == 0
+#endif
+                                )];
 
                         resource.DefaultResourceVersion =
                             // The latest versions are first - so let's take the first non-preview as the default

--- a/sdk/provisioning/Generator/src/Model/Specification.Customize.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Customize.cs
@@ -57,7 +57,10 @@ public abstract partial class Specification : ModelBase
 
     protected void CustomizeProperty<T>(string propertyName, Action<Property> action) =>
         CustomizeProperty(GetModel<T>(), propertyName, action);
-    
+
+    protected void CustomizePropertyIsoDuration<T>(string propertyName) =>
+        CustomizeProperty(GetModel<T>(), propertyName, p => p.Format = "P");
+
     protected void CustomizeProperty(string modelName, string propertyName, Action<Property> action) =>
         CustomizeProperty(ModelNameMapping.GetValueOrDefault(modelName) ??
             throw new InvalidOperationException($"Failed to find {modelName} to customize!"), propertyName, action);

--- a/sdk/provisioning/Generator/src/Specifications/AppServiceSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/AppServiceSpecification.cs
@@ -4,6 +4,7 @@
 using Azure.Provisioning.Generator.Model;
 using Azure.ResourceManager.AppService;
 using Azure.ResourceManager.AppService.Models;
+using Azure.ResourceManager.Sql.Models;
 
 namespace Azure.Provisioning.Generator.Specifications;
 
@@ -41,6 +42,12 @@ public class AppServiceSpecification() :
         RemoveProperty<StaticSiteUserProvidedFunctionAppData>("ResourceType");
         RemoveProperty<WebAppPushSettings>("ResourceType");
         RemoveProperty<HostNameSslState>("Thumbprint");
+
+        // Patch models
+
+        // Not generated today:
+        // CustomizePropertyIsoDuration<MetricAvailability>("BlobDuration");
+        // CustomizePropertyIsoDuration<LogSpecification>("BlobDuration");
 
         // Naming requirements
         AddNameRequirements<AppCertificateResource>(min: 1, max: 260, lower: true, upper: true, digits: true, hyphen: true, underscore: true, period: true, parens: false);

--- a/sdk/provisioning/Generator/src/Specifications/AuthorizationSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/AuthorizationSpecification.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Provisioning.Generator.Model;
+using Azure.ResourceManager.AppService.Models;
 using Azure.ResourceManager.Authorization;
 using Azure.ResourceManager.Authorization.Models;
 using Azure.ResourceManager.Resources;
@@ -26,6 +27,9 @@ public class AuthorizationSpecification : Specification
         CustomizeProperty<AuthorizationRoleDefinitionResource>("Name", p => p.GenerateDefaultValue = true);
         CustomizeProperty<RoleAssignmentResource>("Name", p => p.GenerateDefaultValue = true);
         CustomizeProperty<RoleAssignmentResource>("Scope", p => { p.IsReadOnly = false; p.Path = ["scope"]; });
+        CustomizePropertyIsoDuration<RoleManagementPolicyExpirationRule>("MaximumDuration");
+        CustomizePropertyIsoDuration<RoleAssignmentScheduleRequestResource>("Duration");
+        CustomizePropertyIsoDuration<RoleEligibilityScheduleRequestResource>("Duration");
 
         // Naming requirements
         // RoleAssignmentResource and AuthorizationRoleDefinitionResource must be GUIDs - handled in code

--- a/sdk/provisioning/Generator/src/Specifications/EventGridSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/EventGridSpecification.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using Azure.Provisioning.Generator.Model;
+using Azure.ResourceManager.Authorization;
 using Azure.ResourceManager.EventGrid;
+using Azure.ResourceManager.EventGrid.Models;
 
 namespace Azure.Provisioning.Generator.Specifications;
 
@@ -16,6 +18,7 @@ public class EventGridSpecification() :
 
         // Patch models
         CustomizeModel<EventGridNamespaceClientResource>(m => m.Name = "EventGridNamespaceClientResource");
+        CustomizePropertyIsoDuration<QueueInfo>("EventTimeToLive");
 
         // Naming requirements
         AddNameRequirements<EventGridDomainResource>(min: 3, max: 50, lower: true, upper: true, digits: true, hyphen: true);

--- a/sdk/provisioning/Generator/src/Specifications/RedisSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/RedisSpecification.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Provisioning.Generator.Model;
+using Azure.ResourceManager.EventGrid.Models;
 using Azure.ResourceManager.Redis;
 using Azure.ResourceManager.Redis.Models;
 
@@ -20,6 +21,7 @@ public class RedisSpecification() :
         CustomizeModel<RedisResource>(m => m.Name = "RedisResource");
         CustomizeProperty<RedisAccessKeys>("PrimaryKey", p => p.IsSecure = true);
         CustomizeProperty<RedisAccessKeys>("SecondaryKey", p => p.IsSecure = true);
+        CustomizePropertyIsoDuration<RedisPatchScheduleSetting>("MaintenanceWindow");
 
         // Naming requirements
         AddNameRequirements<RedisResource>(min: 1, max: 63, lower: true, upper: true, digits: true, hyphen: true);

--- a/sdk/provisioning/Generator/src/Specifications/ResourcesSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/ResourcesSpecification.cs
@@ -28,6 +28,15 @@ public class ResourcesSpecification : Specification
         CustomizeResource<ArmDeploymentResource>(r => r.FromExpression = true);
         CustomizeEnum<ResourceTypeAliasPatternType>(e => { foreach (EnumValue member in e.Values) { member.Value = member.Name; } });
         CustomizeEnum<ResourceTypeAliasType>(e => { foreach (EnumValue member in e.Values) { member.Value = member.Name; } });
+        CustomizePropertyIsoDuration<JitSchedulingPolicy>("Duration");
+        CustomizePropertyIsoDuration<ArmApplicationJitAccessPolicy>("MaximumJitAccessDuration");
+        CustomizePropertyIsoDuration<ArmDeploymentPropertiesExtended>("Duration");
+        // Not generated today:
+        // CustomizePropertyIsoDuration<AzureCliScript>("RetentionInterval");
+        // CustomizePropertyIsoDuration<AzureCliScript>("Timeout");
+        // CustomizePropertyIsoDuration<AzurePowerShellScript>("RetentionInterval");
+        // CustomizePropertyIsoDuration<AzurePowerShellScript>("Timeout");
+        // CustomizePropertyIsoDuration<ArmDeploymentOperationProperties>("Duration");
 
         // Naming requirements
         AddNameRequirements<ArmDeploymentResource>(min: 1, max: 64, lower: true, upper: true, digits: true, hyphen: true, underscore: true, period: true, parens: true);

--- a/sdk/provisioning/Generator/src/Specifications/ServiceBusSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/ServiceBusSpecification.cs
@@ -25,6 +25,19 @@ public class ServiceBusSpecification() :
         CustomizeProperty<ServiceBusAccessKeys>("PrimaryKey", p => p.IsSecure = true);
         CustomizeProperty<ServiceBusAccessKeys>("SecondaryKey", p => p.IsSecure = true);
 
+        // Set durations
+        CustomizePropertyIsoDuration<ServiceBusSubscriptionResource>("LockDuration");
+        CustomizePropertyIsoDuration<ServiceBusSubscriptionResource>("DefaultMessageTimeToLive");
+        CustomizePropertyIsoDuration<ServiceBusSubscriptionResource>("DuplicateDetectionHistoryTimeWindow");
+        CustomizePropertyIsoDuration<ServiceBusSubscriptionResource>("AutoDeleteOnIdle");
+        CustomizePropertyIsoDuration<ServiceBusQueueResource>("LockDuration");
+        CustomizePropertyIsoDuration<ServiceBusQueueResource>("DefaultMessageTimeToLive");
+        CustomizePropertyIsoDuration<ServiceBusQueueResource>("DuplicateDetectionHistoryTimeWindow");
+        CustomizePropertyIsoDuration<ServiceBusQueueResource>("AutoDeleteOnIdle");
+        CustomizePropertyIsoDuration<ServiceBusTopicResource>("DefaultMessageTimeToLive");
+        CustomizePropertyIsoDuration<ServiceBusTopicResource>("DuplicateDetectionHistoryTimeWindow");
+        CustomizePropertyIsoDuration<ServiceBusTopicResource>("AutoDeleteOnIdle");
+        
         // Naming requirements
         AddNameRequirements<ServiceBusNamespaceResource>(min: 6, max: 50, lower: true, upper: true, digits: true, hyphen: true);
         AddNameRequirements<ServiceBusNamespaceAuthorizationRuleResource>(min: 1, max: 50, lower: true, upper: true, digits: true, hyphen: true, underscore: true, period: true);

--- a/sdk/provisioning/Generator/src/Specifications/SqlSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/SqlSpecification.cs
@@ -3,6 +3,7 @@
 
 using Azure.Provisioning.Generator.Model;
 using Azure.ResourceManager.AppService;
+using Azure.ResourceManager.Resources.Models;
 using Azure.ResourceManager.Sql;
 using Azure.ResourceManager.Sql.Models;
 
@@ -70,6 +71,9 @@ public class SqlSpecification() :
         // Patch models
         RemoveModel<DiffBackupIntervalInHours>(); // TODO: Maybe support extensible enums of other types?
         CustomizeProperty<BackupShortTermRetentionPolicyResource>("DiffBackupIntervalInHours", p => p.PropertyType = TypeRegistry.Get<int>());
+        CustomizePropertyIsoDuration<SqlServerJobSchedule>("Interval");
+        // Not generated today:
+        // CustomizePropertyIsoDuration<MaintenanceWindowTimeRange>("Duration");
 
         // Naming requirements
         AddNameRequirements<ManagedInstanceResource>(min: 1, max: 63, lower: true, digits: true, hyphen: true);


### PR DESCRIPTION
- Removing features that won't be shipping as GA (like preview versions, `IClientCreator`, `StorageResources`, etc.) and hiding them behind a feature flag
- Fixes #46559 to correctly serialize ISO8601 duration `TimeSpan`s by adding a `Format` to `BicepValue`.
- Fixes #46558 to change string interpolation to use `InterpolatedStringHandler` and also add a `BicepStringBuilder`