### PR TITLE
Adding a .NET 8 target follow up for extensions packages

### DIFF
--- a/sdk/entra/Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents/src/AuthenticationEventBinding.cs
+++ b/sdk/entra/Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents/src/AuthenticationEventBinding.cs
@@ -86,8 +86,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents
         public async Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
         {
             var request = (HttpRequestMessage)value;
+#if NET8_0_OR_GREATER
+            HttpRequestOptionsKey<WebJobsAuthenticationEventResponseHandler> httpRequestOptionsKey = new(WebJobsAuthenticationEventResponseHandler.EventResponseProperty);
+            request.Options.TryGetValue(httpRequestOptionsKey, out WebJobsAuthenticationEventResponseHandler eventResponseHandler);
+#else
             WebJobsAuthenticationEventResponseHandler eventResponseHandler =
                 (WebJobsAuthenticationEventResponseHandler)request.Properties[WebJobsAuthenticationEventResponseHandler.EventResponseProperty];
+#endif
             try
             {
                 if (request == null)

--- a/sdk/entra/Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents/src/AuthenticationEventConfigProvider.cs
+++ b/sdk/entra/Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents/src/AuthenticationEventConfigProvider.cs
@@ -109,7 +109,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents
                 //We create an event response handler and attach it to the income HTTP message, then on the trigger we set the function response
                 //in the event response handler and after the executor calls the functions we have reference to the function response.
                 WebJobsAuthenticationEventResponseHandler eventsResponseHandler = new WebJobsAuthenticationEventResponseHandler();
+#if NET8_0_OR_GREATER
+                HttpRequestOptionsKey<WebJobsAuthenticationEventResponseHandler> httpRequestOptionsKey = new(WebJobsAuthenticationEventResponseHandler.EventResponseProperty);
+                input.Options.Set(httpRequestOptionsKey, eventsResponseHandler);
+#else
                 input.Properties.Add(WebJobsAuthenticationEventResponseHandler.EventResponseProperty, eventsResponseHandler);
+#endif
 
                 TriggeredFunctionData triggerData = new TriggeredFunctionData()
                 {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobQueueTriggerExecutor.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobQueueTriggerExecutor.cs
@@ -115,12 +115,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             // Include the queue details here.
             IDictionary<string, string> details = PopulateTriggerDetails(value);
 
+#pragma warning disable CS8073 // The result of the expression is always true in net8.0, but not this is not true in netstandard2.0
             if (blobProperties.CreatedOn != null)
+#pragma warning restore CS8073
             {
                 details[BlobCreatedKey] = blobProperties.CreatedOn.ToString(Constants.DateTimeFormatString, CultureInfo.InvariantCulture);
             }
 
+#pragma warning disable CS8073 // The result of the expression is always true in net8.0, but not this is not true in netstandard2.0
             if (blobProperties.LastModified != null)
+#pragma warning restore CS8073
             {
                 details[BlobLastModifiedKey] = blobProperties.LastModified.ToString(Constants.DateTimeFormatString, CultureInfo.InvariantCulture);
             }


### PR DESCRIPTION
A follow-up to https://github.com/Azure/azure-sdk-for-net/pull/46637

A few errors in extensions packages were missed by the CIs. Fixing those here.