### PR TITLE
[CODEOWNERS] Remove invalid account

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -897,10 +897,10 @@
 # ServiceOwners:                                                   @shahbj79 @mit2nil @aygoya @ganganarayanan
 
 # PRLabel: %Synapse
-/sdk/synapse/                                                      @wonner @yanjungao718 @annelo-msft
+/sdk/synapse/                                                      @yanjungao718 @annelo-msft
 
 # ServiceLabel: %Synapse
-# ServiceOwners:                                                   @wonner @yanjungao718
+# ServiceOwners:                                                   @yanjungao718
 
 # PRLabel: %Tables
 /sdk/tables/                                                       @christothes @JonathanCrd


### PR DESCRIPTION
# Summary 

The focus of these changes is to remove an invalid account exposed by a linter run failure.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4294542&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=8c98ab76-57b2-59d0-3d3a-18dce788f3ba) _(Microsoft internal)_