### PR TITLE
[Service Bus] Fix sender identifier generation

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where identifier generation for senders did not correctly include the entity path as an informational element.  ([#46952](https://github.com/Azure/azure-sdk-for-net/issues/46952))
+
 ### Other Changes
 
 - Added annotations to make the package compatible with trimming and native AOT compilation.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -119,7 +119,7 @@ namespace Azure.Messaging.ServiceBus
                 Argument.AssertNotNullOrWhiteSpace(entityPath, nameof(entityPath));
                 connection.ThrowIfClosed();
 
-                var identifier = string.IsNullOrEmpty(options?.Identifier) ? DiagnosticUtilities.GenerateIdentifier(EntityPath) : options.Identifier;
+                var identifier = string.IsNullOrEmpty(options?.Identifier) ? DiagnosticUtilities.GenerateIdentifier(entityPath) : options.Identifier;
 
                 EntityPath = entityPath;
                 Identifier = identifier;


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a bug causing identifier generation for `ServiceBusSender` to not include the entity path as informational context.

## References and related

- [ServiceBusSender Identifier not set. (#46952)](https://github.com/Azure/azure-sdk-for-net/issues/46952)
