### PR TITLE
Add test for exception type

### DIFF
--- a/eng/packages/http-client-csharp/.gitattributes
+++ b/eng/packages/http-client-csharp/.gitattributes
@@ -1,0 +1,2 @@
+# Use unix line endings always, even on Windows
+*                            text=auto eol=lf

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Common/Helpers.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Common/Helpers.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using System.Diagnostics;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -8,53 +9,26 @@ namespace Azure.Generator.Tests.Common
 {
     internal static class Helpers
     {
-        private static readonly string _assemblyLocation = Path.GetDirectoryName(typeof(Helpers).Assembly.Location)!;
-
-        public static string GetExpectedFromFile(string? parameters = null)
+        public static string GetExpectedFromFile(
+            string? parameters = null,
+            [CallerMemberName] string method = "",
+            [CallerFilePath] string filePath = "")
         {
-            return File.ReadAllText(GetAssetFileOrDirectoryPath(true, parameters)).Replace("\r\n", "\n");
+            return File.ReadAllText(GetAssetFileOrDirectoryPath(true, parameters, method, filePath));
         }
 
-        private static string GetAssetFileOrDirectoryPath(bool isFile, string? parameters = null)
+        public static string GetAssetFileOrDirectoryPath(
+            bool isFile,
+            string? parameters = null,
+            [CallerMemberName] string method = "",
+            [CallerFilePath] string filePath = "")
         {
-            var stackTrace = new StackTrace();
-            var stackFrame = GetRealMethodInvocation(stackTrace);
-            var method = stackFrame.GetMethod();
-            var callingClass = method!.DeclaringType;
-            var nsSplit = callingClass!.Namespace!.Split('.');
+
+            var callingClass =  Path.GetFileName(filePath).Split('.').First();
             var paramString = parameters is null ? string.Empty : $"({parameters})";
             var extName = isFile ? ".cs" : string.Empty;
-            var path = _assemblyLocation;
-            var nsSkip = 3;
-            for (int i = nsSkip; i < nsSplit.Length; i++)
-            {
-                path = Path.Combine(path, nsSplit[i]);
-            }
-            return Path.Combine(path, "TestData", callingClass.Name, $"{method.Name}{paramString}{extName}");
-        }
 
-        private static StackFrame GetRealMethodInvocation(StackTrace stackTrace)
-        {
-            int i = 1;
-            while (i < stackTrace.FrameCount)
-            {
-                var frame = stackTrace.GetFrame(i);
-                var declaringType = frame!.GetMethod()!.DeclaringType!;
-                // we need to skip those method invocations from this class, or from the async state machine when the caller is an async method
-                if (declaringType != typeof(Helpers) && declaringType.Name != "MockHelpers" && !IsCompilerGenerated(declaringType))
-                {
-                    return frame;
-                }
-                i++;
-            }
-
-            throw new InvalidOperationException($"There is no method invocation outside the {typeof(Helpers)} class in the stack trace");
-
-            static bool IsCompilerGenerated(Type type)
-            {
-                return type.IsDefined(typeof(CompilerGeneratedAttribute), false) || (type.Namespace?.StartsWith("System.Runtime.CompilerServices") ?? false) ||
-                    type.Name.StartsWith("<<", StringComparison.Ordinal);
-            }
+            return Path.Combine(Path.GetDirectoryName(filePath)!, "TestData", callingClass, $"{method}{paramString}{extName}");
         }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/Abstractions/AzureClientResponseProviderTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/Abstractions/AzureClientResponseProviderTests.cs
@@ -1,14 +1,11 @@
-﻿using Azure.Generator.Tests.Common;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Tests.Common;
 using Azure.Generator.Tests.TestHelpers;
 using Microsoft.Generator.CSharp.ClientModel.Providers;
-using Microsoft.Generator.CSharp.ClientModel;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
-using System.ClientModel.Primitives;
 using Azure.Generator.Providers;
 
 namespace Azure.Generator.Tests.Providers.Abstractions
@@ -34,7 +31,19 @@ namespace Azure.Generator.Tests.Providers.Abstractions
             var method = clientProvider.Methods.FirstOrDefault(x => x.Signature.Parameters.Any(p => p.Type.Equals(typeof(RequestContext))) && !x.Signature.Name.EndsWith("Async"));
             Assert.NotNull(method);
             Assert.NotNull(method!.BodyStatements);
-            var test = method.BodyStatements!.ToDisplayString();
+            Assert.AreEqual(Helpers.GetExpectedFromFile(), method.BodyStatements!.ToDisplayString());
+        }
+
+        [Test]
+        public void ValidateClientResponseExceptionTypeIsOverridden()
+        {
+            MockHelpers.LoadMockPlugin();
+            var pipelineExtensions =
+                AzureClientPlugin.Instance.OutputLibrary.TypeProviders.FirstOrDefault(t => t.Name == "ClientPipelineExtensions");
+            Assert.NotNull(pipelineExtensions);
+            var method = pipelineExtensions!.Methods.FirstOrDefault(x => x.Signature.Name == "ProcessMessage");
+            Assert.NotNull(method);
+            Assert.NotNull(method!.BodyStatements);
             Assert.AreEqual(Helpers.GetExpectedFromFile(), method.BodyStatements!.ToDisplayString());
         }
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/Abstractions/TestData/AzureClientResponseProviderTests/ValidateClientResponseExceptionTypeIsOverridden.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/Abstractions/TestData/AzureClientResponseProviderTests/ValidateClientResponseExceptionTypeIsOverridden.cs
@@ -1,0 +1,9 @@
+﻿(global::System.Threading.CancellationToken userCancellationToken, global::Azure.ErrorOptions statusOption) = context.Parse();
+pipeline.Send(message, userCancellationToken);
+
+if ((message.Response.IsError && ((context?.ErrorOptions & global::Azure.ErrorOptions.NoThrow) != global::Azure.ErrorOptions.NoThrow)))
+{
+    throw new global::Azure.RequestFailedException(message.Response);
+}
+
+return message.Response;


### PR DESCRIPTION
Some cleanup of the test helpers file to align with the MGC helper as well as adding a new test that verifies that the exception type is overridden.

Also, adds a gitattributes file so that line endings are consistent in the test data files.