### PR TITLE
[Messaging] Bump AMQP dependency

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -162,7 +162,7 @@
     <PackageReference Update="Microsoft.Bcl.Numerics" Version="8.0.0" />
 
     <!-- Other approved packages -->
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.7" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.9" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.4.0" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.66.1" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.66.1" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 5.12.0-beta.2 (Unreleased)
 
+### Acknowledgments
+
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- tovyhnal _([GitHub](https://github.com/tovyhnal))_
+
 ### Features Added
 
 ### Breaking Changes
@@ -11,6 +17,10 @@
 ### Other Changes
 
 - Added annotations to make the package compatible with trimming and native AOT compilation.
+
+- Added Event Hub name to processor load balancing logs for additional context.  _(A community contribution, courtesy of [tovyhnal](https://github.com/tovyhnal))_
+
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.9, which contains several bug fixes. _(see: [commits](https://github.com/Azure/azure-amqp/commits/hotfix/))_
 
 ## 5.11.5 (2024-08-14)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 5.12.0-beta.2 (Unreleased)
 
+### Acknowledgments
+
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- tovyhnal _([GitHub](https://github.com/tovyhnal))_
+
 ### Features Added
 
 ### Breaking Changes
@@ -13,6 +19,10 @@
 ### Other Changes
 
 - Added annotations to make the package compatible with trimming and native AOT compilation.
+
+- Added Event Hub name to processor load balancing logs for additional context.  _(A community contribution, courtesy of [tovyhnal](https://github.com/tovyhnal))_
+
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.9, which contains several bug fixes. _(see: [commits](https://github.com/Azure/azure-amqp/commits/hotfix/))_
 
 ## 5.11.5 (2024-07-31)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Added annotations to make the package compatible with trimming and native AOT compilation.
 
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.9, which contains several bug fixes. _(see: [commits](https://github.com/Azure/azure-amqp/commits/hotfix/))_
+
 ## 7.18.2 (2024-10-08)
 
 ### Other Changes


### PR DESCRIPTION
# Summary

Bumping the `Microsoft.Azure.Amqp` dependency to absorb bug fixes and updating the library changelogs.

## References and resources

- [Add eventhub name into load balancer logs (#47271)](https://github.com/Azure/azure-sdk-for-net/pull/47271)