### PR TITLE
Microsoft.Azure.WebJobs.Extensions.Tables ci fix

### DIFF
--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/Microsoft.Azure.WebJobs.Extensions.Tables.Tests.csproj
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/Microsoft.Azure.WebJobs.Extensions.Tables.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);SA1636;SA1649</NoWarn>
+		<WarningsNotAsErrors>$(WarningsNotAsErrors);NETSDK1206</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +11,7 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" VersionOverride="5.3.2" Aliases="T1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" VersionOverride="4.0.5" Aliases="T1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/Microsoft.Azure.WebJobs.Extensions.Tables.Tests.csproj
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/Microsoft.Azure.WebJobs.Extensions.Tables.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" VersionOverride="4.0.5" Aliases="T1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" VersionOverride="5.3.2" Aliases="T1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />


### PR DESCRIPTION
A follow-up to https://github.com/Azure/azure-sdk-for-net/pull/46637

This error was not caught by the CIs in that PR, but I saw it in this PR: https://github.com/Azure/azure-sdk-for-net/pull/47212 when all CIs were run.