### PR TITLE
Override DisposeAsync in StorageWriteStream for asynchronous flushing during dispose

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageWriteStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageWriteStream.cs
@@ -340,6 +340,21 @@ namespace Azure.Storage.Shared
             base.Dispose(disposing);
         }
 
+#if NET6_0_OR_GREATER
+        public override async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            await FlushAsync().ConfigureAwait(false);
+            ValidateCallerCrcIfAny();
+            _accumulatedDisposables.Dispose();
+            _disposed = true;
+        }
+#endif
+
         private void ValidateCallerCrcIfAny()
         {
             if (UseMasterCrc && !_userProvidedChecksum.IsEmpty)


### PR DESCRIPTION
Should fix #35548.

Note I opted to place the public `DisposeAsync()` next to protected `Dispose(bool disposing)` to have related methods close together in the source code.