### PR TITLE
Azure OpenAI: remove legacy/standalone Assistants package from service tree CI definition

### DIFF
--- a/sdk/openai/ci.yml
+++ b/sdk/openai/ci.yml
@@ -11,7 +11,6 @@ trigger:
     - sdk/openai
     - sdk/openai/ci.yml
     - sdk/openai/Azure.AI.OpenAI
-    - sdk/openai/Azure.AI.OpenAI.Assistants
 
 pr:
   branches:
@@ -25,7 +24,6 @@ pr:
     - sdk/openai
     - sdk/openai/ci.yml
     - sdk/openai/Azure.AI.OpenAI
-    - sdk/openai/Azure.AI.OpenAI.Assistants
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -38,5 +36,3 @@ extends:
     Artifacts:
     - name: Azure.AI.OpenAI
       safeName: AzureAIOpenAI
-    - name: Azure.AI.OpenAI.Assistants
-      safeName: AzureAIOpenAIAssistants


### PR DESCRIPTION
- The `Azure.AI.OpenAI.Assistants` package is currently preserved in source for the lifetime of the matching March preview API version
- In the interim, we don't plan to re-release the package -- it's been fully replaced by the new 2.* stack
- Contemporary release pipeline behavior is unhappy with the continued (and unnecessarily) presence of the never-released folder