### PR TITLE
Made ASP.NET DI work with CMInfrastructure

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -194,6 +194,10 @@
     <PackageReference Update="NUnit" Version="3.13.2" />
   </ItemGroup>
 
+  <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Provisioning.CloudMachine'))">
+    <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+
   <!--
     Dependency versions for Track 2, Microsoft.* libraries.
     These are dependencies for Track 2 integration packages

--- a/sdk/cloudmachine/Azure.CloudMachine.Web/api/Azure.CloudMachine.Web.net8.0.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine.Web/api/Azure.CloudMachine.Web.net8.0.cs
@@ -2,7 +2,6 @@ namespace Azure.CloudMachine
 {
     public static partial class CloudMachineExtensions
     {
-        public static void AddCloudMachine(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, Azure.Core.ClientWorkspace workspace) { }
         public static void MapCloudMachineApplication<T>(this Microsoft.AspNetCore.Builder.WebApplication application) where T : class { }
         public static void Map<T>(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder, T serviceImplementation) where T : class { }
         public static System.Threading.Tasks.Task UploadFormAsync(this Azure.CloudMachine.StorageServices storage, Microsoft.AspNetCore.Http.HttpRequest multiPartFormData) { throw null; }

--- a/sdk/cloudmachine/Azure.CloudMachine.Web/src/CloudMachineExtensions.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine.Web/src/CloudMachineExtensions.cs
@@ -35,17 +35,6 @@ public static class CloudMachineExtensions
     }
 
     /// <summary>
-    /// Adds a CloudMachine client to the service collection.
-    /// </summary>
-    /// <param name="builder"></param>
-    /// <param name="workspace"></param>
-    public static void AddCloudMachine(this IHostApplicationBuilder builder, ClientWorkspace workspace)
-    {
-        var connections = workspace.GetAllConnectionOptions();
-        builder.Services.AddSingleton(new CloudMachineClient(connections));
-    }
-
-    /// <summary>
     /// Uploads a document to the storage service.
     /// </summary>
     /// <param name="storage"></param>

--- a/sdk/cloudmachine/Azure.CloudMachine/tests/ConnectionTests.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine/tests/ConnectionTests.cs
@@ -70,7 +70,7 @@ public class ConnectionTests
         infra.AddFeature(new OpenAIModelFeature("gpt-35-turbo", "0125"));
 
         IConfiguration configuration = new ConfigurationBuilder()
-            .AddCloudMachineInfrastructure(infra)
+            .AddCloudMachineConfiguration(infra)
             .Build();
 
         CloudMachineClient client = new(configuration);

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/api/Azure.Provisioning.CloudMachine.net8.0.cs
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/api/Azure.Provisioning.CloudMachine.net8.0.cs
@@ -43,7 +43,8 @@ namespace Azure.CloudMachine
     }
     public static partial class CloudMachineInfrastructureConfiguration
     {
-        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddCloudMachineInfrastructure(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Azure.CloudMachine.CloudMachineInfrastructure cm) { throw null; }
+        public static Microsoft.Extensions.Hosting.IHostApplicationBuilder AddCloudMachine(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, Azure.CloudMachine.CloudMachineInfrastructure cm) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddCloudMachineConfiguration(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Azure.CloudMachine.CloudMachineInfrastructure cm) { throw null; }
     }
 }
 namespace Azure.CloudMachine.AppService

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/api/Azure.Provisioning.CloudMachine.netstandard2.0.cs
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/api/Azure.Provisioning.CloudMachine.netstandard2.0.cs
@@ -43,7 +43,8 @@ namespace Azure.CloudMachine
     }
     public static partial class CloudMachineInfrastructureConfiguration
     {
-        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddCloudMachineInfrastructure(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Azure.CloudMachine.CloudMachineInfrastructure cm) { throw null; }
+        public static Microsoft.Extensions.Hosting.IHostApplicationBuilder AddCloudMachine(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, Azure.CloudMachine.CloudMachineInfrastructure cm) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddCloudMachineConfiguration(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Azure.CloudMachine.CloudMachineInfrastructure cm) { throw null; }
     }
 }
 namespace Azure.CloudMachine.AppService

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/src/Azure.Provisioning.CloudMachine.csproj
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/src/Azure.Provisioning.CloudMachine.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Azure.Provisioning.ServiceBus" />
     <PackageReference Include="Azure.Provisioning.EventGrid" />
     <PackageReference Include="Azure.Provisioning.AppService" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/src/CloudMachineInfrastructure/CloudMachineInfrastructure.cs
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/src/CloudMachineInfrastructure/CloudMachineInfrastructure.cs
@@ -14,6 +14,8 @@ using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Primitives;
 using Azure.Provisioning.Roles;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Azure.CloudMachine;
 
@@ -137,15 +139,28 @@ public class CloudMachineInfrastructure
 public static class CloudMachineInfrastructureConfiguration
 {
     /// <summary>
-    /// Adds a connection to the collection.
+    /// Adds a connections and CM ID to the config system.
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="cm"></param>
     /// <returns></returns>
-    public static IConfigurationBuilder AddCloudMachineInfrastructure(this IConfigurationBuilder builder, CloudMachineInfrastructure cm)
+    public static IConfigurationBuilder AddCloudMachineConfiguration(this IConfigurationBuilder builder, CloudMachineInfrastructure cm)
     {
         builder.AddCloudMachineConnections(cm.Connections);
         builder.AddCloudMachineId(cm.Id);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the CloudMachine to DI.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="cm"></param>
+    /// <returns></returns>
+    public static IHostApplicationBuilder AddCloudMachine(this IHostApplicationBuilder builder, CloudMachineInfrastructure cm)
+    {
+        builder.Configuration.AddCloudMachineConfiguration(cm);
+        builder.Services.AddSingleton(new CloudMachineClient(cm.Connections));
         return builder;
     }
 }


### PR DESCRIPTION
```csharp
using Azure.CloudMachine;
using Azure.CloudMachine.AppService;
using Azure.CloudMachine.OpenAI;
using Azure.Core;
using Microsoft.AspNetCore.Mvc;
using Microsoft.Extensions.DependencyInjection.Extensions;
using OpenAI.Chat;

CloudMachineInfrastructure infrastrucutre = new();
infrastrucutre.AddFeature(new OpenAIModelFeature("gpt-35-turbo", "0125"));
infrastrucutre.AddFeature(new OpenAIModelFeature("text-embedding-ada-002", "2", AIModelKind.Embedding));
infrastrucutre.AddFeature(new AppServiceFeature());
infrastrucutre.AddEndpoints<IAssistantService>();

// the app can be called with -bicep or -tsp switches to generate bicep and tsp, respectively.
if (infrastrucutre.TryExecuteCommand(args)) return;

var builder = WebApplication.CreateBuilder(args);
builder.Services.AddRazorPages();
builder.Services.AddHttpClient();
builder.AddCloudMachine(infrastrucutre);
var app = builder.Build();
app.MapRazorPages();
app.MapCloudMachineApplication<AssitantService>(); // this is a special TDK Map method.
app.Run();

internal class AssitantService : IAssistantService
```