### PR TITLE
[Event Hubs] GeoDR - OffsetString

### DIFF
--- a/eng/ApiListing.exclude-attributes.txt
+++ b/eng/ApiListing.exclude-attributes.txt
@@ -3,6 +3,7 @@ T:System.Runtime.CompilerServices.AsyncStateMachineAttribute
 T:System.Runtime.CompilerServices.CompilerGeneratedAttribute
 T:System.Runtime.CompilerServices.NullableContextAttribute
 T:System.Runtime.CompilerServices.NullableAttribute
+T:System.Runtime.CompilerServices.IsReadOnlyAttribute
 T:Azure.Core.CodeGenSuppressAttribute
 T:Azure.Core.CodeGenModelAttribute
 T:Azure.Core.CodeGenMemberAttribute

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/api/Azure.Messaging.EventHubs.Processor.net8.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/api/Azure.Messaging.EventHubs.Processor.net8.0.cs
@@ -38,6 +38,8 @@ namespace Azure.Messaging.EventHubs
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
         protected override System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         protected override System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task ValidateProcessingPreconditions(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
@@ -71,6 +73,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ClaimOwnershipAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership> desiredOwnership, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.Task<Azure.Messaging.EventHubs.Primitives.EventProcessorCheckpoint> GetCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ListOwnershipAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         public override System.Threading.Tasks.Task UpdateCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.Task UpdateCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, string clientIdentifier, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/api/Azure.Messaging.EventHubs.Processor.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/api/Azure.Messaging.EventHubs.Processor.netstandard2.0.cs
@@ -38,6 +38,8 @@ namespace Azure.Messaging.EventHubs
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
         protected override System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         protected override System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task ValidateProcessingPreconditions(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
@@ -71,6 +73,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ClaimOwnershipAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership> desiredOwnership, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.Task<Azure.Messaging.EventHubs.Primitives.EventProcessorCheckpoint> GetCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ListOwnershipAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         public override System.Threading.Tasks.Task UpdateCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.Task UpdateCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, string clientIdentifier, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_MockingClientTypes.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_MockingClientTypes.md
@@ -49,7 +49,7 @@ EventData eventData = EventHubsModelFactory.EventData(
     systemProperties: new Dictionary<string, object>(), //arbitrary value
     partitionKey: "sample-key",
     sequenceNumber: 1000,
-    offset: 1500,
+    offsetString: "1500:1:3344.1",
     enqueuedTime: DateTimeOffset.Parse("11:36 PM"));
 
 // This creates a new instance of ProcessEventArgs to pass into the handler directly.
@@ -110,7 +110,7 @@ TimerCallback dispatchEvent = async _ =>
         systemProperties: new Dictionary<string, object>(), //arbitrary value
         partitionKey: "sample-key",
         sequenceNumber: 1000,
-        offset: 1500,
+        offsetString: "1500:1:1111",
         enqueuedTime: DateTimeOffset.Parse("11:36 PM"));
 
     ProcessEventArgs eventArgs = new(

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
     <Version>5.12.0-beta.2</Version>
-    <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
+    <!--The ApiCompatVersion is managed automatically and should not generally be modified manually. -->
     <ApiCompatVersion>5.11.5</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -16,7 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" />
+    <!-- TEMP TEMP -->
+    <ProjectReference Include="../../Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj" />
+    <!-- PackageReference Include="Azure.Messaging.EventHubs" /-->
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobCheckpointStoreInternal.Diagnostics.cs
@@ -97,7 +97,6 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with the checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with the checkpoint.</param>
         /// <param name="offset">The offset associated with the checkpoint.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
@@ -107,10 +106,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           string replicationSegment,
                                            string offset,
                                            Exception exception) =>
-            Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, exception.Message, sequenceNumber, replicationSegment, offset);
+            Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, exception.Message, sequenceNumber, offset);
 
         /// <summary>
         ///   Indicates that an attempt to update a checkpoint has completed.
@@ -122,7 +120,6 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         partial void UpdateCheckpointComplete(string partitionId,
@@ -131,9 +128,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                                               string consumerGroup,
                                               string clientIdentifier,
                                               string sequenceNumber,
-                                              string replicationSegment,
                                               string offset) =>
-            Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
+            Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, offset);
 
         /// <summary>
         ///   Indicates that an attempt to create/update a checkpoint has started.
@@ -145,7 +141,6 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         partial void UpdateCheckpointStart(string partitionId,
@@ -154,9 +149,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           string replicationSegment,
                                            string offset) =>
-            Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
+            Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, offset);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve claim partition ownership has completed.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -254,22 +254,20 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
-        [Event(32, Level = EventLevel.Verbose, Message = "Starting to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{4}'; at SequenceNumber: '{5}' ReplicationSegment: '{6}' Offset: '{7}'.")]
+        [Event(32, Level = EventLevel.Verbose, Message = "Starting to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{4}'; at SequenceNumber: '{5}' Offset: '{6}'.")]
         public virtual void UpdateCheckpointStart(string partitionId,
                                                   string fullyQualifiedNamespace,
                                                   string eventHubName,
                                                   string consumerGroup,
                                                   string clientIdentifier,
                                                   string sequenceNumber,
-                                                  string replicationSegment,
                                                   string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment ?? string.Empty, offset ?? string.Empty);
+                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, offset ?? string.Empty);
             }
         }
 
@@ -283,22 +281,20 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
-        [Event(33, Level = EventLevel.Verbose, Message = "Completed the attempt to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{4}'; at SequenceNumber: '{5}' ReplicationSegment: '{6}' Offset: '{7}'.")]
+        [Event(33, Level = EventLevel.Verbose, Message = "Completed the attempt to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{4}'; at SequenceNumber: '{5}' Offset: '{6}'.")]
         public virtual void UpdateCheckpointComplete(string partitionId,
                                                      string fullyQualifiedNamespace,
                                                      string eventHubName,
                                                      string consumerGroup,
                                                      string clientIdentifier,
                                                      string sequenceNumber,
-                                                     string replicationSegment,
                                                      string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment ?? string.Empty, offset ?? string.Empty);
+                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, offset ?? string.Empty);
             }
         }
 
@@ -312,11 +308,10 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the processor that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(34, Level = EventLevel.Error, Message = "An exception occurred when creating/updating a checkpoint for  partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ClientIdentifier: '{5}'; at SequenceNumber: '{6}' ReplicationSegment '{7}' Offset '{8}'.  ErrorMessage: '{4}'.")]
+        [Event(34, Level = EventLevel.Error, Message = "An exception occurred when creating/updating a checkpoint for  partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'; ErrorMessage: '{4}'; ClientIdentifier: '{5}'; at SequenceNumber: '{6}' Offset '{7}'.")]
         public virtual void UpdateCheckpointError(string partitionId,
                                                   string fullyQualifiedNamespace,
                                                   string eventHubName,
@@ -324,12 +319,11 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                                                   string clientIdentifier,
                                                   string errorMessage,
                                                   string sequenceNumber,
-                                                  string replicationSegment,
                                                   string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, replicationSegment ?? string.Empty, offset ?? string.Empty);
+                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, clientIdentifier ?? string.Empty, sequenceNumber ?? string.Empty, offset ?? string.Empty);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
@@ -398,6 +398,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         private unsafe void WriteEvent(int eventId,
                                        string arg1,
                                        string arg2,

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
@@ -120,16 +120,20 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="identifier">A unique name used to identify the event processor.</param>
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="sequenceNumber">The sequence number associated with the checkpoint being written.</param>
+        /// <param name="offset">The offset associated with the checkpoint being written.</param>
         ///
-        [Event(23, Level = EventLevel.Verbose, Message = "Starting to perform a checkpoint update for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        [Event(23, Level = EventLevel.Verbose, Message = "Starting to perform a checkpoint update for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3} Sequence Number: {4} Offset {5}.")]
         public virtual void UpdateCheckpointStart(string partitionId,
                                                   string identifier,
                                                   string eventHubName,
-                                                  string consumerGroup)
+                                                  string consumerGroup,
+                                                  string sequenceNumber,
+                                                  string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(23, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+                WriteEvent(23, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, sequenceNumber ?? string.Empty, offset ?? string.Empty);
             }
         }
 
@@ -141,16 +145,20 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="identifier">A unique name used to identify the event processor.</param>
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="sequenceNumber">The sequence number associated with the checkpoint being written.</param>
+        /// <param name="offset">The offset associated with the checkpoint being written.</param>
         ///
-        [Event(24, Level = EventLevel.Verbose, Message = "Completed performing a checkpoint update for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        [Event(24, Level = EventLevel.Verbose, Message = "Completed performing a checkpoint update for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3} Sequence Number: {4} Offset: {5}.")]
         public virtual void UpdateCheckpointComplete(string partitionId,
                                                      string identifier,
                                                      string eventHubName,
-                                                     string consumerGroup)
+                                                     string consumerGroup,
+                                                     string sequenceNumber,
+                                                     string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(24, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+                WriteEvent(24, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, sequenceNumber ?? string.Empty, offset ?? string.Empty);
             }
         }
 
@@ -163,17 +171,21 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
+        /// <param name="sequenceNumber">The sequence number associated with the checkpoint being written.</param>
+        /// <param name="offset">The offset associated with the checkpoint being written.</param>
         ///
-        [Event(25, Level = EventLevel.Error, Message = "An exception occurred while attempting to perform a checkpoint update for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Error Message: '{4}'")]
+        [Event(25, Level = EventLevel.Error, Message = "An exception occurred while attempting to perform a checkpoint update for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Error Message: '{4}. Sequence Number: {5} Offset: {6}'")]
         public virtual void UpdateCheckpointError(string partitionId,
                                                   string identifier,
                                                   string eventHubName,
                                                   string consumerGroup,
-                                                  string errorMessage)
+                                                  string errorMessage,
+                                                  string sequenceNumber,
+                                                  string offset)
         {
             if (IsEnabled())
             {
-                WriteEvent(25, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+                WriteEvent(25, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, sequenceNumber ?? string.Empty, offset ?? string.Empty);
             }
         }
 
@@ -363,10 +375,70 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                 eventPayload[4].Size = (arg5.Length + 1) * sizeof(char);
                 eventPayload[4].DataPointer = (IntPtr)arg5Ptr;
 
-                eventPayload[5].Size = (arg5.Length + 1) * sizeof(char);
-                eventPayload[5].DataPointer = (IntPtr)arg5Ptr;
+                eventPayload[5].Size = (arg6.Length + 1) * sizeof(char);
+                eventPayload[5].DataPointer = (IntPtr)arg6Ptr;
 
                 WriteEventCore(eventId, 6, eventPayload);
+            }
+        }
+
+        /// <summary>
+        ///   Writes an event with five string arguments into a stack allocated
+        ///   <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation on the WriteEvent methods.
+        /// </summary>
+        ///
+        /// <param name="eventId">The identifier of the event.</param>
+        /// <param name="arg1">The first argument.</param>
+        /// <param name="arg2">The second argument.</param>
+        /// <param name="arg3">The third argument.</param>
+        /// <param name="arg4">The fourth argument.</param>
+        /// <param name="arg5">The fifth argument.</param>
+        /// <param name="arg6">The sixth argument.</param>
+        /// <param name="arg7">The seventh argument.</param>
+        ///
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void WriteEvent(int eventId,
+                                       string arg1,
+                                       string arg2,
+                                       string arg3,
+                                       string arg4,
+                                       string arg5,
+                                       string arg6,
+                                       string arg7)
+        {
+            fixed (char* arg1Ptr = arg1)
+            fixed (char* arg2Ptr = arg2)
+            fixed (char* arg3Ptr = arg3)
+            fixed (char* arg4Ptr = arg4)
+            fixed (char* arg5Ptr = arg5)
+            fixed (char* arg6Ptr = arg6)
+            fixed (char* arg7Ptr = arg7)
+            {
+                var eventPayload = stackalloc EventData[7];
+
+                eventPayload[0].Size = (arg1.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)arg1Ptr;
+
+                eventPayload[1].Size = (arg2.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)arg2Ptr;
+
+                eventPayload[2].Size = (arg3.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)arg3Ptr;
+
+                eventPayload[3].Size = (arg4.Length + 1) * sizeof(char);
+                eventPayload[3].DataPointer = (IntPtr)arg4Ptr;
+
+                eventPayload[4].Size = (arg5.Length + 1) * sizeof(char);
+                eventPayload[4].DataPointer = (IntPtr)arg5Ptr;
+
+                eventPayload[5].Size = (arg6.Length + 1) * sizeof(char);
+                eventPayload[5].DataPointer = (IntPtr)arg6Ptr;
+
+                eventPayload[6].Size = (arg7.Length + 1) * sizeof(char);
+                eventPayload[6].DataPointer = (IntPtr)arg7Ptr;
+
+                WriteEventCore(eventId, 7, eventPayload);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -902,15 +902,23 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   Obsolete.
+        ///
         ///   Creates or updates a checkpoint for a specific partition, identifying a position in the partition's event stream
         ///   that an event processor should begin reading from.
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition the checkpoint is for.</param>
-        /// <param name="offset">The offset to associate with the checkpoint, intended as informational metadata. This will only be used for positioning if there is no value provided for <paramref name="sequenceNumber"/>.</param>
+        /// <param name="offset">The offset to associate with the checkpoint, intended as informational metadata. This will only be used from positioning if there is no value provided for <paramref name="sequenceNumber"/>.</param>
         /// <param name="sequenceNumber">The sequence number to associate with the checkpoint, indicating that a processor should begin reading from the next event in the stream.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal a request to cancel the operation.</param>
         ///
+        /// <remarks>
+        ///   This method is obsolete and should no longer be used.  Please use <see cref="UpdateCheckpointAsync(string, CheckpointPosition, CancellationToken)"/> instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetUpdateCheckpointObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected override Task UpdateCheckpointAsync(string partitionId,
                                                       long offset,
                                                       long? sequenceNumber,
@@ -919,14 +927,16 @@ namespace Azure.Messaging.EventHubs
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Argument.AssertNotNull(partitionId, nameof(partitionId));
 
-            Logger.UpdateCheckpointStart(partitionId, Identifier, EventHubName, ConsumerGroup);
+            var offsetString = offset.ToString(CultureInfo.InvariantCulture);
+            Logger.UpdateCheckpointStart(partitionId, Identifier, EventHubName, ConsumerGroup, sequenceNumber?.ToString(CultureInfo.InvariantCulture), offsetString);
 
             using var scope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorCheckpointActivityName, ActivityKind.Internal);
             scope.Start();
 
             try
             {
-                return CheckpointStore.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, partitionId, offset, sequenceNumber, cancellationToken);
+                var checkpointPosition = new CheckpointPosition(offsetString, sequenceNumber ?? long.MinValue);
+                return CheckpointStore.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, partitionId, Identifier, checkpointPosition, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -934,13 +944,13 @@ namespace Azure.Messaging.EventHubs
                 // be thrown directly to the caller here.
 
                 scope.Failed(ex);
-                Logger.UpdateCheckpointError(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+                Logger.UpdateCheckpointError(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message, sequenceNumber?.ToString(CultureInfo.InvariantCulture), offsetString);
 
                 throw;
             }
             finally
             {
-                Logger.UpdateCheckpointComplete(partitionId, Identifier, EventHubName, ConsumerGroup);
+                Logger.UpdateCheckpointComplete(partitionId, Identifier, EventHubName, ConsumerGroup, sequenceNumber?.ToString(CultureInfo.InvariantCulture), offset.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -960,9 +970,19 @@ namespace Azure.Messaging.EventHubs
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             Argument.AssertNotNull(partitionId, nameof(partitionId));
-            Argument.AssertAtLeast(startingPosition.SequenceNumber, 0, nameof(startingPosition.SequenceNumber));
+            if (string.IsNullOrEmpty(startingPosition.OffsetString))
+            {
+                if (EventHubProperties?.IsGeoReplicationEnabled ?? false)
+                {
+                    var message = string.Format(CultureInfo.InvariantCulture, Resources.ProcessorAttemptingToWriteCheckpointWithoutOffset);
+                    var updateCheckpointException = new EventHubsException(true, EventHubName, message, EventHubsException.FailureReason.GeneralError);
+                    _ = InvokeOnProcessingErrorAsync(updateCheckpointException, Resources.OperationEventProcessingLoop, CancellationToken.None);
+                }
 
-            Logger.UpdateCheckpointStart(partitionId, Identifier, EventHubName, ConsumerGroup);
+                Argument.AssertAtLeast(startingPosition.SequenceNumber, 0, nameof(startingPosition.SequenceNumber));
+            }
+
+            Logger.UpdateCheckpointStart(partitionId, Identifier, EventHubName, ConsumerGroup, startingPosition.SequenceNumber.ToString(CultureInfo.InvariantCulture), startingPosition.OffsetString);
 
             using var scope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorCheckpointActivityName, ActivityKind.Internal);
             scope.Start();
@@ -977,15 +997,28 @@ namespace Azure.Messaging.EventHubs
                 // be thrown directly to the caller here.
 
                 scope.Failed(ex);
-                Logger.UpdateCheckpointError(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+                Logger.UpdateCheckpointError(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message, startingPosition.SequenceNumber.ToString(CultureInfo.InvariantCulture), startingPosition.OffsetString);
 
                 throw;
             }
             finally
             {
-                Logger.UpdateCheckpointComplete(partitionId, Identifier, EventHubName, ConsumerGroup);
+                Logger.UpdateCheckpointComplete(partitionId, Identifier, EventHubName, ConsumerGroup, startingPosition.SequenceNumber.ToString(), startingPosition.OffsetString);
             }
         }
+
+        /// <summary>
+        ///   Performs the tasks needed invoke the <see cref="OnProcessingErrorAsync" /> method in the background,
+        ///   as it is intended to be a fire-and-forget operation.
+        /// </summary>
+        ///
+        /// <param name="exception">The exception that occurred during operation of the event processor.</param>
+        /// <param name="operationDescription">A short textual description of the operation during which the exception occurred; intended to be informational only.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the processing.</param>
+        ///
+        private Task InvokeOnProcessingErrorAsync(Exception exception,
+                                                  string operationDescription,
+                                                  CancellationToken cancellationToken) => Task.Run(() => OnProcessingErrorAsync(exception, null, operationDescription, cancellationToken), CancellationToken.None);
 
         /// <summary>
         ///   Creates an <see cref="EventHubConnection" /> to use for communicating with the Event Hubs service.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Primitives/BlobCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Primitives/BlobCheckpointStore.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Processor;
 using Azure.Storage.Blobs;
 
@@ -95,6 +98,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                                           CancellationToken cancellationToken) => _checkpointStoreImplementation.GetCheckpointAsync(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, cancellationToken);
 
         /// <summary>
+        ///   Obsolete.
+        ///
         ///   Creates or updates a checkpoint for a specific partition, identifying a position in the partition's event stream
         ///   that an event processor should begin reading from.
         /// </summary>
@@ -103,17 +108,23 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="partitionId">The identifier of the partition the checkpoint is for.</param>
-        /// <param name="offset">The offset to associate with the checkpoint, intended as informational metadata. This will only be used for positioning if there is no value provided for <paramref name="sequenceNumber"/>.</param>
+        /// <param name="offset">The offset to associate with the checkpoint, intended as informational metadata. This will only be used from positioning if there is no value provided for <paramref name="sequenceNumber"/>.</param>
         /// <param name="sequenceNumber">The sequence number to associate with the checkpoint, indicating that a processor should begin reading from the next event in the stream.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal a request to cancel the operation.</param>
         ///
+        /// <remarks>
+        ///   This method is obsolete and should no longer be used.  Please use <see cref="UpdateCheckpointAsync(string, string, string, string, string, CheckpointPosition, CancellationToken)"/> instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetUpdateCheckpointObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override Task UpdateCheckpointAsync(string fullyQualifiedNamespace,
-                                                   string eventHubName,
-                                                   string consumerGroup,
-                                                   string partitionId,
-                                                   long offset,
-                                                   long? sequenceNumber,
-                                                   CancellationToken cancellationToken) => _checkpointStoreImplementation.UpdateCheckpointAsync(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, offset, sequenceNumber, cancellationToken);
+                                                  string eventHubName,
+                                                  string consumerGroup,
+                                                  string partitionId,
+                                                  long offset,
+                                                  long? sequenceNumber,
+                                                  CancellationToken cancellationToken) => _checkpointStoreImplementation.UpdateCheckpointAsync(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, offset, sequenceNumber, cancellationToken);
 
         /// <summary>
         ///   Creates or updates a checkpoint for a specific partition, identifying a position in the partition's event stream

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// Ignore Spelling: Etag
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -268,9 +270,10 @@ namespace Azure.Messaging.EventHubs.Tests
             target.Logger = mockLog.Object;
 
             var expectedSequenceNumber = 0;
-            await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), "-1", string.Empty));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), "-1", string.Empty));
+            var expectedOffset = "10:1:9853.1";
+            await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedOffset, expectedSequenceNumber), CancellationToken.None);
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), expectedOffset));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), expectedOffset));
         }
 
         /// <summary>
@@ -296,11 +299,12 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockLog = new Mock<BlobEventStoreEventSource>();
             target.Logger = mockLog.Object;
 
-            var expectedSequenceNumber = 0;
+            var expectedOffset = "1:0:8833";
+            var expectedSequence = 23432;
 
-            await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None);
-            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), "-1", string.Empty));
-            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequenceNumber.ToString(), "-1", string.Empty));
+            await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedOffset, expectedSequence), CancellationToken.None);
+            mockLog.Verify(log => log.UpdateCheckpointStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequence.ToString(), expectedOffset));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedSequence.ToString(), expectedOffset));
         }
 
         /// <summary>
@@ -324,8 +328,9 @@ namespace Azure.Messaging.EventHubs.Tests
             target.Logger = mockLog.Object;
 
             var expectedSequenceNumber = 456;
-            Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), "-1", string.Empty));
+            var expectedOffset = "404";
+            Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedOffset, expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), expectedOffset));
         }
 
         /// <summary>
@@ -348,8 +353,9 @@ namespace Azure.Messaging.EventHubs.Tests
             target.Logger = mockLog.Object;
 
             var expectedSequenceNumber = 6;
-            Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
-            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), "-1", string.Empty));
+            var expectedOffset = "9";
+            Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedOffset, expectedSequenceNumber), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(log => log.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, expectedException.Message, expectedSequenceNumber.ToString(), expectedOffset));
         }
 
         /// <summary>
@@ -367,8 +373,9 @@ namespace Azure.Messaging.EventHubs.Tests
             target.Logger = mockLog.Object;
 
             var expectedSequenceNumber = 999;
-            Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedSequenceNumber), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber.ToString(), "-1", string.Empty));
+            var expectedOffset = "777";
+            Assert.That(async () => await target.UpdateCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, PartitionId, Identifier, new CheckpointPosition(expectedOffset, expectedSequenceNumber), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier, ex.Message, expectedSequenceNumber.ToString(), expectedOffset));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -62,13 +62,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Mock.Of<EventHubConnection>());
 
             mockLogger
-                .Setup(log => log.UpdateCheckpointComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(log => log.UpdateCheckpointComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Callback(() => completionSource.TrySetResult(true));
 
             mockProcessor.Object.Logger = mockLogger.Object;
 
             using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
-            await InvokeUpdateCheckpointAsync(mockProcessor.Object, mockContext.Object.PartitionId, 998, default);
+            await InvokeUpdateCheckpointAsync(mockProcessor.Object, mockContext.Object.PartitionId, "998", default);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -93,8 +93,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var enqueuedTime = DateTimeOffset.UtcNow;
             var eventBatch = new[]
             {
-                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123, enqueuedTime: enqueuedTime),
-                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456, enqueuedTime: enqueuedTime)
+                new MockEventData(new byte[] { 0x11 }, offset: "123", sequenceNumber: 123, enqueuedTime: enqueuedTime),
+                new MockEventData(new byte[] { 0x22 }, offset: "456", sequenceNumber: 456, enqueuedTime: enqueuedTime)
             };
 
             for (int i = 0; i < eventBatch.Length; i++)
@@ -150,8 +150,8 @@ namespace Azure.Messaging.EventHubs.Tests
             using var listener = new ClientDiagnosticListener(DiagnosticProperty.DiagnosticNamespace);
             var eventBatch = new[]
             {
-                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123),
-                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456)
+                new MockEventData(new byte[] { 0x11 }, offset: "123", sequenceNumber: 123),
+                new MockEventData(new byte[] { 0x22 }, offset: "456", sequenceNumber: 456)
             };
 
             var mockLogger = new Mock<EventProcessorClientEventSource>();
@@ -199,8 +199,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var enqueuedTime = DateTimeOffset.UtcNow;
             var eventBatch = new[]
             {
-                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123, enqueuedTime: enqueuedTime),
-                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456, enqueuedTime: enqueuedTime)
+                new MockEventData(new byte[] { 0x11 }, offset: "123", sequenceNumber: 123, enqueuedTime: enqueuedTime),
+                new MockEventData(new byte[] { 0x22 }, offset: "456", sequenceNumber: 456, enqueuedTime: enqueuedTime)
             };
 
             var mockLogger = new Mock<EventProcessorClientEventSource>();
@@ -252,18 +252,17 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="target">The client whose method to invoke.</param>
         /// <param name="partitionId">The identifier of the partition the checkpoint is for.</param>
         /// <param name="offset">The offset to associate with the checkpoint, indicating that a processor should begin reading form the next event in the stream.</param>
-        /// <param name="sequenceNumber">An optional sequence number to associate with the checkpoint, intended as informational metadata.  The <paramref name="offset" /> will be used for positioning when events are read.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal a request to cancel the operation.</param>
         ///
         /// <returns>The translated options.</returns>
         ///
         private static Task InvokeUpdateCheckpointAsync(EventProcessorClient target,
                                                         string partitionId,
-                                                        long sequenceNumber,
+                                                        string offset,
                                                         CancellationToken cancellationToken) =>
             (Task)
                 typeof(EventProcessorClient)
                     .GetMethod("UpdateCheckpointAsync", BindingFlags.Instance | BindingFlags.NonPublic, null, new Type[] { typeof(string), typeof(CheckpointPosition), typeof(CancellationToken) }, null)
-                    .Invoke(target, new object[] { partitionId, new CheckpointPosition(sequenceNumber), cancellationToken });
+                    .Invoke(target, new object[] { partitionId, new CheckpointPosition(offset), cancellationToken });
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Primitives/BlobCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Primitives/BlobCheckpointStoreTests.cs
@@ -119,11 +119,11 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedConsumerGroup = "fakeGroup";
             var expectedPartition = "fakePart";
             var expectedProcessorId = "Id";
-            var expectedSequence = 999;
+            var expectedOffset = "999";
             var mockCheckpointStore = new Mock<CheckpointStore>();
             var blobCheckpointStore = new BlobCheckpointStore(mockCheckpointStore.Object);
 
-            await blobCheckpointStore.UpdateCheckpointAsync(expectedNamespace, expectedHub, expectedConsumerGroup, expectedPartition, expectedProcessorId, new CheckpointPosition(expectedSequence), cancellationSource.Token);
+            await blobCheckpointStore.UpdateCheckpointAsync(expectedNamespace, expectedHub, expectedConsumerGroup, expectedPartition, expectedProcessorId, new CheckpointPosition(expectedOffset), cancellationSource.Token);
 
             mockCheckpointStore.Verify(store => store.UpdateCheckpointAsync(
                 expectedNamespace,
@@ -132,39 +132,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 expectedPartition,
                 expectedProcessorId,
                 It.Is<CheckpointPosition>(csp =>
-                    csp.SequenceNumber == expectedSequence),
-                cancellationSource.Token),
-            Times.Once);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="BlobCheckpointStore.UpdateCheckpointAsync" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public async Task UpdateCheckpointAsyncOldOverloadDelegatesTheCall()
-        {
-            using var cancellationSource = new CancellationTokenSource();
-
-            var expectedNamespace = "fakeNS";
-            var expectedHub = "fakeHub";
-            var expectedConsumerGroup = "fakeGroup";
-            var expectedPartition = "fakePart";
-            var expectedOffset = 123;
-            var expectedSequence = 999;
-            var mockCheckpointStore = new Mock<CheckpointStore>();
-            var blobCheckpointStore = new BlobCheckpointStore(mockCheckpointStore.Object);
-
-            await blobCheckpointStore.UpdateCheckpointAsync(expectedNamespace, expectedHub, expectedConsumerGroup, expectedPartition, expectedOffset, expectedSequence, cancellationSource.Token);
-
-            mockCheckpointStore.Verify(store => store.UpdateCheckpointAsync(
-                expectedNamespace,
-                expectedHub,
-                expectedConsumerGroup,
-                expectedPartition,
-                expectedOffset,
-                expectedSequence,
+                    csp.OffsetString == expectedOffset),
                 cancellationSource.Token),
             Times.Once);
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// Ignore Spelling: Checkpointing
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -391,7 +393,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Read the initial set back, marking the offset and sequence number of the last event in the initial set.
 
-            var startingOffset = 0L;
+            string startingOffset = null;
 
             await using (var consumer = new EventHubConsumerClient(
                 scope.ConsumerGroups.First(),
@@ -403,8 +405,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     if (partitionEvent.Data.IsEquivalentTo(lastSourceEvent))
                     {
-                        startingOffset = partitionEvent.Data.Offset;
-
+                        startingOffset = partitionEvent.Data.OffsetString;
                         break;
                     }
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -793,7 +793,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var capturedEventArgs = default(PartitionInitializingEventArgs);
             var partitionId = "0";
-            var startingPosition = EventPosition.FromOffset(433);
+            var startingPosition = EventPosition.FromOffset("433");
             var options = new EventProcessorOptions { DefaultStartingPosition = startingPosition };
             var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), options);
 
@@ -925,8 +925,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = new[]
             {
-                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123),
-                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456)
+                new MockEventData(new byte[] { 0x11 }, offset: "123", sequenceNumber: 123),
+                new MockEventData(new byte[] { 0x22 }, offset: "456", sequenceNumber: 456)
             };
 
             var capturedEventArgs = new List<ProcessEventArgs>();
@@ -1043,8 +1043,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = new[]
             {
-                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123),
-                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456)
+                new MockEventData(new byte[] { 0x11 }, offset: "123", sequenceNumber: 123),
+                new MockEventData(new byte[] { 0x22 }, offset: "456", sequenceNumber: 456)
             };
 
             var invokeCount = 0;
@@ -1089,7 +1089,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = Enumerable
                 .Range(0, eventCount)
-                .Select(index => new MockEventData(Array.Empty<byte>(), offset: 1000 + index, sequenceNumber: 2000 + index))
+                .Select(index => new MockEventData(Array.Empty<byte>(), offset: (1000 + index).ToString(), sequenceNumber: 2000 + index))
                 .ToList();
 
             processorClient.ProcessEventAsync += eventArgs =>
@@ -1133,8 +1133,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = new[]
             {
-                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123),
-                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456)
+                new MockEventData(new byte[] { 0x11 }, offset: "123", sequenceNumber: 123),
+                new MockEventData(new byte[] { 0x22 }, offset: "456", sequenceNumber: 456)
             };
 
             var partitionId = "3";
@@ -1179,8 +1179,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = new[]
             {
-                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123),
-                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456)
+                new MockEventData(new byte[] { 0x11 }, offset: "123", sequenceNumber: 123),
+                new MockEventData(new byte[] { 0x22 }, offset: "456", sequenceNumber: 456)
             };
 
             var partitionId = "3";
@@ -1218,10 +1218,10 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = new[]
             {
-                new MockEventData(new byte[] { 0x11 }, offset: 123, sequenceNumber: 123),
-                new MockEventData(new byte[] { 0x22 }, offset: 456, sequenceNumber: 456),
-                new MockEventData(new byte[] { 0x33 }, offset: 789, sequenceNumber: 789),
-                new MockEventData(new byte[] { 0x44 }, offset: 000, sequenceNumber: 000)
+                new MockEventData(new byte[] { 0x11 }, offset: "123", sequenceNumber: 123),
+                new MockEventData(new byte[] { 0x22 }, offset: "456", sequenceNumber: 456),
+                new MockEventData(new byte[] { 0x33 }, offset: "789", sequenceNumber: 789),
+                new MockEventData(new byte[] { 0x44 }, offset: "000", sequenceNumber: 000)
             };
 
             var processedEventsCount = 0;
@@ -1291,7 +1291,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partitionId = "0";
-            var startingPosition = EventPosition.FromOffset(433);
+            var startingPosition = EventPosition.FromOffset("433");
             var options = new EventProcessorOptions { DefaultStartingPosition = EventPosition.Latest };
             var mockCheckpointStore = new Mock<CheckpointStore>();
             var processorClient = new TestEventProcessorClient(mockCheckpointStore.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), options);
@@ -1330,7 +1330,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partitionId = "0";
-            var startingPosition = EventPosition.FromOffset(433);
+            var startingPosition = EventPosition.FromOffset("433");
             var checkpointStartingPosition = EventPosition.FromSequenceNumber(999);
             var options = new EventProcessorOptions { DefaultStartingPosition = EventPosition.Latest };
             var mockCheckpointStore = new Mock<CheckpointStore>();
@@ -1464,8 +1464,8 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partitionId = "3";
-            var sequenceNumber = 789;
-            var checkpointStartingPosition = new CheckpointPosition(sequenceNumber);
+            var offset = "789";
+            var checkpointStartingPosition = new CheckpointPosition(offset);
             var mockStorage = new Mock<CheckpointStore>();
             var processorClient = new TestEventProcessorClient(mockStorage.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
 
@@ -1479,41 +1479,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     processorClient.Identifier,
                     It.Is<CheckpointPosition>(csp =>
-                        csp.SequenceNumber == sequenceNumber),
-                    It.IsAny<CancellationToken>()),
-                Times.Once);
-
-            cancellationSource.Cancel();
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventProcessorClient.UpdateCheckpointAsync(string, long, long?, CancellationToken)" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public async Task PreviousUpdateCheckpointCallsTheOldUpdateCheckpoint()
-        {
-            using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
-
-            var partitionId = "3";
-            var offset = 456;
-            var sequenceNumber = 789;
-            var checkpointPosition = new CheckpointPosition(sequenceNumber);
-            var mockStorage = new Mock<CheckpointStore>();
-            var processorClient = new TestEventProcessorClient(mockStorage.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
-
-            await processorClient.InvokeOldUpdateCheckpointAsync(partitionId, offset, sequenceNumber, cancellationSource.Token);
-
-            mockStorage
-                .Verify(storage => storage.UpdateCheckpointAsync(
-                    processorClient.FullyQualifiedNamespace,
-                    processorClient.EventHubName,
-                    processorClient.ConsumerGroup,
-                    partitionId,
-                    offset,
-                    sequenceNumber,
+                        csp.OffsetString == offset),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -1532,7 +1498,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.Cancel();
 
             var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
-            Assert.That(async () => await processorClient.InvokeUpdateCheckpointAsync("0", new CheckpointPosition(123), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(async () => await processorClient.InvokeUpdateCheckpointAsync("0", new CheckpointPosition("123"), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
         /// <summary>
@@ -1548,7 +1514,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var partitionId = "3";
             var sequenceNumber = 789;
-            var checkpointStartingPosition = new CheckpointPosition(sequenceNumber);
+            var offset = "135";
+            var checkpointStartingPosition = new CheckpointPosition(offset, sequenceNumber);
             var mockLogger = new Mock<EventProcessorClientEventSource>();
             var processorClient = new TestEventProcessorClient(Mock.Of<CheckpointStore>(), "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
 
@@ -1560,7 +1527,9 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     processorClient.Identifier,
                     processorClient.EventHubName,
-                    processorClient.ConsumerGroup),
+                    processorClient.ConsumerGroup,
+                    sequenceNumber.ToString(),
+                    offset),
                 Times.Once);
 
             mockLogger
@@ -1568,7 +1537,9 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     processorClient.Identifier,
                     processorClient.EventHubName,
-                    processorClient.ConsumerGroup),
+                    processorClient.ConsumerGroup,
+                    sequenceNumber.ToString(),
+                    offset),
                 Times.Once);
 
             cancellationSource.Cancel();
@@ -1587,7 +1558,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedException = new NotImplementedException("This didn't work.");
             var partitionId = "3";
-            var checkpointStartingPosition = new CheckpointPosition(789);
+            var checkpointStartingPosition = new CheckpointPosition("44", 789);
             var mockLogger = new Mock<EventProcessorClientEventSource>();
             var mockStorage = new Mock<CheckpointStore>();
             var processorClient = new TestEventProcessorClient(mockStorage.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
@@ -1612,7 +1583,9 @@ namespace Azure.Messaging.EventHubs.Tests
                     processorClient.Identifier,
                     processorClient.EventHubName,
                     processorClient.ConsumerGroup,
-                    expectedException.Message),
+                    expectedException.Message,
+                    "789",
+                    "44"),
                 Times.Once);
 
             cancellationSource.Cancel();
@@ -1726,7 +1699,6 @@ namespace Azure.Messaging.EventHubs.Tests
             public Task<EventProcessorCheckpoint> InvokeGetCheckpointAsync(string partitionId, CancellationToken cancellationToken) => base.GetCheckpointAsync(partitionId, cancellationToken);
             public Task<IEnumerable<EventProcessorPartitionOwnership>> InvokeListOwnershipAsync(CancellationToken cancellationToken) => base.ListOwnershipAsync(cancellationToken);
             public Task<IEnumerable<EventProcessorPartitionOwnership>> InvokeClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) => base.ClaimOwnershipAsync(desiredOwnership, cancellationToken);
-            public Task InvokeOldUpdateCheckpointAsync(string partitionId, long offset, long sequenceNumber, CancellationToken cancellationToken) => base.UpdateCheckpointAsync(partitionId, offset, sequenceNumber, cancellationToken);
             public Task InvokeUpdateCheckpointAsync(string partitionId, CheckpointPosition checkpointStartingPosition, CancellationToken cancellationToken) => base.UpdateCheckpointAsync(partitionId, checkpointStartingPosition, cancellationToken);
             protected override EventHubConnection CreateConnection() => InjectedConnection;
             protected override Task ValidateProcessingPreconditions(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample08_MockingClientTypesLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample08_MockingClientTypesLiveTests.cs
@@ -64,7 +64,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                 systemProperties: new Dictionary<string, object>(), //arbitrary value
                 partitionKey: "sample-key",
                 sequenceNumber: 1000,
-                offset: 1500,
+                offsetString: "1500:1:3344.1",
                 enqueuedTime: DateTimeOffset.Parse("11:36 PM"));
 
             // This creates a new instance of ProcessEventArgs to pass into the handler directly.
@@ -130,7 +130,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                     systemProperties: new Dictionary<string, object>(), //arbitrary value
                     partitionKey: "sample-key",
                     sequenceNumber: 1000,
-                    offset: 1500,
+                    offsetString: "1500:1:1111",
                     enqueuedTime: DateTimeOffset.Parse("11:36 PM"));
 
                 ProcessEventArgs eventArgs = new(

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/AttributeMessageText.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/AttributeMessageText.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.EventHubs.Core
+{
+    /// <summary>
+    ///   The set of common message text used in attributes,
+    ///   which are unable to be represented in the shared
+    ///   resources due to the constraint of needing to be
+    ///   defined as a constant.
+    /// </summary>
+    ///
+    internal static class AttributeMessageText
+    {
+        /// <summary>
+        ///   The message text detailing numeric offset deprecation.
+        /// </summary>
+        ///
+        public const string LongOffsetOffsetPropertyObsolete = "The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'OffsetString' instead.";
+
+        /// <summary>
+        ///   The message text detailing numeric offset deprecation.
+        /// </summary>
+        ///
+        public const string LongOffsetOffsetParameterObsolete = "The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.";
+
+        /// <summary>
+        ///   The message text detailing numeric offset deprecation.
+        /// </summary>
+        ///
+        public const string LongLastEnqueuedOffsetOffsetObsolete = "The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'LastEnqueuedOffsetString' instead.";
+
+        /// <summary>
+        ///   The message text detailing numeric offset deprecation for the checkpoint-related operations.
+        /// </summary>
+        ///
+        public const string LongOffsetCheckpointObsolete = "The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset instead.";
+
+        /// <summary>
+        ///   The message text detailing numeric offset deprecation for the checkpoint-related operations.
+        /// </summary>
+        ///
+        public const string LongOffsetUpdateCheckpointObsolete = "The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.";
+
+        /// <summary>
+        ///   The message text detailing numeric offset deprecation when positioning readers.
+        /// </summary>
+        ///
+        public const string LongOffsetEventPositionObsolete = "The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Reading events using a numeric offset may not work in all cases going forward. Please use a string-based offset instead.";
+
+        /// <summary>
+        ///   The message text detailing sequence-only checkpoints for processors.
+        /// </summary>
+        ///
+        public const string SequenceNumberOnlyCheckpointObsolete = "The Event Hubs service does not guarantee that a sequence number-only checkpoint can access the event stream for all resource configurations.  Reading events may not work in all cases going forward. Please provide a string-based offset.";
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -848,6 +848,17 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to WARNING: A processor for a geo-replication-enabled Event Hub is trying to write a checkpoint without an offset.  Readers of geo-replicated Event Hubs cannot be positioned without an offset..
+        /// </summary>
+        internal static string ProcessorAttemptingToWriteCheckpointWithoutOffset
+        {
+            get
+            {
+                return ResourceManager.GetString("ProcessorLoadBalancingCycleSlowMask", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to WARNING: The 'PartitionOwnershipExpirationInterval' and 'LoadBalancingUpdateInterval' are configured for intervals that may cause stability issues with partition ownership.  It is recommended that the 'PartitionOwnershipExpirationInterval' be at least 3 times greater than the 'LoadBalancingUpdateInterval' and very strongly advised that it should be no less than twice as long.  It is advised to adjust the intervals in the processor options.  Load Balancing Interval '{1:0:00}' seconds.  Partition Ownership Interval '{1:0:00}' seconds..
         /// </summary>
         internal static string ProcessorLoadBalancingIntervalsTooCloseMask
@@ -921,6 +932,28 @@ namespace Azure.Messaging.EventHubs
             get
             {
                 return ResourceManager.GetString("BufferedProducerStartupTimeout", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Event Hubs services does not return a numeric offset for GeoDR-enabled namespaces.  Please use 'OffsetString' instead..
+        /// </summary>
+        internal static string LongOffsetOffsetUnsupported
+        {
+            get
+            {
+                return ResourceManager.GetString("LongOffsetOffsetUnsupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Event Hubs services does not return a numeric offset for GeoDR-enabled namespaces.  Please use 'LastEnqueuedOffsetString' instead..
+        /// </summary>
+        internal static string LongLastEnqueuedOffsetOffsetUnsupported
+        {
+            get
+            {
+                return ResourceManager.GetString("LongLastEnqueuedOffsetOffsetUnsupported", resourceCulture);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -350,5 +350,14 @@
   </data>
   <data name="ProcessorLoadBalancingFatalErrorMask" xml:space="preserve">
     <value>FATAL: The processor has experienced a fatal error in its load balancing and health check task.  Recovery is NOT possible; the processor is shutting down.  Error message: {0}</value>
+  </data>
+  <data name="ProcessorAttemptingToWriteCheckpointWithoutOffset" xml:space="preserve">
+    <value>WARNING: A processor for a geo-replication-enabled Event Hub is trying to write a checkpoint without an offset.  Readers of geo-replicated Event Hubs cannot be positioned without an offset.</value>
+  </data>
+  <data name="LongOffsetOffsetUnsupported" xml:space="preserve">
+    <value>The Event Hubs services does not return a numeric offset for GeoDR-enabled namespaces.  Please use 'OffsetString' instead.</value>
+  </data>
+  <data name="LongLastEnqueuedOffsetOffsetUnsupported" xml:space="preserve">
+    <value>The Event Hubs services does not return a numeric offset for GeoDR-enabled namespaces.  Please use 'LastEnqueuedOffsetString' instead.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventDataExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventDataExtensions.cs
@@ -65,7 +65,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // Verify that the stand-alone system properties are equivalent.
 
             if ((considerSystemProperties)
-                && ((instance.Offset != other.Offset)
+                && ((instance.OffsetString != other.OffsetString)
                     || (instance.EnqueuedTime != other.EnqueuedTime)
                     || (instance.PartitionKey != other.PartitionKey)
                     || (instance.SequenceNumber != other.SequenceNumber)))

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/MockEventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/MockEventData.cs
@@ -29,9 +29,15 @@ namespace Azure.Messaging.EventHubs.Tests
                              IDictionary<string, object> properties = null,
                              IReadOnlyDictionary<string, object> systemProperties = null,
                              long sequenceNumber = long.MinValue,
-                             long offset = long.MinValue,
+                             string offset = null,
                              DateTimeOffset enqueuedTime = default,
-                             string partitionKey = null) : base(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey)
+                             string partitionKey = null) : base(BinaryData.FromBytes(eventBody),
+                                                                properties,
+                                                                systemProperties,
+                                                                sequenceNumber,
+                                                                offset,
+                                                                enqueuedTime,
+                                                                partitionKey)
         {
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStoreInternal.Diagnostics.cs
@@ -87,7 +87,6 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
@@ -97,10 +96,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           string replicationSegment,
                                            string offset,
                                            Exception exception) =>
-            Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset, exception.Message);
+            Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, offset, exception.Message);
 
         /// <summary>
         ///   Indicates that an attempt to update a checkpoint has completed.
@@ -112,7 +110,6 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         partial void UpdateCheckpointComplete(string partitionId,
@@ -121,9 +118,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                                               string consumerGroup,
                                               string clientIdentifier,
                                               string sequenceNumber,
-                                              string replicationSegment,
                                               string offset) =>
-            Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
+            Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, offset);
 
         /// <summary>
         ///   Indicates that an attempt to create/update a checkpoint has started.
@@ -135,7 +131,6 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         partial void UpdateCheckpointStart(string partitionId,
@@ -144,9 +139,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                                            string consumerGroup,
                                            string clientIdentifier,
                                            string sequenceNumber,
-                                           string replicationSegment,
                                            string offset) =>
-            Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, replicationSegment, offset);
+            Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, clientIdentifier, sequenceNumber, offset);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve claim partition ownership has completed.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
@@ -116,7 +116,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
@@ -126,7 +125,6 @@ namespace Azure.Messaging.EventHubs.Tests
                                    string consumerGroup,
                                    string clientIdentifier,
                                    string sequenceNumber,
-                                   string replicationSegment,
                                    string offset,
                                    string exception);
 
@@ -140,7 +138,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         void UpdateCheckpointComplete(string partitionId,
@@ -149,7 +146,6 @@ namespace Azure.Messaging.EventHubs.Tests
                                       string consumerGroup,
                                       string clientIdentifier,
                                       string sequenceNumber,
-                                      string replicationSegment,
                                       string offset);
 
         /// <summary>
@@ -162,7 +158,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="clientIdentifier">The unique identifier of the client that authored this checkpoint.</param>
         /// <param name="sequenceNumber">The sequence number associated with this checkpoint.</param>
-        /// <param name="replicationSegment">The replication segment associated with this checkpoint.</param>
         /// <param name="offset">The offset associated with this checkpoint.</param>
         ///
         void UpdateCheckpointStart(string partitionId,
@@ -171,7 +166,6 @@ namespace Azure.Messaging.EventHubs.Tests
                                    string consumerGroup,
                                    string clientIdentifier,
                                    string sequenceNumber,
-                                   string replicationSegment,
                                    string offset);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/EventDataExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/EventDataExtensionsTests.cs
@@ -39,13 +39,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var firstEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
             var secondEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },
-                offset: 111,
+                offset: "111",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
@@ -62,13 +62,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var firstEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
             var secondEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
@@ -85,13 +85,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var firstEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
             var secondEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },
-                offset: 1,
+                offset: "1",
                 partitionKey: "goodbye",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
@@ -285,8 +285,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void IsEquivalentToDetectsDifferentTypedSystemProperties()
         {
             var body = new byte[] { 0x22, 0x44, 0x88 };
-            var firstEvent = new MockEventData((byte[])body.Clone(), offset: 1);
-            var secondEvent = new MockEventData((byte[])body.Clone(), offset: 2);
+            var firstEvent = new MockEventData((byte[])body.Clone(), offset: "1");
+            var secondEvent = new MockEventData((byte[])body.Clone(), offset: "2");
 
             Assert.That(firstEvent.IsEquivalentTo(secondEvent, true), Is.False);
         }
@@ -380,13 +380,13 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var firstEvent = new MockEventData(
                 eventBody: (byte[])body.Clone(),
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
             var secondEvent = new MockEventData(
                 eventBody: (byte[])body.Clone(),
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
@@ -405,13 +405,13 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var firstEvent = new MockEventData(
                 eventBody: (byte[])body.Clone(),
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
             var secondEvent = new MockEventData(
                 eventBody: (byte[])body.Clone(),
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
@@ -428,7 +428,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var firstEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44, 0x88 },
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
@@ -456,7 +456,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var firstEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44, 0x88 },
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
@@ -473,7 +473,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var firstEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44, 0x88 },
-                offset: 1,
+                offset: "1",
                 partitionKey: "hello",
                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
@@ -493,9 +493,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                  IDictionary<string, object> properties = null,
                                  IReadOnlyDictionary<string, object> systemProperties = null,
                                  long sequenceNumber = long.MinValue,
-                                 long offset = long.MinValue,
+                                 string offset = null,
                                  DateTimeOffset enqueuedTime = default,
-                                 string partitionKey = null) : base(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey)
+                                 string partitionKey = null) : base(BinaryData.FromBytes(eventBody), properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey)
             {
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/InMemoryCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/InMemoryCheckpointStoreTests.cs
@@ -432,8 +432,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var storageManager = new InMemoryCheckpointStore();
 
-            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName", "consumerGroup1", "partitionId", "Id", new CheckpointPosition(10));
-            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName", "consumerGroup2", "partitionId", "Id", new CheckpointPosition(10));
+            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName", "consumerGroup1", "partitionId", "Id", new CheckpointPosition("10"));
+            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName", "consumerGroup2", "partitionId", "Id", new CheckpointPosition("444", 10));
 
             var storedCheckpoint1 = await storageManager.GetCheckpointAsync("namespace", "eventHubName", "consumerGroup1", "partitionId");
             var storedCheckpoint2 = await storageManager.GetCheckpointAsync("namespace", "eventHubName", "consumerGroup2", "partitionId");
@@ -452,8 +452,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var storageManager = new InMemoryCheckpointStore();
 
-            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName1", "consumerGroup", "partitionId", "Id", new CheckpointPosition(10));
-            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName2", "consumerGroup", "partitionId", "Id", new CheckpointPosition(10));
+            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName1", "consumerGroup", "partitionId", "Id", new CheckpointPosition("10"));
+            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName2", "consumerGroup", "partitionId", "Id", new CheckpointPosition("444", 10));
 
             var storedCheckpoint1 = await storageManager.GetCheckpointAsync("namespace", "eventHubName1", "consumerGroup", "partitionId");
             var storedCheckpoint2 = await storageManager.GetCheckpointAsync("namespace", "eventHubName2", "consumerGroup", "partitionId");
@@ -472,8 +472,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var storageManager = new InMemoryCheckpointStore();
 
-            await storageManager.UpdateCheckpointAsync("namespace1", "eventHubName", "consumerGroup", "partitionId", "Id", new CheckpointPosition(10));
-            await storageManager.UpdateCheckpointAsync("namespace2", "eventHubName", "consumerGroup", "partitionId", "Id", new CheckpointPosition(10));
+            await storageManager.UpdateCheckpointAsync("namespace1", "eventHubName", "consumerGroup", "partitionId", "Id", new CheckpointPosition("10"));
+            await storageManager.UpdateCheckpointAsync("namespace2", "eventHubName", "consumerGroup", "partitionId", "Id", new CheckpointPosition("444", 10));
 
             var storedCheckpoint1 = await storageManager.GetCheckpointAsync("namespace1", "eventHubName", "consumerGroup", "partitionId");
             var storedCheckpoint2 = await storageManager.GetCheckpointAsync("namespace2", "eventHubName", "consumerGroup", "partitionId");
@@ -492,8 +492,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var storageManager = new InMemoryCheckpointStore();
 
-            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName", "consumerGroup", "partitionId1", "Id", new CheckpointPosition(10));
-            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName", "consumerGroup", "partitionId2", "Id", new CheckpointPosition(10));
+            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName", "consumerGroup", "partitionId1", "Id", new CheckpointPosition("111", 10));
+            await storageManager.UpdateCheckpointAsync("namespace", "eventHubName", "consumerGroup", "partitionId2", "Id", new CheckpointPosition("9"));
 
             var storedCheckpoint1 = await storageManager.GetCheckpointAsync("namespace", "eventHubName", "consumerGroup", "partitionId1");
             var storedCheckpoint2 = await storageManager.GetCheckpointAsync("namespace", "eventHubName", "consumerGroup", "partitionId2");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.net8.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.net8.0.cs
@@ -6,9 +6,13 @@ namespace Azure.Messaging.EventHubs
         public EventData(Azure.Core.Amqp.AmqpAnnotatedMessage amqpMessage) { }
         public EventData(System.BinaryData eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         protected EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, string offsetString = null, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
         public EventData(System.ReadOnlyMemory<byte> eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.")]
         protected EventData(System.ReadOnlyMemory<byte> eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
         public EventData(string eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -26,7 +30,10 @@ namespace Azure.Messaging.EventHubs
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool IsReadOnly { get { throw null; } }
         public string MessageId { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'OffsetString' instead.", false)]
         public long Offset { get { throw null; } }
+        public string OffsetString { get { throw null; } }
         public string PartitionKey { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
         public long SequenceNumber { get { throw null; } }
@@ -80,8 +87,11 @@ namespace Azure.Messaging.EventHubs
     }
     public partial class EventHubProperties
     {
-        protected internal EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds) { }
+        protected internal EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds, bool isGeoReplicationEnabled) { }
         public System.DateTimeOffset CreatedOn { get { throw null; } }
+        public bool IsGeoReplicationEnabled { get { throw null; } }
         public string Name { get { throw null; } }
         public string[] PartitionIds { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -139,14 +149,26 @@ namespace Azure.Messaging.EventHubs
     }
     public static partial class EventHubsModelFactory
     {
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         public static Azure.Messaging.EventHubs.EventData EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, string partitionKey = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset)) { throw null; }
+        public static Azure.Messaging.EventHubs.EventData EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, string partitionKey = null, long sequenceNumber = (long)-9223372036854775808, string offsetString = null, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset)) { throw null; }
         public static Azure.Messaging.EventHubs.Producer.EventDataBatch EventDataBatch(long batchSizeBytes, System.Collections.Generic.IList<Azure.Messaging.EventHubs.EventData> batchEventStore, Azure.Messaging.EventHubs.Producer.CreateBatchOptions batchOptions = null, System.Func<Azure.Messaging.EventHubs.EventData, bool> tryAddCallback = null) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Messaging.EventHubs.EventHubProperties EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static Azure.Messaging.EventHubs.EventHubProperties EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds, bool isGeoReplicationEnabled) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         public static Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties LastEnqueuedEventProperties(long? lastSequenceNumber, long? lastOffset, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
+        public static Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties LastEnqueuedEventProperties(long? lastSequenceNumber, string lastOffsetString, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Messaging.EventHubs.Consumer.PartitionContext PartitionContext(string partitionId, Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties lastEnqueuedEventProperties = default(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties)) { throw null; }
         public static Azure.Messaging.EventHubs.Consumer.PartitionContext PartitionContext(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties lastEnqueuedEventProperties = default(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         public static Azure.Messaging.EventHubs.PartitionProperties PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, long lastOffset, System.DateTimeOffset lastEnqueuedTime) { throw null; }
+        public static Azure.Messaging.EventHubs.PartitionProperties PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, string lastOffsetString, System.DateTimeOffset lastEnqueuedTime) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Messaging.EventHubs.Producer.PartitionPublishingProperties PartitionPublishingProperties(bool isIdempotentPublishingEnabled, long? producerGroupId, short? ownerLevel, int? lastPublishedSequenceNumber) { throw null; }
     }
@@ -184,12 +206,18 @@ namespace Azure.Messaging.EventHubs
     }
     public partial class PartitionProperties
     {
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         protected internal PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, long lastOffset, System.DateTimeOffset lastEnqueuedTime) { }
+        protected internal PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, string lastOffsetString, System.DateTimeOffset lastEnqueuedTime) { }
         public long BeginningSequenceNumber { get { throw null; } }
         public string EventHubName { get { throw null; } }
         public string Id { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'LastEnqueuedOffsetString' instead.", false)]
         public long LastEnqueuedOffset { get { throw null; } }
+        public string LastEnqueuedOffsetString { get { throw null; } }
         public long LastEnqueuedSequenceNumber { get { throw null; } }
         public System.DateTimeOffset LastEnqueuedTime { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -260,7 +288,10 @@ namespace Azure.Messaging.EventHubs.Consumer
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         public static Azure.Messaging.EventHubs.Consumer.EventPosition FromEnqueuedTime(System.DateTimeOffset enqueuedTime) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Reading events using a numeric offset may not work in all cases going forward. Please use a string-based offset instead.", false)]
         public static Azure.Messaging.EventHubs.Consumer.EventPosition FromOffset(long offset, bool isInclusive = true) { throw null; }
+        public static Azure.Messaging.EventHubs.Consumer.EventPosition FromOffset(string offsetString, bool isInclusive = true) { throw null; }
         public static Azure.Messaging.EventHubs.Consumer.EventPosition FromSequenceNumber(long sequenceNumber, bool isInclusive = true) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
@@ -271,11 +302,21 @@ namespace Azure.Messaging.EventHubs.Consumer
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct LastEnqueuedEventProperties : System.IEquatable<Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties>
     {
+        private object _dummy;
         private int _dummyPrimitive;
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
+        public LastEnqueuedEventProperties(long? lastSequenceNumber, long lastOffset, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         public LastEnqueuedEventProperties(long? lastSequenceNumber, long? lastOffset, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
+        public LastEnqueuedEventProperties(long? lastSequenceNumber, string lastOffsetString, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
         public System.DateTimeOffset? EnqueuedTime { get { throw null; } }
         public System.DateTimeOffset? LastReceivedTime { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'OffsetString' instead.", false)]
         public long? Offset { get { throw null; } }
+        public string OffsetString { get { throw null; } }
         public long? SequenceNumber { get { throw null; } }
         public bool Equals(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -332,6 +373,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ClaimOwnershipAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership> desiredOwnership, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task<Azure.Messaging.EventHubs.Primitives.EventProcessorCheckpoint> GetCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ListOwnershipAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, System.Threading.CancellationToken cancellationToken);
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         public virtual System.Threading.Tasks.Task UpdateCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task UpdateCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, string clientIdentifier, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
@@ -394,6 +437,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string ConsumerGroup { get { throw null; } }
         protected bool EnableBatchTracing { get { throw null; } set { } }
         public string EventHubName { get { throw null; } }
+        protected Azure.Messaging.EventHubs.EventHubProperties EventHubProperties { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
         public string Identifier { get { throw null; } }
         public bool IsRunning { get { throw null; } protected set { } }
@@ -421,6 +465,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
         protected virtual System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         protected virtual System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected internal virtual System.Threading.Tasks.Task ValidateProcessingPreconditions(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
@@ -483,6 +529,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         protected override System.Threading.Tasks.Task<Azure.Messaging.EventHubs.Primitives.EventProcessorCheckpoint> GetCheckpointAsync(string partitionId, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ListOwnershipAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         protected override System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 }
@@ -491,8 +539,19 @@ namespace Azure.Messaging.EventHubs.Processor
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CheckpointPosition : System.IEquatable<Azure.Messaging.EventHubs.Processor.CheckpointPosition>
     {
+        private object _dummy;
         private int _dummyPrimitive;
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee that a sequence number-only checkpoint can access the event stream for all resource configurations.  Reading events may not work in all cases going forward. Please provide a string-based offset.", false)]
         public CheckpointPosition(long sequenceNumber) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset instead.", false)]
+        public CheckpointPosition(long offset, long sequenceNumber = (long)-9223372036854775808) { throw null; }
+        public CheckpointPosition(string offsetString, long sequenceNumber = (long)-9223372036854775808) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'OffsetString' instead.", false)]
+        public long Offset { get { throw null; } }
+        public string OffsetString { get { throw null; } }
         public long SequenceNumber { get { throw null; } }
         public bool Equals(Azure.Messaging.EventHubs.Processor.CheckpointPosition other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -6,9 +6,13 @@ namespace Azure.Messaging.EventHubs
         public EventData(Azure.Core.Amqp.AmqpAnnotatedMessage amqpMessage) { }
         public EventData(System.BinaryData eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         protected EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, string offsetString = null, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
         public EventData(System.ReadOnlyMemory<byte> eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.")]
         protected EventData(System.ReadOnlyMemory<byte> eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
         public EventData(string eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -26,7 +30,10 @@ namespace Azure.Messaging.EventHubs
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool IsReadOnly { get { throw null; } }
         public string MessageId { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'OffsetString' instead.", false)]
         public long Offset { get { throw null; } }
+        public string OffsetString { get { throw null; } }
         public string PartitionKey { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
         public long SequenceNumber { get { throw null; } }
@@ -80,8 +87,11 @@ namespace Azure.Messaging.EventHubs
     }
     public partial class EventHubProperties
     {
-        protected internal EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds) { }
+        protected internal EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds, bool isGeoReplicationEnabled) { }
         public System.DateTimeOffset CreatedOn { get { throw null; } }
+        public bool IsGeoReplicationEnabled { get { throw null; } }
         public string Name { get { throw null; } }
         public string[] PartitionIds { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -139,14 +149,26 @@ namespace Azure.Messaging.EventHubs
     }
     public static partial class EventHubsModelFactory
     {
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         public static Azure.Messaging.EventHubs.EventData EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, string partitionKey = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset)) { throw null; }
+        public static Azure.Messaging.EventHubs.EventData EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, string partitionKey = null, long sequenceNumber = (long)-9223372036854775808, string offsetString = null, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset)) { throw null; }
         public static Azure.Messaging.EventHubs.Producer.EventDataBatch EventDataBatch(long batchSizeBytes, System.Collections.Generic.IList<Azure.Messaging.EventHubs.EventData> batchEventStore, Azure.Messaging.EventHubs.Producer.CreateBatchOptions batchOptions = null, System.Func<Azure.Messaging.EventHubs.EventData, bool> tryAddCallback = null) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Messaging.EventHubs.EventHubProperties EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static Azure.Messaging.EventHubs.EventHubProperties EventHubProperties(string name, System.DateTimeOffset createdOn, string[] partitionIds, bool isGeoReplicationEnabled) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         public static Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties LastEnqueuedEventProperties(long? lastSequenceNumber, long? lastOffset, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
+        public static Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties LastEnqueuedEventProperties(long? lastSequenceNumber, string lastOffsetString, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Messaging.EventHubs.Consumer.PartitionContext PartitionContext(string partitionId, Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties lastEnqueuedEventProperties = default(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties)) { throw null; }
         public static Azure.Messaging.EventHubs.Consumer.PartitionContext PartitionContext(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties lastEnqueuedEventProperties = default(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         public static Azure.Messaging.EventHubs.PartitionProperties PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, long lastOffset, System.DateTimeOffset lastEnqueuedTime) { throw null; }
+        public static Azure.Messaging.EventHubs.PartitionProperties PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, string lastOffsetString, System.DateTimeOffset lastEnqueuedTime) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Messaging.EventHubs.Producer.PartitionPublishingProperties PartitionPublishingProperties(bool isIdempotentPublishingEnabled, long? producerGroupId, short? ownerLevel, int? lastPublishedSequenceNumber) { throw null; }
     }
@@ -184,12 +206,18 @@ namespace Azure.Messaging.EventHubs
     }
     public partial class PartitionProperties
     {
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         protected internal PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, long lastOffset, System.DateTimeOffset lastEnqueuedTime) { }
+        protected internal PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, string lastOffsetString, System.DateTimeOffset lastEnqueuedTime) { }
         public long BeginningSequenceNumber { get { throw null; } }
         public string EventHubName { get { throw null; } }
         public string Id { get { throw null; } }
         public bool IsEmpty { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'LastEnqueuedOffsetString' instead.", false)]
         public long LastEnqueuedOffset { get { throw null; } }
+        public string LastEnqueuedOffsetString { get { throw null; } }
         public long LastEnqueuedSequenceNumber { get { throw null; } }
         public System.DateTimeOffset LastEnqueuedTime { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -260,7 +288,10 @@ namespace Azure.Messaging.EventHubs.Consumer
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         public static Azure.Messaging.EventHubs.Consumer.EventPosition FromEnqueuedTime(System.DateTimeOffset enqueuedTime) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Reading events using a numeric offset may not work in all cases going forward. Please use a string-based offset instead.", false)]
         public static Azure.Messaging.EventHubs.Consumer.EventPosition FromOffset(long offset, bool isInclusive = true) { throw null; }
+        public static Azure.Messaging.EventHubs.Consumer.EventPosition FromOffset(string offsetString, bool isInclusive = true) { throw null; }
         public static Azure.Messaging.EventHubs.Consumer.EventPosition FromSequenceNumber(long sequenceNumber, bool isInclusive = true) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
@@ -271,10 +302,21 @@ namespace Azure.Messaging.EventHubs.Consumer
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct LastEnqueuedEventProperties : System.IEquatable<Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties>
     {
+        private object _dummy;
+        private int _dummyPrimitive;
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
+        public LastEnqueuedEventProperties(long? lastSequenceNumber, long lastOffset, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use the overload with a string-based offset instead.", false)]
         public LastEnqueuedEventProperties(long? lastSequenceNumber, long? lastOffset, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
+        public LastEnqueuedEventProperties(long? lastSequenceNumber, string lastOffsetString, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
         public System.DateTimeOffset? EnqueuedTime { get { throw null; } }
         public System.DateTimeOffset? LastReceivedTime { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'OffsetString' instead.", false)]
         public long? Offset { get { throw null; } }
+        public string OffsetString { get { throw null; } }
         public long? SequenceNumber { get { throw null; } }
         public bool Equals(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -331,6 +373,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ClaimOwnershipAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership> desiredOwnership, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task<Azure.Messaging.EventHubs.Primitives.EventProcessorCheckpoint> GetCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ListOwnershipAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, System.Threading.CancellationToken cancellationToken);
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         public virtual System.Threading.Tasks.Task UpdateCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task UpdateCheckpointAsync(string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string partitionId, string clientIdentifier, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
@@ -393,6 +437,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string ConsumerGroup { get { throw null; } }
         protected bool EnableBatchTracing { get { throw null; } set { } }
         public string EventHubName { get { throw null; } }
+        protected Azure.Messaging.EventHubs.EventHubProperties EventHubProperties { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
         public string Identifier { get { throw null; } }
         public bool IsRunning { get { throw null; } protected set { } }
@@ -420,6 +465,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
         protected virtual System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         protected virtual System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected internal virtual System.Threading.Tasks.Task ValidateProcessingPreconditions(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
@@ -482,6 +529,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         protected override System.Threading.Tasks.Task<Azure.Messaging.EventHubs.Primitives.EventProcessorCheckpoint> GetCheckpointAsync(string partitionId, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ListOwnershipAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, Azure.Messaging.EventHubs.Processor.CheckpointPosition startingPosition, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset via the overload accepting 'CheckpointPosition' instead.", false)]
         protected override System.Threading.Tasks.Task UpdateCheckpointAsync(string partitionId, long offset, long? sequenceNumber, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 }
@@ -490,8 +539,19 @@ namespace Azure.Messaging.EventHubs.Processor
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CheckpointPosition : System.IEquatable<Azure.Messaging.EventHubs.Processor.CheckpointPosition>
     {
+        private object _dummy;
         private int _dummyPrimitive;
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee that a sequence number-only checkpoint can access the event stream for all resource configurations.  Reading events may not work in all cases going forward. Please provide a string-based offset.", false)]
         public CheckpointPosition(long sequenceNumber) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Checkpoints created from a numeric offset may not work in all cases going forward. Please use a string-based offset instead.", false)]
+        public CheckpointPosition(long offset, long sequenceNumber = (long)-9223372036854775808) { throw null; }
+        public CheckpointPosition(string offsetString, long sequenceNumber = (long)-9223372036854775808) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("The Event Hubs service does not guarantee a numeric offset for all resource configurations.  Please use 'OffsetString' instead.", false)]
+        public long Offset { get { throw null; } }
+        public string OffsetString { get { throw null; } }
         public long SequenceNumber { get { throw null; } }
         public bool Equals(Azure.Messaging.EventHubs.Processor.CheckpointPosition other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_EventHubMetadata.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_EventHubMetadata.md
@@ -100,7 +100,7 @@ try
     Debug.WriteLine($"\tThe partition contains no events: { partitionProperties.IsEmpty }");
     Debug.WriteLine($"\tThe first sequence number is: { partitionProperties.BeginningSequenceNumber }");
     Debug.WriteLine($"\tThe last sequence number is: { partitionProperties.LastEnqueuedSequenceNumber }");
-    Debug.WriteLine($"\tThe last offset is: { partitionProperties.LastEnqueuedOffset }");
+    Debug.WriteLine($"\tThe last offset is: { partitionProperties.LastEnqueuedOffsetString }");
     Debug.WriteLine($"\tThe last enqueued time is: { partitionProperties.LastEnqueuedTime }, in UTC.");
 }
 finally

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_ReadingEvents.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_ReadingEvents.md
@@ -386,7 +386,7 @@ try
 
     string firstPartition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
     PartitionProperties properties = await consumer.GetPartitionPropertiesAsync(firstPartition, cancellationSource.Token);
-    EventPosition startingPosition = EventPosition.FromOffset(properties.LastEnqueuedOffset);
+    EventPosition startingPosition = EventPosition.FromOffset(properties.LastEnqueuedOffsetString);
 
     await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync(
         firstPartition,
@@ -503,7 +503,7 @@ try
 
         Debug.WriteLine($"Partition: { partitionEvent.Partition.PartitionId }");
         Debug.WriteLine($"\tThe last sequence number is: { properties.SequenceNumber }");
-        Debug.WriteLine($"\tThe last offset is: { properties.Offset }");
+        Debug.WriteLine($"\tThe last offset is: { properties.OffsetString }");
         Debug.WriteLine($"\tThe last enqueued time is: { properties.EnqueuedTime }, in UTC.");
         Debug.WriteLine($"\tThe information was updated at: { properties.LastReceivedTime }, in UTC.");
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_MockingClientTypes.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_MockingClientTypes.md
@@ -220,7 +220,7 @@ Mock<EventHubConsumerClient> mockConsumer = new();
 
 LastEnqueuedEventProperties lastEnqueueEventProperties = EventHubsModelFactory.LastEnqueuedEventProperties(
     lastSequenceNumber : 1234,
-    lastOffset : 234,
+    lastOffsetString : "234:1:954-2",
     lastEnqueuedTime : DateTimeOffset.Parse("1:24 AM"),
     lastReceivedTime : DateTimeOffset.Parse("1:26 AM"));
 
@@ -246,7 +246,7 @@ async IAsyncEnumerable<PartitionEvent> mockReturn()
         systemProperties: new Dictionary<string, object>(), //arbitrary value
         partitionKey: "sample-key",
         sequenceNumber: 1000,
-        offset: 1500,
+        offsetString: "1500:44:59492",
         enqueuedTime: DateTimeOffset.Parse("11:36 PM"));
 
     EventData eventData2 = EventHubsModelFactory.EventData(
@@ -254,7 +254,7 @@ async IAsyncEnumerable<PartitionEvent> mockReturn()
         systemProperties: new Dictionary<string, object>(), //arbitrary value
         partitionKey: "sample-key",
         sequenceNumber: 1000,
-        offset: 1500,
+        offsetString: "1500:2:1111",
         enqueuedTime: DateTimeOffset.Parse("11:36 PM"));
 
     // This creates a mock PartitionEvent to return from the consumer client.
@@ -341,7 +341,7 @@ for (int index = 0; index < 10; index++)
         systemProperties: new Dictionary<string, object>(), //arbitrary value
         partitionKey: $"sample-key-{index}",
         sequenceNumber: 1234,
-        offset: 234,
+        offsetString: "234:5:93928381.1",
         enqueuedTime: DateTimeOffset.Parse("9:25 AM"));
 
     receivedEvents.Add(eventData);
@@ -431,7 +431,7 @@ Dictionary<string, PartitionProperties> partitionProperties = new()
         isEmpty : true,
         beginningSequenceNumber: 1000,
         lastSequenceNumber : 1100,
-        lastOffset : 500,
+        lastOffsetString : "500:1:7863",
         lastEnqueuedTime : DateTime.UtcNow) },
 
     // Empty partition
@@ -441,7 +441,7 @@ Dictionary<string, PartitionProperties> partitionProperties = new()
         isEmpty : false,
         beginningSequenceNumber : 2000,
         lastSequenceNumber : 2000,
-        lastOffset : 760,
+        lastOffsetString : "760:1:8800",
         lastEnqueuedTime : DateTime.UtcNow) }
 };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
@@ -33,11 +33,11 @@ namespace Azure.Messaging.EventHubs.Amqp
         public static void PopulateFromEventProperties(this AmqpAnnotatedMessage instance,
                                                        IDictionary<string, object> properties = null,
                                                        long? sequenceNumber = null,
-                                                       long? offset = null,
+                                                       string offset = null,
                                                        DateTimeOffset? enqueuedTime = null,
                                                        string partitionKey = null,
                                                        long? lastPartitionSequenceNumber = null,
-                                                       long? lastPartitionOffset = null,
+                                                       string lastPartitionOffset = null,
                                                        DateTimeOffset? lastPartitionEnqueuedTime = null,
                                                        DateTimeOffset? lastPartitionPropertiesRetrievalTime = null)
         {
@@ -51,9 +51,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                instance.MessageAnnotations[AmqpProperty.SequenceNumber.ToString()] = sequenceNumber.Value;
            }
 
-           if (offset.HasValue)
+           if (!string.IsNullOrEmpty(offset))
            {
-               instance.MessageAnnotations[AmqpProperty.Offset.ToString()] = offset.Value;
+               instance.MessageAnnotations[AmqpProperty.Offset.ToString()] = offset;
            }
 
            if (enqueuedTime.HasValue)
@@ -71,9 +71,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                instance.DeliveryAnnotations[AmqpProperty.PartitionLastEnqueuedSequenceNumber.ToString()] = lastPartitionSequenceNumber.Value;
            }
 
-           if (lastPartitionOffset.HasValue)
+           if (!string.IsNullOrEmpty(lastPartitionOffset))
            {
-               instance.DeliveryAnnotations[AmqpProperty.PartitionLastEnqueuedOffset.ToString()] = lastPartitionOffset.Value;
+               instance.DeliveryAnnotations[AmqpProperty.PartitionLastEnqueuedOffset.ToString()] = lastPartitionOffset;
            }
 
            if (lastPartitionEnqueuedTime.HasValue)
@@ -188,13 +188,13 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <returns>The offset, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
         ///
-        public static long GetOffset(this AmqpAnnotatedMessage instance,
-                                     long defaultValue = long.MinValue)
+        public static string GetOffset(this AmqpAnnotatedMessage instance,
+                                       string defaultValue = default)
         {
             if ((instance.HasSection(AmqpMessageSection.MessageAnnotations))
                 && (instance.MessageAnnotations.TryGetValue(AmqpProperty.Offset.ToString(), out var value)))
             {
-                return (long)value;
+                return (string)value;
             }
 
             return defaultValue;
@@ -298,13 +298,13 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <returns>The offset of the last event published to the partition, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
         ///
-        public static long? GetLastPartitionOffset(this AmqpAnnotatedMessage instance,
-                                                   long? defaultValue = default)
+        public static string GetLastPartitionOffset(this AmqpAnnotatedMessage instance,
+                                                   string defaultValue = default)
         {
             if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
                 && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.PartitionLastEnqueuedOffset.ToString(), out var value)))
             {
-                return (long)value;
+                return (string)value;
             }
 
             return defaultValue;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -702,6 +702,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                     linkSettings.AddProperty(AmqpProperty.ConsumerIdentifier, linkIdentifier);
                 }
 
+                linkSettings.DesiredCapabilities ??= new Multiple<AmqpSymbol>();
+                linkSettings.DesiredCapabilities.Add(AmqpProperty.GeoReplication);
+
                 if (trackLastEnqueuedEventProperties)
                 {
                     linkSettings.DesiredCapabilities ??= new Multiple<AmqpSymbol>();
@@ -806,6 +809,9 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 linkSettings.AddProperty(AmqpProperty.Timeout, (uint)linkTimeout.CalculateRemaining(stopWatch.GetElapsedTime()).TotalMilliseconds);
                 linkSettings.AddProperty(AmqpProperty.EntityType, (int)AmqpProperty.Entity.EventHub);
+
+                linkSettings.DesiredCapabilities ??= new Multiple<AmqpSymbol>();
+                linkSettings.DesiredCapabilities.Add(AmqpProperty.GeoReplication);
 
                 if ((features & TransportProducerFeatures.IdempotentPublishing) != 0)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -297,9 +297,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                             firstReceivedEvent = receivedEvents[0];
                             lastReceivedEvent = receivedEvents[receivedEventCount - 1];
 
-                            if (lastReceivedEvent.Offset > long.MinValue)
+                            if (!string.IsNullOrEmpty(lastReceivedEvent.OffsetString))
                             {
-                                CurrentEventPosition = EventPosition.FromOffset(lastReceivedEvent.Offset, false);
+                                CurrentEventPosition = EventPosition.FromOffset(lastReceivedEvent.OffsetString, false);
                             }
 
                             if (TrackLastEnqueuedEventProperties)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpFilter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpFilter.cs
@@ -57,9 +57,9 @@ namespace Azure.Messaging.EventHubs
         {
             // Build the filter expression, in the order of significance.
 
-            if (!string.IsNullOrEmpty(eventPosition.Offset))
+            if (!string.IsNullOrEmpty(eventPosition.OffsetString))
             {
-                return $"{ OffsetName } { (eventPosition.IsInclusive ? ">=" : ">") } { eventPosition.Offset }";
+                return $"{ OffsetName } { (eventPosition.IsInclusive ? ">=" : ">") } { eventPosition.OffsetString }";
             }
 
             if (!string.IsNullOrEmpty(eventPosition.SequenceNumber))
@@ -72,7 +72,7 @@ namespace Azure.Messaging.EventHubs
                 return $"{ EnqueuedTimeName } > { eventPosition.EnqueuedTime.Value.ToUnixTimeMilliseconds() }";
             }
 
-            // If no filter was built, than the event position is not valid for filtering.
+            // If no filter was built, then the event position is not valid for filtering.
 
             throw new ArgumentException(Resources.InvalidEventPositionForFilter, nameof(eventPosition));
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpManagement.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpManagement.cs
@@ -75,6 +75,12 @@ namespace Azure.Messaging.EventHubs
             public static MapKey PartitionIdentifiers { get; } = new MapKey("partition_ids");
 
             /// <summary>
+            ///   The message property that identifies whether this Event Hub has geo-replication enabled.
+            /// </summary>
+            ///
+            public static MapKey GeoReplicationFactor { get; } = new MapKey("georeplication_factor");
+
+            /// <summary>
             ///   The message property that identifies the beginning sequence number in a partition.
             /// </summary>
             ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -39,9 +39,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         private static readonly HashSet<string> SystemPropertyLongKeys = new()
         {
             AmqpProperty.SequenceNumber.ToString(),
-            AmqpProperty.Offset.ToString(),
             AmqpProperty.PartitionLastEnqueuedSequenceNumber.ToString(),
-            AmqpProperty.PartitionLastEnqueuedOffset.ToString()
         };
 
         /// <summary>
@@ -181,10 +179,17 @@ namespace Azure.Messaging.EventHubs.Amqp
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidMessageBody, typeof(AmqpMap).Name));
             }
 
+            var geoReplicationEnabled = responseData[AmqpManagement.ResponseMap.GeoReplicationFactor] switch
+            {
+                int count when count > 1 => true,
+                _ => false
+            };
+
             return new EventHubProperties(
                 (string)responseData[AmqpManagement.ResponseMap.Name],
                 new DateTimeOffset((DateTime)responseData[AmqpManagement.ResponseMap.CreatedAt], TimeSpan.Zero),
-                (string[])responseData[AmqpManagement.ResponseMap.PartitionIdentifiers]);
+                (string[])responseData[AmqpManagement.ResponseMap.PartitionIdentifiers],
+                geoReplicationEnabled);
         }
 
         /// <summary>
@@ -250,7 +255,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 (bool)responseData[AmqpManagement.ResponseMap.PartitionRuntimeInfoPartitionIsEmpty],
                 (long)responseData[AmqpManagement.ResponseMap.PartitionBeginSequenceNumber],
                 (long)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedSequenceNumber],
-                long.Parse((string)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedOffset], NumberStyles.Integer, CultureInfo.InvariantCulture),
+                (string)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedOffset],
                 new DateTimeOffset((DateTime)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedTimeUtc], TimeSpan.Zero));
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
@@ -44,6 +44,12 @@ namespace Azure.Messaging.EventHubs
         public static AmqpSymbol TrackLastEnqueuedEventProperties { get; } = AmqpConstants.Vendor + ":enable-receiver-runtime-metric";
 
         /// <summary>
+        ///   The capability for geo replication in a namespace, to associate with a link.
+        /// </summary>
+        ///
+        public static AmqpSymbol GeoReplication { get; } = AmqpConstants.Vendor + ":georeplication";
+
+        /// <summary>
         ///   The capability for opting-into idempotent publishing.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
     <Version>5.12.0-beta.2</Version>
-    <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
+    <!--The ApiCompatVersion is managed automatically and should not generally be modified manually. -->
     <ApiCompatVersion>5.11.4</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using Azure.Core;
@@ -11,6 +12,7 @@ using Azure.Core.Amqp;
 using Azure.Core.Serialization;
 using Azure.Messaging.EventHubs.Amqp;
 using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
 
 namespace Azure.Messaging.EventHubs
@@ -284,15 +286,44 @@ namespace Azure.Messaging.EventHubs
         public long SequenceNumber => _amqpMessage.GetSequenceNumber(long.MinValue);
 
         /// <summary>
+        ///   Obsolete.
+        ///   A numeric representation of the offset of an event when it was received from the associated Event Hub partition.
+        /// </summary>
+        ///
+        /// <value>
+        ///   This value is obsolete and should no longer be used.  Please use <see cref="OffsetString"/> instead.
+        /// </value>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetOffsetPropertyObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public long Offset
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(OffsetString))
+                {
+                    return long.MinValue;
+                }
+
+                if (long.TryParse(OffsetString, out var value))
+                {
+                    return value;
+                }
+
+                throw new NotSupportedException(Resources.LongOffsetOffsetUnsupported);
+            }
+        }
+
+        /// <summary>
         ///   The offset of the event when it was received from the associated Event Hub partition.
         /// </summary>
         ///
         /// <value>
         ///   This value is read-only and will only be populated for events that have been read from Event Hubs. The default value
-        ///   when not populated is <see cref="long.MinValue"/>.
+        ///   when not populated is <c>null</c>.
         /// </value>
         ///
-        public long Offset => _amqpMessage.GetOffset(long.MinValue);
+        public string OffsetString => _amqpMessage.GetOffset(null);
 
         /// <summary>
         ///   The date and time, in UTC, of when the event was enqueued in the Event Hub partition.
@@ -383,7 +414,7 @@ namespace Azure.Messaging.EventHubs
         ///   populated is <c>null</c>.
         /// </value>
         ///
-        internal long? LastPartitionOffset => _amqpMessage.GetLastPartitionOffset();
+        internal string LastPartitionOffset => _amqpMessage.GetLastPartitionOffset();
 
         /// <summary>
         ///   The date and time, in UTC, that the last event was enqueued into the Event Hub partition from
@@ -553,11 +584,11 @@ namespace Azure.Messaging.EventHubs
                            IDictionary<string, object> properties = null,
                            IReadOnlyDictionary<string, object> systemProperties = null,
                            long? sequenceNumber = null,
-                           long? offset = null,
+                           string offset = null,
                            DateTimeOffset? enqueuedTime = null,
                            string partitionKey = null,
                            long? lastPartitionSequenceNumber = null,
-                           long? lastPartitionOffset = null,
+                           string lastPartitionOffset = null,
                            DateTimeOffset? lastPartitionEnqueuedTime = null,
                            DateTimeOffset? lastPartitionPropertiesRetrievalTime = null,
                            int? publishedSequenceNumber = null,
@@ -603,17 +634,17 @@ namespace Azure.Messaging.EventHubs
         /// <param name="properties">The set of free-form event properties to send with the event.</param>
         /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
         /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
-        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="offsetString">The offset of the event when it was received from the associated Event Hub partition.</param>
         /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
         /// <param name="partitionKey">The partition hashing key associated with the event when it was published.</param>
         ///
         /// <remarks>
-        ///   <para>This constructor has been superseded by the <see cref="EventHubsModelFactory.EventData" /> factory method.
-        ///   It is strongly recommended that the model factory be preferred over use of this constructor.</para>
+        ///   <para>This constructor exists only for backwards compatibility and has been replaced by <see cref="EventHubsModelFactory.EventData(BinaryData, IDictionary{string, object}, IReadOnlyDictionary{string, object}, string, long, string, DateTimeOffset)" />.
+        ///   It should no longer be called.</para>
         ///
         ///   <para>This overload was previously intended for mocking in support of testing efforts.  It is recommended that
         ///   it not be used in production scenarios, as it allows setting of data that is broker-owned and is only
-        ///   meaningful on events that have been read from the Event Hubs service.</para>
+        ///   meaningful on events that have been read from the Event Hubs service.</para>SSS
         /// </remarks>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -621,13 +652,15 @@ namespace Azure.Messaging.EventHubs
                             IDictionary<string, object> properties = null,
                             IReadOnlyDictionary<string, object> systemProperties = null,
                             long sequenceNumber = long.MinValue,
-                            long offset = long.MinValue,
+                            string offsetString = default,
                             DateTimeOffset enqueuedTime = default,
-                            string partitionKey = null) : this(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey, lastPartitionSequenceNumber: null)
+                            string partitionKey = null) : this(eventBody, properties, systemProperties, sequenceNumber, offsetString, enqueuedTime, partitionKey, lastPartitionSequenceNumber: null)
         {
         }
 
         /// <summary>
+        ///   Obsolete.
+        ///
         ///   Initializes a new instance of the <see cref="EventData"/> class.
         /// </summary>
         ///
@@ -640,14 +673,50 @@ namespace Azure.Messaging.EventHubs
         /// <param name="partitionKey">The partition hashing key associated with the event when it was published.</param>
         ///
         /// <remarks>
-        ///   <para>This constructor has been superseded by the <see cref="EventHubsModelFactory.EventData" /> factory method.
-        ///   It is strongly recommended that the model factory be preferred over use of this constructor.</para>
+        ///   <para>This constructor is obsolete and has been replaced by <see cref="EventHubsModelFactory.EventData(BinaryData, IDictionary{string, object}, IReadOnlyDictionary{string, object}, string, long, string, DateTimeOffset)" />.
+        ///   It should no longer be called.</para>
+        ///
+        ///   <para>This overload was previously intended for mocking in support of testing efforts.  It is recommended that
+        ///   it not be used in production scenarios, as it allows setting of data that is broker-owned and is only
+        ///   meaningful on events that have been read from the Event Hubs service.</para>SSS
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetOffsetParameterObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected EventData(BinaryData eventBody,
+                            IDictionary<string, object> properties = null,
+                            IReadOnlyDictionary<string, object> systemProperties = null,
+                            long sequenceNumber = long.MinValue,
+                            long offset = long.MinValue,
+                            DateTimeOffset enqueuedTime = default,
+                            string partitionKey = null) : this(eventBody, properties, systemProperties, sequenceNumber, (offset > long.MinValue) ? offset.ToString(CultureInfo.InvariantCulture) : null, enqueuedTime, partitionKey, lastPartitionSequenceNumber: null)
+        {
+        }
+
+        /// <summary>
+        ///   Obsolete.
+        ///
+        ///   Initializes a new instance of the <see cref="EventData"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The raw data to use as the body of the event.</param>
+        /// <param name="properties">The set of free-form event properties to send with the event.</param>
+        /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
+        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
+        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
+        /// <param name="partitionKey">The partition hashing key associated with the event when it was published.</param>
+        ///
+        /// <remarks>
+        ///   <para>This constructor is obsolete and has been replaced by <see cref="EventHubsModelFactory.EventData(BinaryData, IDictionary{string, object}, IReadOnlyDictionary{string, object}, string, long, string, DateTimeOffset)" />.
+        ///   It should no longer be called.</para>
         ///
         ///   <para>This overload was previously intended for mocking in support of testing efforts.  It is recommended that
         ///   it not be used in production scenarios, as it allows setting of data that is broker-owned and is only
         ///   meaningful on events that have been read from the Event Hubs service.</para>
         /// </remarks>
         ///
+        [Obsolete(AttributeMessageText.LongOffsetOffsetParameterObsolete)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected EventData(ReadOnlyMemory<byte> eventBody,
                             IDictionary<string, object> properties = null,
@@ -655,7 +724,7 @@ namespace Azure.Messaging.EventHubs
                             long sequenceNumber = long.MinValue,
                             long offset = long.MinValue,
                             DateTimeOffset enqueuedTime = default,
-                            string partitionKey = null) : this(new BinaryData(eventBody), properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey, lastPartitionSequenceNumber: null)
+                            string partitionKey = null) : this(new BinaryData(eventBody), properties, systemProperties, sequenceNumber, (offset > long.MinValue) ? offset.ToString(CultureInfo.InvariantCulture) : null, enqueuedTime, partitionKey, lastPartitionSequenceNumber: null)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProperties.cs
@@ -32,6 +32,32 @@ namespace Azure.Messaging.EventHubs
         public string[] PartitionIds { get; }
 
         /// <summary>
+        ///   A flag indicating whether or not the Event Hub has geo-replication enabled.
+        /// </summary>
+        ///
+        public bool IsGeoReplicationEnabled { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubProperties"/> class.
+        /// </summary>
+        ///
+        /// <param name="name">The name of the Event Hub.</param>
+        /// <param name="createdOn">The date and time at which the Event Hub was created.</param>
+        /// <param name="partitionIds">The set of unique identifiers for each partition.</param>
+        /// <param name="isGeoReplicationEnabled">A flag indicating whether or not the Event Hub has geo-replication enabled.</param>
+        ///
+        protected internal EventHubProperties(string name,
+                                              DateTimeOffset createdOn,
+                                              string[] partitionIds,
+                                              bool isGeoReplicationEnabled)
+        {
+            Name = name;
+            CreatedOn = createdOn;
+            PartitionIds = partitionIds;
+            IsGeoReplicationEnabled = isGeoReplicationEnabled;
+        }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="EventHubProperties"/> class.
         /// </summary>
         ///
@@ -39,13 +65,11 @@ namespace Azure.Messaging.EventHubs
         /// <param name="createdOn">The date and time at which the Event Hub was created.</param>
         /// <param name="partitionIds">The set of unique identifiers for each partition.</param>
         ///
-        protected internal EventHubProperties(string name,
-                                              DateTimeOffset createdOn,
-                                              string[] partitionIds)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected EventHubProperties(string name,
+                                     DateTimeOffset createdOn,
+                                     string[] partitionIds) : this(name, createdOn, partitionIds, false)
         {
-            Name = name;
-            CreatedOn = createdOn;
-            PartitionIds = partitionIds;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProperties.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs
         public string[] PartitionIds { get; }
 
         /// <summary>
-        ///   A flag indicating whether or not the Event Hub has geo-replication enabled.
+        ///   A flag indicating whether or not the Event Hubs namespace has geo-replication enabled.
         /// </summary>
         ///
         public bool IsGeoReplicationEnabled { get; }
@@ -44,7 +44,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="name">The name of the Event Hub.</param>
         /// <param name="createdOn">The date and time at which the Event Hub was created.</param>
         /// <param name="partitionIds">The set of unique identifiers for each partition.</param>
-        /// <param name="isGeoReplicationEnabled">A flag indicating whether or not the Event Hub has geo-replication enabled.</param>
+        /// <param name="isGeoReplicationEnabled">A flag indicating whether or not the Event Hubs namespace has geo-replication enabled.</param>
         ///
         protected internal EventHubProperties(string name,
                                               DateTimeOffset createdOn,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
@@ -22,20 +22,39 @@ namespace Azure.Messaging.EventHubs
     public static class EventHubsModelFactory
     {
         /// <summary>
-        ///   Initializes a new instance of the <see cref="EventHubProperties"/> class.
+        ///   Initializes a new instance of the <see cref="EventHubs.EventHubProperties"/> class.
         /// </summary>
         ///
         /// <param name="name">The name of the Event Hub.</param>
         /// <param name="createdOn">The date and time at which the Event Hub was created.</param>
         /// <param name="partitionIds">The set of unique identifiers for each partition.</param>
         ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static EventHubProperties EventHubProperties(string name,
                                                             DateTimeOffset createdOn,
                                                             string[] partitionIds) =>
-           new EventHubProperties(name, createdOn, partitionIds);
+           new EventHubProperties(name, createdOn, partitionIds, false);
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="PartitionProperties"/> class.
+        ///   Initializes a new instance of the <see cref="EventHubs.EventHubProperties"/> class.
+        /// </summary>
+        ///
+        /// <param name="name">The name of the Event Hub.</param>
+        /// <param name="createdOn">The date and time at which the Event Hub was created.</param>
+        /// <param name="partitionIds">The set of unique identifiers for each partition.</param>
+        /// <param name="isGeoReplicationEnabled">A flag indicating whether or not the Event Hub has geo-replication enabled.</param>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static EventHubProperties EventHubProperties(string name,
+                                                            DateTimeOffset createdOn,
+                                                            string[] partitionIds,
+                                                            bool isGeoReplicationEnabled) =>
+           new EventHubProperties(name, createdOn, partitionIds, isGeoReplicationEnabled);
+
+        /// <summary>
+        ///   Obsolete.
+        ///
+        ///   Initializes a new instance of the <see cref="EventHubs.PartitionProperties"/> class.
         /// </summary>
         ///
         /// <param name="eventHubName">The name of the Event Hub that contains the partitions.</param>
@@ -46,6 +65,12 @@ namespace Azure.Messaging.EventHubs
         /// <param name="lastOffset">The offset of the last event to be enqueued in the partition.</param>
         /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
         ///
+        /// <remarks>
+        ///   This method is obsolete and should no longer be used.  Please use the overload with a string-based offset instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetOffsetParameterObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static PartitionProperties PartitionProperties(string eventHubName,
                                                               string partitionId,
                                                               bool isEmpty,
@@ -53,10 +78,31 @@ namespace Azure.Messaging.EventHubs
                                                               long lastSequenceNumber,
                                                               long lastOffset,
                                                               DateTimeOffset lastEnqueuedTime) =>
-            new PartitionProperties(eventHubName, partitionId, isEmpty, beginningSequenceNumber, lastSequenceNumber, lastOffset, lastEnqueuedTime);
+            new PartitionProperties(eventHubName, partitionId, isEmpty, beginningSequenceNumber, lastSequenceNumber, (lastOffset > long.MinValue) ? lastOffset.ToString(CultureInfo.InvariantCulture) : null, lastEnqueuedTime);
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="EventHubProperties"/> class.
+        ///   Initializes a new instance of the <see cref="EventHubs.PartitionProperties"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub that contains the partitions.</param>
+        /// <param name="partitionId">The identifier of the partition.</param>
+        /// <param name="isEmpty">Indicates whether or not the partition is currently empty.</param>
+        /// <param name="beginningSequenceNumber">The first sequence number available for events in the partition.</param>
+        /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
+        /// <param name="lastOffsetString">The offset of the last event to be enqueued in the partition.</param>
+        /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
+        ///
+        public static PartitionProperties PartitionProperties(string eventHubName,
+                                                              string partitionId,
+                                                              bool isEmpty,
+                                                              long beginningSequenceNumber,
+                                                              long lastSequenceNumber,
+                                                              string lastOffsetString,
+                                                              DateTimeOffset lastEnqueuedTime) =>
+            new PartitionProperties(eventHubName, partitionId, isEmpty, beginningSequenceNumber, lastSequenceNumber, lastOffsetString, lastEnqueuedTime);
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="Producer.PartitionPublishingProperties"/> class.
         /// </summary>
         ///
         /// <param name="isIdempotentPublishingEnabled">Indicates whether idempotent publishing is enabled.</param>
@@ -71,8 +117,8 @@ namespace Azure.Messaging.EventHubs
                                                                                     int? lastPublishedSequenceNumber) =>
             new PartitionPublishingProperties(isIdempotentPublishingEnabled, producerGroupId, ownerLevel, lastPublishedSequenceNumber);
 
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="LastEnqueuedEventProperties"/> class.
+                /// <summary>
+        ///   Initializes a new instance of the <see cref="Consumer.LastEnqueuedEventProperties"/> class.
         /// </summary>
         ///
         /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
@@ -80,11 +126,28 @@ namespace Azure.Messaging.EventHubs
         /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
         /// <param name="lastReceivedTime">The date and time, in UTC, that the information was last received.</param>
         ///
+        [Obsolete(AttributeMessageText.LongOffsetOffsetParameterObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static LastEnqueuedEventProperties LastEnqueuedEventProperties(long? lastSequenceNumber,
                                                                               long? lastOffset,
                                                                               DateTimeOffset? lastEnqueuedTime,
                                                                               DateTimeOffset? lastReceivedTime) =>
-            new LastEnqueuedEventProperties(lastSequenceNumber, lastOffset, lastEnqueuedTime, lastReceivedTime);
+            new LastEnqueuedEventProperties(lastSequenceNumber, lastOffset?.ToString(CultureInfo.InvariantCulture), lastEnqueuedTime, lastReceivedTime);
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="Consumer.LastEnqueuedEventProperties"/> class.
+        /// </summary>
+        ///
+        /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
+        /// <param name="lastOffsetString">The offset of the last event to be enqueued in the partition.</param>
+        /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
+        /// <param name="lastReceivedTime">The date and time, in UTC, that the information was last received.</param>
+        ///
+        public static LastEnqueuedEventProperties LastEnqueuedEventProperties(long? lastSequenceNumber,
+                                                                              string lastOffsetString,
+                                                                              DateTimeOffset? lastEnqueuedTime,
+                                                                              DateTimeOffset? lastReceivedTime) =>
+            new LastEnqueuedEventProperties(lastSequenceNumber, lastOffsetString, lastEnqueuedTime, lastReceivedTime);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="Consumer.PartitionContext"/> class.
@@ -116,7 +179,9 @@ namespace Azure.Messaging.EventHubs
             new FactoryPartitionContext("<< NULL >>", "<< NULL >>", "<< NULL >>", partitionId, lastEnqueuedEventProperties);
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="EventData"/> class.
+        ///   Obsolete.
+        ///
+        ///   Initializes a new instance of the <see cref="EventHubs.EventData"/> class.
         /// </summary>
         ///
         /// <param name="eventBody">The data to use as the body of the event.</param>
@@ -127,6 +192,12 @@ namespace Azure.Messaging.EventHubs
         /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
         /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
         ///
+        /// <remarks>
+        ///   This method is obsolete and should no longer be used.  Please use the overload with a string-based offset instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetOffsetParameterObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static EventData EventData(BinaryData eventBody,
                                           IDictionary<string, object> properties = null,
                                           IReadOnlyDictionary<string, object> systemProperties = null,
@@ -134,7 +205,28 @@ namespace Azure.Messaging.EventHubs
                                           long sequenceNumber = long.MinValue,
                                           long offset = long.MinValue,
                                           DateTimeOffset enqueuedTime = default) =>
-             new EventData(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey);
+            EventData(eventBody, properties, systemProperties, partitionKey, sequenceNumber, (offset > long.MinValue) ? offset.ToString(CultureInfo.InvariantCulture) : null, enqueuedTime);
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubs.EventData"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The data to use as the body of the event.</param>
+        /// <param name="properties">The set of free-form event properties to send with the event.</param>
+        /// <param name="systemProperties">The set of system properties that accompany events read from the Event Hubs service.</param>
+        /// <param name="partitionKey">The partition hashing key associated with the event when it was published.</param>
+        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
+        /// <param name="offsetString">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
+        ///
+        public static EventData EventData(BinaryData eventBody,
+                                          IDictionary<string, object> properties = null,
+                                          IReadOnlyDictionary<string, object> systemProperties = null,
+                                          string partitionKey = null,
+                                          long sequenceNumber = long.MinValue,
+                                          string offsetString = default,
+                                          DateTimeOffset enqueuedTime = default) =>
+             new EventData(eventBody, properties, systemProperties, sequenceNumber, offsetString, enqueuedTime, partitionKey);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventDataBatch" /> class.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="name">The name of the Event Hub.</param>
         /// <param name="createdOn">The date and time at which the Event Hub was created.</param>
         /// <param name="partitionIds">The set of unique identifiers for each partition.</param>
-        /// <param name="isGeoReplicationEnabled">A flag indicating whether or not the Event Hub has geo-replication enabled.</param>
+        /// <param name="isGeoReplicationEnabled">A flag indicating whether or not the Event Hubs namespace has geo-replication enabled.</param>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static EventHubProperties EventHubProperties(string name,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionProperties.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
+using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -41,7 +43,26 @@ namespace Azure.Messaging.EventHubs
         ///   The offset of the last observed event to be enqueued in the partition.
         /// </summary>
         ///
-        public long LastEnqueuedOffset { get; }
+        [Obsolete(AttributeMessageText.LongLastEnqueuedOffsetOffsetObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public long LastEnqueuedOffset
+        {
+            get
+            {
+                if (long.TryParse(LastEnqueuedOffsetString, out var value))
+                {
+                    return value;
+                }
+
+                throw new NotSupportedException(Resources.LongLastEnqueuedOffsetOffsetUnsupported);
+            }
+        }
+
+        /// <summary>
+        ///   The offset of the last observed event to be enqueued in the partition.
+        /// </summary>
+        ///
+        public string LastEnqueuedOffsetString { get; }
 
         /// <summary>
         ///   The date and time, in UTC, that the last observed event was enqueued in the partition.
@@ -58,6 +79,8 @@ namespace Azure.Messaging.EventHubs
         public bool IsEmpty { get; }
 
         /// <summary>
+        ///   Obsolete.
+        ///
         ///   Initializes a new instance of the <see cref="PartitionProperties"/> class.
         /// </summary>
         ///
@@ -69,19 +92,53 @@ namespace Azure.Messaging.EventHubs
         /// <param name="lastOffset">The offset of the last event to be enqueued in the partition.</param>
         /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
         ///
+        /// <remarks>
+        ///   This constructor is obsolete and should no longer be used.  Please use the string-based offset overload instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetOffsetParameterObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected internal PartitionProperties(string eventHubName,
                                                string partitionId,
                                                bool isEmpty,
                                                long beginningSequenceNumber,
                                                long lastSequenceNumber,
                                                long lastOffset,
+                                               DateTimeOffset lastEnqueuedTime) : this(eventHubName,
+                                                                                       partitionId,
+                                                                                       isEmpty,
+                                                                                       beginningSequenceNumber,
+                                                                                       lastSequenceNumber,
+                                                                                       (lastOffset > long.MinValue) ? lastOffset.ToString(CultureInfo.InvariantCulture) : null,
+                                                                                       lastEnqueuedTime)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PartitionProperties"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub that contains the partitions.</param>
+        /// <param name="partitionId">The identifier of the partition.</param>
+        /// <param name="isEmpty">Indicates whether or not the partition is currently empty.</param>
+        /// <param name="beginningSequenceNumber">The first sequence number available for events in the partition.</param>
+        /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
+        /// <param name="lastOffsetString">The offset of the last event to be enqueued in the partition.</param>
+        /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
+        ///
+        protected internal PartitionProperties(string eventHubName,
+                                               string partitionId,
+                                               bool isEmpty,
+                                               long beginningSequenceNumber,
+                                               long lastSequenceNumber,
+                                               string lastOffsetString,
                                                DateTimeOffset lastEnqueuedTime)
         {
             EventHubName = eventHubName;
             Id = partitionId;
             BeginningSequenceNumber = beginningSequenceNumber;
             LastEnqueuedSequenceNumber = lastSequenceNumber;
-            LastEnqueuedOffset = lastOffset;
+            LastEnqueuedOffsetString = lastOffsetString;
             LastEnqueuedTime = lastEnqueuedTime;
             IsEmpty = isEmpty;
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/CheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/CheckpointStore.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Processor;
 
 namespace Azure.Messaging.EventHubs.Primitives
@@ -70,6 +70,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                                           CancellationToken cancellationToken);
 
         /// <summary>
+        ///   Obsolete.
+        ///
         ///   Creates or updates a checkpoint for a specific partition, identifying a position in the partition's event stream
         ///   that an event processor should begin reading from.
         /// </summary>
@@ -82,6 +84,12 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="sequenceNumber">The sequence number to associate with the checkpoint, indicating that a processor should begin reading from the next event in the stream.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal a request to cancel the operation.</param>
         ///
+        /// <remarks>
+        ///   This method is obsolete and should no longer be used.  Please use <see cref="UpdateCheckpointAsync(string, string, string, string, string, CheckpointPosition, CancellationToken)"/> instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetUpdateCheckpointObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task UpdateCheckpointAsync(string fullyQualifiedNamespace,
                                                   string eventHubName,
                                                   string consumerGroup,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PluggableCheckpointStoreEventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PluggableCheckpointStoreEventProcessor.cs
@@ -220,6 +220,8 @@ namespace Azure.Messaging.EventHubs.Primitives
             _checkpointStore.GetCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, partitionId, cancellationToken);
 
         /// <summary>
+        ///   Obsolete.
+        ///
         ///   Creates or updates a checkpoint for a specific partition, identifying a position in the partition's event stream
         ///   that an event processor should begin reading from.
         /// </summary>
@@ -229,6 +231,13 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="sequenceNumber">The sequence number to associate with the checkpoint, indicating that a processor should begin reading from the next event in the stream.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal a request to cancel the operation.</param>
         ///
+        /// <remarks>
+        ///   This method is obsolete and should no longer be used.  Please use <see cref="UpdateCheckpointAsync(string, CheckpointPosition, CancellationToken)" />
+        ///   instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetUpdateCheckpointObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected override Task UpdateCheckpointAsync(string partitionId,
                                                       long offset,
                                                       long? sequenceNumber,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/CheckpointPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/CheckpointPosition.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using Azure.Core;
+using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs.Processor
 {
@@ -16,10 +18,42 @@ namespace Azure.Messaging.EventHubs.Processor
     public struct CheckpointPosition : IEquatable<CheckpointPosition>
     {
         /// <summary>
-        ///   The sequence number to associate with the checkpoint. This indicates that a processor should begin reading from the next event in the stream.
+        ///   The sequence number to associate with the checkpoint. The sequence number is intended to be informational, and will only be used for
+        ///   positioning if no <see cref="Offset"/> is set.
         /// </summary>
         ///
         public long SequenceNumber { get; }
+
+        /// <summary>
+        ///   Obsolete.
+        ///   A numeric representation of the offset to associate with the checkpoint. This indicates that a processor
+        ///   should begin reading from the next event in the stream.
+        /// </summary>
+        ///
+        /// <value>
+        ///   This value is obsolete and should no longer be used.  Please use <see cref="OffsetString"/> instead.
+        /// </value>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetOffsetPropertyObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public long Offset
+        {
+            get
+            {
+                if (long.TryParse(OffsetString, out var value))
+                {
+                    return value;
+                }
+
+                throw new NotSupportedException(Resources.LongOffsetOffsetUnsupported);
+            }
+        }
+
+        /// <summary>
+        ///   The offset to associate with the checkpoint. This indicates that a processor should begin reading from the next event in the stream.
+        /// </summary>
+        ///
+        public string OffsetString { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="CheckpointPosition"/> struct.
@@ -27,9 +61,53 @@ namespace Azure.Messaging.EventHubs.Processor
         ///
         /// <param name="sequenceNumber">The sequence number to associate with the checkpoint. This indicates that a processor should begin reading from the next event in the stream.</param>
         ///
+        /// <remarks>
+        ///   This constructor is not compatible when processing a geo-replicated Event Hub. Use <see cref="CheckpointPosition(string, long)"/> or
+        ///   <see cref="FromEvent(EventData)"/> instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.SequenceNumberOnlyCheckpointObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public CheckpointPosition(long sequenceNumber)
         {
             SequenceNumber = sequenceNumber;
+        }
+
+        /// <summary>
+        ///   Obsolete.
+        ///
+        ///   Initializes a new instance of the <see cref="CheckpointPosition"/> struct.
+        /// </summary>
+        ///
+        /// <param name="offset">The offset to associate with the checkpoint. This indicates that a processor should begin reading from the next event in the stream.</param>
+        /// <param name="sequenceNumber">The sequence number to associate with the checkpoint. This is used as informational metadata.</param>
+        ///
+        /// <remarks>
+        ///   This constructor is obsolete and should no longer be used.  Please use <see cref="CheckpointPosition(string, long)"/> instead.
+        /// </remarks>
+        ///
+        [Obsolete(AttributeMessageText.LongOffsetCheckpointObsolete, false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CheckpointPosition(long offset,
+                                  long sequenceNumber = long.MinValue)
+        {
+            SequenceNumber = sequenceNumber;
+            OffsetString = (offset != long.MinValue) ? offset.ToString(CultureInfo.InvariantCulture) : null;
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="CheckpointPosition"/> struct.
+        /// </summary>
+        /// <param name="offsetString">The offset to associate with the checkpoint. This indicates that a processor should begin reading from the next event in the stream.</param>
+        /// <param name="sequenceNumber">The sequence number to associate with the checkpoint. This is used as informational metadata.</param>
+        ///
+        public CheckpointPosition(string offsetString,
+                                  long sequenceNumber = long.MinValue)
+        {
+            Argument.AssertNotNullOrEmpty(offsetString, nameof(offsetString));
+
+            SequenceNumber = sequenceNumber;
+            OffsetString = offsetString;
         }
 
         /// <summary>
@@ -38,10 +116,8 @@ namespace Azure.Messaging.EventHubs.Processor
         ///
         /// <param name="eventData">The <see cref="EventData"/> to use to determine the starting point of a checkpoint, indicating that an event processor should begin reading from the next event in the stream.</param>
         ///
-        public static CheckpointPosition FromEvent(EventData eventData)
-        {
-            return new CheckpointPosition(eventData.SequenceNumber);
-        }
+        public static CheckpointPosition FromEvent(EventData eventData) =>
+            new CheckpointPosition(eventData.OffsetString, eventData.SequenceNumber);
 
         /// <summary>
         ///   Determines whether the specified <see cref="CheckpointPosition" /> is equal to this instance.
@@ -53,7 +129,8 @@ namespace Azure.Messaging.EventHubs.Processor
         ///
         public bool Equals(CheckpointPosition other)
         {
-            return (SequenceNumber == other.SequenceNumber);
+            return ((SequenceNumber == other.SequenceNumber)
+                   && (OffsetString == other.OffsetString));
         }
 
         /// <summary>
@@ -83,6 +160,7 @@ namespace Azure.Messaging.EventHubs.Processor
         {
             var hashCode = new HashCodeBuilder();
             hashCode.Add(SequenceNumber);
+            hashCode.Add(OffsetString);
 
             return hashCode.ToHashCode();
         }
@@ -95,7 +173,7 @@ namespace Azure.Messaging.EventHubs.Processor
         ///
         public override string ToString()
         {
-            return $"Sequence Number: [{SequenceNumber}]";
+            return $"Offset: [{OffsetString}] Sequence Number: [{SequenceNumber}]";
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpAnnotatedMessageExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpAnnotatedMessageExtensionsTests.cs
@@ -295,11 +295,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SystemPropertiesCanBeRead()
         {
             var sequenceNumber = 123L;
-            var offset = 456L;
+            var offset = "456L";
             var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
             var partitionKey = "fake-key";
             var lastSequence = 321L;
-            var lastOffset = 654L;
+            var lastOffset = "654L";
             var lastEnqueue = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
             var lastRetrieve = new DateTimeOffset(2020, 01, 01, 05, 15, 37, TimeSpan.Zero);
             var message = CreateDataBodyMessageWithSystemProperties(sequenceNumber, lastSequence, offset, lastOffset, partitionKey, enqueueTime, lastEnqueue, lastRetrieve);
@@ -330,11 +330,11 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var sequenceNumber = 123L;
-            var offset = 456L;
+            var offset = "456L";
             var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
             var partitionKey = "fake-key";
             var lastSequence = 321L;
-            var lastOffset = 654L;
+            var lastOffset = "654L";
             var lastEnqueue = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
             var lastRetrieve = new DateTimeOffset(2020, 01, 01, 05, 15, 37, TimeSpan.Zero);
 
@@ -361,11 +361,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SystemPropertiesReturnCustomDefaultValuesWhenNotInTheMessage()
         {
             var sequenceNumber = 123L;
-            var offset = 456L;
+            var offset = "456L";
             var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
             var partitionKey = "fake-key";
             var lastSequence = 321L;
-            var lastOffset = 654L;
+            var lastOffset = "654L";
             var lastEnqueue = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
             var lastRetrieve = new DateTimeOffset(2020, 01, 01, 05, 15, 37, TimeSpan.Zero);
             var message = CreateDataBodyMessageWithSystemProperties(default, default, default, default, default, default, default, default);
@@ -391,7 +391,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var message = CreateDataBodyMessageWithSystemProperties(default, default, default, default, default, default, default, default);
 
             Assert.That(message.GetSequenceNumber(), Is.EqualTo(long.MinValue), "The sequence number should match.");
-            Assert.That(message.GetOffset(), Is.EqualTo(long.MinValue), "The offset should match.");
+            Assert.That(message.GetOffset(), Is.EqualTo(null), "The offset should match.");
             Assert.That(message.GetEnqueuedTime(), Is.EqualTo(default(DateTimeOffset)), "The enqueue time should match.");
             Assert.That(message.GetPartitionKey(), Is.EqualTo(null), "The partition key should match.");
             Assert.That(message.GetLastPartitionSequenceNumber(), Is.EqualTo(null), "The last sequence number should match.");
@@ -510,8 +510,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private static AmqpAnnotatedMessage CreateDataBodyMessageWithSystemProperties(long? sequenceNumber,
                                                                                       long? lastSequenceNumber,
-                                                                                      long? offset,
-                                                                                      long? lastOffset,
+                                                                                      string offset,
+                                                                                      string lastOffset,
                                                                                       string partitionKey,
                                                                                       DateTimeOffset? enqueueTime,
                                                                                       DateTimeOffset? lastEnqueueTime,
@@ -526,9 +526,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 message.MessageAnnotations.Add(AmqpProperty.SequenceNumber.ToString(), sequenceNumber.Value);
             }
 
-            if (offset.HasValue)
+            if (!string.IsNullOrEmpty(offset))
             {
-                message.MessageAnnotations.Add(AmqpProperty.Offset.ToString(), offset.Value);
+                message.MessageAnnotations.Add(AmqpProperty.Offset.ToString(), offset);
             }
 
             if (enqueueTime.HasValue)
@@ -550,9 +550,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedSequenceNumber.ToString(), lastSequenceNumber.Value);
             }
 
-            if (lastOffset.HasValue)
+            if (!string.IsNullOrEmpty(lastOffset))
             {
-                message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedOffset.ToString(), lastOffset.Value);
+                message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedOffset.ToString(), lastOffset);
             }
 
             if (lastEnqueueTime.HasValue)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -778,7 +778,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, TimeSpan.FromDays(1), TimeSpan.FromDays(1), prefetchCount, prefetchSizeInBytes, ownerLevel, trackLastEvent, identifier, cancellationSource.Token);
             Assert.That(link, Is.Not.Null, "The link produced was null");
-            Assert.That(link.Settings.DesiredCapabilities, Is.Null, "There should have not have been a set of desired capabilities created, as we're not tracking the last event.");
+            Assert.That(link.Settings.DesiredCapabilities.Contains(AmqpProperty.GeoReplication), Is.True, "Geo replication should always be requested.");
         }
 
         /// <summary>
@@ -1292,6 +1292,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(link.Settings.Properties.Any(item => item.Key.Key.ToString() == AmqpProperty.EntityType.ToString()), Is.True, "There should be an entity type specified.");
             Assert.That(link.Settings.Properties[AmqpProperty.ProducerGroupId], Is.EqualTo(options.ProducerGroupId), "The producer group should have been set.");
             Assert.That(link.Settings.Properties[AmqpProperty.ProducerOwnerLevel], Is.EqualTo(options.OwnerLevel), "The owner level should have been set.");
+            Assert.That(link.Settings.DesiredCapabilities.Contains(AmqpProperty.GeoReplication), Is.True, "Geo replication should always be requested.");
             Assert.That(link.Settings.Properties[AmqpProperty.ProducerSequenceNumber], Is.EqualTo(options.StartingSequenceNumber), "The published sequence number should have been set.");
         }
 
@@ -1435,6 +1436,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var linkTarget = (Target)link.Settings.Target;
             Assert.That(linkTarget.Address.ToString(), Contains.Substring($"/{ partitionId }"), "The partition identifier should have been part of the link address.");
             Assert.That(link.Settings.DesiredCapabilities.Contains(AmqpProperty.EnableIdempotentPublishing), Is.True, "The idempotent publishing capability should have been set.");
+            Assert.That(link.Settings.DesiredCapabilities.Contains(AmqpProperty.GeoReplication), Is.True, "Geo replication should always be requested.");
             Assert.That(link.Settings.Properties.Any(item => item.Key.Key.ToString() == AmqpProperty.EntityType.ToString()), Is.True, "There should be an entity type specified.");
             Assert.That(link.Settings.Properties.Any(item => item.Key.Key.ToString() == AmqpProperty.ProducerGroupId.ToString()), Is.True, "The producer group should have been set.");
             Assert.That(link.Settings.Properties.Any(item => item.Key.Key.ToString() == AmqpProperty.ProducerOwnerLevel.ToString()), Is.True, "The owner level should have been set.");
@@ -1513,7 +1515,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var linkTarget = (Target)link.Settings.Target;
             Assert.That(linkTarget.Address.ToString(), Contains.Substring($"/{ partitionId }"), "The partition identifier should have been part of the link address.");
-            Assert.That(link.Settings.DesiredCapabilities, Is.Null, "The idempotent publishing capability should not have been set.");
+            Assert.That(link.Settings.DesiredCapabilities.Contains(AmqpProperty.GeoReplication), Is.True, "Geo replication should always be requested.");
             Assert.That(link.Settings.Properties.Any(item => item.Key.Key.ToString() == AmqpProperty.EntityType.ToString()), Is.True, "There should be an entity type specified.");
             Assert.That(link.Settings.Properties[AmqpProperty.ProducerGroupId], Is.EqualTo(options.ProducerGroupId), "The producer group should have been set.");
             Assert.That(link.Settings.Properties[AmqpProperty.ProducerOwnerLevel], Is.EqualTo(options.OwnerLevel), "The owner level should have been set.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -162,7 +162,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var retriableException = new EventHubsException(true, "Test");
             var mockConverter = new Mock<AmqpMessageConverter>();
@@ -187,7 +187,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var retriableException = new EventHubsException(true, "Test");
             var mockConverter = new Mock<AmqpMessageConverter>();
@@ -215,7 +215,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
             var ownerLevel = 123L;
@@ -279,7 +279,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
             var ownerLevel = 123L;
@@ -344,7 +344,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
             var ownerLevel = 123L;
@@ -407,7 +407,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
             var ownerLevel = 123L;
@@ -470,7 +470,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
             var ownerLevel = 123L;
@@ -533,7 +533,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var options = new EventHubConsumerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var retriableException = new EventHubsException(true, "Test");
@@ -562,7 +562,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var identifier = "cusTOM-1D";
-            var eventPosition = EventPosition.FromOffset(123);
+            var eventPosition = EventPosition.FromOffset("123");
             var options = new EventHubConsumerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpFilterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpFilterTests.cs
@@ -26,8 +26,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             // Unset all properties for the event position.
 
-            var position = EventPosition.FromOffset(1);
-            position.Offset = null;
+            var position = EventPosition.FromOffset("1");
+            position.OffsetString = null;
 
             Assert.That(() => AmqpFilter.BuildFilterExpression(position), Throws.ArgumentException);
         }
@@ -42,7 +42,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             // Set all properties for the event position.
 
-            var offset = 1;
+            var offset = "1";
             var position = EventPosition.FromOffset(offset);
             position.SequenceNumber = "222";
             position.EnqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
@@ -122,7 +122,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void BuildFilterExpressionHonorsInclusiveFlagForOffset(bool inclusive)
         {
             var comparison = (inclusive) ? ">=" : ">";
-            var position = EventPosition.FromOffset(1);
+            var position = EventPosition.FromOffset("1");
             position.IsInclusive = inclusive;
 
             var filter = AmqpFilter.BuildFilterExpression(position);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// Ignore Spelling: Accessor
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -1214,7 +1216,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateEventFromMessagePopulatesTypedSystemProperties()
         {
-            var offset = 123;
+            var offset = "123";
             var sequenceNumber = (long.MaxValue - 10);
             var enqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
             var partitionKey = "OMG! partition!";
@@ -1225,7 +1227,7 @@ namespace Azure.Messaging.EventHubs.Tests
             message.ApplicationProperties.Map.Add("First", 1);
             message.ApplicationProperties.Map.Add("Second", "2");
 
-            message.MessageAnnotations.Map.Add(AmqpProperty.Offset, offset.ToString());
+            message.MessageAnnotations.Map.Add(AmqpProperty.Offset, offset);
             message.MessageAnnotations.Map.Add(AmqpProperty.SequenceNumber, sequenceNumber);
             message.MessageAnnotations.Map.Add(AmqpProperty.EnqueuedTime, enqueuedTime.Ticks);
             message.MessageAnnotations.Map.Add(AmqpProperty.PartitionKey, partitionKey);
@@ -1236,11 +1238,11 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
             Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Count, Is.EqualTo(message.ApplicationProperties.Map.Count()), "The event should have a set of properties.");
-            Assert.That(eventData.Offset, Is.EqualTo(offset), "The offset should match.");
+            Assert.That(eventData.OffsetString, Is.EqualTo(offset), "The offset should match.");
             Assert.That(eventData.SequenceNumber, Is.EqualTo(sequenceNumber), "The sequence number should match.");
             Assert.That(eventData.EnqueuedTime, Is.EqualTo(enqueuedTime), "The enqueue time should match.");
             Assert.That(eventData.PartitionKey, Is.EqualTo(partitionKey), "The partition key should match.");
-            Assert.That(eventData.LastPartitionOffset.HasValue, Is.False, "The last offset should not be set.");
+            Assert.That(eventData.LastPartitionOffset, Is.Null, "The last offset should not be set.");
             Assert.That(eventData.LastPartitionSequenceNumber.HasValue, Is.False, "The last sequence number should not be set.");
             Assert.That(eventData.LastPartitionEnqueuedTime.HasValue, Is.False, "The last enqueued time should not be set.");
             Assert.That(eventData.LastPartitionPropertiesRetrievalTime.HasValue, Is.False, "The last retrieval time should not be set.");
@@ -1291,8 +1293,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateEventFromMessagePopulatesTypedSystemPropertiesAndMetrics()
         {
-            var offset = 123;
-            var lastOffset = 987;
+            string offset = "123";
+            var lastOffset = "987";
             var sequenceNumber = (long.MaxValue - 10);
             var lastSequenceNumber = (long.MaxValue - 100);
             var enqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
@@ -1322,7 +1324,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
             Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Count, Is.EqualTo(message.ApplicationProperties.Map.Count()), "The event should have a set of properties.");
-            Assert.That(eventData.Offset, Is.EqualTo(offset), "The offset should match.");
+            Assert.That(eventData.OffsetString, Is.EqualTo(offset), "The offset should match.");
             Assert.That(eventData.SequenceNumber, Is.EqualTo(sequenceNumber), "The sequence number should match.");
             Assert.That(eventData.EnqueuedTime, Is.EqualTo(enqueuedTime), "The enqueue time should match.");
             Assert.That(eventData.PartitionKey, Is.EqualTo(partitionKey), "The partition key should match.");
@@ -1564,17 +1566,17 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateEventFromMessageAllowsAnEmptyMessageWithProperties()
         {
-            var propertyValue = 1;
+            var propertyValue = "1";
 
             using var message = AmqpMessage.Create();
             message.ApplicationProperties.Map.Add("Test", propertyValue);
-            message.MessageAnnotations.Map.Add(AmqpProperty.Offset, propertyValue.ToString());
+            message.MessageAnnotations.Map.Add(AmqpProperty.Offset, propertyValue);
 
             var eventData = new AmqpMessageConverter().CreateEventFromMessage(message);
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
             Assert.That(eventData.Properties.Count, Is.EqualTo(message.ApplicationProperties.Map.Count()), "There should have been properties present.");
             Assert.That(eventData.Properties.First().Value, Is.EqualTo(propertyValue), "The application property should have been populated.");
-            Assert.That(eventData.Offset, Is.EqualTo(propertyValue), "The offset should have been populated.");
+            Assert.That(eventData.OffsetString, Is.EqualTo(propertyValue), "The offset should have been populated.");
         }
 
         /// <summary>
@@ -2046,7 +2048,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "55";
             var beginSequenceNumber = 555L;
             var lastSequenceNumber = 666L;
-            var lastOffset = 777L;
+            var lastOffset = "777L";
             var lastEnqueueTime = DateTimeOffset.Parse("2015-10-27T00:00:00z");
             var isEmpty = false;
             var converter = new AmqpMessageConverter();
@@ -2056,7 +2058,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 { AmqpManagement.ResponseMap.PartitionIdentifier, partition },
                 { AmqpManagement.ResponseMap.PartitionBeginSequenceNumber, beginSequenceNumber },
                 { AmqpManagement.ResponseMap.PartitionLastEnqueuedSequenceNumber, lastSequenceNumber },
-                { AmqpManagement.ResponseMap.PartitionLastEnqueuedOffset, lastOffset.ToString() },
+                { AmqpManagement.ResponseMap.PartitionLastEnqueuedOffset, lastOffset },
                 { AmqpManagement.ResponseMap.PartitionLastEnqueuedTimeUtc, lastEnqueueTime.UtcDateTime },
                 { AmqpManagement.ResponseMap.PartitionRuntimeInfoPartitionIsEmpty, isEmpty }
             };
@@ -2069,7 +2071,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(properties.Id, Is.EqualTo(partition), "The partition should match");
             Assert.That(properties.BeginningSequenceNumber, Is.EqualTo(beginSequenceNumber), "The beginning sequence number should match");
             Assert.That(properties.LastEnqueuedSequenceNumber, Is.EqualTo(lastSequenceNumber), "The last sequence number should match");
-            Assert.That(properties.LastEnqueuedOffset, Is.EqualTo(lastOffset), "The offset should match");
+            Assert.That(properties.LastEnqueuedOffsetString, Is.EqualTo(lastOffset), "The offset should match");
             Assert.That(properties.LastEnqueuedTime, Is.EqualTo(lastEnqueueTime), "The last enqueued time should match");
             Assert.That(properties.IsEmpty, Is.EqualTo(isEmpty), "The empty flag should match");
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionLiveTests.cs
@@ -246,7 +246,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(partitionProperties.EventHubName, Is.EqualTo(scope.EventHubName).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
                     Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(long)), "The beginning sequence number should have been populated.");
                     Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(long)), "The last sequence number should have been populated.");
-                    Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedOffsetString, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
@@ -746,7 +746,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var date = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
             var partitionIds = new[] { "first", "second", "third" };
-            var properties = new EventHubProperties("dummy", date, partitionIds);
+            var properties = new EventHubProperties("dummy", date, partitionIds, false);
             var mockConnection = new Mock<EventHubConnection> { CallBase = true };
 
             mockConnection
@@ -835,7 +835,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportClient = new ObservableTransportClientMock();
             var connection = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
-            var expectedPosition = EventPosition.FromOffset(65);
+            var expectedPosition = EventPosition.FromOffset("65");
             var expectedPartition = "2123";
             var expectedIdentifier = "OMG-ID";
             var expectedConsumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
@@ -851,7 +851,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(actualPartition, Is.EqualTo(expectedPartition), "The partition should have been passed.");
             Assert.That(actualConsumerGroup, Is.EqualTo(expectedConsumerGroup), "The consumer group should match.");
             Assert.That(actualIdentifier, Is.EqualTo(expectedIdentifier), "The identifier should match.");
-            Assert.That(actualPosition.Offset, Is.EqualTo(expectedPosition.Offset), "The event position to receive should match.");
+            Assert.That(actualPosition.OffsetString, Is.EqualTo(expectedPosition.OffsetString), "The event position to receive should match.");
             Assert.That(actualRetry, Is.SameAs(expectedRetryPolicy), "The retryPolicy should match.");
             Assert.That(actualOwnerLevel, Is.EqualTo(expectedOwnerLevel), "The owner levels should match.");
             Assert.That(actualPrefetch, Is.EqualTo(expectedPrefetch), "The prefetch counts should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -856,7 +856,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     // Query the partition and determine the offset of the last enqueued event, then send the new set
                     // of events that should appear after the starting position.
 
-                    var lastOffset = (await consumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token)).LastEnqueuedOffset;
+                    var lastOffset = (await consumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token)).LastEnqueuedOffsetString;
                     var startingPosition = EventPosition.FromOffset(lastOffset, isInclusive);
 
                     await SendEventsAsync(scope.EventHubName, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
@@ -876,7 +876,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                     Assert.That(readState.Events.Count, Is.EqualTo(expectedCount), "The wrong number of events was read for the value of the inclusive flag.");
-                    Assert.That(readState.Events.Values.Any(readEvent => readEvent.Data.Offset == lastOffset), Is.EqualTo(isInclusive), $"The event with offset [{ lastOffset }] was { ((isInclusive) ? "not" : "") } in the set of read events, which is inconsistent with the inclusive flag.");
+                    Assert.That(readState.Events.Values.Any(readEvent => readEvent.Data.OffsetString == lastOffset), Is.EqualTo(isInclusive), $"The event with offset [{ lastOffset }] was { ((isInclusive) ? "not" : "") } in the set of read events, which is inconsistent with the inclusive flag.");
 
                     foreach (var sourceEvent in sourceEvents)
                     {
@@ -2099,7 +2099,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(partitionProperties.EventHubName, Is.EqualTo(scope.EventHubName).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
                     Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(long)), "The beginning sequence number should have been populated.");
                     Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(long)), "The last sequence number should have been populated.");
-                    Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedOffsetString, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -684,7 +684,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
-            IAsyncEnumerable<PartitionEvent> enumerable = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12));
+            IAsyncEnumerable<PartitionEvent> enumerable = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"));
 
             Assert.That(enumerable, Is.Not.Null, "An enumerable should have been returned.");
             Assert.That(enumerable, Is.InstanceOf<IAsyncEnumerable<PartitionEvent>>(), "The enumerable should be of the correct type.");
@@ -709,7 +709,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
             var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
-            var enumerable = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), options);
+            var enumerable = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), options);
 
             Assert.That(enumerable, Is.Not.Null, "An enumerable should have been returned.");
             Assert.That(enumerable, Is.InstanceOf<IAsyncEnumerable<PartitionEvent>>(), "The enumerable should be of the correct type.");
@@ -734,7 +734,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25), CacheEventCount = 999 };
 
-            await using var enumerator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), options).GetAsyncEnumerator();
+            await using var enumerator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), options).GetAsyncEnumerator();
 
             for (var index = 0; index < 5; ++index)
             {
@@ -776,7 +776,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<long?>()))
                 .Returns(transportConsumer);
 
-            await using var enumerator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), options).GetAsyncEnumerator();
+            await using var enumerator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), options).GetAsyncEnumerator();
             await enumerator.MoveNextAsync();
 
             mockConnection
@@ -824,7 +824,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 await consumer.CloseAsync(cancellationSource.Token);
 
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellationSource.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), cancellationSource.Token))
                 {
                     receivedEvents = true;
                     break;
@@ -862,7 +862,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(async () =>
             {
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellation.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), cancellation.Token))
                 {
                     if (partitionEvent.Data == null)
                     {
@@ -905,7 +905,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(async () =>
             {
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellation.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), cancellation.Token))
                 {
                     if (++receivedEvents >= expectedEvents)
                     {
@@ -946,7 +946,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(async () =>
             {
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellation.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), cancellation.Token))
                 {
                     if (++receivedEvents >= expectedEvents)
                     {
@@ -983,7 +983,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             try
             {
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellation.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), cancellation.Token))
                 {
                     if (++receivedEvents >= expectedEvents)
                     {
@@ -1024,7 +1024,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             try
             {
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellation.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), cancellation.Token))
                 {
                     if (++receivedEvents >= expectedEvents)
                     {
@@ -1075,7 +1075,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             try
             {
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellation.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), cancellation.Token))
                 {
                     ++receivedEvents;
                 }
@@ -1114,7 +1114,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellation = new CancellationTokenSource();
             cancellation.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellation.Token))
+            await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), cancellation.Token))
             {
                 receivedEvents.Add(partitionEvent.Data);
 
@@ -1147,7 +1147,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(5) };
             var partition = "0";
-            var position = EventPosition.FromOffset(22);
+            var position = EventPosition.FromOffset("22");
             var mockConnection = new MockConnection(() => new PublishingTransportConsumerMock(events));
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var firstSubscriberEvents = new List<EventData>();
@@ -1337,7 +1337,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellation = new CancellationTokenSource();
             cancellation.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), options, cancellation.Token))
+            await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("12"), options, cancellation.Token))
             {
                 receivedEvents.Add(partitionEvent.Data);
                 consecutiveEmptyCount = (partitionEvent.Data == null) ? consecutiveEmptyCount + 1 : 0;
@@ -1377,7 +1377,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(async () =>
             {
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(2), cancellation.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset("2"), cancellation.Token))
                 {
                     ++receivedEvents;
                     break;
@@ -1445,7 +1445,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellation = new CancellationTokenSource();
             cancellation.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync(expectedPartition, EventPosition.FromOffset(12), cancellation.Token))
+            await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync(expectedPartition, EventPosition.FromOffset("12"), cancellation.Token))
             {
                 Assert.That(partitionEvent.Partition.PartitionId, Is.EqualTo(expectedPartition), $"The event in position: { actualCount } was not associated with the expected partition.");
                 Assert.That(partitionEvent.Partition.FullyQualifiedNamespace, Is.EqualTo(mockConnection.FullyQualifiedNamespace), $"The event in position: { actualCount } was not associated with the expected namespace.");
@@ -2774,7 +2774,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                         CancellationToken cancellationToken = default)
             {
                 GetPropertiesInvokedWith = retryPolicy;
-                return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }));
+                return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }, false));
             }
 
             internal override async Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventPositionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventPositionTests.cs
@@ -40,8 +40,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void TheSameOffsetAreEqual()
         {
-            var first = EventPosition.FromOffset(12);
-            var second = EventPosition.FromOffset(12);
+            var first = EventPosition.FromOffset("12");
+            var second = EventPosition.FromOffset("12");
 
             Assert.That(first.Equals((object)second), Is.True, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.True, "The IEquatable comparison is incorrect.");
@@ -57,8 +57,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void DifferentOffsetsAreNotEqual()
         {
-            var first = EventPosition.FromOffset(12);
-            var second = EventPosition.FromOffset(34);
+            var first = EventPosition.FromOffset("12");
+            var second = EventPosition.FromOffset("34");
 
             Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
@@ -179,7 +179,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DifferentMembersAreNotEqual()
         {
             var first = EventPosition.FromSequenceNumber(234234);
-            var second = EventPosition.FromOffset(12);
+            var second = EventPosition.FromOffset("12");
 
             Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
@@ -195,7 +195,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void GetHashCodeReturnsDifferentValuesForDifferentMembers()
         {
-            var first = EventPosition.FromOffset(12);
+            var first = EventPosition.FromOffset("12");
             var second = EventPosition.FromSequenceNumber(123);
 
             Assert.That(first.GetHashCode(), Is.Not.EqualTo(second.GetHashCode()));
@@ -210,7 +210,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ToStringReflectsTheState()
         {
             var inclusive = true;
-            var offset = 123;
+            var offset = "123";
             var sequence = 778;
             var enqueued = DateTimeOffset.Now.AddHours(1);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/LastEnqueuedEventPropertiesTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/LastEnqueuedEventPropertiesTests.cs
@@ -24,8 +24,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void TheSameValuesAreEqual()
         {
             var now = DateTimeOffset.UtcNow;
-            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
-            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffsetString: "887", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffsetString: "887", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
 
             Assert.That(first.Equals((object)second), Is.True, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.True, "The IEquatable comparison is incorrect.");
@@ -42,8 +42,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DifferentOffsetsAreNotEqual()
         {
             var now = DateTimeOffset.UtcNow;
-            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 999, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
-            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 888, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffsetString: "999", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffsetString: "888", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
 
             Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
@@ -60,8 +60,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DifferentEnqueueTimesAreNotEqual()
         {
             var now = DateTimeOffset.UtcNow;
-            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
-            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("1974-12-09T21:30:00Z"), lastReceivedTime: now);
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffsetString: "887", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffsetString: "887", lastEnqueuedTime: DateTimeOffset.Parse("1974-12-09T21:30:00Z"), lastReceivedTime: now);
 
             Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
@@ -78,8 +78,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DifferentSequenceNumbersAreNotEqual()
         {
             var now = DateTimeOffset.UtcNow;
-            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 333, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
-            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 444, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 333, lastOffsetString: "887", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 444, lastOffsetString: "887", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
 
             Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
@@ -96,8 +96,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DifferentLastReceiveTimesAreNotEqual()
         {
             var now = DateTimeOffset.UtcNow;
-            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
-            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now.AddHours(1));
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffsetString: "887", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffsetString: "887", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now.AddHours(1));
 
             Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
@@ -114,8 +114,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void GetHashCodeReturnsDifferentValuesForDifferentMembers()
         {
             var now = DateTimeOffset.UtcNow;
-            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 333, lastOffset: 888, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
-            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 555, lastOffset: 777, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 333, lastOffsetString: "888", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 555, lastOffsetString: "777", lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
 
             Assert.That(first.GetHashCode(), Is.Not.EqualTo(second.GetHashCode()));
         }
@@ -128,7 +128,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ToStringReflectsTheState()
         {
-            var offset = 123;
+            var offset = "123";
             var sequence = 778;
             var enqueued = DateTimeOffset.Now.AddHours(1);
             var received = DateTimeOffset.Now.AddHours(7);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/PartitionContextTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/PartitionContextTests.cs
@@ -89,7 +89,7 @@ namespace Azure.Messaging.EventHubs.Tests
             (
                 eventBody: new BinaryData(Array.Empty<byte>()),
                 lastPartitionSequenceNumber: 1234,
-                lastPartitionOffset: 42,
+                lastPartitionOffset: "42",
                 lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
                 lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2012-03-04T08:42Z")
             );
@@ -99,7 +99,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var information = context.ReadLastEnqueuedEventProperties();
 
             Assert.That(information.SequenceNumber, Is.EqualTo(lastEvent.LastPartitionSequenceNumber), "The sequence number should match.");
-            Assert.That(information.Offset, Is.EqualTo(lastEvent.LastPartitionOffset), "The offset should match.");
+            Assert.That(information.OffsetString, Is.EqualTo(lastEvent.LastPartitionOffset), "The offset should match.");
             Assert.That(information.EnqueuedTime, Is.EqualTo(lastEvent.LastPartitionEnqueuedTime), "The last enqueue time should match.");
             Assert.That(information.LastReceivedTime, Is.EqualTo(lastEvent.LastPartitionPropertiesRetrievalTime), "The retrieval time should match.");
             Assert.That(mockConsumer.IsClosed, Is.False, "The consumer should not have been closed or disposed of.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -142,14 +142,14 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void NonIdempotentStatePropertyAcessorsDeferToTheAmqpMessage()
+        public void NonIdempotentStatePropertyAccessorsDeferToTheAmqpMessage()
         {
             var sequenceNumber = 123L;
-            var offset = 456L;
+            var offset = "456L";
             var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
             var partitionKey = "fake-key";
             var lastSequence = 321L;
-            var lastOffset = 654L;
+            var lastOffset = "654L";
             var lastEnqueue = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
             var lastRetrieve = new DateTimeOffset(2020, 01, 01, 05, 15, 37, TimeSpan.Zero);
             var message = CreateFullyPopulatedAmqpMessage(sequenceNumber, lastSequence, offset, lastOffset, partitionKey, enqueueTime, lastEnqueue, lastRetrieve);
@@ -158,7 +158,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(message.Body.TryGetData(out var messageBody), Is.True, "The message body should have been read.");
             Assert.That(eventData.EventBody.ToArray(), Is.EquivalentTo(messageBody.First().ToArray()), "The message body should match.");
             Assert.That(eventData.Properties, Is.EquivalentTo(message.ApplicationProperties), "The application properties should match.");
-            Assert.That(eventData.Offset, Is.EqualTo(offset), "The offset should match.");
+            Assert.That(eventData.OffsetString, Is.EqualTo(offset), "The offset should match.");
             Assert.That(eventData.SequenceNumber, Is.EqualTo(sequenceNumber), "The sequence number should match.");
             Assert.That(eventData.EnqueuedTime, Is.EqualTo(enqueueTime), "The enqueued time should match.");
             Assert.That(eventData.PartitionKey, Is.EqualTo(partitionKey), "The partition key should match.");
@@ -245,11 +245,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 new Dictionary<string, object> { { "Test", 123 } },
                 new Dictionary<string, object> { { "System", "Hello" } },
                 33334444,
-                666777,
+                "666777",
                 DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
                 "TestKey",
                 111222,
-                999888,
+                "999888",
                 DateTimeOffset.Parse("2012-03-04T09:00:00Z"),
                 DateTimeOffset.Parse("2003-09-27T15:00:00Z"),
                 787878,
@@ -275,11 +275,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 null,
                 null,
                 33334444,
-                666777,
+                "666777",
                 DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
                 "TestKey",
                 111222,
-                999888,
+                "999888",
                 DateTimeOffset.Parse("2012-03-04T09:00:00Z"),
                 DateTimeOffset.Parse("2003-09-27T15:00:00Z"),
                 787878,
@@ -304,11 +304,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 new Dictionary<string, object> { { "Test", 123 } },
                 new Dictionary<string, object> { { "System", "Hello" } },
                 33334444,
-                666777,
+                "666777",
                 DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
                 "TestKey",
                 111222,
-                999888,
+                "999888",
                 DateTimeOffset.Parse("2012-03-04T09:00:00Z"),
                 DateTimeOffset.Parse("2003-09-27T15:00:00Z"),
                 787878,
@@ -341,8 +341,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private static AmqpAnnotatedMessage CreateFullyPopulatedAmqpMessage(long sequenceNumber,
                                                                             long lastSequenceNumber,
-                                                                            long offset,
-                                                                            long lastOffset,
+                                                                            string offset,
+                                                                            string lastOffset,
                                                                             string partitionKey,
                                                                             DateTimeOffset enqueueTime,
                                                                             DateTimeOffset lastEnqueueTime,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventHubsModelFactoryTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventHubsModelFactoryTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var isEmpty = false;
             var beginningSequenceNumber = 123;
             var lastSequenceNumber = 9999;
-            var lastOffset = 767;
+            var lastOffset = "767";
             var lastEnqueuedTime = new DateTimeOffset(2015, 10, 27, 12, 0, 0, TimeSpan.Zero);
             var properties = EventHubsModelFactory.PartitionProperties(eventHubName, partitionId, isEmpty, beginningSequenceNumber, lastSequenceNumber, lastOffset, lastEnqueuedTime);
 
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(properties.IsEmpty, Is.EqualTo(isEmpty), "The `is empty` flag should have been set.");
             Assert.That(properties.BeginningSequenceNumber, Is.EqualTo(beginningSequenceNumber), "The beginning sequence number should have been set.");
             Assert.That(properties.LastEnqueuedSequenceNumber, Is.EqualTo(lastSequenceNumber), "The last sequence number should have been set.");
-            Assert.That(properties.LastEnqueuedOffset, Is.EqualTo(lastOffset), "The last offset should have been set.");
+            Assert.That(properties.LastEnqueuedOffsetString, Is.EqualTo(lastOffset), "The last offset should have been set.");
             Assert.That(properties.LastEnqueuedTime, Is.EqualTo(lastEnqueuedTime), "The last enqueue date/time should have been set.");
         }
 
@@ -96,14 +96,14 @@ namespace Azure.Messaging.EventHubs.Tests
         public void LastEnqueuedEventPropertiesInitializesProperties()
         {
             var lastSequence = long.MaxValue - 100;
-            var lastOffset = long.MaxValue - 10;
+            var lastOffset = (long.MaxValue - 10).ToString();
             var lastEnqueued = new DateTimeOffset(2015, 10, 27, 12, 0, 0, TimeSpan.Zero);
             var lastReceived = new DateTimeOffset(2012, 03, 04, 08, 0, 0, TimeSpan.Zero);
             var properties = EventHubsModelFactory.LastEnqueuedEventProperties(lastSequence, lastOffset, lastEnqueued, lastReceived);
 
             Assert.That(properties, Is.Not.Null, "The properties should have been created.");
             Assert.That(properties.SequenceNumber, Is.EqualTo(lastSequence), "The sequence number should have been set.");
-            Assert.That(properties.Offset, Is.EqualTo(lastOffset), "The offset should have been set.");
+            Assert.That(properties.OffsetString, Is.EqualTo(lastOffset), "The offset should have been set.");
             Assert.That(properties.EnqueuedTime, Is.EqualTo(lastEnqueued), "The enqueued date/time should have been set.");
             Assert.That(properties.LastReceivedTime, Is.EqualTo(lastReceived), "The last received date/time should have been set.");
         }
@@ -121,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHubName = "fakeHub";
             var consumerGroup = "fakeConsumerGroup";
             var partition = "0";
-            var properties = EventHubsModelFactory.LastEnqueuedEventProperties(465, 988, fakeDate, fakeDate);
+            var properties = EventHubsModelFactory.LastEnqueuedEventProperties(465, "988", fakeDate, fakeDate);
             var context = EventHubsModelFactory.PartitionContext(fullyQualifiedNamespace, eventHubName, consumerGroup, partition, properties);
 
             Assert.That(context, Is.Not.Null, "The context should have been created.");
@@ -166,7 +166,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var properties = new Dictionary<string, object> { { "id", 12 } };
             var systemProperties = new Dictionary<string, object> { { "custom", "sys-value" } };
             var sequenceNumber = long.MaxValue - 512;
-            var offset = long.MaxValue - 1024;
+            string offset = (long.MaxValue - 1024).ToString();
             var enqueueTime = new DateTimeOffset(2015, 10, 27, 12, 0, 0, TimeSpan.Zero);
             var partitionKey = "omghai!";
             var eventData = EventHubsModelFactory.EventData(body, properties, systemProperties, partitionKey, sequenceNumber, offset, enqueueTime);
@@ -177,7 +177,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(eventData.SystemProperties, Is.EquivalentTo(systemProperties), "The system properties should have been set.");
             Assert.That(eventData.PartitionKey, Is.EqualTo(partitionKey), "The partition key should have been set.");
             Assert.That(eventData.SequenceNumber, Is.EqualTo(sequenceNumber), "The sequence number should have been set.");
-            Assert.That(eventData.Offset, Is.EqualTo(offset), "The offset should have been set.");
+            Assert.That(eventData.OffsetString, Is.EqualTo(offset), "The offset should have been set.");
             Assert.That(eventData.EnqueuedTime, Is.EqualTo(enqueueTime), "The sequence number should have been set.");
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
@@ -620,11 +620,11 @@ namespace Azure.Messaging.EventHubs.Tests
 
             if (useOldOverload)
             {
-                await mockProcessor.InvokeOldUpdateCheckpointAsync("65", 12345, 67890, cancellationSource.Token);
+                await mockProcessor.InvokeOldUpdateCheckpointAsync("65", "12345", 67890, cancellationSource.Token);
             }
             else
             {
-                await mockProcessor.InvokeUpdateCheckpointAsync("65", new CheckpointPosition(12345), cancellationSource.Token);
+                await mockProcessor.InvokeUpdateCheckpointAsync("65", new CheckpointPosition("12345"), cancellationSource.Token);
             }
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -783,7 +783,7 @@ namespace Azure.Messaging.EventHubs.Tests
             protected override Task OnProcessingErrorAsync(Exception exception, EventProcessorPartition partition, string operationDescription, CancellationToken cancellationToken) => throw new NotImplementedException();
 
             public Task<EventProcessorCheckpoint> InvokeGetCheckpointAsync(string partitionId, CancellationToken cancellationToken) => GetCheckpointAsync(partitionId, cancellationToken);
-            public Task InvokeOldUpdateCheckpointAsync(string partitionId, long offset, long? sequenceNumber, CancellationToken cancellationToken) => UpdateCheckpointAsync(partitionId, offset, sequenceNumber, cancellationToken);
+            public Task InvokeOldUpdateCheckpointAsync(string partitionId, string offset, long? sequenceNumber, CancellationToken cancellationToken) => UpdateCheckpointAsync(partitionId, new CheckpointPosition(offset, sequenceNumber ?? long.MinValue), cancellationToken);
             public Task InvokeUpdateCheckpointAsync(string partitionId, CheckpointPosition checkpointPosition, CancellationToken cancellationToken) => UpdateCheckpointAsync(partitionId, checkpointPosition, cancellationToken);
             public Task<IEnumerable<EventProcessorPartitionOwnership>> InvokeListOwnershipAsync(CancellationToken cancellationToken) => ListOwnershipAsync(cancellationToken);
             public Task<IEnumerable<EventProcessorPartitionOwnership>> InvokeClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) => ClaimOwnershipAsync(desiredOwnership, cancellationToken);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorOptionsTests.cs
@@ -35,7 +35,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 PartitionOwnershipExpirationInterval = TimeSpan.FromHours(16),
                 Identifier = "Rick Springfield is a bad friend",
                 TrackLastEnqueuedEventProperties = false,
-                DefaultStartingPosition = EventPosition.FromOffset(555)
+                DefaultStartingPosition = EventPosition.FromOffset("555")
             };
 
             EventProcessorOptions clone = options.Clone();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "27";
             var partitionIds = new[] { "0", partitionId };
             var ownedPartitions = new List<string>();
-            var lastEventProperties = new LastEnqueuedEventProperties(1234, 9876, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), DateTimeOffset.Parse("2012-03-04T08:30:00Z"));
+            var lastEventProperties = new LastEnqueuedEventProperties(1234, "9876", DateTimeOffset.Parse("2015-10-27T00:00:00Z"), DateTimeOffset.Parse("2012-03-04T08:30:00Z"));
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMinutes(5), TrackLastEnqueuedEventProperties = true };
             var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
@@ -72,8 +72,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(() => default);
 
             mockConnection
-                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(partitionIds);
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
@@ -112,7 +112,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var partitionId = "27";
             var partitionIds = new[] { "0", partitionId };
-            var lastEventProperties = new LastEnqueuedEventProperties(1234, 9876, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), DateTimeOffset.Parse("2012-03-04T08:30:00Z"));
+            var lastEventProperties = new LastEnqueuedEventProperties(1234, "9876", DateTimeOffset.Parse("2015-10-27T00:00:00Z"), DateTimeOffset.Parse("2012-03-04T08:30:00Z"));
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMinutes(5), TrackLastEnqueuedEventProperties = true };
             var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
@@ -129,8 +129,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Callback(() => completionSource.TrySetResult(true));
 
             mockConnection
-                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(partitionIds);
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
@@ -231,7 +231,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var checkpointStore = EventProcessor<EventProcessorPartition>.CreateCheckpointStore(mockProcessor.Object);
 
             Assert.That(checkpointStore, Is.Not.Null, "The storage manager should have been created.");
-            Assert.That(() => checkpointStore.UpdateCheckpointAsync(fqNamespace, eventHub, consumerGroup, partitionId, "Id", new CheckpointPosition(0), CancellationToken.None), Throws.InstanceOf<NotImplementedException>(), "Calling to update checkpoints should not be implemented.");
+            Assert.That(() => checkpointStore.UpdateCheckpointAsync(fqNamespace, eventHub, consumerGroup, partitionId, "Id", new CheckpointPosition("0"), CancellationToken.None), Throws.InstanceOf<NotImplementedException>(), "Calling to update checkpoints should not be implemented.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -142,11 +143,16 @@ namespace Azure.Messaging.EventHubs.Tests
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = new Mock<EventHubConnection>();
             var mockProcessor = new Mock<MinimalProcessorMock>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+            var partitionIds = new[] { "0", "1" };
 
             mockConnection
-                .SetupSequence(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .SetupSequence(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
                 .Throws(expectedException)
-                .ReturnsAsync(new[] { "0", "1" });
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
+
+            mockConnection
+                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partitionIds);
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
@@ -216,6 +222,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(partitionIds);
+
+            mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
 
             mockProcessor.Object.Logger = mockLogger.Object;
 
@@ -301,8 +311,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Throws(expectedException);
 
             mockConnection
-                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(partitionIds);
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
 
             mockProcessor.Object.Logger = mockLogger.Object;
 
@@ -387,8 +397,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Throws(expectedException);
 
             mockConnection
-                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(partitionIds);
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
 
             mockProcessor.Object.Logger = mockLogger.Object;
 
@@ -486,8 +496,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Mock.Of<TransportConsumer>());
 
             mockConnection
-                .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -604,8 +614,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConsumer.Object);
 
             mockConnection
-                .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -744,7 +754,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -875,7 +885,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1000,7 +1010,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1091,6 +1101,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(() => default);
 
             mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, partitionIds, false));
+
+            mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(partitionIds);
 
@@ -1149,7 +1163,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var createConsumerCalls = 0;
-            var expectedStartingPosition = EventPosition.FromOffset(775, true);
+            var expectedStartingPosition = EventPosition.FromOffset("775", true);
             var partitionId = "27";
             var partitionIds = new[] { "0", partitionId, "11" };
             var ownedPartitions = new List<string> { partitionId };
@@ -1174,7 +1188,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1253,7 +1267,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1372,7 +1386,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1485,6 +1499,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(() => default);
 
             mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, partitionIds, false));
+
+            mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(partitionIds);
 
@@ -1581,6 +1599,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = partitionId }))
                 .Returns(() => default);
+
+            mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1701,7 +1723,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1814,7 +1836,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1877,7 +1899,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "27";
             var partitionIds = new[] { "0", partitionId, "111" };
             var ownedPartitions = new List<string> { partitionId };
-            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250),  PartitionOwnershipExpirationInterval = TimeSpan.FromMilliseconds(750), LoadBalancingStrategy = LoadBalancingStrategy.Balanced };
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250), PartitionOwnershipExpirationInterval = TimeSpan.FromMilliseconds(750), LoadBalancingStrategy = LoadBalancingStrategy.Balanced };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
@@ -1901,6 +1923,10 @@ namespace Azure.Messaging.EventHubs.Tests
                     await Task.Delay(options.PartitionOwnershipExpirationInterval.Add(TimeSpan.FromSeconds(1))).ConfigureAwait(false);
                     return default;
                 });
+
+            mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1959,7 +1985,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "27";
             var partitionIds = new[] { "0", partitionId, "111" };
             var ownedPartitions = new List<string> { partitionId };
-            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250),  PartitionOwnershipExpirationInterval = TimeSpan.FromMilliseconds(750), LoadBalancingStrategy = LoadBalancingStrategy.Balanced };
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250), PartitionOwnershipExpirationInterval = TimeSpan.FromMilliseconds(750), LoadBalancingStrategy = LoadBalancingStrategy.Balanced };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
@@ -2000,7 +2026,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -2100,8 +2126,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(default(EventProcessorPartitionOwnership)));
 
             mockConnection
-                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(partitionIds);
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
@@ -2186,6 +2212,10 @@ namespace Azure.Messaging.EventHubs.Tests
                         completionSource.TrySetResult(true);
                     }
                 });
+
+            mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -2282,11 +2312,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 });
 
             mockConnection
-                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
                 .Returns(async () =>
                 {
                     await Task.Yield();
-                    return partitionIds;
+                    return new EventHubProperties("", DateTime.Now, partitionIds, false);
                 });
 
             mockConsumer
@@ -2377,8 +2407,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 });
 
             mockConnection
-                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(partitionIds);
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
@@ -2475,8 +2505,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 });
 
             mockConnection
-                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(partitionIds);
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("", DateTime.Now, partitionIds, false));
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
@@ -2584,7 +2614,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -2617,7 +2647,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     ItExpr.IsAny<IEnumerable<EventData>>(),
                     ItExpr.Is<EventProcessorPartition>(part => part.PartitionId == firstPartiton),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback (() =>
+                .Callback(() =>
                 {
                     if (loadBalancingCountAtDelay == 0)
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -132,8 +132,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = new[]
             {
-                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), sequenceNumber: 12345),
-                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), sequenceNumber: 67890),
+                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), sequenceNumber: 12345, offsetString: default),
+                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), sequenceNumber: 67890, offsetString: default),
             };
 
             var partition = new EventProcessorPartition { PartitionId = "123" };
@@ -364,7 +364,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = true };
-            var lastEvent = new EventData(new BinaryData(Array.Empty<byte>()), lastPartitionSequenceNumber: 123, lastPartitionOffset: 887, lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
+            var lastEvent = new EventData(new BinaryData(Array.Empty<byte>()), lastPartitionSequenceNumber: 123, lastPartitionOffset: "887", lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = Mock.Of<EventHubConnection>();
             var mockConsumer = new Mock<SettableTransportConsumer>();
@@ -413,7 +413,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = true, RetryOptions = retryOptions };
-            var lastEvent = new EventData(new BinaryData(Array.Empty<byte>()), lastPartitionSequenceNumber: 123, lastPartitionOffset: 887, lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
+            var lastEvent = new EventData(new BinaryData(Array.Empty<byte>()), lastPartitionSequenceNumber: 123, lastPartitionOffset: "887", lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = Mock.Of<EventHubConnection>();
             var mockConsumer = new Mock<SettableTransportConsumer>();
@@ -482,7 +482,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var options = new EventProcessorOptions { Identifier = "fake", TrackLastEnqueuedEventProperties = false, PrefetchCount = 37, PrefetchSizeInBytes = 44, LoadBalancingUpdateInterval = TimeSpan.FromMinutes(1) };
             var expectedOwnerLevel = 0;
             var expectedInvalidationOnSteal = true;
@@ -542,7 +542,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = Mock.Of<EventHubConnection>();
@@ -596,7 +596,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = Mock.Of<EventHubConnection>();
@@ -644,7 +644,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false };
             var receiveCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var closeCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -754,7 +754,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false };
             var receiveCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var closeCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -846,7 +846,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -903,7 +903,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var startSequenceNumber = "4444";
             var endSequenceNumber = "8888";
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -914,8 +914,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = new List<EventData>
             {
-                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), offset: 0, sequenceNumber: long.Parse(startSequenceNumber)),
-                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), offset: 1, sequenceNumber: long.Parse(endSequenceNumber))
+                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), offsetString: "0", sequenceNumber: long.Parse(startSequenceNumber)),
+                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), offsetString: "1", sequenceNumber: long.Parse(endSequenceNumber))
             };
 
             mockConsumer
@@ -994,7 +994,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedException = new DivideByZeroException();
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1048,7 +1048,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedException = new DivideByZeroException();
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var receiveCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1111,7 +1111,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedException = new DivideByZeroException("OMG FAIL!");
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var receiveCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1176,7 +1176,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedException = new DivideByZeroException("I'm special!");
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var receiveCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1232,7 +1232,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedException = new DeveloperCodeException(new DivideByZeroException());
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 1, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1293,7 +1293,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedException = new DeveloperCodeException(new DivideByZeroException("Yay, I'm on the inside!"));
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 1, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1356,7 +1356,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedException = new InvalidOperationException("BOOM!");
             var developerException = new DeveloperCodeException(expectedException);
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 1, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1403,7 +1403,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedException = new EventHubsException(true, "frank", "BOOM!", EventHubsException.FailureReason.GeneralError);
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 2, MaximumDelay = TimeSpan.FromMilliseconds(15) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1658,7 +1658,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var partition = new EventProcessorPartition { PartitionId = "4" };
-            var lastEventBatch = new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>()), offset: 9987) };
+            var lastEventBatch = new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>()), offset: "9987") };
             var initialStartingPosition = EventPosition.FromSequenceNumber(332);
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = Mock.Of<EventHubConnection>();
@@ -1711,7 +1711,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     mockProcessor.Object.ConsumerGroup,
                     partition.PartitionId,
                     It.IsAny<string>(),
-                    EventPosition.FromOffset(lastEventBatch.Last().Offset, false),
+                    EventPosition.FromOffset(lastEventBatch.Last().OffsetString, false),
                     mockConnection,
                     It.IsAny<EventProcessorOptions>(),
                     It.IsAny<bool>()),

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.StartStop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.StartStop.cs
@@ -133,6 +133,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(default(EventProcessorPartitionOwnership));
 
             mockConnection
+                .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, partitions, false));
+
+            mockConnection
                 .Setup(connection => connection.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(partitions);
 
@@ -362,7 +366,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), new[] { "0" }));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), new[] { "0" }, false));
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
@@ -429,9 +433,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConnection = new Mock<EventHubConnection>();
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
 
-             mockProcessor
-                .Setup(processor => processor.CreateConnection())
-                .Returns(mockConnection.Object);
+            mockProcessor
+               .Setup(processor => processor.CreateConnection())
+               .Returns(mockConnection.Object);
 
             mockProcessor
                 .Protected()
@@ -630,6 +634,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(default(EventProcessorPartitionOwnership)));
 
             mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, partitionIds, false));
+
+            mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(partitionIds);
 
@@ -729,6 +737,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .Setup(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(default(EventProcessorPartitionOwnership)));
+
+            mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, partitionIds, false));
 
             mockConnection
                 .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -922,6 +934,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(lb => lb.RelinquishOwnershipAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask)
                 .Callback(() => stopCompletionSource.TrySetResult(true));
+
+            mockConnection
+                .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, Array.Empty<string>(), false));
 
             mockConnection
                 .Setup(connection => connection.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
@@ -1268,9 +1284,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Callback(() => stopCompletionSource.TrySetResult(true));
 
             mockConnection
-                .SetupSequence(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Array.Empty<string>())
-                .ReturnsAsync(Array.Empty<string>())
+                .SetupSequence(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, Array.Empty<string>(), false))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTimeOffset.Now, Array.Empty<string>(), false))
                 .Returns(async () =>
                 {
                     await startCompletionSource.Task;
@@ -1364,7 +1380,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var firstCall = true;
             var partition = new EventProcessorPartition { PartitionId = "99" };
-            var position = EventPosition.FromOffset(12);
+            var position = EventPosition.FromOffset("12");
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) } };
             var handlerCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockEventSource = new Mock<EventHubsEventSource>();
@@ -1374,7 +1390,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), new[] { "0" }));
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), new[] { "0" }, false));
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
@@ -647,7 +647,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 // Once sent, query the partition and determine the offset of the last enqueued event, then send the new set
                 // of events that should appear after the starting position.
 
-                long lastOffset;
+                string lastOffset;
                 EventPosition startingPosition;
 
                 await using (var producer = new EventHubProducerClient(
@@ -658,7 +658,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     await SendEventsAsync(scope.EventHubName, seedEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
                     await Task.Delay(250);
 
-                    lastOffset = (await producer.GetPartitionPropertiesAsync(partition, cancellationSource.Token)).LastEnqueuedOffset;
+                    lastOffset = (await producer.GetPartitionPropertiesAsync(partition, cancellationSource.Token)).LastEnqueuedOffsetString;
                     startingPosition = EventPosition.FromOffset(lastOffset, isInclusive);
 
                     await SendEventsAsync(scope.EventHubName, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
@@ -687,7 +687,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                     Assert.That(readState.Events.Count, Is.EqualTo(expectedCount), "The wrong number of events was read for the value of the inclusive flag.");
-                    Assert.That(readState.Events.Values.Any(readEvent => readEvent.Offset == lastOffset), Is.EqualTo(isInclusive), $"The event with offset [{ lastOffset }] was { ((isInclusive) ? "not" : "") } in the set of read events, which is inconsistent with the inclusive flag.");
+                    Assert.That(readState.Events.Values.Any(readEvent => readEvent.OffsetString == lastOffset), Is.EqualTo(isInclusive), $"The event with offset [{ lastOffset }] was { ((isInclusive) ? "not" : "") } in the set of read events, which is inconsistent with the inclusive flag.");
 
                     foreach (var sourceEvent in sourceEvents)
                     {
@@ -1527,7 +1527,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ExclusiveReceiverSupercedesNonExclusiveActiveReader()
+        public async Task ExclusiveReceiverSupersedesNonExclusiveActiveReader()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -1598,7 +1598,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ReceiverWithHigherOwnerLevelSupercedesActiveReader()
+        public async Task ReceiverWithHigherOwnerLevelSupersedesActiveReader()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -1818,7 +1818,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ReceiverIsNotCompromisedByBeingSupercededByAnotherReaderWithHigherLevel()
+        public async Task ReceiverIsNotCompromisedByBeingSupersededByAnotherReaderWithHigherLevel()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
@@ -2436,7 +2436,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(partitionProperties.EventHubName, Is.EqualTo(scope.EventHubName).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
                     Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(long)), "The beginning sequence number should have been populated.");
                     Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(long)), "The last sequence number should have been populated.");
-                    Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedOffsetString, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -582,7 +582,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionStringConstructorSetsTheInitialPosition()
         {
-            var expectedPosition = EventPosition.FromOffset(999);
+            var expectedPosition = EventPosition.FromOffset("999");
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var receiver = new PartitionReceiver("cg", "pid", expectedPosition, connectionString);
 
@@ -596,7 +596,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void TokenCredentialConstructorSetsTheInitialPosition()
         {
-            var expectedPosition = EventPosition.FromOffset(999);
+            var expectedPosition = EventPosition.FromOffset("999");
             var receiver = new PartitionReceiver("cg", "pid", expectedPosition, "fqns", "eh", Mock.Of<TokenCredential>());
 
             Assert.That(receiver.InitialPosition, Is.EqualTo(expectedPosition));
@@ -609,7 +609,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SharedKeyCredentialConstructorSetsTheInitialPosition()
         {
-            var expectedPosition = EventPosition.FromOffset(999);
+            var expectedPosition = EventPosition.FromOffset("999");
             var receiver = new PartitionReceiver("cg", "pid", expectedPosition, "fqns", "eh", new AzureNamedKeyCredential("key", "value"));
 
             Assert.That(receiver.InitialPosition, Is.EqualTo(expectedPosition));
@@ -622,7 +622,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SasCredentialConstructorSetsTheInitialPosition()
         {
-            var expectedPosition = EventPosition.FromOffset(999);
+            var expectedPosition = EventPosition.FromOffset("999");
             var receiver = new PartitionReceiver("cg", "pid", expectedPosition, "fqns", "eh", new AzureSasCredential(new SharedAccessSignature("sb://this.is.Fake/blah", "key", "value").Value));
 
             Assert.That(receiver.InitialPosition, Is.EqualTo(expectedPosition));
@@ -635,7 +635,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionConstructorSetsTheInitialPosition()
         {
-            var expectedPosition = EventPosition.FromOffset(999);
+            var expectedPosition = EventPosition.FromOffset("999");
             var receiver = new PartitionReceiver("cg", "pid", expectedPosition, Mock.Of<EventHubConnection>());
 
             Assert.That(receiver.InitialPosition, Is.EqualTo(expectedPosition));
@@ -730,7 +730,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedConsumerGroup = "consumerGroup";
             var expectedPartitionId = "partitionId";
             var expectedIdentifier = "customIdent!fi3r!";
-            var expectedPosition = EventPosition.FromOffset(55);
+            var expectedPosition = EventPosition.FromOffset("55");
             var expectedInvalidateOnSteal = false;
 
             var expectedOptions = new PartitionReceiverOptions
@@ -771,7 +771,7 @@ namespace Azure.Messaging.EventHubs.Tests
             (
                 eventBody: new BinaryData(Array.Empty<byte>()),
                 lastPartitionSequenceNumber: 1234,
-                lastPartitionOffset: 42,
+                lastPartitionOffset: "42",
                 lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
                 lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2012-03-04T08:42Z")
             );
@@ -798,7 +798,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var information = receiver.ReadLastEnqueuedEventProperties();
 
             Assert.That(information.SequenceNumber, Is.EqualTo(lastEvent.LastPartitionSequenceNumber), "The sequence number should match.");
-            Assert.That(information.Offset, Is.EqualTo(lastEvent.LastPartitionOffset), "The offset should match.");
+            Assert.That(information.OffsetString, Is.EqualTo(lastEvent.LastPartitionOffset), "The offset should match.");
             Assert.That(information.EnqueuedTime, Is.EqualTo(lastEvent.LastPartitionEnqueuedTime), "The last enqueue time should match.");
             Assert.That(information.LastReceivedTime, Is.EqualTo(lastEvent.LastPartitionPropertiesRetrievalTime), "The retrieval time should match.");
         }
@@ -834,7 +834,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var information = receiver.ReadLastEnqueuedEventProperties();
 
             Assert.That(information.SequenceNumber, Is.EqualTo(defaultProperties.SequenceNumber), "The sequence number should match.");
-            Assert.That(information.Offset, Is.EqualTo(defaultProperties.Offset), "The offset should match.");
+            Assert.That(information.OffsetString, Is.EqualTo(defaultProperties.OffsetString), "The offset should match.");
             Assert.That(information.EnqueuedTime, Is.EqualTo(defaultProperties.EnqueuedTime), "The last enqueue time should match.");
             Assert.That(information.LastReceivedTime, Is.EqualTo(defaultProperties.LastReceivedTime), "The retrieval time should match.");
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/CheckpointPositionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/CheckpointPositionTests.cs
@@ -16,6 +16,25 @@ namespace Azure.Messaging.EventHubs.Tests
     public class CheckpointPositionTests
     {
         /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesOffset(string offset)
+        {
+            if (offset == null)
+            {
+                Assert.That(() => new CheckpointPosition(offset), Throws.InstanceOf<ArgumentNullException>());
+            }
+            else
+            {
+                Assert.That(() => new CheckpointPosition(offset), Throws.InstanceOf<ArgumentException>());
+            }
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="CheckpointPosition "/>
         ///   equality.
         /// </summary>
@@ -23,8 +42,24 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void TheSamePositionAreEqual()
         {
-            var first = new CheckpointPosition(121);
-            var second = new CheckpointPosition(121);
+            var first = new CheckpointPosition("121");
+            var second = new CheckpointPosition("121");
+
+            Assert.That(first.Equals((object)second), Is.True, "The default Equals comparison is incorrect.");
+            Assert.That(first.Equals(second), Is.True, "The IEquatable comparison is incorrect.");
+            Assert.That((first == second), Is.True, "The == operator comparison is incorrect.");
+            Assert.That((first != second), Is.False, "The != operator comparison is incorrect.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CheckpointPosition "/>
+        ///   equality.
+        /// </summary>
+        [Test]
+        public void TheSamePositionAreEqualWithSequenceNumber()
+        {
+            var first = new CheckpointPosition("44", 121);
+            var second = new CheckpointPosition("44", 121);
 
             Assert.That(first.Equals((object)second), Is.True, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.True, "The IEquatable comparison is incorrect.");
@@ -40,8 +75,42 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void DifferentPositionsAreNotEqual()
         {
-            var first = new CheckpointPosition(10);
-            var second = new CheckpointPosition(121);
+            var first = new CheckpointPosition("10");
+            var second = new CheckpointPosition("121");
+
+            Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
+            Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
+            Assert.That((first == second), Is.False, "The == operator comparison is incorrect.");
+            Assert.That((first != second), Is.True, "The != operator comparison is incorrect.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CheckpointPosition "/>
+        ///   equality.
+        /// </summary>
+        ///
+        [Test]
+        public void DifferentPositionsAreNotEqualWithDifferentMembers()
+        {
+            var first = new CheckpointPosition("121");
+            var second = new CheckpointPosition("121", 10);
+
+            Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
+            Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
+            Assert.That((first == second), Is.False, "The == operator comparison is incorrect.");
+            Assert.That((first != second), Is.True, "The != operator comparison is incorrect.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CheckpointPosition "/>
+        ///   equality.
+        /// </summary>
+        ///
+        [Test]
+        public void DifferentPositionsAreNotEqualWithOffset()
+        {
+            var first = new CheckpointPosition("10");
+            var second = new CheckpointPosition("121");
 
             Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
             Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
@@ -57,8 +126,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void GetHashCodeReturnsDifferentValuesForDifferentMembers()
         {
-            var first = new CheckpointPosition(10);
-            var second = new CheckpointPosition(121);
+            var first = new CheckpointPosition("10", 12);
+            var second = new CheckpointPosition("121");
 
             Assert.That(first.GetHashCode(), Is.Not.EqualTo(second.GetHashCode()));
         }
@@ -72,7 +141,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void FromEventSetsProperties()
         {
             var sequence = 4566;
-            var eventData = new EventData(new BinaryData("Hello"), sequenceNumber: sequence, offset: 123);
+            var eventData = new EventData(new BinaryData("Hello"), sequenceNumber: sequence, offset: "123");
 
             var checkpoint = CheckpointPosition.FromEvent(eventData);
 
@@ -87,11 +156,26 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ToStringReflectsTheState()
         {
-            var sequence = 121;
+            var offset = "121";
+            var checkpoint = new CheckpointPosition(offset);
 
-            var checkpoint = new CheckpointPosition(sequence);
+            Assert.That(checkpoint.ToString(), Contains.Substring($"[{offset}]"), "The offset should be represented.");
+        }
 
-            Assert.That(checkpoint.ToString(), Contains.Substring($"[{sequence}]"), "The sequence should be represented.");
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CheckpointPosition.ToString "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ToStringReflectsTheStateWithSequenceNumber()
+        {
+            var offset = "121";
+            var sequence = 10;
+            var checkpoint = new CheckpointPosition(offset, sequence);
+
+            Assert.That(checkpoint.ToString(), Contains.Substring($"[{offset}]"), "The offset should be represented.");
+            Assert.That(checkpoint.ToString(), Contains.Substring($"[{sequence}]"), "The sequence number should be represented.");
         }
 
         /// <summary>
@@ -102,7 +186,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ToStringReflectsTheStateFromEventData()
         {
-            var offset = 400;
+            var offset = "400";
             var sequence = 121;
             var eventData = new EventData(new BinaryData("Hello"), sequenceNumber: sequence, offset: offset);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
@@ -1601,7 +1601,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(partitionProperties.EventHubName, Is.EqualTo(scope.EventHubName).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
             Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(long)), "The beginning sequence number should have been populated.");
             Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(long)), "The last sequence number should have been populated.");
-            Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
+            Assert.That(partitionProperties.LastEnqueuedOffsetString, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
@@ -412,7 +412,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.GetPartitionPropertiesAsync(
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new PartitionProperties("test", "1", true, 12345, 6789, 22, new DateTimeOffset(2015, 10, 27, 0, 0, 0, TimeSpan.Zero)));
+                .ReturnsAsync(new PartitionProperties("test", "1", true, 12345, 6789, "22", new DateTimeOffset(2015, 10, 27, 0, 0, 0, TimeSpan.Zero)));
 
             await bufferedProducer.GetPartitionPropertiesAsync(expectedPartition, cancellationSource.Token);
             mockProducer.Verify(producer => producer.GetPartitionPropertiesAsync(expectedPartition, cancellationSource.Token), Times.Once);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
@@ -869,7 +869,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         // The following properties should have been updated.
 
                         Assert.That(newPartitionProperties.LastEnqueuedSequenceNumber, Is.GreaterThan(oldPartitionProperties.LastEnqueuedSequenceNumber));
-                        Assert.That(newPartitionProperties.LastEnqueuedOffset, Is.GreaterThan(oldPartitionProperties.LastEnqueuedOffset));
+                        Assert.That(newPartitionProperties.LastEnqueuedOffsetString, Is.GreaterThan(oldPartitionProperties.LastEnqueuedOffsetString));
                     }
                 }
             }
@@ -920,7 +920,8 @@ namespace Azure.Messaging.EventHubs.Tests
                         // The following properties should have been updated.
 
                         Assert.That(newPartitionProperties.LastEnqueuedSequenceNumber, Is.GreaterThan(oldPartitionProperties.LastEnqueuedSequenceNumber));
-                        Assert.That(newPartitionProperties.LastEnqueuedOffset, Is.GreaterThan(oldPartitionProperties.LastEnqueuedOffset));
+                        Assert.That(newPartitionProperties.LastEnqueuedOffsetString, Is.Not.EqualTo(oldPartitionProperties.LastEnqueuedOffsetString));
+                        Assert.That(newPartitionProperties.LastEnqueuedOffsetString, Is.Not.Null.And.Not.Empty);
                     }
                 }
             }
@@ -964,7 +965,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         Assert.That(newPartitionProperties.EventHubName, Is.EqualTo(oldPartitionProperties.EventHubName));
                         Assert.That(newPartitionProperties.BeginningSequenceNumber, Is.EqualTo(oldPartitionProperties.BeginningSequenceNumber));
                         Assert.That(newPartitionProperties.LastEnqueuedSequenceNumber, Is.EqualTo(oldPartitionProperties.LastEnqueuedSequenceNumber));
-                        Assert.That(newPartitionProperties.LastEnqueuedOffset, Is.EqualTo(oldPartitionProperties.LastEnqueuedOffset));
+                        Assert.That(newPartitionProperties.LastEnqueuedOffsetString, Is.EqualTo(oldPartitionProperties.LastEnqueuedOffsetString));
                     }
                 }
             }
@@ -1375,7 +1376,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(partitionProperties.EventHubName, Is.EqualTo(scope.EventHubName).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
                     Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(long)), "The beginning sequence number should have been populated.");
                     Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(long)), "The last sequence number should have been populated.");
-                    Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedOffsetString, Is.Not.Null.And.Not.Empty, "The last offset should have been populated.");
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -2888,7 +2888,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                           CancellationToken cancellationToken = default)
             {
                 GetPropertiesInvokedWith = retryPolicy;
-                return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }));
+                return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }, false));
             }
 
             internal override async Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -398,7 +398,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                           CancellationToken cancellationToken = default)
             {
                 GetPropertiesInvokedWith = retryPolicy;
-                return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }));
+                return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }, false));
             }
 
             internal async override Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample03_EventHubMetadataLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample03_EventHubMetadataLiveTests.cs
@@ -142,7 +142,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                 Debug.WriteLine($"\tThe partition contains no events: { partitionProperties.IsEmpty }");
                 Debug.WriteLine($"\tThe first sequence number is: { partitionProperties.BeginningSequenceNumber }");
                 Debug.WriteLine($"\tThe last sequence number is: { partitionProperties.LastEnqueuedSequenceNumber }");
-                Debug.WriteLine($"\tThe last offset is: { partitionProperties.LastEnqueuedOffset }");
+                Debug.WriteLine($"\tThe last offset is: { partitionProperties.LastEnqueuedOffsetString }");
                 Debug.WriteLine($"\tThe last enqueued time is: { partitionProperties.LastEnqueuedTime }, in UTC.");
             }
             finally

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample05_ReadingEventsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample05_ReadingEventsLiveTests.cs
@@ -453,7 +453,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
                 string firstPartition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
                 PartitionProperties properties = await consumer.GetPartitionPropertiesAsync(firstPartition, cancellationSource.Token);
-                EventPosition startingPosition = EventPosition.FromOffset(properties.LastEnqueuedOffset);
+                EventPosition startingPosition = EventPosition.FromOffset(properties.LastEnqueuedOffsetString);
 
                 await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync(
                     firstPartition,
@@ -592,7 +592,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
                     Debug.WriteLine($"Partition: { partitionEvent.Partition.PartitionId }");
                     Debug.WriteLine($"\tThe last sequence number is: { properties.SequenceNumber }");
-                    Debug.WriteLine($"\tThe last offset is: { properties.Offset }");
+                    Debug.WriteLine($"\tThe last offset is: { properties.OffsetString }");
                     Debug.WriteLine($"\tThe last enqueued time is: { properties.EnqueuedTime }, in UTC.");
                     Debug.WriteLine($"\tThe information was updated at: { properties.LastReceivedTime }, in UTC.");
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample11_MockingClientTypesLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample11_MockingClientTypesLiveTests.cs
@@ -88,7 +88,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                     isEmpty : true,
                     beginningSequenceNumber: 1000,
                     lastSequenceNumber : 1100,
-                    lastOffset : 500,
+                    lastOffsetString : "500:1:7863",
                     lastEnqueuedTime : DateTime.UtcNow) },
 
                 // Empty partition
@@ -98,7 +98,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                     isEmpty : false,
                     beginningSequenceNumber : 2000,
                     lastSequenceNumber : 2000,
-                    lastOffset : 760,
+                    lastOffsetString : "760:1:8800",
                     lastEnqueuedTime : DateTime.UtcNow) }
             };
 
@@ -360,7 +360,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             LastEnqueuedEventProperties lastEnqueueEventProperties = EventHubsModelFactory.LastEnqueuedEventProperties(
                 lastSequenceNumber : 1234,
-                lastOffset : 234,
+                lastOffsetString : "234:1:954-2",
                 lastEnqueuedTime : DateTimeOffset.Parse("1:24 AM"),
                 lastReceivedTime : DateTimeOffset.Parse("1:26 AM"));
 
@@ -386,7 +386,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                     systemProperties: new Dictionary<string, object>(), //arbitrary value
                     partitionKey: "sample-key",
                     sequenceNumber: 1000,
-                    offset: 1500,
+                    offsetString: "1500:44:59492",
                     enqueuedTime: DateTimeOffset.Parse("11:36 PM"));
 
                 EventData eventData2 = EventHubsModelFactory.EventData(
@@ -394,7 +394,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                     systemProperties: new Dictionary<string, object>(), //arbitrary value
                     partitionKey: "sample-key",
                     sequenceNumber: 1000,
-                    offset: 1500,
+                    offsetString: "1500:2:1111",
                     enqueuedTime: DateTimeOffset.Parse("11:36 PM"));
 
                 // This creates a mock PartitionEvent to return from the consumer client.
@@ -480,7 +480,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                     systemProperties: new Dictionary<string, object>(), //arbitrary value
                     partitionKey: $"sample-key-{index}",
                     sequenceNumber: 1234,
-                    offset: 234,
+                    offsetString: "234:5:93928381.1",
                     enqueuedTime: DateTimeOffset.Parse("9:25 AM"));
 
                 receivedEvents.Add(eventData);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
@@ -463,19 +463,21 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                     // leave the property name as lease for backcompat with T1
                     writer.WritePropertyName("lease");
                     writer.WriteStartObject();
-                    WritePropertyIfNotNull(writer, "offset", context.Checkpoint.Value.Offset.ToString(CultureInfo.InvariantCulture));
+                    WritePropertyIfNotNull(writer, "offset", context.Checkpoint.Value.Offset);
                     WritePropertyIfNotNull(writer, "sequenceNumber", context.Checkpoint.Value.SequenceNumber.ToString(CultureInfo.InvariantCulture));
                     writer.WriteEndObject();
                 }
 
                 // Log RuntimeInformation if EnableReceiverRuntimeMetric is enabled
-                writer.WritePropertyName("runtimeInformation");
-                writer.WriteStartObject();
-                WritePropertyIfNotNull(writer, "lastEnqueuedOffset", context.LastEnqueuedEventProperties.Offset?.ToString(CultureInfo.InvariantCulture));
-                WritePropertyIfNotNull(writer, "lastSequenceNumber", context.LastEnqueuedEventProperties.SequenceNumber?.ToString(CultureInfo.InvariantCulture));
-                WritePropertyIfNotNull(writer, "lastEnqueuedTimeUtc", context.LastEnqueuedEventProperties.EnqueuedTime?.ToString("o", CultureInfo.InvariantCulture));
-                writer.WriteEndObject();
-
+                if (context.LastEnqueuedEventProperties != null)
+                {
+                    writer.WritePropertyName("runtimeInformation");
+                    writer.WriteStartObject();
+                    WritePropertyIfNotNull(writer, "lastEnqueuedOffset", context.LastEnqueuedEventProperties.OffsetString);
+                    WritePropertyIfNotNull(writer, "lastSequenceNumber", context.LastEnqueuedEventProperties.SequenceNumber?.ToString(CultureInfo.InvariantCulture));
+                    WritePropertyIfNotNull(writer, "lastEnqueuedTimeUtc", context.LastEnqueuedEventProperties.EnqueuedTime?.ToString("o", CultureInfo.InvariantCulture));
+                    writer.WriteEndObject();
+                }
                 writer.WriteEndObject();
 
                 return sw.ToString();

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
@@ -469,15 +469,13 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                 }
 
                 // Log RuntimeInformation if EnableReceiverRuntimeMetric is enabled
-                if (context.LastEnqueuedEventProperties != null)
-                {
-                    writer.WritePropertyName("runtimeInformation");
-                    writer.WriteStartObject();
-                    WritePropertyIfNotNull(writer, "lastEnqueuedOffset", context.LastEnqueuedEventProperties.OffsetString);
-                    WritePropertyIfNotNull(writer, "lastSequenceNumber", context.LastEnqueuedEventProperties.SequenceNumber?.ToString(CultureInfo.InvariantCulture));
-                    WritePropertyIfNotNull(writer, "lastEnqueuedTimeUtc", context.LastEnqueuedEventProperties.EnqueuedTime?.ToString("o", CultureInfo.InvariantCulture));
-                    writer.WriteEndObject();
-                }
+                writer.WritePropertyName("runtimeInformation");
+                writer.WriteStartObject();
+                WritePropertyIfNotNull(writer, "lastEnqueuedOffset", context.LastEnqueuedEventProperties.OffsetString);
+                WritePropertyIfNotNull(writer, "lastSequenceNumber", context.LastEnqueuedEventProperties.SequenceNumber?.ToString(CultureInfo.InvariantCulture));
+                WritePropertyIfNotNull(writer, "lastEnqueuedTimeUtc", context.LastEnqueuedEventProperties.EnqueuedTime?.ToString("o", CultureInfo.InvariantCulture));
+                writer.WriteEndObject();
+
                 writer.WriteEndObject();
 
                 return sw.ToString();

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -12,7 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" />
+    <!-- TEMP TEMP -->
+    <ProjectReference Include="../../Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj" />
+    <!-- PackageReference Include="Azure.Messaging.EventHubs" /-->
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
@@ -22,6 +24,7 @@
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="SharedSource" />
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" LinkBase="SharedSource" />
     <Compile Include="$(AzureCoreSharedSources)ValueStopwatch.cs" LinkBase="SharedSource" />
+    <Compile Include="../../Azure.Messaging.EventHubs.Shared/src/Core/AttributeMessageText.cs" LinkBase="SharedSource" />
     <Compile Include="../../Azure.Messaging.EventHubs.Shared/src/Core/CancellationTokenExtensions.cs" LinkBase="SharedSource" />
     <Compile Include="../../Azure.Messaging.EventHubs.Shared/src/Core/BasicRetryPolicy.cs" LinkBase="SharedSource" />
     <Compile Include="../../Azure.Messaging.EventHubs.Shared/src/Core/EventHubsRetryOptionsExtensions.cs" LinkBase="SharedSource" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/CheckpointInfo.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/CheckpointInfo.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
 {
     internal struct CheckpointInfo
     {
-        public long Offset { get; }
+        public string Offset { get; }
         public long SequenceNumber { get; }
         public DateTimeOffset? LastModified { get; }
 
-        public CheckpointInfo(long offset, long sequenceNumber, DateTimeOffset? lastModified)
+        public CheckpointInfo(string offset, long sequenceNumber, DateTimeOffset? lastModified)
         {
             Offset = offset;
             SequenceNumber = sequenceNumber;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
 
             if (checkpoint is BlobCheckpointStoreInternal.BlobStorageCheckpoint blobCheckpoint && blobCheckpoint is not null)
             {
-                _lastReadCheckpoint[partitionId] = new CheckpointInfo(blobCheckpoint.Offset ?? -1, blobCheckpoint.SequenceNumber ?? -1,
+                _lastReadCheckpoint[partitionId] = new CheckpointInfo(blobCheckpoint.Offset, blobCheckpoint.SequenceNumber ?? -1,
                     blobCheckpoint.LastModified);
             }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHostPartition.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHostPartition.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
         public async Task CheckpointAsync(EventData checkpointEvent)
         {
             await ProcessorHost.CheckpointAsync(PartitionId, checkpointEvent).ConfigureAwait(false);
-            Checkpoint = new CheckpointInfo(checkpointEvent.Offset, checkpointEvent.SequenceNumber, DateTimeOffset.UtcNow);
+            Checkpoint = new CheckpointInfo(checkpointEvent.OffsetString, checkpointEvent.SequenceNumber, DateTimeOffset.UtcNow);
         }
 
         private class EventProcessorHostPartitionContext : TriggerPartitionContext

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerBindingStrategy.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerBindingStrategy.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             for (int i = 0; i < events.Length; i++)
             {
                 partitionKeys[i] = events[i].PartitionKey;
-                offsets[i] = events[i].Offset.ToString(CultureInfo.InvariantCulture);
+                offsets[i] = events[i].OffsetString;
                 sequenceNumbers[i] = events[i].SequenceNumber;
                 enqueuedTimesUtc[i] = events[i].EnqueuedTime.DateTime;
                 properties[i] = events[i].Properties;
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         private static void AddBindingData(Dictionary<string, object> bindingData, EventData eventData)
         {
             SafeAddValue(() => bindingData.Add("PartitionKey", eventData.PartitionKey));
-            SafeAddValue(() => bindingData.Add("Offset", eventData.Offset));
+            SafeAddValue(() => bindingData.Add("Offset", eventData.OffsetString));
             SafeAddValue(() => bindingData.Add("SequenceNumber", eventData.SequenceNumber));
             SafeAddValue(() => bindingData.Add("EnqueuedTimeUtc", eventData.EnqueuedTime.DateTime));
             SafeAddValue(() => bindingData.Add("Properties", eventData.Properties));
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
             // Following is needed to maintain structure of bindingdata: https://github.com/Azure/azure-webjobs-sdk/pull/1849
             modifiedDictionary["SequenceNumber"] = eventData.SequenceNumber;
-            modifiedDictionary["Offset"] = eventData.Offset;
+            modifiedDictionary["Offset"] = eventData.OffsetString;
             modifiedDictionary["PartitionKey"] = eventData.PartitionKey;
             modifiedDictionary["EnqueuedTimeUtc"] = eventData.EnqueuedTime.DateTime;
             return modifiedDictionary;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerInput.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerInput.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             string offset, enqueueTimeUtc, sequenceNumber;
             if (IsSingleDispatch)
             {
-                offset = Events[0].Offset.ToString(CultureInfo.InvariantCulture);
+                offset = Events[0].OffsetString;
                 enqueueTimeUtc = Events[0].EnqueuedTime.ToString("o", CultureInfo.InvariantCulture);
                 sequenceNumber = Events[0].SequenceNumber.ToString(CultureInfo.InvariantCulture);
             }
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 EventData first = Events[0];
                 EventData last = Events[Events.Length - 1];
 
-                offset = $"{first.Offset}-{last.Offset}";
+                offset = $"{first.OffsetString}-{last.OffsetString}";
                 enqueueTimeUtc = $"{first.EnqueuedTime.ToString("o", CultureInfo.InvariantCulture)}-{last.EnqueuedTime.ToString("o", CultureInfo.InvariantCulture)}";
                 sequenceNumber = $"{first.SequenceNumber}-{last.SequenceNumber}";
             }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+// Ignore Spelling: Poco evt
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -925,7 +927,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                         EventHubConsumerClient.DefaultConsumerGroupName,
                         partition,
                         producer.Identifier,
-                        new CheckpointPosition(-1),
+                        new CheckpointPosition("-1", -1),
                         CancellationToken.None);
                 }
             }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+// Ignore Spelling: Checkpointing Rebalancing
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -186,7 +188,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
             processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo(123, 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(1))));
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo("123:1:11", 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(1))));
             partitionContext.ProcessorHost = processor.Object;
 
             var loggerMock = new Mock<ILogger>();
@@ -240,7 +242,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
             processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo(123, 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1))));
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo("123", 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1))));
             partitionContext.ProcessorHost = processor.Object;
 
             var loggerMock = new Mock<ILogger>();
@@ -292,7 +294,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
             processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo(123, 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1))));
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo("123", 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1))));
             partitionContext.ProcessorHost = processor.Object;
 
             // Because the first invocation will allow a partial batch due to the old checkpoint,

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreSame(input.ProcessorPartition.PartitionContext, bindingData["TriggerPartitionContext"]);
             Assert.AreSame(input.ProcessorPartition.PartitionContext, bindingData["PartitionContext"]);
             Assert.AreEqual(evt.PartitionKey, bindingData["PartitionKey"]);
-            Assert.AreEqual(evt.Offset, bindingData["Offset"]);
+            Assert.AreEqual(evt.OffsetString, bindingData["Offset"]);
             Assert.AreEqual(evt.SequenceNumber, bindingData["SequenceNumber"]);
             Assert.AreEqual(evt.EnqueuedTime.DateTime, bindingData["EnqueuedTimeUtc"]);
             Assert.AreSame(evt.Properties, bindingData["Properties"]);
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         }
 
         private static EventData GetSystemProperties(byte[] body, string partitionKey = "TestKey") =>
-            EventHubsModelFactory.EventData(new BinaryData(body), partitionKey: partitionKey, offset: 140, enqueuedTime: DateTimeOffset.MinValue, sequenceNumber: 4294967296, systemProperties: new Dictionary<string, object>()
+            EventHubsModelFactory.EventData(new BinaryData(body), partitionKey: partitionKey, offsetString: "140:1:12", enqueuedTime: DateTimeOffset.MinValue, sequenceNumber: 4294967296, systemProperties: new Dictionary<string, object>()
             {
                 {"iothub-connection-device-id", "testDeviceId"},
                 {"iothub-enqueuedtime", DateTime.MinValue}

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             this._checkpoints = new EventProcessorCheckpoint[]
             {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 0 }
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 0 }
             };
 
             var metrics = await _metricsProvider.GetMetricsAsync();
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             // Checkpointing is ahead of partition info and invalid (SequenceNumber > LastEnqueued)
             this._checkpoints = new EventProcessorCheckpoint[]
             {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 999, SequenceNumber = 11 }
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "999", SequenceNumber = 11 }
             };
 
             _partitions = new List<PartitionProperties>
@@ -129,9 +129,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             // No messages processed, no messages in queue
             this._checkpoints = new EventProcessorCheckpoint[]
             {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 0, PartitionId = "1" },
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 0, PartitionId = "2" },
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 0, PartitionId = "3" }
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 0, PartitionId = "1" },
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 0, PartitionId = "2" },
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 0, PartitionId = "3" }
             };
 
             _partitions = new List<PartitionProperties>
@@ -150,9 +150,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             // Messages processed, Messages in queue
             this._checkpoints = new EventProcessorCheckpoint[]
             {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 2, PartitionId = "1" },
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 3, PartitionId = "2" },
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 4, PartitionId = "3" }
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 2, PartitionId = "1" },
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 3, PartitionId = "2" },
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 4, PartitionId = "3" }
             };
 
             _partitions = new List<PartitionProperties>
@@ -171,9 +171,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             // One invalid sample
             this._checkpoints = new EventProcessorCheckpoint[]
             {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 2, PartitionId = "1" },
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 3, PartitionId = "2" },
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 0,  SequenceNumber = 4, PartitionId = "3" }
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 2, PartitionId = "1" },
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 3, PartitionId = "2" },
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = "0",  SequenceNumber = 4, PartitionId = "3" }
             };
 
             _partitions = new List<PartitionProperties>
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             long checkpointSequenceNumber,
             long partitionBeginningSequenceNumber,
             long partitionLastSequenceNumber,
-            long expectedUprocessedMessageCount)
+            long expectedUnprocessedMessageCount)
         {
             if (!isNullCheckpoint)
             {
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             };
 
             var metrics = await _metricsProvider.GetMetricsAsync();
-            Assert.AreEqual(expectedUprocessedMessageCount, metrics.EventCount);
+            Assert.AreEqual(expectedUnprocessedMessageCount, metrics.EventCount);
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/TestPartitionProperties.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/TestPartitionProperties.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 {
     public class TestPartitionProperties : PartitionProperties
     {
-        public TestPartitionProperties(string eventHubName = default, string partitionId = default, bool isEmpty = default, long beginningSequenceNumber = default, long lastSequenceNumber = default, long lastOffset = default, DateTimeOffset lastEnqueuedTime = default) : base(eventHubName, partitionId, isEmpty, beginningSequenceNumber, lastSequenceNumber, lastOffset, lastEnqueuedTime)
+        public TestPartitionProperties(string eventHubName = default, string partitionId = default, bool isEmpty = default, long beginningSequenceNumber = default, long lastSequenceNumber = default, string lastOffset = default, DateTimeOffset lastEnqueuedTime = default) : base(eventHubName, partitionId, isEmpty, beginningSequenceNumber, lastSequenceNumber, lastOffset, lastEnqueuedTime)
         {
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to introduce members for the string-based offset format and mark the numeric-based offset members as obsolete.  This is part of the Event Hubs GeoDR feature design for the service, where replication-based offsets will be composite strings and no longer parsable to numeric values.

Not included in these changes is the error handling for the new error for an invalid reader position after failover.  The error details are still being finalized by the service and will be included in a future change set.

## References and resources

- [[Event Hubs] Restore package references (#47302)](https://github.com/Azure/azure-sdk-for-net/issues/47302)
- [[Event Hubs] GeoDR Failover Error Handling (#47303)](https://github.com/Azure/azure-sdk-for-net/issues/47303)