### PR TITLE
[Storage] Move all Storage live tests to westus2

### DIFF
--- a/sdk/storage/tests.datamovement.yml
+++ b/sdk/storage/tests.datamovement.yml
@@ -7,7 +7,7 @@ extends:
     ServiceDirectory: storage
     BuildInParallel: true
     TimeoutInMinutes: 180
-    Location: canadacentral
+    Location: westus2
     CloudConfig:
       Public:
       # PrivatePreview:

--- a/sdk/storage/tests.functions.yml
+++ b/sdk/storage/tests.functions.yml
@@ -7,7 +7,7 @@ extends:
     ServiceDirectory: storage
     BuildInParallel: true
     TimeoutInMinutes: 180
-    Location: canadacentral
+    Location: westus2
     CloudConfig:
       Public:
       # PrivatePreview:

--- a/sdk/storage/tests.mgmt.yml
+++ b/sdk/storage/tests.mgmt.yml
@@ -7,7 +7,7 @@ extends:
     ServiceDirectory: storage
     BuildInParallel: true
     TimeoutInMinutes: 180
-    Location: canadacentral
+    Location: westus2
     CloudConfig:
       Public:
       # PrivatePreview:


### PR DESCRIPTION
The Storage Live test ARM template deploys a VM which does not work in `candacentral` on the new TME subscription. To mitigate this, the Storage base Live tests were moved to `westus2` but none of the auxiliary Live test pipelines were moved. They all use the same ARM template so these have been failing since TME.

Longer term follow-ups:
- Why do we deploy a VM? Can we remove that dependency?
- Creating separate, smaller ARM templates for these auxiliary pipelines 