### PR TITLE
add version and readMe or typespecProject information in ci output

### DIFF
--- a/eng/scripts/Invoke-GenerateAndBuildV2.ps1
+++ b/eng/scripts/Invoke-GenerateAndBuildV2.ps1
@@ -87,6 +87,7 @@ for ($i = 0; $i -le $readmeFiles.Count - 1; $i++) {
         $autorestConfigYaml = ConvertTo-YAML $yml
     }
     Invoke-GenerateAndBuildSDK -readmeAbsolutePath $readme -sdkRootPath $sdkPath -autorestConfigYaml "$autorestConfigYaml" -downloadUrlPrefix "$downloadUrlPrefix" -generatedSDKPackages $generatedSDKPackages
+    $generatedSDKPackages[$generatedSDKPackages.Count - 1]['readmeMd'] = @($readmeFile)
 }
 
 #update services without readme.md
@@ -156,6 +157,7 @@ if ($relatedTypeSpecProjectFolder) {
             -generatedSDKPackages $generatedSDKPackages `
             -specRepoRoot $swaggerDir
         }
+        $generatedSDKPackages[$generatedSDKPackages.Count - 1]['typespecProject'] = @($typespecRelativeFolder)
     }
 }
 $outputJson = [PSCustomObject]@{

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -891,7 +891,11 @@ function GeneratePackage()
         $ciFilePath = "sdk/$service/ci.mgmt.yml"
     }
 
+    # get the sdk version
+    $projectFile = Join-Path $srcPath "$packageName.csproj"
+    $version=([xml](Get-Content $projectFile)).Project.PropertyGroup.Version
     $packageDetails = @{
+        version=$version;
         packageName="$packageName";
         result=$result;
         path=@("$path", "$ciFilePath");
@@ -899,7 +903,7 @@ function GeneratePackage()
         artifacts=$artifacts;
         apiViewArtifact=$apiViewArtifact;
         language=".Net";
-        changelog=$changelog
+        changelog=$changelog;
     }
     
     if ($null -ne $installInstructions) {

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -892,8 +892,15 @@ function GeneratePackage()
     }
 
     # get the sdk version
+    $version = ""
     $projectFile = Join-Path $srcPath "$packageName.csproj"
-    $version=([xml](Get-Content $projectFile)).Project.PropertyGroup.Version
+    $csproj = new-object xml
+    $csproj.PreserveWhitespace = $true
+    $csproj.Load($projectFile)
+    $versionNode = ($csproj | Select-Xml "Project/PropertyGroup/Version").Node
+    if ($versionNode) {
+        $version = $versionNode.InnerText
+    }
     $packageDetails = @{
         version=$version;
         packageName="$packageName";


### PR DESCRIPTION
# Contributing to the Azure SDK
Fix https://github.com/Azure/azure-sdk-tools/issues/9221

- emit version and typespecProject/readmeMd of ask package in sdk automation output

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
