### PR TITLE
`sdk\resourcemanager\ci.mgmt.yml` sorting  explicitly  for consistency in docker environment.

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -181,9 +181,9 @@ function Update-CIYmlFile() {
 
 function RegisterMgmtSDKToMgmtCoreClient () {
     param(
-        [string]$packagesPath
+        [string]$packagesPath<##>
     )
-    $track2MgmtDirs = Get-ChildItem -Path "$packagesPath" -Directory -Recurse -Depth 1 | Where-Object { $_.Name -match "(Azure.ResourceManager.)" -and $(Test-Path("$($_.FullName)/src")) }
+    $track2MgmtDirs = Get-ChildItem -Path "$packagesPath" -Directory -Recurse -Depth 1 | Where-Object { $_.Name -match "(Azure.ResourceManager.)" -and $(Test-Path("$($_.FullName)/src")) }|Sort-Object -Property { (Split-Path $_.FullName -Parent) }
     Write-Host "Updating mgmt core client ci.mgmt.yml"
     #add path for each mgmt library into Azure.ResourceManager
     $armCiFile = "$packagesPath/resourcemanager/ci.mgmt.yml"

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -183,7 +183,7 @@ function RegisterMgmtSDKToMgmtCoreClient () {
     param(
         [string]$packagesPath
     )
-    $track2MgmtDirs = Get-ChildItem -Path "$packagesPath" -Directory -Recurse -Depth 1 | Where-Object { $_.Name -match "(Azure.ResourceManager.)" -and $(Test-Path("$($_.FullName)/src")) }|Sort-Object -Property { (Split-Path $_.FullName -Parent) }
+    $track2MgmtDirs = Get-ChildItem -Path "$packagesPath" -Directory -Recurse -Depth 1 | Where-Object { $_.Name -match "(Azure.ResourceManager.)" -and $(Test-Path("$($_.FullName)/src")) } | Sort-Object -Property { (Split-Path $_.FullName -Parent) }
     Write-Host "Updating mgmt core client ci.mgmt.yml"
     #add path for each mgmt library into Azure.ResourceManager
     $armCiFile = "$packagesPath/resourcemanager/ci.mgmt.yml"

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -181,7 +181,7 @@ function Update-CIYmlFile() {
 
 function RegisterMgmtSDKToMgmtCoreClient () {
     param(
-        [string]$packagesPath<##>
+        [string]$packagesPath
     )
     $track2MgmtDirs = Get-ChildItem -Path "$packagesPath" -Directory -Recurse -Depth 1 | Where-Object { $_.Name -match "(Azure.ResourceManager.)" -and $(Test-Path("$($_.FullName)/src")) }|Sort-Object -Property { (Split-Path $_.FullName -Parent) }
     Write-Host "Updating mgmt core client ci.mgmt.yml"


### PR DESCRIPTION
When running the `Update-Mgmt-CI.ps1` script in the Docker environment, it causes a change in the sorting of the `azure-sdk-for-net\sdk\resourcemanager\ci.mgmt.yml` file. 
The default sorting is different across different platform (windows and linux) therefore sorting them explicitly in `eng/scripts/automation/GenerateAndBuildLib.ps1` script would solve the ordering issue.