### PR TITLE
[Storage][DataMovement] Record remaining tests previously not recorded

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/StartTransferCopyFromShareDirectoryTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/StartTransferCopyFromShareDirectoryTestBase.cs
@@ -15,13 +15,11 @@ using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Common;
 using Azure.Storage.DataMovement.Files.Shares;
 using Azure.Storage.DataMovement.Tests;
 using BaseShares::Azure.Storage.Files.Shares;
 using BaseShares::Azure.Storage.Files.Shares.Models;
-using Azure.Storage.Shared;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using DMBlob::Azure.Storage.DataMovement.Blobs;
@@ -259,7 +257,6 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             };
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public override Task DirectoryToDirectory_OAuth()
         {
             // NoOp this test since File To Blob

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/StartTransferCopyToShareDirectoryTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/StartTransferCopyToShareDirectoryTestBase.cs
@@ -326,7 +326,6 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         }
 
         [Test]
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/33082
         public override Task DirectoryToDirectory_OAuth()
         {
             // NoOp this test since File To Blob

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_7fbc694d75"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_68ba386e23"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.sln
+++ b/sdk/storage/Azure.Storage.DataMovement.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Storage.DataMovement.Perf", "Azure.Storage.DataMovement.Blobs\perf\Microsoft.Azure.Storage.DataMovement.Perf\Microsoft.Azure.Storage.DataMovement.Perf.csproj", "{AD9565FD-86A1-41A6-8B73-E7C2C66BF891}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Storage.DataMovement.Blobs.Files.Shares.Tests", "Azure.Storage.DataMovement.Files.Shares\BlobToFileSharesTests\Azure.Storage.DataMovement.Blobs.Files.Shares.Tests.csproj", "{4603F1BF-EDCF-44B7-8A85-E13EC4267A35}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -99,6 +101,10 @@ Global
 		{AD9565FD-86A1-41A6-8B73-E7C2C66BF891}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD9565FD-86A1-41A6-8B73-E7C2C66BF891}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AD9565FD-86A1-41A6-8B73-E7C2C66BF891}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4603F1BF-EDCF-44B7-8A85-E13EC4267A35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4603F1BF-EDCF-44B7-8A85-E13EC4267A35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4603F1BF-EDCF-44B7-8A85-E13EC4267A35}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4603F1BF-EDCF-44B7-8A85-E13EC4267A35}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Recording a few strangling tests that were previously set to `LiveOnly` due to issue. All these test recordings are blank since the tests are no-ops. Also add `BlobToFileSharesTests` tests to DMLib solution.