### PR TITLE
Publish pipeline artifact with converted symbols

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -164,6 +164,10 @@ stages:
                               BuildToolsRepositoryPath: $(Pipeline.Workspace)/azure-sdk-build-tools
                               PackagesPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}
                               StagingDirectory: $(Build.ArtifactStagingDirectory)/symbols
+                          - task: 1ES.PublishPipelineArtifact@1
+                            inputs:
+                              targetPath: $(Build.ArtifactStagingDirectory)/symbols
+                              artifactName: ${{parameters.ArtifactName}}-release-symbols
                           - template: /eng/common/pipelines/templates/steps/create-apireview.yml
                             parameters:
                               ArtifactPath: $(Pipeline.Workspace)/packages

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -132,6 +132,11 @@ stages:
                       packageParentPath: '$(Pipeline.Workspace)'
                       packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                       publishVstsFeed: ${{ parameters.DevOpsFeedID }}
+                    - ${{if ne(artifact.skipSymbolsUpload, 'true')}}:
+                      - output: pipelineArtifact
+                        displayName: 'Store converted symbols in ${{parameters.ArtifactName}}-windows-symbols artifact'
+                        targetPath: $(Build.ArtifactStagingDirectory)/symbols
+                        artifactName: ${{parameters.ArtifactName}}-windows-symbols
 
                 strategy:
                   runOnce:
@@ -164,10 +169,6 @@ stages:
                               BuildToolsRepositoryPath: $(Pipeline.Workspace)/azure-sdk-build-tools
                               PackagesPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}
                               StagingDirectory: $(Build.ArtifactStagingDirectory)/symbols
-                          - task: 1ES.PublishPipelineArtifact@1
-                            inputs:
-                              targetPath: $(Build.ArtifactStagingDirectory)/symbols
-                              artifactName: ${{parameters.ArtifactName}}-release-symbols
                           - template: /eng/common/pipelines/templates/steps/create-apireview.yml
                             parameters:
                               ArtifactPath: $(Pipeline.Workspace)/packages


### PR DESCRIPTION
To better troubleshoot symbol publishing issues, we should upload the Pdb2Pdb converted symbols as a pipeline artifact.