### PR TITLE
Add Docs variables to globals.yml instead of needlessly passing them around

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -16,8 +16,6 @@ jobs:
       name: $(LINUXPOOL)
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs
-      DocRepoOwner: Azure
-      DocRepoName: azure-docs-sdk-dotnet
     steps:
       # Checkout the eng folder from the SDK repo
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -4,8 +4,6 @@ parameters:
   ArtifactName: 'not-specified'
   # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
   DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
-  TargetDocRepoOwner: 'not-specified'
-  TargetDocRepoName: 'not-specified'
 
 
 stages:
@@ -208,8 +206,8 @@ stages:
                               PackageInfoLocations:
                                 - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
                               WorkingDirectory: $(System.DefaultWorkingDirectory)
-                              TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
-                              TargetDocRepoName: ${{parameters.TargetDocRepoName}}
+                              TargetDocRepoOwner: $(DocRepoOwner)
+                              TargetDocRepoName: $(DocRepoName)
                               Language: 'dotnet'
                               SparseCheckoutPaths:
                                 - /api/overview/azure/
@@ -342,8 +340,8 @@ stages:
                   - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
                     - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
               WorkingDirectory: $(System.DefaultWorkingDirectory)
-              TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
-              TargetDocRepoName: ${{parameters.TargetDocRepoName}}
+              TargetDocRepoOwner: $(DocRepoOwner)
+              TargetDocRepoName: $(DocRepoName)
               Language: 'dotnet'
               DailyDocsBuild: true
               SparseCheckoutPaths:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -14,12 +14,6 @@ parameters:
   - name: ServiceDirectory
     type: string
     default: not-specified
-  - name: TargetDocRepoOwner
-    type: string
-    default: Azure
-  - name: TargetDocRepoName
-    type: string
-    default: azure-docs-sdk-dotnet
   - name: BuildSnippets
     type: boolean
     default: true
@@ -111,6 +105,4 @@ extends:
             ${{ if eq(parameters.ServiceDirectory, 'template') }}:
               TestPipeline: true
             ArtifactName: packages
-            TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
-            TargetDocRepoName: ${{ parameters.TargetDocRepoName }}
 

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -18,3 +18,7 @@ variables:
   # Define optional AdditionalTestFilters via pipeline runtime variables or matrix config variables
   # See https://docs.microsoft.com/dotnet/core/testing/selective-unit-tests?pivots=nunit
   AdditionalTestFilters: "Placeholder!=DefaultIgnoreMe"
+
+  # Docs publishing variables for repo/owner
+  DocRepoOwner: 'Azure'
+  DocRepoName: 'azure-docs-sdk-dotnet'


### PR DESCRIPTION
The same variables, for docs repo and owner, had two different names, one in doc index and a different one being passed through the archetype templates. I'm hoisting these into globals.yml so the same variables are used where they're needed.

This is also being done in preparation for the inevitable move of the azure-docs-sdk-dotnet from Azure into MicrosoftDocs.

I verified the changes work doing a DailyDevRelease of core which worked as expected.