### PR TITLE
Update logging docs to indicate that IsLoggingContentEnabled requires EventLevel.Verbose

### DIFF
--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -41,7 +41,7 @@ using AzureEventSourceListener traceListener = AzureEventSourceListener.CreateTr
 
 ### Enabling content logging
 
-By default only URI and headers are logged. To enable content logging, set the `Diagnostics.IsLoggingContentEnabled` client option:
+By default only URI and headers are logged. To enable content logging, set the logging level to `EventLevel.Verbose` and set the `Diagnostics.IsLoggingContentEnabled` client option:
 
 ```C# Snippet:LoggingContent
 SecretClientOptions options = new SecretClientOptions()


### PR DESCRIPTION
see https://github.com/Azure/azure-sdk-for-net/blob/89ebe48fe7037f9b8eb13f7c2e142ff40959fb8e/sdk/core/Azure.Core/src/Diagnostics/AzureCoreEventSource.cs#L69