### PR TITLE
Fix LanguageVersion for perf tests

### DIFF
--- a/eng/pipelines/templates/jobs/perf.yml
+++ b/eng/pipelines/templates/jobs/perf.yml
@@ -1,7 +1,8 @@
 parameters:
+# LanguageVersion in context of .NET perf tests corresponds to the .NET framework version and is set in individual perf.yml files
 - name: LanguageVersion
   type: string
-  default: '7'
+  default: ''
 - name: ServiceDirectory
   type: string
   default: ''

--- a/sdk/monitor/perf.yml
+++ b/sdk/monitor/perf.yml
@@ -1,8 +1,8 @@
 parameters:
 - name: LanguageVersion
-  displayName: LanguageVersion (6, 7)
+  displayName: LanguageVersion
   type: string
-  default: '7'
+  default: '8'
 - name: PackageVersions
   displayName: PackageVersions (regex of package versions to run)
   type: string


### PR DESCRIPTION
LanguageVersion in context of .NET perf tests corresponds to the .NET framework version https://github.com/Azure/azure-sdk-tools/blob/45e08850a0367b2a491e1ff57e9fffeff9e5ea08/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Net.cs#L46