### PR TITLE
[CODEOWNERS] Add CodeGen/Azure Plugin reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1101,7 +1101,7 @@
 /eng/packages/http-client-csharp/                                  @JoshLove-msft @m-nash @jorgerangel-msft
 
 # ServiceLabel: %CodeGen 
-# AzureSdkOwners:                                                  @JoshLove-msf
+# AzureSdkOwners:                                                  @JoshLove-msft
 
 #PRLabel: %CodeGen %Client
 /eng/packages/http-client-csharp/generator/Azure.Generator/        @JoshLove-msft @m-nash @jorgerangel-msft @jsquire @annelo-msft

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1095,7 +1095,10 @@
 # Add owners for package dependency changes
 /eng/Packages.Data.props                                           @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @tg-msft @jsquire @m-nash @ArthurMa1978
 
-# ######## DPG ########
+# ######## Code Generation ########
 
-# Onboarding Documentation and Quickstarts
-/doc/DataPlaneCodeGeneration                                       @chunyu3 @pshao25 @lirenhe @annelo-msft
+#PRLabel: %CodeGen %Client
+/eng/packages/http-client-csharp/                                  @JoshLove-msft @m-nash @jorgerangel-msft
+
+#PRLabel: %CodeGen %Client
+/eng/packages/http-client-csharp/generator/Azure.Generator/        @JoshLove-msft @m-nash @jorgerangel-msft @jsquire @annelo-msft

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1100,5 +1100,8 @@
 #PRLabel: %CodeGen %Client
 /eng/packages/http-client-csharp/                                  @JoshLove-msft @m-nash @jorgerangel-msft
 
+# ServiceLabel: %CodeGen 
+# AzureSdkOwners:                                                  @JoshLove-msf
+
 #PRLabel: %CodeGen %Client
 /eng/packages/http-client-csharp/generator/Azure.Generator/        @JoshLove-msft @m-nash @jorgerangel-msft @jsquire @annelo-msft


### PR DESCRIPTION
# Summary

The focus of these changes is to add the PR labels and reviewers for the code generation infrastructure and Azure generation plugins.