### PR TITLE
[Storage][DataMovement] Adjust local file buffer size

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPartPlanFile.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPartPlanFile.cs
@@ -66,7 +66,10 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 using (FileStream fileStream = File.Create(result.FileName.ToString()))
                 {
-                    await headerStream.CopyToAsync(fileStream, DefaultBufferSize, cancellationToken).ConfigureAwait(false);
+                    await headerStream.CopyToAsync(
+                        fileStream,
+                        DataMovementConstants.DefaultStreamCopyBufferSize,
+                        cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception)

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPartPlanFile.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPartPlanFile.cs
@@ -29,8 +29,6 @@ namespace Azure.Storage.DataMovement.JobPlan
         /// </summary>
         public readonly SemaphoreSlim WriteLock;
 
-        private const int DefaultBufferSize = 81920;
-
         private JobPartPlanFile()
         {
             WriteLock = new SemaphoreSlim(1);

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPlanFile.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPlanFile.cs
@@ -63,7 +63,10 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 using (FileStream fileStream = File.Create(jobPlanFile.FilePath))
                 {
-                    await headerStream.CopyToAsync(fileStream, DefaultBufferSize, cancellationToken).ConfigureAwait(false);
+                    await headerStream.CopyToAsync(
+                        fileStream,
+                        DataMovementConstants.DefaultStreamCopyBufferSize,
+                        cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception)

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPlanFile.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPlanFile.cs
@@ -35,8 +35,6 @@ namespace Azure.Storage.DataMovement.JobPlan
         /// </summary>
         public readonly SemaphoreSlim WriteLock;
 
-        private const int DefaultBufferSize = 81920;
-
         private JobPlanFile(string id, string filePath)
         {
             Id = id;

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
@@ -142,11 +142,11 @@ namespace Azure.Storage.DataMovement
                     {
                         fileStream.Seek(position, SeekOrigin.Begin);
                     }
-                    await stream.CopyToAsync(
-                        fileStream,
-                        (int)streamLength,
-                        cancellationToken)
-                        .ConfigureAwait(false);
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+                    await stream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
+#else
+                    await stream.CopyToAsync(fileStream, 4096, cancellationToken).ConfigureAwait(false);
+#endif
                 }
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
@@ -142,11 +142,9 @@ namespace Azure.Storage.DataMovement
                     {
                         fileStream.Seek(position, SeekOrigin.Begin);
                     }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-                    await stream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
-#else
-                    await stream.CopyToAsync(fileStream, 4096, cancellationToken).ConfigureAwait(false);
-#endif
+
+                    int bufferSize = Math.Min((int)streamLength, DataMovementConstants.DefaultStreamCopyBufferSize);
+                    await stream.CopyToAsync(fileStream, bufferSize, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
@@ -14,7 +14,7 @@ namespace Azure.Storage.DataMovement
         internal const int MaxJobPartReaders = 64;
         internal const int MaxJobChunkTasks = 3000;
         internal const int StatusCheckInSec = 10;
-        internal const int DefaultArrayPoolArraySize = 4 * 1024;
+        internal const int DefaultStreamCopyBufferSize = 81920;  // Use the .NET default
 
         internal const long DefaultInitialTransferSize = 32 * Constants.MB;
         internal const long DefaultChunkSize = 4 * Constants.MB;

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -472,7 +472,7 @@ namespace Azure.Storage.DataMovement
             {
                 await source.CopyToAsync(
                     fileStream,
-                    Constants.DefaultDownloadCopyBufferSize,
+                    DataMovementConstants.DefaultStreamCopyBufferSize,
                     _cancellationToken)
                     .ConfigureAwait(false);
             }


### PR DESCRIPTION
This change adjusts the buffer size we use copying data between streams to a max of 81920, the current .NET default. I tried to make one constant and apply it everywhere we do a stream copy in DMLib.