### PR TITLE
[EngSys] .NET 9 SDK

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "Azure.Sdk.Tools.SnippetGenerator": {
-      "version": "1.0.0-dev.20230124.1",
+      "version": "1.0.0-dev.20241213.1",
       "commands": [
         "snippet-generator"
       ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@
 - Install Visual Studio 2022 (Community or higher) and make sure you have the latest updates (https://www.visualstudio.com/).
   - Need at least .NET Framework 4.6.1 and 4.7 development tools
 - Install the **.NET cross-platform development** workloads in VisualStudio
-- Install **.NET 8.0.100 SDK** for your specific platform. (or a higher version within the 8.0.*** band)  (https://dotnet.microsoft.com/download/dotnet-core/8.0)
+- Install **.NET 9.0.101 SDK** for your specific platform. (or a higher version within the 9.0.*** band)  (https://dotnet.microsoft.com/download/dotnet-core/9.0)
 - Install the latest version of git (https://git-scm.com/downloads)
-- Install [PowerShell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell), version 6 or higher, if you plan to make public API changes or are working with generated code snippets.
+- Install [PowerShell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell), version 7 or higher, if you plan to make public API changes or are working with generated code snippets.
 - Install [NodeJS](https://nodejs.org/) (16.x.x) if you plan to use [C# code generation](https://github.com/Azure/autorest.csharp).
 - [Fork the repository](https://docs.github.com/get-started/quickstart/fork-a-repo); work will be done on a [topic branch](https://docs.github.com/get-started/quickstart/github-flow#create-a-branch) in your fork and a [pull request opened](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) against the `main` branch of the Azure SDK for .NET repository when ready for review.
 

--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -143,7 +143,7 @@
   <PropertyGroup Condition="'$(IsGeneratorLibrary)' != 'true' and ('$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true' or '$(IsSamplesProject)' == 'true' or '$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true')">
     <IsPackable>false</IsPackable>
     <!-- List newest targets first so that recordings are made with latest, running tests from editor runs latest, etc. -->
-    <RequiredTargetFrameworks>net8.0;net6.0</RequiredTargetFrameworks>
+    <RequiredTargetFrameworks>net9.0;net8.0</RequiredTargetFrameworks>
     <!-- Also test net462 on Windows. net461 is out of support as of 4/2022 and is not supported in version 4.4.x and beyond of NUnit3TestAdapter. -->
     <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(RequiredTargetFrameworks);net462</RequiredTargetFrameworks>
     <!-- But only build snippets for the latest. -->

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -247,7 +247,7 @@
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20250104.1" PrivateAssets="All" />
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20240813.2" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20467.1" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19552.1" PrivateAssets="All" />

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -5,10 +5,10 @@
   },
   "matrix": {
     "Agent": {
-      "Ubuntu-20.04_NET6.0": {
+      "Ubuntu-20.04_NET9.0": {
         "OSVmImage": "env:LINUXVMIMAGE",
         "Pool": "env:LINUXPOOL",
-        "TestTargetFramework": "net6.0"
+        "TestTargetFramework": "net9.0"
       },
       "Ubuntu-20.04_NET8.0": {
         "OSVmImage": "env:LINUXVMIMAGE",
@@ -25,10 +25,10 @@
         "Pool": "env:WINDOWSPOOL",
         "TestTargetFramework": "net8.0"
       },
-      "MacOS_NET6.0": {
+      "MacOS_NET9.0": {
         "OSVmImage": "env:MACVMIMAGE",
         "Pool": "env:MACPOOL",
-        "TestTargetFramework": "net6.0"
+        "TestTargetFramework": "net9.0"
       },
       "MacOS_NET8.0": {
         "OSVmImage": "env:MACVMIMAGE",

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -12,20 +12,20 @@ steps:
       msbuildArguments: /p:WorkFolder="$(Agent.WorkFolder)" /p:BuildDirectory="$(Agent.BuildDirectory)"
   # Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK'
+    displayName: 'Use .NET SDK' # Uses the SDK defined in global.json
     retryCountOnTaskFailure: 3
     inputs:
       useGlobalJson: true
       performMultiLevelLookup: true
-  - task: UseDotNet@2 # We need .NET 6 for azure-sdk-tools and the .NET 6 tests
+  - task: UseDotNet@2 # We need .NET 8 for azure-sdk-tools and the .NET 8 tests
     condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT')) # Windows supports MultiLevelLookup and doesn't need explicit framework installation
-    displayName: 'Use .NET 6.0 SDK'
+    displayName: 'Use .NET 8.0 SDK'
     retryCountOnTaskFailure: 3
     inputs:
       # AspNetCore runtime pack can't be installed outside of SDK and we need it for integration tests
       packageType: sdk
       performMultiLevelLookup: true
-      version: "6.0.x"
+      version: "8.0.x"
   - task: Cache@2
     inputs:
       key: 'nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/eng/Packages.Data.props | ${{parameters.NuGetCacheKey}}'

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Traversal": "3.2.0"
   },
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.101",
     "rollForward": "feature"
   }
 }

--- a/sdk/core/Azure.Core.TestFramework/src/ProxyTransport.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ProxyTransport.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
@@ -100,7 +102,9 @@ namespace Azure.Core.TestFramework
 
                 if (_isWebRequestTransport)
                 {
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete and does not affect HttpClient
                     ServicePointManager.ServerCertificateValidationCallback -= _serverCertificateCustomValidationCallback;
+#pragma warning restore SYSLIB0014 // ServicePointManager is obsolete and does not affect HttpClient
                 }
             }
         }
@@ -192,7 +196,9 @@ namespace Azure.Core.TestFramework
 
             if (_isWebRequestTransport)
             {
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete and does not affect HttpClient
                 ServicePointManager.ServerCertificateValidationCallback += _serverCertificateCustomValidationCallback;
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete and does not affect HttpClient
             }
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to move the repository global SDK version to .NET 9 and include it in the test matrix.  The .NET tools (such as snippet generator) are moving from .NET 6 to .NET 8 so that we're not running on an unsupported platform.