### PR TITLE
[DocumentIntelligence] Fixing typo in samples

### DIFF
--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/README.md
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/README.md
@@ -524,7 +524,7 @@ For example, if you submit a receipt image with an invalid `Uri`, a `400` error 
 
 ```C# Snippet:DocumentIntelligenceBadRequest
 var uriSource = new Uri("http://invalid.uri");
-var options = new AnalyzeDocumentOptions("prebuild-receipt", uriSource);
+var options = new AnalyzeDocumentOptions("prebuilt-receipt", uriSource);
 
 try
 {

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/samples/Sample_AddOnCapabilities.md
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/samples/Sample_AddOnCapabilities.md
@@ -210,7 +210,7 @@ To extract barcodes from a given file at a URI with the add-on barcodes capabili
 ```C# Snippet:DocumentIntelligenceSampleBarcodeExtraction
 Uri uriSource = new Uri("<uriSource>");
 
-var options = new AnalyzeDocumentOptions("prebuild-layout", uriSource)
+var options = new AnalyzeDocumentOptions("prebuilt-layout", uriSource)
 {
     Features = { DocumentAnalysisFeature.Barcodes }
 };

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/samples/SampleSnippets.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/samples/SampleSnippets.cs
@@ -82,7 +82,7 @@ namespace Azure.AI.DocumentIntelligence.Samples
 
             #region Snippet:DocumentIntelligenceBadRequest
             var uriSource = new Uri("http://invalid.uri");
-            var options = new AnalyzeDocumentOptions("prebuild-receipt", uriSource);
+            var options = new AnalyzeDocumentOptions("prebuilt-receipt", uriSource);
 
             try
             {

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/samples/Sample_AnalyzeWithAddOnCapabilities.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/samples/Sample_AnalyzeWithAddOnCapabilities.cs
@@ -226,7 +226,7 @@ namespace Azure.AI.DocumentIntelligence.Samples
             Uri uriSource = DocumentIntelligenceTestEnvironment.CreateUri("Form_1.jpg");
 #endif
 
-            var options = new AnalyzeDocumentOptions("prebuild-layout", uriSource)
+            var options = new AnalyzeDocumentOptions("prebuilt-layout", uriSource)
             {
                 Features = { DocumentAnalysisFeature.Barcodes }
             };


### PR DESCRIPTION
Fixing a single-letter typo in samples that was causing failures in our live tests pipeline.