### PR TITLE
[ResourceManager] Local extensions overrides

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Azure.ResourceManager.Tests.csproj
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Azure.ResourceManager.Tests.csproj
@@ -7,7 +7,14 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.Extensions.Azure" />
+
+    <!-- TEMP: Override until central version is bumped to mitigate project reference CI error -->
+    <PackageReference Include="Microsoft.Extensions.Azure" VersionOverride="1.9.0" />
+
+    <!-- TEMP: Overrides until central packages bumped, needed for new extensions -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the project reference CI leg which is failing due to in-process work to bump extension package dependencies.  These packages are being bumped locally to force transitive dependencies to play nice while we work on the central updates.

## References and related

- [[EngSys] Bump extensions package references (#47365)](https://github.com/Azure/azure-sdk-for-net/pull/47365)