### PR TITLE
Added extra security hardening

### DIFF
--- a/sdk/healthdataaiservices/test-resources.bicep
+++ b/sdk/healthdataaiservices/test-resources.bicep
@@ -37,6 +37,28 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   kind: 'StorageV2'
   properties: {
     minimumTlsVersion: 'TLS1_2'
+
+    accessTier: 'Hot'
+    supportsHttpsTrafficOnly: true
+    allowBlobPublicAccess: false
+    allowCrossTenantReplication: false
+    allowSharedKeyAccess: false
+
+    encryption: {
+      services: {
+        blob: {
+          enabled: true
+          keyType: 'Account'
+        }
+        file: {
+          enabled: true
+          keyType: 'Account'
+        }
+      }
+      requireInfrastructureEncryption: true
+      keySource: 'Microsoft.Storage'
+    }
+
     networkAcls: {
       bypass: 'AzureServices'
       defaultAction: 'Deny'


### PR DESCRIPTION
Created azure storage created for live tests was being flagged by security wave.

Storage should be Identity-Based Access Control, and then apply the AllowSharedKeyAccess = false
https://eng.ms/docs/products/azure-storage/security/standards/identity-based-access

All tests passing after changes and advisor recommendations all green.
