### PR TITLE
run Update-Mgmt-CI.ps1 in automation

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -772,7 +772,7 @@ function GeneratePackage()
 
     if ($isGenerateSuccess) {
         # update resourcemanager ci.mgmt.yml for mgmt sdk
-        if ( $serviceType -eq "resource-manager" ) {
+        if ($serviceType -eq "resource-manager") {
             & $sdkRootPath/eng/scripts/Update-Mgmt-CI.ps1
         }
         # Build project when successfully generated the code

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -771,6 +771,10 @@ function GeneratePackage()
     }
 
     if ($isGenerateSuccess) {
+        # update resourcemanager ci.mgmt.yml for mgmt sdk
+        if ( $serviceType -eq "resource-manager" ) {
+            & $sdkRootPath/eng/scripts/Update-Mgmt-CI.ps1
+        }
         # Build project when successfully generated the code
         Write-Host "Start to build sdk project: $srcPath"
         dotnet build $srcPath /p:RunApiCompat=$false


### PR DESCRIPTION
# Contributing to the Azure SDK

Fix https://github.com/Azure/azure-sdk-for-net/issues/46747

In automation, when onboard a new mgmt SDK, the build will fail because there is no item in resourcemanager ci.mgmt.yaml.
```
error : The core resourcemanager pipeline ['D:\project\azure-sdk-for-net\/sdk/resourcemanager/ci.mgmt.yml'] does not contain a trigger path for your library please run 'eng/scripts/Update-Mgmt-CI.ps1' to add
 the correct trigger paths.
```

We will run `Update-Mgmt-CI.ps1` to update ci.mgmt.yaml of resourcemanager in automation.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
