### PR TITLE
[CODEOWNERS] Fix linter errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -300,7 +300,7 @@
 /sdk/communication/                                                @acsdevx-msft
 
 # ServiceLabel: %Communication
-# ServiceOwners:                                                   @acsdevx-msft
+# ServiceOwners:                                                   @Azure/azure-sdk-write-communication
 
 # PRLabel: %Communication - Calling Server
 /sdk/communication/Azure.Communication.CallingServer/              @minwoolee-msft
@@ -318,7 +318,7 @@
 /sdk/communication/Azure.Communication.PhoneNumbers/               @miguhern @whisper6284 @danielav7
 
 # PRLabel: %Communication - Programmable Connectivity
-/sdk/communication/Azure.Communication.ProgrammableConnectivity/   @acsdevx-msft
+/sdk/communication/Azure.Communication.ProgrammableConnectivity/   @Azure/azure-sdk-write-communication
 
 # PRLabel: %Communication - Short Codes
 /sdk/communication/Azure.Communication.ShortCodes/                 @guilhermeluizsp @danielav7

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -318,7 +318,7 @@
 /sdk/communication/Azure.Communication.PhoneNumbers/               @miguhern @whisper6284 @danielav7
 
 # PRLabel: %Communication - Programmable Connectivity
-/sdk/communication/Azure.Communication.ProgrammableConnectivity/   @aronhegedusms
+/sdk/communication/Azure.Communication.ProgrammableConnectivity/   @acsdevx-msft
 
 # PRLabel: %Communication - Short Codes
 /sdk/communication/Azure.Communication.ShortCodes/                 @guilhermeluizsp @danielav7


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an account that is no longer associated with Azure SDK development and failing linter checks.   Because there is no other contact for this area, PR reviews have been redirected to the wider team.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4268509&view=results) _(Microsoft internal)_