### PR TITLE
[Storage][DataMovement] Fix progress reports appearing out of order

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/ProgressHandlerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/ProgressHandlerTests.cs
@@ -310,22 +310,27 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
 
             await PopulateTestContainer(source.Container);
 
-            StorageResourceContainer sourceResource =
-                new BlobStorageResourceContainer(source.Container);
-            StorageResourceContainer destinationResource =
-                new LocalDirectoryStorageResourceContainer(destination.DirectoryPath);
+            BlobsStorageResourceProvider blobProvider = new(TestEnvironment.Credential);
+            LocalFilesStorageResourceProvider localProvider = new();
 
-            TransferManager transferManager = new TransferManager();
+            TransferManagerOptions transferManagerOptions = new()
+            {
+                ResumeProviders = [blobProvider, localProvider]
+            };
+            TransferManager transferManager = new(transferManagerOptions);
 
-            TestProgressHandler progressHandler = new TestProgressHandler();
-            DataTransferOptions transferOptions = new DataTransferOptions()
+            TestProgressHandler progressHandler = new();
+            DataTransferOptions transferOptions = new()
             {
                 ProgressHandlerOptions = new ProgressHandlerOptions(progressHandler, true)
             };
-            TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
+            TestEventsRaised testEventsRaised = new(transferOptions);
 
             // Act - Start transfer
-            DataTransfer transfer = await transferManager.StartTransferAsync(sourceResource, destinationResource, transferOptions);
+            DataTransfer transfer = await transferManager.StartTransferAsync(
+                blobProvider.FromContainer(source.Container.Uri),
+                localProvider.FromDirectory(destination.DirectoryPath),
+                transferOptions);
 
             // TODO: This can likely be replaced with something better once mocking is in place
             // Wait for the transfer to start happening
@@ -334,7 +339,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             // Pause transfer
             CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             await transferManager.PauseTransferIfRunningAsync(transfer.Id, tokenSource.Token);
-            Assert.AreEqual(DataTransferState.Paused, transfer.TransferStatus);
+            Assert.AreEqual(DataTransferState.Paused, transfer.TransferStatus.State);
 
             // Record the current number of progress updates to use during assertions
             int pause = progressHandler.Updates.Count;
@@ -348,7 +353,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             await resumeTransfer.WaitForCompletionAsync(tokenSource.Token);
 
             // Assert
-            Assert.AreEqual(DataTransferState.Completed, resumeTransfer.TransferStatus);
+            Assert.AreEqual(DataTransferState.Completed, resumeTransfer.TransferStatus.State);
             ProgressHandlerAsserts.AssertFileProgress(progressHandler.Updates, 5, pauseIndexes: pause);
             ProgressHandlerAsserts.AssertBytesTransferred(progressHandler.Updates, _expectedBytesTransferred);
         }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/ProgressHandlerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/ProgressHandlerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core.TestFramework;
 using Azure.Storage.DataMovement.Tests;
 using BaseBlobs::Azure.Storage.Blobs;
 using DMBlobs::Azure.Storage.DataMovement.Blobs;
@@ -298,7 +299,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
                 waitTime: 30);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35558")]
+        [LiveOnly]
         [Test]
         [TestCase(0)]
         [TestCase(150)]

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -51,7 +51,7 @@ namespace Azure.Storage.DataMovement
     }
     public partial class DataTransferProgress
     {
-        protected internal DataTransferProgress() { }
+        internal DataTransferProgress() { }
         public long? BytesTransferred { get { throw null; } }
         public long CompletedCount { get { throw null; } }
         public long FailedCount { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
@@ -51,7 +51,7 @@ namespace Azure.Storage.DataMovement
     }
     public partial class DataTransferProgress
     {
-        protected internal DataTransferProgress() { }
+        internal DataTransferProgress() { }
         public long? BytesTransferred { get { throw null; } }
         public long CompletedCount { get { throw null; } }
         public long FailedCount { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -51,7 +51,7 @@ namespace Azure.Storage.DataMovement
     }
     public partial class DataTransferProgress
     {
-        protected internal DataTransferProgress() { }
+        internal DataTransferProgress() { }
         public long? BytesTransferred { get { throw null; } }
         public long CompletedCount { get { throw null; } }
         public long FailedCount { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/src/CommitChunkHandler.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CommitChunkHandler.cs
@@ -13,7 +13,7 @@ namespace Azure.Storage.DataMovement
         #region Delegate Definitions
         public delegate Task QueuePutBlockTaskInternal(long offset, long blockSize, long expectedLength, StorageResourceItemProperties properties);
         public delegate Task QueueCommitBlockTaskInternal(StorageResourceItemProperties sourceProperties);
-        public delegate void ReportProgressInBytes(long bytesWritten);
+        public delegate ValueTask ReportProgressInBytes(long bytesWritten);
         public delegate Task InvokeFailedEventHandlerInternal(Exception ex);
         #endregion Delegate Definitions
 
@@ -99,7 +99,7 @@ namespace Azure.Storage.DataMovement
             try
             {
                 _bytesTransferred += args.BytesTransferred;
-                _reportProgressInBytes(args.BytesTransferred);
+                await _reportProgressInBytes(args.BytesTransferred).ConfigureAwait(false);
 
                 if (_bytesTransferred == _expectedLength)
                 {

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransferProgress.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransferProgress.cs
@@ -8,10 +8,7 @@ namespace Azure.Storage.DataMovement
     /// </summary>
     public class DataTransferProgress
     {
-        /// <summary>
-        /// Constructor for mocking.
-        /// </summary>
-        protected internal DataTransferProgress() { }
+        internal DataTransferProgress() { }
 
         /// <summary>
         /// Number of files that were transferred successfully.

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
@@ -284,11 +284,11 @@ namespace Azure.Storage.DataMovement
                 // Progress tracking, do before invoking the event below
                 if (transferState == DataTransferState.InProgress)
                 {
-                    _progressTracker.IncrementInProgressFiles();
+                    await _progressTracker.IncrementInProgressFilesAsync(_cancellationToken).ConfigureAwait(false);
                 }
                 else if (JobPartStatus.HasCompletedSuccessfully)
                 {
-                    _progressTracker.IncrementCompletedFiles();
+                    await _progressTracker.IncrementCompletedFilesAsync(_cancellationToken).ConfigureAwait(false);
                     await InvokeSingleCompletedArgAsync().ConfigureAwait(false);
                 }
 
@@ -309,13 +309,9 @@ namespace Azure.Storage.DataMovement
             }
         }
 
-        /// <summary>
-        /// To change all transfer statues at the same time
-        /// </summary>
-        /// <param name="bytesTransferred"></param>
-        internal void ReportBytesWritten(long bytesTransferred)
+        protected async ValueTask ReportBytesWrittenAsync(long bytesTransferred)
         {
-            _progressTracker.IncrementBytesTransferred(bytesTransferred);
+            await _progressTracker.IncrementBytesTransferred(bytesTransferred, _cancellationToken).ConfigureAwait(false);
         }
 
         public async virtual Task InvokeSingleCompletedArgAsync()
@@ -356,7 +352,7 @@ namespace Azure.Storage.DataMovement
                     ClientDiagnostics)
                     .ConfigureAwait(false);
             }
-            _progressTracker.IncrementSkippedFiles();
+            await _progressTracker.IncrementSkippedFilesAsync(_cancellationToken).ConfigureAwait(false);
 
             // Update the JobPartStatus. If was already updated (e.g. there was a failed item before)
             // then don't raise the PartTransferStatusEventHandler
@@ -413,7 +409,7 @@ namespace Azure.Storage.DataMovement
                         ClientDiagnostics)
                         .ConfigureAwait(false);
                 }
-                _progressTracker.IncrementFailedFiles();
+                await _progressTracker.IncrementFailedFilesAsync(_cancellationToken).ConfigureAwait(false);
 
                 // Update the JobPartStatus. If was already updated (e.g. there was a failed item before)
                 // then don't raise the PartTransferStatusEventHandler

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -275,7 +275,7 @@ namespace Azure.Storage.DataMovement
                     options: options,
                     cancellationToken: _cancellationToken).ConfigureAwait(false);
 
-                ReportBytesWritten(completeLength);
+                await ReportBytesWrittenAsync(completeLength).ConfigureAwait(false);
                 await OnTransferStateChangedAsync(DataTransferState.Completed).ConfigureAwait(false);
             }
             catch (RequestFailedException exception)
@@ -316,7 +316,7 @@ namespace Azure.Storage.DataMovement
                     cancellationToken: _cancellationToken).ConfigureAwait(false);
 
                 // Report first chunk written to progress tracker
-                ReportBytesWritten(blockSize);
+                await ReportBytesWrittenAsync(blockSize).ConfigureAwait(false);
 
                 if (blockSize == length)
                 {
@@ -346,7 +346,7 @@ namespace Azure.Storage.DataMovement
             {
                 QueuePutBlockTask = jobPart.QueueStageBlockRequest,
                 QueueCommitBlockTask = jobPart.QueueCompleteTransferAsync,
-                ReportProgressInBytes = jobPart.ReportBytesWritten,
+                ReportProgressInBytes = jobPart.ReportBytesWrittenAsync,
                 InvokeFailedHandler = jobPart.InvokeFailedArgAsync,
             };
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -328,7 +328,7 @@ namespace Azure.Storage.DataMovement
                 }
 
                 // Report bytes written before completion
-                ReportBytesWritten(blockSize);
+                await ReportBytesWrittenAsync(blockSize).ConfigureAwait(false);
 
                 // Set completion status to completed
                 await OnTransferStateChangedAsync(DataTransferState.Completed).ConfigureAwait(false);
@@ -360,7 +360,7 @@ namespace Azure.Storage.DataMovement
                         cancellationToken: _cancellationToken).ConfigureAwait(false);
                 }
 
-                ReportBytesWritten(blockSize);
+                await ReportBytesWrittenAsync(blockSize).ConfigureAwait(false);
             }
         }
 
@@ -372,7 +372,7 @@ namespace Azure.Storage.DataMovement
             {
                 QueuePutBlockTask = jobPart.QueueStageBlockRequest,
                 QueueCommitBlockTask = jobPart.QueueCompleteTransferAsync,
-                ReportProgressInBytes = jobPart.ReportBytesWritten,
+                ReportProgressInBytes = jobPart.ReportBytesWrittenAsync,
                 InvokeFailedHandler = jobPart.InvokeFailedArgAsync,
             };
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -720,9 +720,9 @@ namespace Azure.Storage.DataMovement
             return new HashSet<Uri>(_jobParts.Select(x => x._sourceResource.Uri));
         }
 
-        internal void IncrementJobParts()
+        internal async ValueTask IncrementJobParts()
         {
-            _progressTracker.IncrementQueuedFiles();
+            await _progressTracker.IncrementQueuedFilesAsync(_cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -109,7 +109,7 @@ namespace Azure.Storage.DataMovement
         {
             await foreach (JobPartInternal partItem in job.ProcessJobToJobPartAsync().ConfigureAwait(false))
             {
-                job.IncrementJobParts();
+                await job.IncrementJobParts().ConfigureAwait(false);
                 await _partsProcessor.QueueAsync(partItem, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace Azure.Storage.DataMovement
 {
@@ -10,94 +12,127 @@ namespace Azure.Storage.DataMovement
     /// Internal class for tracking progress of transfers and reporting back to
     /// user's progress handler.
     /// </summary>
-    internal class TransferProgressTracker
+    internal class TransferProgressTracker : IAsyncDisposable
     {
+        private class ProgressEventArgs
+        {
+            public int CompletedChange { get; set; } = 0;
+            public int SkippedChange { get; set; } = 0;
+            public int FailedChange { get; set; } = 0;
+            public int InProgressChange { get; set; } = 0;
+            public int QueuedChange { get; set; } = 0;
+            public long BytesChange { get; set; } = 0;
+        }
+
         private readonly ProgressHandlerOptions _options;
 
+        private IProcessor<ProgressEventArgs> _progressProcessor;
         private long _completedCount = 0;
         private long _skippedCount = 0;
         private long _failedCount = 0;
         private long _inProgressCount = 0;
         private long _queuedCount = 0;
         private long _bytesTransferred = 0;
-        private object _bytesTransferredLock = new();
 
         public TransferProgressTracker(ProgressHandlerOptions options)
         {
             _options = options;
+            _progressProcessor = ChannelProcessing.NewProcessor<ProgressEventArgs>(readers: 1);
+            _progressProcessor.Process = ProcessProgressEvent;
         }
 
-        /// <summary>
-        /// Atomically increments completed files, decrements in-progress files and reports progress.
-        /// </summary>
-        public void IncrementCompletedFiles()
+        public async ValueTask DisposeAsync()
         {
-            Interlocked.Decrement(ref _inProgressCount);
-            Interlocked.Increment(ref _completedCount);
-            _options?.ProgressHandler?.Report(GetTransferProgress());
+            // This will close the channel and block on all pending items being processed
+            await _progressProcessor.DisposeAsync().ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Atomically increments skipped files, decrements in-progress files and reports progress.
-        /// </summary>
-        public void IncrementSkippedFiles()
+        public async ValueTask IncrementCompletedFilesAsync(CancellationToken cancellationToken)
         {
-            Interlocked.Decrement(ref _inProgressCount);
-            Interlocked.Increment(ref _skippedCount);
-            _options?.ProgressHandler?.Report(GetTransferProgress());
-        }
-
-        /// <summary>
-        /// Atomically increments failed files, decrements in-progress files and reports progress.
-        /// </summary>
-        public void IncrementFailedFiles()
-        {
-            Interlocked.Decrement(ref _inProgressCount);
-            Interlocked.Increment(ref _failedCount);
-            _options?.ProgressHandler?.Report(GetTransferProgress());
-        }
-
-        /// <summary>
-        /// Atomically increments in-progress files, decrements queued files and reports progress.
-        /// </summary>
-        public void IncrementInProgressFiles()
-        {
-            Interlocked.Decrement(ref _queuedCount);
-            Interlocked.Increment(ref _inProgressCount);
-            _options?.ProgressHandler?.Report(GetTransferProgress());
-        }
-
-        /// <summary>
-        /// Atomically increments queued files and reports progress.
-        /// </summary>
-        public void IncrementQueuedFiles()
-        {
-            Interlocked.Increment(ref _queuedCount);
-            _options?.ProgressHandler?.Report(GetTransferProgress());
-        }
-
-        /// <summary>
-        /// Increments the number of bytes transferred by the given amount and reports progress.
-        /// </summary>
-        /// <param name="bytesTransferred"></param>
-        public void IncrementBytesTransferred(long bytesTransferred)
-        {
-            if (_options != default)
+            await QueueProgressEvent(new ProgressEventArgs()
             {
-                if ((bool)(_options?.TrackBytesTransferred))
+                InProgressChange = -1,
+                CompletedChange = 1,
+            },
+            cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask IncrementSkippedFilesAsync(CancellationToken cancellationToken)
+        {
+            await QueueProgressEvent(new ProgressEventArgs()
+            {
+                InProgressChange = -1,
+                SkippedChange = 1,
+            },
+            cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask IncrementFailedFilesAsync(CancellationToken cancellationToken)
+        {
+            await QueueProgressEvent(new ProgressEventArgs()
+            {
+                InProgressChange = -1,
+                FailedChange = 1,
+            },
+            cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask IncrementInProgressFilesAsync(CancellationToken cancellationToken)
+        {
+            await QueueProgressEvent(new ProgressEventArgs()
+            {
+                QueuedChange = -1,
+                InProgressChange = 1,
+            },
+            cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask IncrementQueuedFilesAsync(CancellationToken cancellationToken)
+        {
+            await QueueProgressEvent(new ProgressEventArgs()
+            {
+                QueuedChange = 1,
+            },
+            cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask IncrementBytesTransferred(long bytesTransferred, CancellationToken cancellationToken)
+        {
+            if (_options?.TrackBytesTransferred == true)
+            {
+                await QueueProgressEvent(new ProgressEventArgs()
                 {
-                    lock (_bytesTransferredLock)
-                    {
-                        _bytesTransferred += bytesTransferred;
-                        _options?.ProgressHandler?.Report(GetTransferProgress());
-                    }
-                }
+                    BytesChange = bytesTransferred,
+                },
+                cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private DataTransferProgress GetTransferProgress()
+        private async ValueTask QueueProgressEvent(ProgressEventArgs args, CancellationToken cancellationToken)
         {
-            return new DataTransferProgress()
+            try
+            {
+                await _progressProcessor.QueueAsync(args, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is ChannelClosedException || ex is OperationCanceledException)
+            {
+                // The only time we should get these exceptions is if the job is being
+                // disposed, either by pause or failure, in which case its safe to ignore these.
+            }
+        }
+
+        private Task ProcessProgressEvent(ProgressEventArgs args, CancellationToken cancellationToken = default)
+        {
+            // Only ever one thread processing at a time so its safe to update these
+            // Changes can be negative
+            _completedCount += args.CompletedChange;
+            _skippedCount += args.SkippedChange;
+            _failedCount += args.FailedChange;
+            _inProgressCount += args.InProgressChange;
+            _queuedCount += args.QueuedChange;
+            _bytesTransferred += args.BytesChange;
+
+            DataTransferProgress progress = new()
             {
                 CompletedCount = _completedCount,
                 SkippedCount = _skippedCount,
@@ -106,6 +141,9 @@ namespace Azure.Storage.DataMovement
                 QueuedCount = _queuedCount,
                 BytesTransferred = _options.TrackBytesTransferred ? _bytesTransferred : null
             };
+            _options?.ProgressHandler?.Report(progress);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -263,7 +263,7 @@ namespace Azure.Storage.DataMovement
                     initial: true).ConfigureAwait(false);
                 if (successfulInitialCopy)
                 {
-                    ReportBytesWritten(initialLength.Value);
+                    await ReportBytesWrittenAsync(initialLength.Value).ConfigureAwait(false);
                     if (totalLength == initialLength)
                     {
                         // Complete download since it was done in one go
@@ -316,7 +316,7 @@ namespace Azure.Storage.DataMovement
                     initial: true).ConfigureAwait(false);
                 if (successfulCopy)
                 {
-                    ReportBytesWritten(downloadLength);
+                    await ReportBytesWrittenAsync(downloadLength).ConfigureAwait(false);
                     // Queue the work to end the download
                     await QueueCompleteFileDownload().ConfigureAwait(false);
                 }
@@ -470,7 +470,7 @@ namespace Azure.Storage.DataMovement
             return new DownloadChunkHandler.Behaviors()
             {
                 CopyToDestinationFile = jobPart.CopyToStreamInternal,
-                ReportProgressInBytes = jobPart.ReportBytesWritten,
+                ReportProgressInBytes = jobPart.ReportBytesWrittenAsync,
                 InvokeFailedHandler = jobPart.InvokeFailedArgAsync,
                 QueueCompleteFileDownload = jobPart.QueueCompleteFileDownload
             };

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CommitChunkHandlerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CommitChunkHandlerTests.cs
@@ -116,7 +116,8 @@ namespace Azure.Storage.DataMovement.Tests
         private Mock<CommitChunkHandler.ReportProgressInBytes> GetReportProgressInBytesTask()
         {
             var mock = new Mock<CommitChunkHandler.ReportProgressInBytes>(MockBehavior.Strict);
-            mock.Setup(del => del(It.IsNotNull<long>()));
+            mock.Setup(del => del(It.IsNotNull<long>()))
+                .Returns(new ValueTask());
             return mock;
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/DownloadChunkHandlerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/DownloadChunkHandlerTests.cs
@@ -107,7 +107,8 @@ namespace Azure.Storage.DataMovement.Tests
         private Mock<DownloadChunkHandler.ReportProgressInBytes> GetReportProgressInBytesTask()
         {
             var mock = new Mock<DownloadChunkHandler.ReportProgressInBytes>(MockBehavior.Strict);
-            mock.Setup(del => del(It.IsNotNull<long>()));
+            mock.Setup(del => del(It.IsNotNull<long>()))
+                .Returns(new ValueTask());
             return mock;
         }
 


### PR DESCRIPTION
This change addresses an issue where progress reports could be sent out of order, resulting in file counts jumping around.

The issue was caused by not having anything to synchronize the progress reports which could be coming from multiple threads at the same time. The fix was to add a Channel with a single reader to synchronize the events and have one source of truth for current counts and send progress reports from a single thread.
