### PR TITLE
Update the docIndex default for manual runs

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -44,11 +44,11 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
 
-      # Updating main is the default reason that manual builds of the docIndex run are kicked off.
-      # Manual builds of DocIndex are typically done to update Main when certain updates are made.
-      # These updates include new libraries and CSV updates in azure-sdk which, depending on the
-      # column(s) updated can cause anything from package deprecation to service level readme or
-      # ToC updates.
+      # Updating main is the default reason to kick off manual builds of the docIndex run.
+      # Manual builds of docIndex are typically done to update Main when certain updates are
+      # made. These updates include new libraries and CSV updates in azure-sdk which, depending
+      # on the column(s) updated can cause anything from package deprecation to service level
+      # readme or ToC updates.
       - ${{if or(eq(variables['Build.Reason'], 'Schedule'), ne(variables['Skip.MainUpdate'], 'true'))}}:
 
         - task: Powershell@2

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -1,11 +1,11 @@
 trigger: none
 
 parameters:
-- name: SkipMainUpdate
+- name: UpdateMain
   displayName: |
-    Skip updating main.
+    Updating main branch.
   type: boolean
-  default: false
+  default: true
 
 - name: ForceDailyUpdate
   displayName: |
@@ -63,7 +63,7 @@ jobs:
       # made. These updates include new libraries and CSV updates in azure-sdk which, depending
       # on the column(s) updated can cause anything from package deprecation to service level
       # readme or ToC updates.
-      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), ne(parameters.SkipMainUpdate, 'true')) }}:
+      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), parameters.UpdateMain) }}:
         - task: Powershell@2
           inputs:
             pwsh: true
@@ -117,7 +117,7 @@ jobs:
 
       # The scenario for running a Manual build is normally only for the main updates. The daily build
       # should really only get kicked off for scheduled runs.
-      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), eq(parameters.ForceDailyUpdate, 'true')) }}:
+      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), parameters.ForceDailyUpdate) }}:
         - template: /eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
           parameters:
             DailyBranchVariableName: DailyDocsBranchName

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -1,5 +1,19 @@
 trigger: none
 
+parameters:
+- name: SkipMainUpdate
+  displayName: |
+    Skip updating main.
+  type: boolean
+  default: false
+
+- name: ForceDailyUpdate
+  displayName: |
+    Force the daily branch update (includes starting daily branch run).
+  type: boolean
+  default: false
+
+
 variables:
   - template: /eng/pipelines/templates/variables/globals.yml
   - template: /eng/pipelines/templates/variables/image.yml
@@ -49,7 +63,7 @@ jobs:
       # made. These updates include new libraries and CSV updates in azure-sdk which, depending
       # on the column(s) updated can cause anything from package deprecation to service level
       # readme or ToC updates.
-      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), ne(variables['Skip.MainUpdate'], 'true')) }}:
+      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), ne(parameters.SkipMainUpdate, 'true')) }}:
         - task: Powershell@2
           inputs:
             pwsh: true
@@ -57,7 +71,6 @@ jobs:
             arguments: >-
               -DocRepoLocation $(DocRepoLocation)
           displayName: Verify Required Docs Json Members
-          condition: succeeded()
 
         - task: Powershell@2
           inputs:
@@ -72,7 +85,6 @@ jobs:
             filePath: eng/common/scripts/Update-DocsMsPackages.ps1
             arguments: -DocRepoLocation $(DocRepoLocation)
           displayName: Update Docs Onboarding for main branch
-          condition: succeeded()
 
         - task: Powershell@2
           inputs:
@@ -82,7 +94,6 @@ jobs:
               -DocRepoLocation $(DocRepoLocation)
               -ReadmeFolderRoot 'api/overview/azure'
           displayName: Generate Service Level Readme for main branch
-          condition: succeeded()
 
         - task: Powershell@2
           inputs:
@@ -93,7 +104,6 @@ jobs:
               -OutputLocation $(DocRepoLocation)/docs-ref-toc/reference-unified.yml
               -ReadmeFolderRoot "api/overview/azure"
           displayName: Generate ToC for main branch
-          condition: succeeded()
 
         - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
           parameters:
@@ -107,7 +117,7 @@ jobs:
 
       # The scenario for running a Manual build is normally only for the main updates. The daily build
       # should really only get kicked off for scheduled runs.
-      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.DailyUpdate'], 'true')) }}:
+      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), eq(parameters.ForceDailyUpdate, 'true')) }}:
         - template: /eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
           parameters:
             DailyBranchVariableName: DailyDocsBranchName
@@ -139,7 +149,6 @@ jobs:
             filePath: eng/common/scripts/Update-DocsMsPackageMonikers.ps1
             arguments: -DocRepoLocation $(DocRepoLocation)
           displayName: Move deprecated packages to legacy moniker
-          condition: succeeded()
 
         - task: Powershell@2
           inputs:
@@ -151,7 +160,6 @@ jobs:
               -DocRepoLocation $(DocRepoLocation)
               -PackageSourceOverride $(PackageSourceOverride)
           displayName: Update Docs Onboarding for Daily docs
-          condition: succeeded()
 
         - task: Powershell@2
           inputs:
@@ -161,7 +169,6 @@ jobs:
               -DocRepoLocation $(DocRepoLocation)
               -ReadmeFolderRoot 'api/overview/azure'
           displayName: Generate Service Level Readme for Daily docs
-          condition: succeeded()
 
         - task: Powershell@2
           inputs:
@@ -173,7 +180,6 @@ jobs:
               -ReadmeFolderRoot "api/overview/azure"
               -PackageSourceOverride $(PackageSourceOverride)
           displayName: Generate ToC for Daily docs
-          condition: succeeded()
 
         - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
           parameters:
@@ -201,4 +207,3 @@ jobs:
                 -DefinitionId 397 `
                 -BuildParametersJson $buildParamJson `
                 -BearerToken $accessToken
-          condition: succeeded()

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -49,8 +49,7 @@ jobs:
       # made. These updates include new libraries and CSV updates in azure-sdk which, depending
       # on the column(s) updated can cause anything from package deprecation to service level
       # readme or ToC updates.
-      - ${{if or(eq(variables['Build.Reason'], 'Schedule'), ne(variables['Skip.MainUpdate'], 'true'))}}:
-
+      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), ne(variables['Skip.MainUpdate'], 'true')) }}:
         - task: Powershell@2
           inputs:
             pwsh: true
@@ -105,11 +104,10 @@ jobs:
             TargetRepoOwner: $(DocRepoOwner)
             WorkingDirectory: $(DocRepoLocation)
 
+
       # The scenario for running a Manual build is normally only for the main updates. The daily build
       # should really only get kicked off for scheduled runs.
-      - ${{if or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.DailyUpdate'], 'true'))}}:
-
-        # Prepare daily docs CI
+      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.DailyUpdate'], 'true')) }}:
         - template: /eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
           parameters:
             DailyBranchVariableName: DailyDocsBranchName

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -44,144 +44,163 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
 
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Update-DocsMsPackageMonikers.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation)
-        displayName: Move deprecated packages to legacy moniker
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.MainUpdate'], 'true')))
+      # Updating main is the default reason that manual builds of the docIndex run are kicked off.
+      # Manual builds of DocIndex are typically done to update Main when certain updates are made.
+      # These updates include new libraries and CSV updates in azure-sdk which, depending on the
+      # column(s) updated can cause anything from package deprecation to service level readme or
+      # ToC updates.
+      - ${{if or(eq(variables['Build.Reason'], 'Schedule'), ne(variables['Skip.MainUpdate'], 'true'))}}:
 
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation)
-        displayName: Update Docs Onboarding for main branch
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.MainUpdate'], 'true')))
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Service-Level-Readme-Automation.ps1
-          arguments: >-
-            -DocRepoLocation $(DocRepoLocation)
-            -ReadmeFolderRoot 'api/overview/azure'
-        displayName: Generate Service Level Readme for main branch
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.MainUpdate'], 'true')))
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Update-DocsMsToc.ps1
-          arguments: >-
-            -DocRepoLocation $(DocRepoLocation)
-            -OutputLocation $(DocRepoLocation)/docs-ref-toc/reference-unified.yml
-            -ReadmeFolderRoot "api/overview/azure"
-        displayName: Generate ToC for main branch
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.MainUpdate'], 'true')))
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Verify-RequiredDocsJsonMembers.ps1
+            arguments: >-
+              -DocRepoLocation $(DocRepoLocation)
+          displayName: Verify Required Docs Json Members
+          condition: succeeded()
 
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Verify-RequiredDocsJsonMembers.ps1
-          arguments: >-
-            -DocRepoLocation $(DocRepoLocation)
-        displayName: Verify Required Docs Json Members
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Update-DocsMsPackageMonikers.ps1
+            arguments: -DocRepoLocation $(DocRepoLocation)
+          displayName: Move deprecated packages to legacy moniker
 
-      - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
-        parameters:
-          BaseRepoBranch: $(DefaultBranch)
-          BaseRepoOwner: $(DocRepoOwner)
-          CommitMsg: "Update docs CI configuration"
-          TargetRepoName: $(DocRepoName)
-          TargetRepoOwner: $(DocRepoOwner)
-          WorkingDirectory: $(DocRepoLocation)
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Update-DocsMsPackages.ps1
+            arguments: -DocRepoLocation $(DocRepoLocation)
+          displayName: Update Docs Onboarding for main branch
+          condition: succeeded()
 
-      # Prepare daily docs CI
-      - template: /eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
-        parameters:
-          DailyBranchVariableName: DailyDocsBranchName
-      - pwsh: |
-          $ErrorActionPreference = "Continue"
-          git checkout "origin/$(DailyDocsBranchName)" 2>&1 | Out-Null
-          $LASTEXITCODE = 0 # This ignores any error from git checkout
-          git status
-        displayName: Checkout daily branch if it exists
-        workingDirectory: $(DocRepoLocation)
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Service-Level-Readme-Automation.ps1
+            arguments: >-
+              -DocRepoLocation $(DocRepoLocation)
+              -ReadmeFolderRoot 'api/overview/azure'
+          displayName: Generate Service Level Readme for main branch
+          condition: succeeded()
 
-      - pwsh: |
-          $publicFeedUrl = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
-          Write-Host "##vso[task.setvariable variable=PackageSourceOverride]$publicFeedUrl"
-        displayName: Set package source variable
-        workingDirectory: $(DocRepoLocation)
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Update-DocsMsToc.ps1
+            arguments: >-
+              -DocRepoLocation $(DocRepoLocation)
+              -OutputLocation $(DocRepoLocation)/docs-ref-toc/reference-unified.yml
+              -ReadmeFolderRoot "api/overview/azure"
+          displayName: Generate ToC for main branch
+          condition: succeeded()
 
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Update-DocsMsPackageMonikers.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation)
-        displayName: Move deprecated packages to legacy moniker
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.MainUpdate'], 'true')))
+        - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+          parameters:
+            BaseRepoBranch: $(DefaultBranch)
+            BaseRepoOwner: $(DocRepoOwner)
+            CommitMsg: "Update docs CI configuration"
+            TargetRepoName: $(DocRepoName)
+            TargetRepoOwner: $(DocRepoOwner)
+            WorkingDirectory: $(DocRepoLocation)
 
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          # Use the dotnet public daily package preview feed as the source for
-          # updated packages.
-          arguments: >
-            -DocRepoLocation $(DocRepoLocation)
-            -PackageSourceOverride $(PackageSourceOverride)
-        displayName: Update Docs Onboarding for Daily docs
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Service-Level-Readme-Automation.ps1
-          arguments: >-
-            -DocRepoLocation $(DocRepoLocation)
-            -ReadmeFolderRoot 'api/overview/azure'
-        displayName: Generate Service Level Readme for Daily docs
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Update-DocsMsToc.ps1
-          arguments: >-
-            -DocRepoLocation $(DocRepoLocation)
-            -OutputLocation $(DocRepoLocation)/docs-ref-toc/reference-unified.yml
-            -ReadmeFolderRoot "api/overview/azure"
-            -PackageSourceOverride $(PackageSourceOverride)
-        displayName: Generate ToC for Daily docs
+      # The scenario for running a Manual build is normally only for the main updates. The daily build
+      # should really only get kicked off for scheduled runs.
+      - ${{if or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.DailyUpdate'], 'true'))}}:
 
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Verify-RequiredDocsJsonMembers.ps1
-          arguments: >-
-            -DocRepoLocation $(DocRepoLocation)
-        displayName: Verify Required Docs Json Members
+        # Prepare daily docs CI
+        - template: /eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
+          parameters:
+            DailyBranchVariableName: DailyDocsBranchName
+        - pwsh: |
+            $ErrorActionPreference = "Continue"
+            git checkout "origin/$(DailyDocsBranchName)" 2>&1 | Out-Null
+            $LASTEXITCODE = 0 # This ignores any error from git checkout
+            git status
+          displayName: Checkout daily branch if it exists
+          workingDirectory: $(DocRepoLocation)
 
-      - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
-        parameters:
-          BaseRepoBranch: $(DailyDocsBranchName)
-          BaseRepoOwner: $(DocRepoOwner)
-          CommitMsg: "Update targeting packages based on release metadata. (Daily docs)"
-          TargetRepoName: $(DocRepoName)
-          TargetRepoOwner: $(DocRepoOwner)
-          WorkingDirectory: $(DocRepoLocation)
-          ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts
-          PushArgs: -f
+        - pwsh: |
+            $publicFeedUrl = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
+            Write-Host "##vso[task.setvariable variable=PackageSourceOverride]$publicFeedUrl"
+          displayName: Set package source variable
+          workingDirectory: $(DocRepoLocation)
 
-      - task: AzureCLI@2
-        displayName: Queue Docs CI build
-        inputs:
-          azureSubscription: msdocs-apidrop-connection
-          scriptType: pscore
-          scriptLocation: inlineScript
-          inlineScript: |
-            $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
-            $buildParamJson = (@{ params = (Get-Content ./eng/dailydocsconfig.json -Raw) -replace '%%DailyDocsBranchName%%', "$(DailyDocsBranchName)" } | ConvertTo-Json)
-            eng/common/scripts/Queue-Pipeline.ps1 `
-              -Organization "apidrop" `
-              -Project "Content%20CI" `
-              -DefinitionId 397 `
-              -BuildParametersJson $buildParamJson `
-              -BearerToken $accessToken
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Verify-RequiredDocsJsonMembers.ps1
+            arguments: >-
+              -DocRepoLocation $(DocRepoLocation)
+          displayName: Verify Required Docs Json Members
+
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Update-DocsMsPackageMonikers.ps1
+            arguments: -DocRepoLocation $(DocRepoLocation)
+          displayName: Move deprecated packages to legacy moniker
+          condition: succeeded()
+
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Update-DocsMsPackages.ps1
+            # Use the dotnet public daily package preview feed as the source for
+            # updated packages.
+            arguments: >
+              -DocRepoLocation $(DocRepoLocation)
+              -PackageSourceOverride $(PackageSourceOverride)
+          displayName: Update Docs Onboarding for Daily docs
+          condition: succeeded()
+
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Service-Level-Readme-Automation.ps1
+            arguments: >-
+              -DocRepoLocation $(DocRepoLocation)
+              -ReadmeFolderRoot 'api/overview/azure'
+          displayName: Generate Service Level Readme for Daily docs
+          condition: succeeded()
+
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/Update-DocsMsToc.ps1
+            arguments: >-
+              -DocRepoLocation $(DocRepoLocation)
+              -OutputLocation $(DocRepoLocation)/docs-ref-toc/reference-unified.yml
+              -ReadmeFolderRoot "api/overview/azure"
+              -PackageSourceOverride $(PackageSourceOverride)
+          displayName: Generate ToC for Daily docs
+          condition: succeeded()
+
+        - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+          parameters:
+            BaseRepoBranch: $(DailyDocsBranchName)
+            BaseRepoOwner: $(DocRepoOwner)
+            CommitMsg: "Update targeting packages based on release metadata. (Daily docs)"
+            TargetRepoName: $(DocRepoName)
+            TargetRepoOwner: $(DocRepoOwner)
+            WorkingDirectory: $(DocRepoLocation)
+            ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts
+            PushArgs: -f
+
+        - task: AzureCLI@2
+          displayName: Queue Docs CI build
+          inputs:
+            azureSubscription: msdocs-apidrop-connection
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
+              $buildParamJson = (@{ params = (Get-Content ./eng/dailydocsconfig.json -Raw) -replace '%%DailyDocsBranchName%%', "$(DailyDocsBranchName)" } | ConvertTo-Json)
+              eng/common/scripts/Queue-Pipeline.ps1 `
+                -Organization "apidrop" `
+                -Project "Content%20CI" `
+                -DefinitionId 397 `
+                -BuildParametersJson $buildParamJson `
+                -BearerToken $accessToken
+          condition: succeeded()

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -3,7 +3,7 @@ trigger: none
 parameters:
 - name: UpdateMain
   displayName: |
-    Updating main branch.
+    Update main branch.
   type: boolean
   default: true
 


### PR DESCRIPTION
This PR only updates the manual run conditions which were completely backwards. When running manually they wouldn't update main unless a variable was set and would always kick off the daily run which is only supposed to be kicked off during the scheduled run. The daily branch updates kick off a docs run against the daily branch which is created/updated when scheduled runs publish daily libraries. On the docs side, when the run against the daily branch completes, it nukes the branch and renames it to "daily/<date>-[ci-succeeded|ci-failed"]. Unless we're specifically testing something related to kicking off the daily runs, it should only ever be run from the scheduled doc index runs. Multiple daily runs can cause issues on the docs with the way the success/failure branch is created.

UpdateMain and ForceDailyUpdate are both template parameters. UpdateMain defaults to true and ForceDailyUpdate defaults to false.

I also moved the verify required metadata json members _before_ running anything because if any of these are borked, any one of the steps running afterwards could fail. 

With these changes:

- Scheduled runs will still update the main and daily branches and kick off the daily run.
- Manual runs will run update main unless UpdateMain is set to true (which is the default) 
- Manual runs will not update the daily branch and kick off the daily run unless ForceDailyUpdate  is set to true but the default is false. The Daily runs should only really be being kicked off during the scheduled run which is at the end of the day UTC.

Testing the changes:

- [Manual docIndex run with defaultst](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4363109&view=results). This will process/update main without touching the daily branch.
- [Manual docIndex run with the UpdateMain unchecked (false) and ForceDailyUpdate checked (true)](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4363112&view=results). This will skip processing main and only process the daily branch and kick off the daily docs run.

