### PR TITLE
Azure Web PubSub service: MapWebPubSubHub extension with custom hub name

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/README.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/README.md
@@ -61,12 +61,26 @@ public void ConfigureServices(IServiceCollection services)
 
 ### Map `WebPubSubHub` to endpoint routing
 
+The name of the hub has to match the class name e.g. `SampleHub`.
+
 ```C# Snippet:WebPubSubMapHub
 public void Configure(IApplicationBuilder app)
 {
     app.UseEndpoints(endpoint =>
     {
         endpoint.MapWebPubSubHub<SampleHub>("/eventhandler");
+    });
+}
+```
+
+Hub name can be overriden by using extension method.
+
+```C# Snippet:WebPubSubMapHubCustom
+public void Configure(IApplicationBuilder app)
+{
+    app.UseEndpoints(endpoint =>
+    {
+        endpoint.MapWebPubSubHub<SampleHub>("/eventhandler", "customHub");
     });
 }
 ```

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/api/Microsoft.Azure.WebPubSub.AspNetCore.netcoreapp3.1.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/api/Microsoft.Azure.WebPubSub.AspNetCore.netcoreapp3.1.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Builder
     public static partial class WebPubSubEndpointRouteBuilderExtensions
     {
         public static Microsoft.AspNetCore.Builder.IEndpointConventionBuilder MapWebPubSubHub<THub>(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string path) where THub : Microsoft.Azure.WebPubSub.AspNetCore.WebPubSubHub { throw null; }
+        public static Microsoft.AspNetCore.Builder.IEndpointConventionBuilder MapWebPubSubHub<THub>(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string path, string hubName) where THub : Microsoft.Azure.WebPubSub.AspNetCore.WebPubSubHub { throw null; }
     }
 }
 namespace Microsoft.Azure.WebPubSub.AspNetCore

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Extensions/WebPubSubEndpointRouteBuilderExtensions.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Extensions/WebPubSubEndpointRouteBuilderExtensions.cs
@@ -24,24 +24,7 @@ namespace Microsoft.AspNetCore.Builder
         public static IEndpointConventionBuilder MapWebPubSubHub<THub>(
             this IEndpointRouteBuilder endpoints,
             string path) where THub: WebPubSubHub
-        {
-            if (endpoints == null)
-            {
-                throw new ArgumentNullException(nameof(endpoints));
-            }
-
-            var marker = endpoints.ServiceProvider.GetService<WebPubSubMarkerService>() ?? throw new InvalidOperationException(
-                    "Unable to find the required services. Please add all the required services by calling " +
-                    "'IServiceCollection.AddWebPubSub' inside the call to 'ConfigureServices(...)' in the application startup code.");
-
-            var adaptor = endpoints.ServiceProvider.GetService<ServiceRequestHandlerAdapter>();
-            adaptor.RegisterHub<THub>();
-
-            var app = endpoints.CreateApplicationBuilder();
-            app.UseMiddleware<WebPubSubMiddleware>();
-
-            return endpoints.Map(path, app.Build());
-        }
+            => MapWebPubSubHub<THub>(endpoints, path, typeof(THub).Name);
 
         /// <summary>
         /// Maps the <see cref="WebPubSubHub"/> to the path "/client" with the specified hub name.

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Internal/ServiceRequestHandlerAdapter.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Internal/ServiceRequestHandlerAdapter.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore
             RegisterHub(hub.GetType().Name, hub);
         }
 
+        public void RegisterHub<THub>(string hubName) where THub : WebPubSubHub
+        {
+            var hub = Create<THub>();
+            RegisterHub(hubName, hub);
+        }
+
         // For test only
         internal void RegisterHub(string hubName, WebPubSubHub hub)
         {

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/AddWebPubSubTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/AddWebPubSubTests.cs
@@ -77,6 +77,27 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore.Tests
             Assert.True(validator.IsValidOrigin(new List<string> { testHost }));
         }
 
+        [Test]
+        public void TestMapWebPubSubHubConfigureCustomHub()
+        {
+            var testHost = "webpubsub.azure.net";
+            var customHub = "customhub";
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.Services
+             .AddWebPubSub(o => o.ServiceEndpoint = new WebPubSubServiceEndpoint($"Endpoint=https://{testHost};AccessKey=7aab239577fd4f24bc919802fb629f5f;Version=1.0;"));
+
+            using var app = builder.Build();
+            app.MapWebPubSubHub<TestHub>("/testhub", customHub);
+
+            var validator = app.Services.GetRequiredService<RequestValidator>();
+            var adaptor = app.Services.GetRequiredService<ServiceRequestHandlerAdapter>();
+
+            Assert.NotNull(validator);
+            Assert.NotNull(adaptor);
+            Assert.True(validator.IsValidOrigin(new List<string> { testHost }));
+            Assert.NotNull(adaptor.GetHub(customHub), "Custom hub should be registered");
+        }
+
         private sealed class TestHub : WebPubSubHub
         { }
 

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/AddWebPubSubTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/AddWebPubSubTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #if NETCOREAPP
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
@@ -57,6 +58,23 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore.Tests
 
             Assert.NotNull(clientFactory);
             Assert.Throws<ArgumentException>(() => clientFactory.Create<TestHub>());
+        }
+
+        [Test]
+        public void TestMapWebPubSubHubConfigureNormal()
+        {
+            var testHost = "webpubsub.azure.net";
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.Services
+             .AddWebPubSub(o => o.ServiceEndpoint = new WebPubSubServiceEndpoint($"Endpoint=https://{testHost};AccessKey=7aab239577fd4f24bc919802fb629f5f;Version=1.0;"));
+
+            using var app = builder.Build();
+            app.MapWebPubSubHub<TestHub>("/testhub");
+
+            var validator = app.Services.GetRequiredService<RequestValidator>();
+
+            Assert.NotNull(validator);
+            Assert.True(validator.IsValidOrigin(new List<string> { testHost }));
         }
 
         private sealed class TestHub : WebPubSubHub

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/AddWebPubSubTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/AddWebPubSubTests.cs
@@ -98,6 +98,26 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore.Tests
             Assert.NotNull(adaptor.GetHub(customHub), "Custom hub should be registered");
         }
 
+        [Test]
+        public void TestMapWebPubSubHubConfigureHubByTypeName()
+        {
+            var testHost = "webpubsub.azure.net";
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.Services
+             .AddWebPubSub(o => o.ServiceEndpoint = new WebPubSubServiceEndpoint($"Endpoint=https://{testHost};AccessKey=7aab239577fd4f24bc919802fb629f5f;Version=1.0;"));
+
+            using var app = builder.Build();
+            app.MapWebPubSubHub<TestHub>("/testhub");
+
+            var validator = app.Services.GetRequiredService<RequestValidator>();
+            var adaptor = app.Services.GetRequiredService<ServiceRequestHandlerAdapter>();
+
+            Assert.NotNull(validator);
+            Assert.NotNull(adaptor);
+            Assert.True(validator.IsValidOrigin(new List<string> { testHost }));
+            Assert.NotNull(adaptor.GetHub(nameof(TestHub)), "Custom hub should be registered");
+        }
+
         private sealed class TestHub : WebPubSubHub
         { }
 

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/AddWebPubSubTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/AddWebPubSubTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore.Tests
             Assert.NotNull(validator);
             Assert.NotNull(adaptor);
             Assert.True(validator.IsValidOrigin(new List<string> { testHost }));
-            Assert.NotNull(adaptor.GetHub(nameof(TestHub)), "Custom hub should be registered");
+            Assert.NotNull(adaptor.GetHub(nameof(TestHub)), "Hub with the name that matches the class name should be registered");
         }
 
         private sealed class TestHub : WebPubSubHub

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-		<PackageReference Include="Azure.Identity"/>
+		<PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="NUnit" />

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Samples/WebPubSubSampleCreateWithAzureIdentity.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Samples/WebPubSubSampleCreateWithAzureIdentity.cs
@@ -26,13 +26,15 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore.Tests.Samples
         }
 #endregion
 
+        #region Snippet:WebPubSubMapHubCustom
         public void Configure(IApplicationBuilder app)
         {
             app.UseEndpoints(endpoint =>
             {
-                endpoint.MapWebPubSubHub<SampleHub>("/eventhandler");
+                endpoint.MapWebPubSubHub<SampleHub>("/eventhandler", "customHub");
             });
         }
+        #endregion
 
         private sealed class SampleHub : WebPubSubHub
         {

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/ServiceRequestHandlerTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/ServiceRequestHandlerTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Security.Authentication;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -309,6 +308,20 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore.Tests
             var response = await new StreamReader(context.Response.Body).ReadToEndAsync();
             // validate response matches exception
             Assert.AreEqual("Invalid user", response);
+        }
+
+        [Test]
+        public async Task TestHubBaseReturnsWhenCustomHubName()
+        {
+            var hubName = "customHub";
+            _adaptor.RegisterHub<TestDefaultHub>(hubName);
+            var connectBody = "{\"claims\":{\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":[\"ddd\"],\"nbf\":[\"1629183374\"],\"exp\":[\"1629186974\"],\"iat\":[\"1629183374\"],\"aud\":[\"http://localhost:8080/client/hubs/chat\"],\"sub\":[\"ddd\"]},\"query\":{\"access_token\":[\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZGQiLCJuYmYiOjE2MjkxODMzNzQsImV4cCI6MTYyOTE4Njk3NCwiaWF0IjoxNjI5MTgzMzc0LCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvY2xpZW50L2h1YnMvY2hhdCJ9.tqD8ykjv5NmYw6gzLKglUAv-c-AVWu-KNZOptRKkgMM\"]},\"subprotocols\":[\"protocol1\", \"protocol2\"],\"clientCertificates\":[],\"headers\":{}}";
+            var context = PrepareHttpContext(httpMethod: HttpMethods.Post, eventName: "connect", body: connectBody, hub: hubName);
+
+            await _adaptor.HandleRequest(context);
+
+            Assert.AreEqual(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.Null(context.Response.ContentLength);
         }
 
         private static HttpContext PrepareHttpContext(


### PR DESCRIPTION
# Contributing to the Azure SDK

Adding extension method for specifying custom hub name:

```C# Snippet:WebPubSubMapHubCustom
public void Configure(IApplicationBuilder app)
{
    app.UseEndpoints(endpoint =>
    {
        endpoint.MapWebPubSubHub<SampleHub>("/eventhandler", "customHub");
    });
}
```

Updated documentation to make it clear that by default class name is used for hub name.