### PR TITLE
added ASP.NET APIs to transfer connections

### DIFF
--- a/sdk/cloudmachine/Azure.CloudMachine.Web/api/Azure.CloudMachine.Web.net8.0.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine.Web/api/Azure.CloudMachine.Web.net8.0.cs
@@ -2,6 +2,8 @@ namespace Azure.CloudMachine
 {
     public static partial class CloudMachineExtensions
     {
+        public static void AddCloudMachine(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, Azure.Core.ClientWorkspace workspace) { }
+        public static void MapCloudMachineApplication<T>(this Microsoft.AspNetCore.Builder.WebApplication application) where T : class { }
         public static void Map<T>(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder, T serviceImplementation) where T : class { }
         public static System.Threading.Tasks.Task UploadFormAsync(this Azure.CloudMachine.StorageServices storage, Microsoft.AspNetCore.Http.HttpRequest multiPartFormData) { throw null; }
     }

--- a/sdk/cloudmachine/Azure.CloudMachine.Web/src/CloudMachineExtensions.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine.Web/src/CloudMachineExtensions.cs
@@ -7,10 +7,13 @@ using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Azure.CloudMachine;
+using Azure.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Azure.CloudMachine;
 
@@ -19,6 +22,29 @@ namespace Azure.CloudMachine;
 /// </summary>
 public static class CloudMachineExtensions
 {
+    /// <summary>
+    /// Adds a CloudMachine client to the service collection.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="application"></param>
+    public static void MapCloudMachineApplication<T>(this WebApplication application) where T : class
+    {
+        CloudMachineClient cm = application.Services.GetRequiredService<CloudMachineClient>();
+        T service = (T)Activator.CreateInstance(typeof(T), cm)!;
+        application.Map<T>(service);
+    }
+
+    /// <summary>
+    /// Adds a CloudMachine client to the service collection.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="workspace"></param>
+    public static void AddCloudMachine(this IHostApplicationBuilder builder, ClientWorkspace workspace)
+    {
+        var connections = workspace.GetAllConnectionOptions();
+        builder.Services.AddSingleton(new CloudMachineClient(connections));
+    }
+
     /// <summary>
     /// Uploads a document to the storage service.
     /// </summary>

--- a/sdk/cloudmachine/Azure.CloudMachine.Web/src/CloudMachineExtensions.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine.Web/src/CloudMachineExtensions.cs
@@ -23,7 +23,7 @@ namespace Azure.CloudMachine;
 public static class CloudMachineExtensions
 {
     /// <summary>
-    /// Adds a CloudMachine client to the service collection.
+    /// Maps TSP endpoints. CloudMachineClient needs to be in the container for this method to work.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="application"></param>

--- a/sdk/cloudmachine/Azure.CloudMachine/api/Azure.CloudMachine.net8.0.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine/api/Azure.CloudMachine.net8.0.cs
@@ -3,8 +3,8 @@ namespace Azure.CloudMachine
     public partial class CloudMachineClient : Azure.Core.ClientWorkspace
     {
         protected CloudMachineClient() : base (default(Azure.Core.TokenCredential)) { }
-        public CloudMachineClient(Azure.Core.ConnectionCollection connections = null, Azure.Core.TokenCredential credential = null) : base (default(Azure.Core.TokenCredential)) { }
         public CloudMachineClient(Microsoft.Extensions.Configuration.IConfiguration configuration, Azure.Core.TokenCredential credential = null) : base (default(Azure.Core.TokenCredential)) { }
+        public CloudMachineClient(System.Collections.Generic.IEnumerable<Azure.Core.ClientConnection> connections = null, Azure.Core.TokenCredential credential = null) : base (default(Azure.Core.TokenCredential)) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public Azure.Core.ConnectionCollection Connections { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -13,6 +13,7 @@ namespace Azure.CloudMachine
         public Azure.CloudMachine.StorageServices Storage { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
+        public override System.Collections.Generic.IEnumerable<Azure.Core.ClientConnection> GetAllConnectionOptions() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Core.ClientConnection GetConnectionOptions(string connectionId) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -169,6 +170,7 @@ namespace Azure.Core
         public Azure.Core.TokenCredential Credential { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public Azure.Core.ClientCache Subclients { get { throw null; } }
+        public abstract System.Collections.Generic.IEnumerable<Azure.Core.ClientConnection> GetAllConnectionOptions();
         public abstract Azure.Core.ClientConnection GetConnectionOptions(string connectionId);
     }
     public static partial class CloudMachineClientConfiguration

--- a/sdk/cloudmachine/Azure.CloudMachine/api/Azure.CloudMachine.netstandard2.0.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine/api/Azure.CloudMachine.netstandard2.0.cs
@@ -3,8 +3,8 @@ namespace Azure.CloudMachine
     public partial class CloudMachineClient : Azure.Core.ClientWorkspace
     {
         protected CloudMachineClient() : base (default(Azure.Core.TokenCredential)) { }
-        public CloudMachineClient(Azure.Core.ConnectionCollection connections = null, Azure.Core.TokenCredential credential = null) : base (default(Azure.Core.TokenCredential)) { }
         public CloudMachineClient(Microsoft.Extensions.Configuration.IConfiguration configuration, Azure.Core.TokenCredential credential = null) : base (default(Azure.Core.TokenCredential)) { }
+        public CloudMachineClient(System.Collections.Generic.IEnumerable<Azure.Core.ClientConnection> connections = null, Azure.Core.TokenCredential credential = null) : base (default(Azure.Core.TokenCredential)) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public Azure.Core.ConnectionCollection Connections { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -13,6 +13,7 @@ namespace Azure.CloudMachine
         public Azure.CloudMachine.StorageServices Storage { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
+        public override System.Collections.Generic.IEnumerable<Azure.Core.ClientConnection> GetAllConnectionOptions() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override Azure.Core.ClientConnection GetConnectionOptions(string connectionId) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -169,6 +170,7 @@ namespace Azure.Core
         public Azure.Core.TokenCredential Credential { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public Azure.Core.ClientCache Subclients { get { throw null; } }
+        public abstract System.Collections.Generic.IEnumerable<Azure.Core.ClientConnection> GetAllConnectionOptions();
         public abstract Azure.Core.ClientConnection GetConnectionOptions(string connectionId);
     }
     public static partial class CloudMachineClientConfiguration

--- a/sdk/cloudmachine/Azure.CloudMachine/src/ClientWorkspace.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine/src/ClientWorkspace.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Azure.Core;
@@ -26,6 +27,12 @@ public abstract class ClientWorkspace
     /// <param name="connectionId"></param>
     /// <returns>The connection options for the specified client type and instance ID.</returns>
     public abstract ClientConnection GetConnectionOptions(string connectionId);
+
+    /// <summary>
+    /// Retrieves all connection options.
+    /// </summary>
+    /// <returns></returns>
+    public abstract IEnumerable<ClientConnection> GetAllConnectionOptions();
 
     /// <summary>
     /// Gets the token credential.

--- a/sdk/cloudmachine/Azure.CloudMachine/src/CloudMachineClient.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine/src/CloudMachineClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Azure.Core;
 using Azure.Identity;
@@ -75,7 +76,7 @@ public partial class CloudMachineClient : ClientWorkspace
     /// <param name="connections"></param>
     /// <param name="credential">The token credential.</param>
     // TODO: we need to combine the configuration and the connections into a single parameter.
-    public CloudMachineClient(ConnectionCollection connections = default, TokenCredential credential = default)
+    public CloudMachineClient(IEnumerable<ClientConnection> connections = default, TokenCredential credential = default)
 #pragma warning restore AZC0007 // DO provide a minimal constructor that takes only the parameters required to connect to the service.
         : base(BuildCredential(credential))
     {
@@ -144,4 +145,11 @@ public partial class CloudMachineClient : ClientWorkspace
     /// <inheritdoc/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override string ToString() => Id;
+
+    /// <summary>
+    /// Retrieves all connection options.
+    /// </summary>
+    /// <returns></returns>
+    public override IEnumerable<ClientConnection> GetAllConnectionOptions()
+        => Connections;
 }


### PR DESCRIPTION
Connections can now be transferred from infa to client using:

```csharp
CloudMachineInfrastructure infrastrucutre = new();
infrastrucutre.AddFeature(new OpenAIModelFeature("gpt-35-turbo", "0125"));
infrastrucutre.AddFeature(new OpenAIModelFeature("text-embedding-ada-002", "2", AIModelKind.Embedding));
infrastrucutre.AddFeature(new AppServiceFeature());
infrastrucutre.AddEndpoints<IAssistantService>();

// the app can be called with -bicep or -tsp switches to generate bicep and tsp, respectively.
if (infrastrucutre.TryExecuteCommand(args)) return;

var builder = WebApplication.CreateBuilder(args);
builder.Services.AddRazorPages();
builder.Services.AddHttpClient();
builder.AddCloudMachine(infrastrucutre);
var app = builder.Build();
app.MapRazorPages();
app.MapCloudMachineApplication<AssitantService>(); // this is a special TDK Map method.
app.Run();

internal class AssitantService : IAssistantService
...
```