### PR TITLE
Bump Microsoft.Extensions.Azure for test

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -332,7 +332,7 @@
     <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
     <PackageReference Update="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.3" />
-    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.7.6" />
+    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.9.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.10" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />


### PR DESCRIPTION
To unblock mgmt test CI.

Leave the extension package unchanged as there are more dependency chains to be resolved and `Microsoft.AspNetCore.DataProtection` has been set to 8.x in all extension individual projects already.
https://github.com/Azure/azure-sdk-for-net/blob/7ed2d42793f640eff28ec213371142c73d70b48d/eng/Packages.Data.props#L228

Update the dependency of test to fix the mgmt test failure. 