### PR TITLE
Update ArgumentNullException description for AzurePipelinesCredential…

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs
@@ -42,7 +42,7 @@ namespace Azure.Identity
         /// <param name="serviceConnectionId">The service connection Id for the service connection associated with the pipeline.</param>
         /// <param name="systemAccessToken">The pipeline's <see href="https://learn.microsoft.com/azure/devops/pipelines/build/variables?view=azure-devops%26tabs=yaml#systemaccesstoken">System.AccessToken</see> value.</param>
         /// <param name="options">An instance of <see cref="AzurePipelinesCredentialOptions"/>.</param>
-        /// <exception cref="ArgumentNullException">When <paramref name="systemAccessToken"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="tenantId"/>, <paramref name="clientId"/>, <paramref name="serviceConnectionId"/>, or <paramref name="systemAccessToken"/> is null.</exception>
         public AzurePipelinesCredential(string tenantId, string clientId, string serviceConnectionId, string systemAccessToken, AzurePipelinesCredentialOptions options = default)
         {
             Argument.AssertNotNull(systemAccessToken, nameof(systemAccessToken));


### PR DESCRIPTION
Update the description of when `ArgumentNullException` is thrown. Only 1 of the required parameters was listed. See the following snippet for reference:

https://github.com/Azure/azure-sdk-for-net/blob/5fadaee34aec4e6e8925434cf3fd70e1a5140b20/sdk/identity/Azure.Identity/src/Credentials/AzurePipelinesCredential.cs#L48-L51