### PR TITLE
Suppress AZC0030 warning in Azure.Health.Deidentification.csproj

### DIFF
--- a/sdk/healthdataaiservices/Azure.Health.Deidentification/src/Azure.Health.Deidentification.csproj
+++ b/sdk/healthdataaiservices/Azure.Health.Deidentification/src/Azure.Health.Deidentification.csproj
@@ -6,6 +6,7 @@
     <PackageTags>Azure.Health.Deidentification</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>AZC0030</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Suppress AZC0030 warning in Azure.Health.Deidentification.csproj to allow future model names to end in `Options`

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
