### PR TITLE
Upgrade python versions < 3.11 to 3.11

### DIFF
--- a/eng/common/pipelines/templates/jobs/docindex.yml
+++ b/eng/common/pipelines/templates/jobs/docindex.yml
@@ -19,7 +19,7 @@ jobs:
         displayName: 'Generate Doc Index'
         inputs:
           pwsh: true
-          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1
+          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1 
           arguments: >
             -Docfx $(docfxPath)
             -RepoRoot $(Build.SourcesDirectory)
@@ -34,14 +34,14 @@ jobs:
           Copy-Item -Path $(Build.SourcesDirectory)/eng/* -Destination ./ -Recurse -Force
           echo "##vso[task.setvariable variable=toolPath]$(Build.BinariesDirectory)"
         workingDirectory: $(Build.BinariesDirectory)
-        displayName: Move eng/common to Tool Directory
+        displayName: Move eng/common to Tool Directory   
 
       - task: PublishPipelineArtifact@0
         condition: succeeded()
         inputs:
           artifactName: "Doc.Index"
           targetPath: $(Build.ArtifactStagingDirectory)/docfx_project/_site
-
+          
       - pwsh: |
           git checkout -b gh-pages-local --track origin/gh-pages-root -f
         workingDirectory: $(Build.SourcesDirectory)

--- a/eng/common/pipelines/templates/jobs/docindex.yml
+++ b/eng/common/pipelines/templates/jobs/docindex.yml
@@ -19,7 +19,7 @@ jobs:
         displayName: 'Generate Doc Index'
         inputs:
           pwsh: true
-          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1 
+          filePath: $(Build.SourcesDirectory)/eng/common/docgeneration/Generate-DocIndex.ps1
           arguments: >
             -Docfx $(docfxPath)
             -RepoRoot $(Build.SourcesDirectory)
@@ -34,14 +34,14 @@ jobs:
           Copy-Item -Path $(Build.SourcesDirectory)/eng/* -Destination ./ -Recurse -Force
           echo "##vso[task.setvariable variable=toolPath]$(Build.BinariesDirectory)"
         workingDirectory: $(Build.BinariesDirectory)
-        displayName: Move eng/common to Tool Directory   
+        displayName: Move eng/common to Tool Directory
 
       - task: PublishPipelineArtifact@0
         condition: succeeded()
         inputs:
           artifactName: "Doc.Index"
           targetPath: $(Build.ArtifactStagingDirectory)/docfx_project/_site
-          
+
       - pwsh: |
           git checkout -b gh-pages-local --track origin/gh-pages-root -f
         workingDirectory: $(Build.SourcesDirectory)

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -99,9 +99,9 @@ jobs:
           echo "##vso[task.setvariable variable=VersioningProperties]$versioningProperties"
         displayName: "Setup .NET specific versioning properties"
       - task: UsePythonVersion@0
-        displayName: 'Use Python 3.9'
+        displayName: 'Use Python 3.11'
         inputs:
-          versionSpec: '3.9'
+          versionSpec: '3.11'
       - template: /eng/pipelines/templates/steps/dotnet-diagnostics.yml
         parameters:
           LogFilePath: $(Build.ArtifactStagingDirectory)/pack.binlog

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -267,9 +267,9 @@ jobs:
         os: windows
       steps:
         - task: UsePythonVersion@0
-          displayName: "Use Python 3.9"
+          displayName: "Use Python 3.11"
           inputs:
-            versionSpec: "3.9"
+            versionSpec: "3.11"
 
         - template: /eng/common/pipelines/templates/steps/validate-filename.yml
 


### PR DESCRIPTION
There are issues happening on the Mac with intermittent failures trying to install Python versions < 3.11. This is the only install of Python in net. 
