### PR TITLE
[Service Bus] Changelog updates

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Added annotations to make the package compatible with trimming and native AOT compilation.
+
 ## 7.18.2 (2024-10-08)
 
 ### Other Changes


### PR DESCRIPTION
# Summary

The focus of these changes is to update the change log to capture recent AOT annotations made.

## References and related

- [Annotate Azure.Messaging.ServiceBus for trim/AOT compat (#47004)](https://github.com/Azure/azure-sdk-for-net/pull/47004)