### PR TITLE
Update docIndex to kick off the docs SDK CI run for main

### DIFF
--- a/eng/docsSDKCIConfig.json
+++ b/eng/docsSDKCIConfig.json
@@ -2,12 +2,12 @@
     "TFM": "net471",
     "target_repo": {
         "url": "https://github.com/Azure/azure-docs-sdk-dotnet",
-        "branch": "%%DailyDocsBranchName%%",
+        "branch": "%%DocsBranchName%%",
         "folder": "xml"
     },
     "source_repo": {
         "url": "https://github.com/Azure/azure-docs-sdk-dotnet",
-        "branch": "%%DailyDocsBranchName%%",
+        "branch": "%%DocsBranchName%%",
         "csvPath": "bundlepackages"
     },
     "import_content": true

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -135,7 +135,8 @@ jobs:
                 -DefinitionId 397 `
                 -BuildParametersJson $buildParamJson `
                 -BearerToken $accessToken
-            condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), ${{ parameters.StartMainSDKCIRun }}))
+
+            condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(${{ parameters.StartMainSDKCIRun }}, true)))
 
       # The scenario for running a Manual build is normally only for the main updates. The daily build
       # should really only get kicked off for scheduled runs.

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -128,6 +128,7 @@ jobs:
             scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
+              # Resource here is the Devops API scope
               $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
               $buildParamJson = (@{ params = (Get-Content ./eng/docsSDKCIConfig.json -Raw) -replace '%%DocsBranchName%%', "main" } | ConvertTo-Json)
               eng/common/scripts/Queue-Pipeline.ps1 `

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -7,6 +7,12 @@ parameters:
   type: boolean
   default: true
 
+- name: StartMainSDKCIRun
+  displayName: |
+    Kick off the main SDK CI docs run when manually running the pipeline
+  type: boolean
+  default: false
+
 - name: ForceDailyUpdate
   displayName: |
     Force the daily branch update (includes starting daily branch run).
@@ -129,7 +135,7 @@ jobs:
                 -DefinitionId 397 `
                 -BuildParametersJson $buildParamJson `
                 -BearerToken $accessToken
-
+            condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), ${{ parameters.StartMainSDKCIRun }}))
 
       # The scenario for running a Manual build is normally only for the main updates. The daily build
       # should really only get kicked off for scheduled runs.

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -121,7 +121,7 @@ jobs:
             WorkingDirectory: $(DocRepoLocation)
 
         - task: AzureCLI@2
-          displayName: Queue Docs CI build
+          displayName: Queue Docs CI build for main branch
           condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(${{ parameters.StartMainSDKCIRun }}, true)))
           inputs:
             azureSubscription: msdocs-apidrop-connection

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -122,6 +122,7 @@ jobs:
 
         - task: AzureCLI@2
           displayName: Queue Docs CI build
+          condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(${{ parameters.StartMainSDKCIRun }}, true)))
           inputs:
             azureSubscription: msdocs-apidrop-connection
             scriptType: pscore
@@ -135,8 +136,6 @@ jobs:
                 -DefinitionId 397 `
                 -BuildParametersJson $buildParamJson `
                 -BearerToken $accessToken
-
-            condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(${{ parameters.StartMainSDKCIRun }}, true)))
 
       # The scenario for running a Manual build is normally only for the main updates. The daily build
       # should really only get kicked off for scheduled runs.

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -114,6 +114,22 @@ jobs:
             TargetRepoOwner: $(DocRepoOwner)
             WorkingDirectory: $(DocRepoLocation)
 
+        - task: AzureCLI@2
+          displayName: Queue Docs CI build
+          inputs:
+            azureSubscription: msdocs-apidrop-connection
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
+              $buildParamJson = (@{ params = (Get-Content ./eng/docsSDKCIConfig.json -Raw) -replace '%%DocsBranchName%%', "main" } | ConvertTo-Json)
+              eng/common/scripts/Queue-Pipeline.ps1 `
+                -Organization "apidrop" `
+                -Project "Content%20CI" `
+                -DefinitionId 397 `
+                -BuildParametersJson $buildParamJson `
+                -BearerToken $accessToken
+
 
       # The scenario for running a Manual build is normally only for the main updates. The daily build
       # should really only get kicked off for scheduled runs.
@@ -200,7 +216,7 @@ jobs:
             scriptLocation: inlineScript
             inlineScript: |
               $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
-              $buildParamJson = (@{ params = (Get-Content ./eng/dailydocsconfig.json -Raw) -replace '%%DailyDocsBranchName%%', "$(DailyDocsBranchName)" } | ConvertTo-Json)
+              $buildParamJson = (@{ params = (Get-Content ./eng/docsSDKCIConfig.json -Raw) -replace '%%DocsBranchName%%', "$(DailyDocsBranchName)" } | ConvertTo-Json)
               eng/common/scripts/Queue-Pipeline.ps1 `
                 -Organization "apidrop" `
                 -Project "Content%20CI" `


### PR DESCRIPTION
Right now, the docs SDK CI runs run a scheduled run against main and the timing of the runs is isn't great. The solution here is to have the docIndex runs kick off SDK CI the run against main the same way we're kicking off the run against the daily branch. This will remove anything fiddly.

As part of this change, add a parameter, defaulting to false, to determine whether or not the SDK CI run should be kicked off.

This is what the parameter I'd added looks like. It's the second checkbox down, unchecked by default.
![image](https://github.com/user-attachments/assets/d8be62b6-a7be-411e-a8ed-9bc7b7388562)

This is the [docIndex run with it unchecked](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4389617&view=logs&j=293d82b9-e70f-547c-66fb-8f46778b3a20&t=80491158-f2d9-5292-6b97-19eaf71c54db). Notice it didn't kick off the SDK CI run.
This is the [docIndex run with it checked](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4389677&view=logs&j=293d82b9-e70f-547c-66fb-8f46778b3a20&t=80491158-f2d9-5292-6b97-19eaf71c54db&l=37).  It would have kicked off the run but there's a weird authentication thing happening in pipelines right now that's affecting Azure.