### PR TITLE
[Storage] [DataMovement] Using Entra ID with Share File will set the ShareFileIntent for FromDirectory and FromFile

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFilesStorageResourceProvider.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFilesStorageResourceProvider.cs
@@ -304,7 +304,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 CredentialType.Token => new ShareDirectoryClient(
                     directoryUri,
                     _getTokenCredential(directoryUri, false),
-                    new ShareClientOptions {  ShareTokenIntent = ShareTokenIntent.Backup }),
+                    new ShareClientOptions { ShareTokenIntent = ShareTokenIntent.Backup }),
                 CredentialType.Sas => new ShareDirectoryClient(directoryUri, _getAzureSasCredential(directoryUri, false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFilesStorageResourceProvider.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFilesStorageResourceProvider.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Storage.Files.Shares;
+using Azure.Storage.Files.Shares.Models;
 
 namespace Azure.Storage.DataMovement.Files.Shares
 {
@@ -300,7 +301,10 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 CredentialType.None => new ShareDirectoryClient(directoryUri),
                 CredentialType.SharedKey => new ShareDirectoryClient(directoryUri, _getStorageSharedKeyCredential(directoryUri, false)),
-                CredentialType.Token => new ShareDirectoryClient(directoryUri, _getTokenCredential(directoryUri, false)),
+                CredentialType.Token => new ShareDirectoryClient(
+                    directoryUri,
+                    _getTokenCredential(directoryUri, false),
+                    new ShareClientOptions {  ShareTokenIntent = ShareTokenIntent.Backup }),
                 CredentialType.Sas => new ShareDirectoryClient(directoryUri, _getAzureSasCredential(directoryUri, false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };
@@ -327,7 +331,10 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 CredentialType.None => new ShareFileClient(fileUri),
                 CredentialType.SharedKey => new ShareFileClient(fileUri, _getStorageSharedKeyCredential(fileUri, false)),
-                CredentialType.Token => new ShareFileClient(fileUri, _getTokenCredential(fileUri, false)),
+                CredentialType.Token => new ShareFileClient(
+                    fileUri,
+                    _getTokenCredential(fileUri, false),
+                    new ShareClientOptions { ShareTokenIntent = ShareTokenIntent.Backup }),
                 CredentialType.Sas => new ShareFileClient(fileUri, _getAzureSasCredential(fileUri, false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };


### PR DESCRIPTION
This by default will set the `ShareTokenIntent` to `Backup` (as that's currently the only option) and this will be set when Entra ID / OAuth is the credential being used when calling `FromDirectory` and `FromFile` from the `ShareFilesStorageResourceProvider` to generate a `StorageResource` object.
