### PR TITLE
Update Azure.ClientSdk.Analyzers version

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -245,7 +245,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20241201.1" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20240813.2" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20241211.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />


### PR DESCRIPTION
This draft PR is meant to test the changes made to the analyzer in https://github.com/Azure/azure-sdk-tools/pull/9388, as suggested in [these instructions](https://github.com/Azure/azure-sdk-tools/tree/main/src/dotnet/Azure.ClientSdk.Analyzers#readme).