### PR TITLE
[Storage][DataMovement] Add perf pipeline definition

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/perf-resources.bicep
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/perf-resources.bicep
@@ -1,0 +1,17 @@
+param baseName string = resourceGroup().name
+param location string = resourceGroup().location
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: '${baseName}blob'
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Premium_LRS'
+  }
+}
+
+var name = storageAccount.name
+var key = storageAccount.listKeys().keys[0].value
+
+output AZURE_STORAGE_ACCOUNT_NAME string = name
+output AZURE_STORAGE_ACCOUNT_KEY string = key

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/perf-tests.yml
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/perf-tests.yml
@@ -1,0 +1,22 @@
+Service: storage-datamovement-blob
+
+Project: sdk\storage\Azure.Storage.DataMovement.Blobs\perf\Azure.Storage.DataMovement.Blobs.Perf\Azure.Storage.DataMovement.Blobs.Perf.csproj
+
+PackageVersions:
+- Azure.Storage.DataMovement.Blobs: source
+
+Tests:
+- Test: download
+  Class: DownloadDirectory
+  Arguments: &sizes
+  - --size 1024 --count 10000 --duration 60
+  - --size 10485760 --count 1000 --duration 60
+  - --size 1073741824 --count 10 --duration 120
+
+- Test: upload
+  Class: UploadDireactory
+  Arguments: *sizes
+
+- Test: copy
+  Class: CopyDirectory
+  Arguments: *sizes

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/perf.yml
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/perf.yml
@@ -1,0 +1,40 @@
+parameters:
+- name: LanguageVersion
+  displayName: LanguageVersion (6, 8)
+  type: string
+  default: '8'
+- name: PackageVersions
+  displayName: PackageVersions (regex of package versions to run)
+  type: string
+  default: 'source'
+- name: Tests
+  displayName: Tests (regex of tests to run)
+  type: string
+  default: '^(upload|download|copy)$'
+- name: Arguments
+  displayName: Arguments (regex of arguments to run)
+  type: string
+  default: '(1024)|(10485760)|(1073741824)'
+- name: Iterations
+  displayName: Iterations (times to run each test)
+  type: number
+  default: '5'
+- name: Profile
+  type: boolean
+  default: false
+- name: AdditionalArguments
+  displayName: AdditionalArguments (passed to PerfAutomation)
+  type: string
+  default: ' '
+
+extends:
+  template: /eng/pipelines/templates/jobs/perf.yml
+  parameters:
+    LanguageVersion: ${{ parameters.LanguageVersion }}
+    ServiceDirectory: storage/Azure.Storage.Blobs
+    PackageVersions: ${{ parameters.PackageVersions }}
+    Tests: ${{ parameters.Tests }}
+    Arguments: ${{ parameters.Arguments }}
+    Iterations: ${{ parameters.Iterations }}
+    Profile: ${{ parameters.Profile }}
+    AdditionalArguments: ${{ parameters.AdditionalArguments }}


### PR DESCRIPTION
Adding a perf pipeline definition for DMLib. The pipeline is set up to run the Track2 tests since that's what we'll want most of the time but can be tweaked in a branch to run the Track1 tests when we need that.