### PR TITLE
Return correct `WebHook-Allowed-Origin` response header for CloudEvent schema subscriptions for gov cloud

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/CHANGELOG.md
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.4.4 (2024-11-19)
+
+### Bugs Fixed
+
+- Return correct `WebHook-Allowed-Origin` response header for CloudEvent schema subscriptions for gov cloud.
+
 ## 3.4.3 (2024-09-10)
 
 ### Bugs Fixed

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>This extension adds bindings for EventGrid</Description>
-    <Version>3.4.3</Version>
+    <Version>3.4.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>3.4.2</ApiCompatVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/HttpRequestProcessor.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/HttpRequestProcessor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                     };
                 }
                 var response = new HttpResponseMessage(HttpStatusCode.OK);
-                response.Headers.Add("Webhook-Allowed-Origin", "eventgrid.azure.net");
+                response.Headers.Add("Webhook-Allowed-Origin", GetAllowedOriginResponseHeader(req));
                 return response;
             }
 
@@ -126,6 +126,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                 // TODO disable function?
                 new HttpResponseMessage(HttpStatusCode.Accepted) :
                 new HttpResponseMessage(HttpStatusCode.BadRequest);
+        }
+
+        private static string GetAllowedOriginResponseHeader(HttpRequestMessage req)
+        {
+            const string publicCloudOrigin = "eventgrid.azure.net";
+            const string requestOriginHeader = "WebHook-Request-Origin";
+
+            if (!req.Headers.Contains(requestOriginHeader))
+            {
+                return publicCloudOrigin;
+            }
+
+            string allowedOrigin = req.Headers.GetValues(requestOriginHeader).FirstOrDefault();
+            switch (allowedOrigin)
+            {
+                case publicCloudOrigin:
+                case "eventgrid.azure.us":
+                case "eventgrid.azure.eaglex.ic.gov":
+                case "eventgrid.azure.microsoft.scloud":
+                case "eventgrid.azure.cn":
+                    return allowedOrigin;
+                default:
+                    return publicCloudOrigin;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/47175