### PR TITLE
fix(playwrighttesting): suiteId to use hash instead of classname

### DIFF
--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/Processor/DataProcessor.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/Processor/DataProcessor.cs
@@ -105,9 +105,10 @@ namespace Azure.Developer.MicrosoftPlaywrightTesting.TestLogger.Processor
             testCaseResultData.TestCombinationId = testCaseResultData.TestExecutionId; // TODO check
             testCaseResultData.TestId = testResultSource.TestCase.Id.ToString();
             testCaseResultData.TestTitle = testResultSource.TestCase.DisplayName;
-            var className = FetchTestClassName(testResultSource.TestCase.FullyQualifiedName);
-            testCaseResultData.SuiteTitle = className;
-            testCaseResultData.SuiteId = className;
+            string inputString = $"{testResultSource.TestCase.DisplayName}-{testResultSource.TestCase.CodeFilePath}";
+            var SuiteName = ReporterUtils.CalculateSha1Hash(inputString);
+            testCaseResultData.SuiteTitle = SuiteName;
+            testCaseResultData.SuiteId = SuiteName;
             testCaseResultData.FileName = FetchFileName(testResultSource.TestCase.Source);
             testCaseResultData.LineNumber = testResultSource.TestCase.LineNumber;
             testCaseResultData.Retry = 0; // TODO Retry and PreviousRetries

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/Processor/DataProcessor.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/src/Processor/DataProcessor.cs
@@ -105,10 +105,9 @@ namespace Azure.Developer.MicrosoftPlaywrightTesting.TestLogger.Processor
             testCaseResultData.TestCombinationId = testCaseResultData.TestExecutionId; // TODO check
             testCaseResultData.TestId = testResultSource.TestCase.Id.ToString();
             testCaseResultData.TestTitle = testResultSource.TestCase.DisplayName;
-            string inputString = $"{testResultSource.TestCase.DisplayName}-{testResultSource.TestCase.CodeFilePath}";
-            var SuiteName = ReporterUtils.CalculateSha1Hash(inputString);
-            testCaseResultData.SuiteTitle = SuiteName;
-            testCaseResultData.SuiteId = SuiteName;
+            var className = FetchTestClassName(testResultSource.TestCase.FullyQualifiedName);
+            testCaseResultData.SuiteTitle = className;
+            testCaseResultData.SuiteId = ReporterUtils.CalculateSha1Hash(className);
             testCaseResultData.FileName = FetchFileName(testResultSource.TestCase.Source);
             testCaseResultData.LineNumber = testResultSource.TestCase.LineNumber;
             testCaseResultData.Retry = 0; // TODO Retry and PreviousRetries

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/Processor/DataProcessorTests.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/Processor/DataProcessorTests.cs
@@ -155,7 +155,7 @@ namespace Azure.Developer.MicrosoftPlaywrightTesting.TestLogger.Tests.Processor
             var testResult = new TestResult(new TestCase("Test.Reporting", new System.Uri("file:///test.cs"), "TestNamespace.TestClass"));
 
             TestResults result = dataProcessor.GetTestCaseResultData(testResult);
-
+            string inputString = $"{testResult.TestCase.DisplayName}-{testResult.TestCase.CodeFilePath}";
             Assert.IsNotNull(result);
             Assert.IsEmpty(result.ArtifactsPath);
             Assert.AreEqual(cloudRunMetadata.WorkspaceId, result.AccountId);
@@ -164,8 +164,8 @@ namespace Azure.Developer.MicrosoftPlaywrightTesting.TestLogger.Tests.Processor
             Assert.IsNotNull(result.TestCombinationId);
             Assert.IsNotNull(result.TestId);
             Assert.AreEqual(testResult.TestCase.DisplayName, result.TestTitle);
-            Assert.AreEqual("Test", result.SuiteTitle);
-            Assert.AreEqual("Test", result.SuiteId);
+            Assert.AreEqual(ReporterUtils.CalculateSha1Hash(inputString), result.SuiteTitle);
+            Assert.AreEqual(ReporterUtils.CalculateSha1Hash(inputString), result.SuiteId);
             Assert.AreEqual("TestNamespace.TestClass", result.FileName);
             Assert.AreEqual(testResult.TestCase.LineNumber, result.LineNumber);
             Assert.AreEqual(0, result.Retry);

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/Processor/DataProcessorTests.cs
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/tests/Processor/DataProcessorTests.cs
@@ -155,7 +155,7 @@ namespace Azure.Developer.MicrosoftPlaywrightTesting.TestLogger.Tests.Processor
             var testResult = new TestResult(new TestCase("Test.Reporting", new System.Uri("file:///test.cs"), "TestNamespace.TestClass"));
 
             TestResults result = dataProcessor.GetTestCaseResultData(testResult);
-            string inputString = $"{testResult.TestCase.DisplayName}-{testResult.TestCase.CodeFilePath}";
+
             Assert.IsNotNull(result);
             Assert.IsEmpty(result.ArtifactsPath);
             Assert.AreEqual(cloudRunMetadata.WorkspaceId, result.AccountId);
@@ -164,8 +164,8 @@ namespace Azure.Developer.MicrosoftPlaywrightTesting.TestLogger.Tests.Processor
             Assert.IsNotNull(result.TestCombinationId);
             Assert.IsNotNull(result.TestId);
             Assert.AreEqual(testResult.TestCase.DisplayName, result.TestTitle);
-            Assert.AreEqual(ReporterUtils.CalculateSha1Hash(inputString), result.SuiteTitle);
-            Assert.AreEqual(ReporterUtils.CalculateSha1Hash(inputString), result.SuiteId);
+            Assert.AreEqual("Test", result.SuiteTitle);
+            Assert.AreEqual(ReporterUtils.CalculateSha1Hash("Test"), result.SuiteId);
             Assert.AreEqual("TestNamespace.TestClass", result.FileName);
             Assert.AreEqual(testResult.TestCase.LineNumber, result.LineNumber);
             Assert.AreEqual(0, result.Retry);


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
