### PR TITLE
[Service Bus] Admin Client emulator slug

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/HttpRequestAndResponse.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/HttpRequestAndResponse.cs
@@ -22,6 +22,7 @@ namespace Azure.Messaging.ServiceBus.Administration
         private readonly int _port;
         private readonly ClientDiagnostics _diagnostics;
         private readonly string _versionQuery;
+        private readonly string _scheme;
 
         /// <summary>
         /// Initializes a new <see cref="HttpRequestAndResponse"/> which can be used to send http request and response.
@@ -31,7 +32,8 @@ namespace Azure.Messaging.ServiceBus.Administration
             ClientDiagnostics diagnostics,
             TokenCredential tokenCredential,
             string fullyQualifiedNamespace,
-            ServiceBusAdministrationClientOptions.ServiceVersion version)
+            ServiceBusAdministrationClientOptions.ServiceVersion version,
+            bool useTls)
         {
             _pipeline = pipeline;
             _diagnostics = diagnostics;
@@ -39,6 +41,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             _tokenCredential = tokenCredential;
             _fullyQualifiedNamespace = fullyQualifiedNamespace;
             _port = GetPort(_fullyQualifiedNamespace);
+            _scheme = useTls ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
         }
 
         internal void ThrowIfRequestFailed(Request request, Response response)
@@ -171,7 +174,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             Uri uri = new UriBuilder(_fullyQualifiedNamespace)
             {
                 Path = entityPath,
-                Scheme = Uri.UriSchemeHttps,
+                Scheme = _scheme,
                 Port = _port,
                 Query = queryString
             }.Uri;
@@ -199,7 +202,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             {
                 Path = entityPath,
                 Port = _port,
-                Scheme = Uri.UriSchemeHttps,
+                Scheme = _scheme,
                 Query = _versionQuery
             }.Uri;
             var requestUriBuilder = new RequestUriBuilder();
@@ -245,7 +248,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             Uri uri = new UriBuilder(_fullyQualifiedNamespace)
             {
                 Path = entityPath,
-                Scheme = Uri.UriSchemeHttps,
+                Scheme = _scheme,
                 Port = _port,
                 Query = _versionQuery
             }.Uri;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusAdministrationClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusAdministrationClient.cs
@@ -105,12 +105,16 @@ namespace Azure.Messaging.ServiceBus.Administration
             });
             _clientDiagnostics = new ClientDiagnostics(options);
 
+            // The Service Bus emulator does not support TLS.
+            var useTls = (!connectionStringProperties.UseDevelopmentEmulator);
+
             _httpRequestAndResponse = new HttpRequestAndResponse(
                 pipeline,
                 _clientDiagnostics,
                 tokenCredential,
                 _fullyQualifiedNamespace,
-                options.Version);
+                options.Version,
+                useTls);
         }
 
         /// <summary>
@@ -211,7 +215,8 @@ namespace Azure.Messaging.ServiceBus.Administration
                 _clientDiagnostics,
                 credential,
                 _fullyQualifiedNamespace,
-                options.Version);
+                options.Version,
+                true);
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/RequestResponseTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/RequestResponseTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
         {
             var options = new ServiceBusAdministrationClientOptions();
             var pipeline = HttpPipelineBuilder.Build(options);
-            _requestResponse = new HttpRequestAndResponse(pipeline, new ClientDiagnostics(options), null, "fakeNamespace", ServiceBusAdministrationClientOptions.ServiceVersion.V2017_04);
+            _requestResponse = new HttpRequestAndResponse(pipeline, new ClientDiagnostics(options), null, "fakeNamespace", ServiceBusAdministrationClientOptions.ServiceVersion.V2017_04, true);
         }
 
         [Test]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
@@ -11,7 +11,6 @@ using Azure.Core.TestFramework;
 using Azure.Core.TestFramework.Models;
 using Azure.Messaging.ServiceBus.Administration;
 using Azure.Messaging.ServiceBus.Authorization;
-using Azure.Messaging.ServiceBus.Tests.Infrastructure;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Management


### PR DESCRIPTION
# Summary

Adding support for the emulator slug to the Service Bus Administration client. While the emulator itself currently does not support the management operations, there is no harm in proactively enabling awareness in the client for potential future support.  _(note: I'm intentionally not updating the change log to avoid potential developer confusion due to lack of emulator support for the scenario.)_

Besides, @l0lawrence told me that I have to do this "or else."   I don't want to find out what that means.