### PR TITLE
[DocumentIntelligence] Use TME subscription static resource in live tests

### DIFF
--- a/sdk/documentintelligence/test-resources.json
+++ b/sdk/documentintelligence/test-resources.json
@@ -32,7 +32,7 @@
         },
         "trainingDataAccount": {
             "type": "string",
-            "defaultValue": "azuresdktrainingdata"
+            "defaultValue": "azuresdktrainingdatatme"
         },
         "trainingDataContainer": {
             "type": "string",
@@ -44,7 +44,7 @@
         },
         "trainingDataResourceId": {
             "type": "string",
-            "defaultValue": "[resourceId('TrainingData', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
+            "defaultValue": "[resourceId('static-test-resources', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
         },
         "trainingDataSasProperties": {
             "type": "object",

--- a/sdk/documentintelligence/tests.yml
+++ b/sdk/documentintelligence/tests.yml
@@ -4,6 +4,7 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: documentintelligence
+    TimeoutInMinutes: 120
     CloudConfig:
       Public:
         Location: 'eastus'


### PR DESCRIPTION
The name of the static resource we use for testing has changed once we moved to the TME Azure subscription. This PR makes the necessary updates to make our live tests pass again.