### PR TITLE
Filter out Breaking changes info and return in automation result

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -856,6 +856,7 @@ function GeneratePackage()
                 $hasBreakingChange = $false
             }
             else {
+                Write-Host "Breaking changes detected in the build log."
                 $logFile = Get-Content -Path $logFilePath | select-object -SkipLast 1
                 $breakingChanges = $logFile -join ",`n"
                 $content = "Breaking Changes: $breakingChanges"

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -856,7 +856,7 @@ function GeneratePackage()
                 $hasBreakingChange = $false
             }
             else {
-                $logFile = Get-Content -Path $logFilePath | select-object -skip 2
+                $logFile = Get-Content -Path $logFilePath | select-object -SkipLast 1
                 $breakingChanges = $logFile -join ",`n"
                 $content = "Breaking Changes: $breakingChanges"
                 $hasBreakingChange = $true


### PR DESCRIPTION
# Contributing to the Azure SDK
Fix https://github.com/Azure/azure-sdk-for-net/issues/46859

- update the filter constrains in the breaking change result. Current it skip first of 2 which cause the breaking change log missing. Update to skip only the latest one which is the `ApiCompat` information
- Add regex to retrieve out the breaking change info from log and return it in the automation result

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
