### PR TITLE
fix(playwrighttesting): no auth error when scalable scenario is disabled

### DIFF
--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/src/PlaywrightServiceNUnit.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/src/PlaywrightServiceNUnit.cs
@@ -5,7 +5,7 @@ using Azure.Core;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
-using System.Threading;
+using System;
 using Azure.Developer.MicrosoftPlaywrightTesting.TestLogger;
 
 namespace Azure.Developer.MicrosoftPlaywrightTesting.NUnit;
@@ -45,6 +45,10 @@ public class PlaywrightServiceNUnit : PlaywrightService
     [OneTimeSetUp]
     public async Task SetupAsync()
     {
+        if (!UseCloudHostedBrowsers)
+            return;
+        TestContext.Progress.WriteLine("\nRunning tests using Microsoft Playwright Testing service.\n");
+
         await InitializeAsync().ConfigureAwait(false);
     }
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/PlaywrightService.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/PlaywrightService.cs
@@ -145,6 +145,7 @@ public class PlaywrightService
             // Since playwright-dotnet checks PLAYWRIGHT_SERVICE_ACCESS_TOKEN and PLAYWRIGHT_SERVICE_URL to be set, remove PLAYWRIGHT_SERVICE_URL so that tests are run locally.
             // If customers use GetConnectOptionsAsync, after setting disableScalableExecution, an error will be thrown.
             Environment.SetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceUri, null);
+            return;
         }
         // If default auth mechanism is Access token and token is available in the environment variable, no need to setup rotation handler
         if (ServiceAuth == ServiceAuthType.AccessToken)

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/PlaywrightServiceTests.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/PlaywrightServiceTests.cs
@@ -185,9 +185,9 @@ public class PlaywrightServiceTests
         Assert.That(Environment.GetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceUri), Is.Not.Null);
 
         service.InitializeAsync().Wait();
-        defaultAzureCredentialMock.Verify(x => x.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        defaultAzureCredentialMock.Verify(x => x.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Never);
 
-        service.RotationTimer!.Dispose();
+        Assert.That(service.RotationTimer, Is.Null);
 
         Assert.That(Environment.GetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceUri), Is.Null);
     }


### PR DESCRIPTION
The message - Using cloud hosted browser.... is only displayed when customer enables the console logger with verbosity as normal. (https://github.com/nunit/nunit3-vs-adapter/issues/1089)
