### PR TITLE
ITransferCheckpointer

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
@@ -11,7 +11,7 @@ namespace Azure.Storage.DataMovement
 {
     internal static partial class CheckpointerExtensions
     {
-        internal static TransferCheckpointer BuildCheckpointer(TransferCheckpointStoreOptions options)
+        internal static ITransferCheckpointer BuildCheckpointer(TransferCheckpointStoreOptions options)
         {
             if (options?.Enabled == false)
             {
@@ -26,7 +26,7 @@ namespace Azure.Storage.DataMovement
         internal static bool IsLocalResource(this StorageResource resource) => resource.Uri.IsFile;
 
         internal static async Task<DataTransferStatus> GetJobStatusAsync(
-            this TransferCheckpointer checkpointer,
+            this SerializerTransferCheckpointer checkpointer,
             string transferId,
             CancellationToken cancellationToken = default)
         {
@@ -43,7 +43,7 @@ namespace Azure.Storage.DataMovement
         }
 
         internal static async Task<bool> IsResumableAsync(
-            this TransferCheckpointer checkpointer,
+            this ITransferCheckpointer checkpointer,
             string transferId,
             CancellationToken cancellationToken)
         {
@@ -54,7 +54,7 @@ namespace Azure.Storage.DataMovement
         }
 
         internal static async Task<DataTransferProperties> GetDataTransferPropertiesAsync(
-            this TransferCheckpointer checkpointer,
+            this SerializerTransferCheckpointer checkpointer,
             string transferId,
             CancellationToken cancellationToken)
         {
@@ -82,7 +82,7 @@ namespace Azure.Storage.DataMovement
         }
 
         internal static async Task<bool> IsEnumerationCompleteAsync(
-            this TransferCheckpointer checkpointer,
+            this SerializerTransferCheckpointer checkpointer,
             string transferId,
             CancellationToken cancellationToken = default)
         {
@@ -97,7 +97,7 @@ namespace Azure.Storage.DataMovement
         }
 
         internal static async Task OnEnumerationCompleteAsync(
-            this TransferCheckpointer checkpointer,
+            this SerializerTransferCheckpointer checkpointer,
             string transferId,
             CancellationToken cancellationToken = default)
         {

--- a/sdk/storage/Azure.Storage.DataMovement/src/DisabledTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DisabledTransferCheckpointer.cs
@@ -5,91 +5,70 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage.DataMovement.JobPlan;
 
 namespace Azure.Storage.DataMovement
 {
-    internal class DisabledTransferCheckpointer : TransferCheckpointer
+    internal class DisabledTransferCheckpointer : ITransferCheckpointer
     {
-        public DisabledTransferCheckpointer() { }
-
-        public override Task AddNewJobAsync(
-            string transferId,
-            StorageResource source,
-            StorageResource destination,
-            CancellationToken cancellationToken = default)
+        public Task AddNewJobAsync(string transferId, StorageResource source, StorageResource destination, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public override Task AddNewJobPartAsync(
-            string transferId,
-            int partNumber,
-            Stream headerStream,
-            CancellationToken cancellationToken = default)
+        public Task AddNewJobPartAsync(string transferId, int partNumber, Stream headerStream, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public override Task<int> CurrentJobPartCountAsync(string transferId, CancellationToken cancellationToken = default)
+        public Task<int> GetCurrentJobPartCountAsync(string transferId, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(0);
         }
 
-        public override Task<List<string>> GetStoredTransfersAsync(CancellationToken cancellationToken = default)
+        public Task<DataTransferProperties> GetDataTransferPropertiesAsync(string transferId, CancellationToken cancellationToken = default)
+        {
+            throw Errors.CheckpointerDisabled(nameof(GetDataTransferPropertiesAsync));
+        }
+
+        public Task<JobPartPlanHeader> GetJobPartAsync(string transferId, int partNumber, CancellationToken cancellationToken = default)
+        {
+            throw Errors.CheckpointerDisabled(nameof(GetJobPartAsync));
+        }
+
+        public Task<DataTransferStatus> GetJobStatusAsync(string transferId, CancellationToken cancellationToken = default)
+        {
+            throw Errors.CheckpointerDisabled(nameof(GetJobStatusAsync));
+        }
+
+        public Task<List<string>> GetStoredTransfersAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new List<string>());
         }
 
-        public override Task<Stream> ReadJobPartPlanFileAsync(
-            string transferId,
-            int partNumber,
-            int offset,
-            int length,
-            CancellationToken cancellationToken = default)
+        public Task<bool> IsEnumerationCompleteAsync(string transferId, CancellationToken cancellationToken = default)
         {
-            throw Errors.CheckpointerDisabled("ReadJobPartPlanFileAsync");
+            return Task.FromResult(true);
         }
 
-        public override Task<Stream> ReadJobPlanFileAsync(
-            string transferId,
-            int offset,
-            int length,
-            CancellationToken cancellationToken = default)
-        {
-            throw Errors.CheckpointerDisabled("ReadJobPlanFileAsync");
-        }
-
-        public override Task SetJobPartTransferStatusAsync(
-            string transferId,
-            int partNumber,
-            DataTransferStatus status,
-            CancellationToken cancellationToken = default)
+        public Task SetEnumerationCompleteAsync(string transferId, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public override Task SetJobTransferStatusAsync(
-            string transferId,
-            DataTransferStatus status,
-            CancellationToken cancellationToken = default)
+        public Task SetJobPartStatusAsync(string transferId, int partNumber, DataTransferStatus status, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public override Task<bool> TryRemoveStoredTransferAsync(string transferId, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult(false);
-        }
-
-        public override Task WriteToJobPlanFileAsync(
-            string transferId,
-            int fileOffset,
-            byte[] buffer,
-            int bufferOffset,
-            int length,
-            CancellationToken cancellationToken = default)
+        public Task SetJobStatusAsync(string transferId, DataTransferStatus status, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
+        }
+
+        public Task<bool> TryRemoveStoredTransferAsync(string transferId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(true);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/ITransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ITransferCheckpointer.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.DataMovement.JobPlan;
+
+namespace Azure.Storage.DataMovement
+{
+    internal interface ITransferCheckpointer
+    {
+        Task AddNewJobAsync(
+            string transferId,
+            StorageResource source,
+            StorageResource destination,
+            CancellationToken cancellationToken = default);
+
+        Task AddNewJobPartAsync(
+            string transferId,
+            int partNumber,
+            Stream headerStream,
+            CancellationToken cancellationToken = default);
+
+        Task<bool> IsEnumerationCompleteAsync(
+            string transferId,
+            CancellationToken cancellationToken = default);
+
+        Task SetEnumerationCompleteAsync(
+            string transferId,
+            CancellationToken cancellationToken = default);
+
+        Task<int> GetCurrentJobPartCountAsync(
+            string transferId,
+            CancellationToken cancellationToken = default);
+
+        Task<DataTransferStatus> GetJobStatusAsync(
+            string transferId,
+            CancellationToken cancellationToken = default);
+
+        Task SetJobStatusAsync(
+            string transferId,
+            DataTransferStatus status,
+            CancellationToken cancellationToken = default);
+
+        Task<JobPartPlanHeader> GetJobPartAsync(
+            string transferId,
+            int partNumber,
+            CancellationToken cancellationToken = default);
+
+        Task SetJobPartStatusAsync(
+            string transferId,
+            int partNumber,
+            DataTransferStatus status,
+            CancellationToken cancellationToken = default);
+
+        Task<DataTransferProperties> GetDataTransferPropertiesAsync(
+            string transferId,
+            CancellationToken cancellationToken = default);
+
+        Task<bool> TryRemoveStoredTransferAsync(
+            string transferId,
+            CancellationToken cancellationToken = default);
+
+        Task<List<string>> GetStoredTransfersAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
@@ -42,7 +42,7 @@ namespace Azure.Storage.DataMovement
         /// <summary>
         /// Plan file writer for the respective job.
         /// </summary>
-        internal TransferCheckpointer _checkpointer { get; set; }
+        internal ITransferCheckpointer _checkpointer { get; set; }
 
         private TransferProgressTracker _progressTracker;
 
@@ -151,7 +151,7 @@ namespace Azure.Storage.DataMovement
             long? initialTransferSize,
             DataTransferErrorMode errorHandling,
             StorageResourceCreationPreference createMode,
-            TransferCheckpointer checkpointer,
+            ITransferCheckpointer checkpointer,
             TransferProgressTracker progressTracker,
             ArrayPool<byte> arrayPool,
             SyncAsyncEventHandler<TransferStatusEventArgs> jobPartEventHandler,
@@ -487,7 +487,7 @@ namespace Azure.Storage.DataMovement
 
         internal async virtual Task SetCheckpointerStatus()
         {
-            await _checkpointer.SetJobPartTransferStatusAsync(
+            await _checkpointer.SetJobPartStatusAsync(
                 transferId: _dataTransfer.Id,
                 partNumber: PartNumber,
                 status: JobPartStatus).ConfigureAwait(false);

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
@@ -20,7 +20,7 @@ namespace Azure.Storage.DataMovement
     /// Creates a checkpointer which uses a locally stored file to obtain
     /// the information in order to resume transfers in the future.
     /// </summary>
-    internal class LocalTransferCheckpointer : TransferCheckpointer
+    internal class LocalTransferCheckpointer : SerializerTransferCheckpointer
     {
         internal string _pathToCheckpointer;
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
@@ -23,13 +23,10 @@ namespace Azure.Storage.DataMovement
 
         public static StreamToUriJobPart ToStreamToUriJobPartAsync(
             this TransferJobInternal baseJob,
-            Stream planFileStream,
+            JobPartPlanHeader header,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource)
         {
-            // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
             // Override header values if options were specified by user.
             long initialTransferSize = baseJob._initialTransferSize ?? header.InitialTransferSize;
             long transferChunkSize = baseJob._maximumTransferChunkSize ?? header.ChunkSize;
@@ -55,13 +52,10 @@ namespace Azure.Storage.DataMovement
 
         public static ServiceToServiceJobPart ToServiceToServiceJobPartAsync(
             this TransferJobInternal baseJob,
-            Stream planFileStream,
+            JobPartPlanHeader header,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource)
         {
-            // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
             // Override header values if options were specified by user.
             long initialTransferSize = baseJob._initialTransferSize ?? header.InitialTransferSize;
             long transferChunkSize = baseJob._maximumTransferChunkSize ?? header.ChunkSize;
@@ -87,13 +81,10 @@ namespace Azure.Storage.DataMovement
 
         public static UriToStreamJobPart ToUriToStreamJobPartAsync(
             this TransferJobInternal baseJob,
-            Stream planFileStream,
+            JobPartPlanHeader header,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource)
         {
-            // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
             // Override header values if options were specified by user.
             long initialTransferSize = baseJob._initialTransferSize ?? header.InitialTransferSize;
             long transferChunkSize = baseJob._maximumTransferChunkSize ?? header.ChunkSize;
@@ -119,13 +110,10 @@ namespace Azure.Storage.DataMovement
 
         public static StreamToUriJobPart ToStreamToUriJobPartAsync(
             this TransferJobInternal baseJob,
-            Stream planFileStream,
+            JobPartPlanHeader header,
             StorageResourceContainer sourceResource,
             StorageResourceContainer destinationResource)
         {
-            // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
             string childSourcePath = header.SourcePath;
             string childSourceName = childSourcePath.Substring(sourceResource.Uri.AbsoluteUri.Length + 1);
             string childDestinationPath = header.DestinationPath;
@@ -155,13 +143,10 @@ namespace Azure.Storage.DataMovement
 
         public static ServiceToServiceJobPart ToServiceToServiceJobPartAsync(
             this TransferJobInternal baseJob,
-            Stream planFileStream,
+            JobPartPlanHeader header,
             StorageResourceContainer sourceResource,
             StorageResourceContainer destinationResource)
         {
-            // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
             string childSourcePath = header.SourcePath;
             string childDestinationPath = header.DestinationPath;
             // Override header values if options were specified by user.
@@ -189,13 +174,10 @@ namespace Azure.Storage.DataMovement
 
         public static UriToStreamJobPart ToUriToStreamJobPartAsync(
             this TransferJobInternal baseJob,
-            Stream planFileStream,
+            JobPartPlanHeader header,
             StorageResourceContainer sourceResource,
             StorageResourceContainer destinationResource)
         {
-            // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
             // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
             string childSourceName = childSourcePath.Substring(sourceResource.Uri.AbsoluteUri.Length + 1);

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.DataMovement
         /// <summary>
         /// Plan file writer for the respective job
         /// </summary>
-        internal TransferCheckpointer _checkpointer { get; set; }
+        internal ITransferCheckpointer _checkpointer { get; set; }
 
         /// <summary>
         /// Internal progress tracker for tracking and reporting progress of the transfer
@@ -151,7 +151,7 @@ namespace Azure.Storage.DataMovement
             DataTransfer dataTransfer,
             CreateJobPartSingleAsync createJobPartSingleAsync,
             CreateJobPartMultiAsync createJobPartMultiAsync,
-            TransferCheckpointer checkPointer,
+            ITransferCheckpointer checkPointer,
             DataTransferErrorMode errorHandling,
             long? initialTransferSize,
             long? maximumTransferChunkSize,
@@ -202,7 +202,7 @@ namespace Azure.Storage.DataMovement
             CreateJobPartSingleAsync createJobPartSingleAsync,
             CreateJobPartMultiAsync createJobPartMultiAsync,
             DataTransferOptions transferOptions,
-            TransferCheckpointer checkpointer,
+            ITransferCheckpointer checkpointer,
             DataTransferErrorMode errorHandling,
             ArrayPool<byte> arrayPool,
             ClientDiagnostics clientDiagnostics)
@@ -237,7 +237,7 @@ namespace Azure.Storage.DataMovement
             CreateJobPartSingleAsync createJobPartSingleAsync,
             CreateJobPartMultiAsync createJobPartMultiAsync,
             DataTransferOptions transferOptions,
-            TransferCheckpointer checkpointer,
+            ITransferCheckpointer checkpointer,
             DataTransferErrorMode errorHandling,
             ArrayPool<byte> arrayPool,
             ClientDiagnostics clientDiagnostics)
@@ -600,7 +600,7 @@ namespace Azure.Storage.DataMovement
 
         internal async virtual Task SetCheckpointerStatus()
         {
-            await _checkpointer.SetJobTransferStatusAsync(
+            await _checkpointer.SetJobStatusAsync(
                 transferId: _dataTransfer.Id,
                 status: _dataTransfer.TransferStatus).ConfigureAwait(false);
         }
@@ -636,7 +636,7 @@ namespace Azure.Storage.DataMovement
         /// </summary>
         protected async Task OnAllResourcesEnumerated()
         {
-            await _checkpointer.OnEnumerationCompleteAsync(_dataTransfer.Id).ConfigureAwait(false);
+            await _checkpointer.SetEnumerationCompleteAsync(_dataTransfer.Id).ConfigureAwait(false);
         }
 
         internal async Task CheckAndUpdateStatusAsync()

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.DataMovement
         ///
         /// If unspecified will default to LocalTransferCheckpointer at {currentpath}/.azstoragedml
         /// </summary>
-        private readonly TransferCheckpointer _checkpointer;
+        private readonly ITransferCheckpointer _checkpointer;
 
         private readonly List<StorageResourceProvider> _resumeProviders;
 
@@ -77,7 +77,7 @@ namespace Azure.Storage.DataMovement
             IProcessor<JobPartInternal> partsProcessor,
             IProcessor<Func<Task>> chunksProcessor,
             JobBuilder jobBuilder,
-            TransferCheckpointer checkpointer,
+            ITransferCheckpointer checkpointer,
             ICollection<StorageResourceProvider> resumeProviders,
             Func<string> generateTransferId = default)
         {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CheckpointerTesting.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CheckpointerTesting.cs
@@ -71,7 +71,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         internal static async Task AssertJobPlanHeaderAsync(
-            this TransferCheckpointer checkpointer,
+            this SerializerTransferCheckpointer checkpointer,
             string transferId,
             int partNumber,
             JobPartPlanHeader expectedHeader)

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
@@ -74,7 +74,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         internal async Task AddJobToCheckpointer(
-            TransferCheckpointer transferCheckpointer,
+            SerializerTransferCheckpointer transferCheckpointer,
             string transferId,
             string sourcePath = CheckpointerTesting.DefaultWebSourcePath,
             string destinationPath = CheckpointerTesting.DefaultWebDestinationPath)
@@ -88,7 +88,7 @@ namespace Azure.Storage.DataMovement.Tests
         [Test]
         public void Ctor()
         {
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(default);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(default);
 
             Assert.NotNull(transferCheckpointer);
         }
@@ -97,7 +97,7 @@ namespace Azure.Storage.DataMovement.Tests
         public void Ctor_CustomPath()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory(Guid.NewGuid().ToString());
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             Assert.NotNull(transferCheckpointer);
         }
@@ -117,7 +117,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Arrange
             string transferId = GetNewTransferId();
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -133,7 +133,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
             // Arrange
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -149,7 +149,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange / Act
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             int jobCount = 3;
             List<string> expectedTransferIds = new();
@@ -174,7 +174,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -201,7 +201,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -238,7 +238,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -288,7 +288,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: 3);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -349,7 +349,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: 1);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -386,7 +386,7 @@ namespace Azure.Storage.DataMovement.Tests
         public async Task TryRemoveStoredTransferAsync()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -400,7 +400,7 @@ namespace Azure.Storage.DataMovement.Tests
         public async Task TryRemoveStoredTransferAsync_Error()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
 
@@ -414,7 +414,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             string transferId = GetNewTransferId();
             int partNumber = 0;
             JobPartPlanHeader header = CheckpointerTesting.CreateDefaultJobPartHeader(
@@ -435,7 +435,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -454,7 +454,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             int jobCount = 3;
             List<string> expectedTransferIds = new();
@@ -481,7 +481,7 @@ namespace Azure.Storage.DataMovement.Tests
             // Arrange - populate checkpointer directory with existing jobs
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             string transferId = GetNewTransferId();
             string transferId2 = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -533,7 +533,7 @@ namespace Azure.Storage.DataMovement.Tests
             // Arrange
             string transferId = GetNewTransferId();
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -556,7 +556,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -597,7 +597,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: 3);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -653,7 +653,7 @@ namespace Azure.Storage.DataMovement.Tests
             // Arrange
             string transferId = GetNewTransferId();
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act / Assert
             Assert.CatchAsync<ArgumentException>(
@@ -665,7 +665,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -690,7 +690,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -727,7 +727,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
             using (MemoryStream stream = new MemoryStream())
@@ -753,7 +753,7 @@ namespace Azure.Storage.DataMovement.Tests
             string transferId = GetNewTransferId();
             int partNumber = 0;
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act
             Assert.CatchAsync<ArgumentException>(
@@ -769,7 +769,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -817,7 +817,7 @@ namespace Azure.Storage.DataMovement.Tests
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
             string transferId = GetNewTransferId();
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act / Assert
             byte[] bytes = { 0x00 };
@@ -839,7 +839,7 @@ namespace Azure.Storage.DataMovement.Tests
             string transferId = GetNewTransferId();
             DataTransferStatus newStatus = SuccessfulCompletedStatus;
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
             // Act
@@ -867,7 +867,7 @@ namespace Azure.Storage.DataMovement.Tests
             string transferId = GetNewTransferId();
             DataTransferStatus newStatus = SuccessfulCompletedStatus;
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act / Assert
             Assert.CatchAsync<ArgumentException>(
@@ -888,7 +888,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
             using (MemoryStream stream = new MemoryStream())
@@ -923,7 +923,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            TransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act / Assert
             Assert.CatchAsync<ArgumentException>(

--- a/sdk/storage/Azure.Storage.DataMovement/tests/RehydrateStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/RehydrateStorageResourceTests.cs
@@ -58,7 +58,6 @@ namespace Azure.Storage.DataMovement.Tests
             [Values(true, false)] bool isSource)
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            TransferCheckpointer checkpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             Random random = new();
             string transferId = GetNewTransferId();
             string sourcePath = string.Concat("/", random.NextString(20));
@@ -87,7 +86,6 @@ namespace Azure.Storage.DataMovement.Tests
             [Values(true, false)] bool isSource)
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            TransferCheckpointer checkpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             Random random = new();
             string transferId = GetNewTransferId();
             string sourceParentPath = string.Concat("/", random.NextString(20));

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -95,7 +95,7 @@ public class TransferManagerTests
 
         (var jobsProcessor, var partsProcessor, var chunksProcessor) = StepProcessors();
         JobBuilder jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
-        Mock<TransferCheckpointer> checkpointer = new();
+        Mock<ITransferCheckpointer> checkpointer = new();
 
         var resources = Enumerable.Range(0, items).Select(_ =>
         {
@@ -201,7 +201,7 @@ public class TransferManagerTests
 
         (var jobsProcessor, var partsProcessor, var chunksProcessor) = StepProcessors();
         JobBuilder jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
-        Mock<TransferCheckpointer> checkpointer = new();
+        Mock<ITransferCheckpointer> checkpointer = new();
 
         var resources = Enumerable.Range(1, numJobs).Select(i =>
         {
@@ -295,7 +295,7 @@ public class TransferManagerTests
         {
             CallBase = true,
         };
-        Mock<TransferCheckpointer> checkpointer = new();
+        Mock<ITransferCheckpointer> checkpointer = new();
 
         (StorageResource srcResource, StorageResource dstResource, Func<IDisposable> srcThrowScope, Func<IDisposable> dstThrowScope)
             = GetBasicSetupResources(isContainer, srcUri, dstUri);
@@ -305,7 +305,7 @@ public class TransferManagerTests
         {
             case 0:
                 jobBuilder.Setup(b => b.BuildJobAsync(It.IsAny<StorageResource>(), It.IsAny<StorageResource>(),
-                    It.IsAny<DataTransferOptions>(), It.IsAny<TransferCheckpointer>(), It.IsAny<string>(),
+                    It.IsAny<DataTransferOptions>(), It.IsAny<ITransferCheckpointer>(), It.IsAny<string>(),
                     It.IsAny<bool>(), It.IsAny<CancellationToken>())
                 ).Throws(expectedException);
                 break;
@@ -346,7 +346,7 @@ public class TransferManagerTests
 
         (var jobsProcessor, var partsProcessor, var chunksProcessor) = StepProcessors();
         JobBuilder jobBuilder = new(ArrayPool<byte>.Shared, default, new(ClientOptions.Default));
-        Mock<TransferCheckpointer> checkpointer = new(MockBehavior.Loose);
+        Mock<ITransferCheckpointer> checkpointer = new(MockBehavior.Loose);
 
         (StorageResource srcResource, StorageResource dstResource, Func<IDisposable> srcThrowScope, Func<IDisposable> dstThrowScope)
             = GetBasicSetupResources(isContainer, srcUri, dstUri);
@@ -394,7 +394,7 @@ public class TransferManagerTests
 
         (var jobsProcessor, var partsProcessor, var chunksProcessor) = StepProcessors();
         JobBuilder jobBuilder = new(ArrayPool<byte>.Shared, default, new(ClientOptions.Default));
-        Mock<TransferCheckpointer> checkpointer = new(MockBehavior.Loose);
+        Mock<ITransferCheckpointer> checkpointer = new(MockBehavior.Loose);
 
         (StorageResource srcResource, StorageResource dstResource, Func<IDisposable> srcThrowScope, Func<IDisposable> dstThrowScope)
             = GetBasicSetupResources(isContainer, srcUri, dstUri);


### PR DESCRIPTION
Creates a new interface for checkpointing without any serialization concepts in its API. Structure for this is derived from the previous abstract class for checkpointing and its extension methods for serialization. This allows for checkpointer mocking in tests without needing to worry about data serialization structure to inject behaviors or create resumable jobs.

To reduce scope of PR, the previous checkpointing code has been left largely untouched. The previous abstract class `TransferCheckpointer` has been renamed `SerializerTransferCheckpointer` to avoid naming confusion with the new interface, and has had its interface implementation mapped to its existing extension methods. In the future, this can be more broadly cleaned up.

Future work:
- Create mocking tools to better inject checkpointing functionality for tests.
- Revisit transfer manager tests to assert how well checkpointer state is maintained when errors occur.