### PR TITLE
[Storage][DataMovement] Fix some flakey tests with concurrent eventing

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/TestEventsRaised.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/TestEventsRaised.cs
@@ -32,19 +32,18 @@ namespace Azure.Storage.DataMovement.Tests
         private static readonly DataTransferStatus SkippedCompletedStatus = new DataTransferStatusInternal(DataTransferState.Completed, false, true);
         private static readonly DataTransferStatus FailedCompletedStatus = new DataTransferStatusInternal(DataTransferState.Completed, true, false);
 
-        public List<TransferItemFailedEventArgs> FailedEvents { get; internal set; }
-        private object _failedEventsLock = new();
         public List<TransferStatusEventArgs> StatusEvents { get; internal set; }
-        public List<TransferItemSkippedEventArgs> SkippedEvents { get; internal set; }
+        public ConcurrentBag<TransferItemFailedEventArgs> FailedEvents { get; internal set; }
+        public ConcurrentBag<TransferItemSkippedEventArgs> SkippedEvents { get; internal set; }
         public ConcurrentBag<TransferItemCompletedEventArgs> SingleCompletedEvents { get; internal set; }
 
         private List<DataTransferOptions> _options;
 
         private TestEventsRaised()
         {
-            FailedEvents = new List<TransferItemFailedEventArgs>();
             StatusEvents = new List<TransferStatusEventArgs>();
-            SkippedEvents = new List<TransferItemSkippedEventArgs>();
+            FailedEvents = new ConcurrentBag<TransferItemFailedEventArgs>();
+            SkippedEvents = new ConcurrentBag<TransferItemSkippedEventArgs>();
             SingleCompletedEvents = new ConcurrentBag<TransferItemCompletedEventArgs>();
         }
 
@@ -85,10 +84,7 @@ namespace Azure.Storage.DataMovement.Tests
 
         private Task AppendFailedArg(TransferItemFailedEventArgs args)
         {
-            lock (_failedEventsLock)
-            {
-                FailedEvents.Add(args);
-            }
+            FailedEvents.Add(args);
             return Task.CompletedTask;
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferValidationTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferValidationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -58,7 +59,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             Assert.That(transfer.HasCompleted, Is.True);
             Assert.That(events.FailedEvents, Is.Not.Empty);
-            Assert.That(events.FailedEvents[0].Exception.Message, Does.Contain("Intentionally failing"));
+            Assert.That(events.FailedEvents.First().Exception.Message, Does.Contain("Intentionally failing"));
         }
 
         [Test, Pairwise]
@@ -83,7 +84,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             Assert.That(transfer.HasCompleted, Is.True);
             Assert.That(events.FailedEvents, Is.Not.Empty);
-            Assert.That(events.FailedEvents[0].Exception.Message, Does.Contain("Intentionally failing"));
+            Assert.That(events.FailedEvents.First().Exception.Message, Does.Contain("Intentionally failing"));
         }
     }
 }


### PR DESCRIPTION
This change should fix some flakey tests, most notably `UploadSkipIfExists` by switching the collection of skipped events to a concurrent collection. These events can be called by multiple threads and so the collection needs to be thread safe. I also converted the failed event collection to `ConcurrentBag` instead of a `List` with a lock for consistency.