### PR TITLE
[DocumentIntelligence] Added tests for the batch API

### DIFF
--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/assets.json
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/documentintelligence/Azure.AI.DocumentIntelligence",
-  "Tag": "net/documentintelligence/Azure.AI.DocumentIntelligence_c6ca5d0f3d"
+  "Tag": "net/documentintelligence/Azure.AI.DocumentIntelligence_1586f1c28d"
 }

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentAssert.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentAssert.cs
@@ -9,6 +9,32 @@ namespace Azure.AI.DocumentIntelligence.Tests
 {
     internal static class DocumentAssert
     {
+        public static void AreEqual(AnalyzeBatchResult expected, AnalyzeBatchResult actual)
+        {
+            if (expected == null)
+            {
+                Assert.That(actual, Is.Null);
+                return;
+            }
+
+            Assert.That(actual, Is.Not.Null);
+
+            Assert.That(actual.SucceededCount, Is.EqualTo(expected.SucceededCount));
+            Assert.That(actual.FailedCount, Is.EqualTo(expected.FailedCount));
+            Assert.That(actual.SkippedCount, Is.EqualTo(expected.SkippedCount));
+
+            AreEquivalent(expected.Details, actual.Details);
+        }
+
+        public static void AreEqual(AnalyzeBatchResultDetails expected, AnalyzeBatchResultDetails actual)
+        {
+            Assert.That(actual.SourceUri.AbsoluteUri, Is.EqualTo(expected.SourceUri.AbsoluteUri));
+            Assert.That(actual.ResultUri.AbsoluteUri, Is.EqualTo(expected.ResultUri.AbsoluteUri));
+            Assert.That(actual.Status, Is.EqualTo(expected.Status));
+
+            AreEqual(expected.Error, actual.Error);
+        }
+
         public static void AreEqual(BlobContentSource expected, BlobContentSource actual)
         {
             if (expected == null)
@@ -77,6 +103,40 @@ namespace Azure.AI.DocumentIntelligence.Tests
             AreEquivalent(expected.Properties, actual.Properties);
         }
 
+        public static void AreEqual(DocumentIntelligenceError expected, DocumentIntelligenceError actual)
+        {
+            if (expected == null)
+            {
+                Assert.That(actual, Is.Null);
+                return;
+            }
+
+            Assert.That(actual, Is.Not.Null);
+
+            Assert.That(actual.Code, Is.EqualTo(expected.Code));
+            Assert.That(actual.Message, Is.EqualTo(expected.Message));
+            Assert.That(actual.Target, Is.EqualTo(expected.Target));
+
+            AreEquivalent(expected.Details, actual.Details);
+            AreEqual(expected.InnerError, actual.InnerError);
+        }
+
+        public static void AreEqual(DocumentIntelligenceInnerError expected, DocumentIntelligenceInnerError actual)
+        {
+            if (expected == null)
+            {
+                Assert.That(actual, Is.Null);
+                return;
+            }
+
+            Assert.That(actual, Is.Not.Null);
+
+            Assert.That(actual.Code, Is.EqualTo(expected.Code));
+            Assert.That(actual.Message, Is.EqualTo(expected.Message));
+
+            AreEqual(expected.InnerError, actual.InnerError);
+        }
+
         public static void AreEqual(DocumentModelDetails expected, DocumentModelDetails actual)
         {
             Assert.That(actual.ModelId, Is.EqualTo(expected.ModelId));
@@ -99,6 +159,26 @@ namespace Azure.AI.DocumentIntelligence.Tests
             Assert.That(actual.FieldConfidence, Is.EquivalentTo(expected.FieldConfidence));
 
             AreEquivalent(expected.FieldSchema, actual.FieldSchema);
+        }
+
+        public static void AreEquivalent(IReadOnlyList<AnalyzeBatchResultDetails> expected, IReadOnlyList<AnalyzeBatchResultDetails> actual)
+        {
+            Assert.That(actual.Count, Is.EqualTo(expected.Count));
+
+            for (int i = 0; i < actual.Count; i++)
+            {
+                AreEqual(expected[i], actual[i]);
+            }
+        }
+
+        public static void AreEquivalent(IReadOnlyList<DocumentIntelligenceError> expected, IReadOnlyList<DocumentIntelligenceError> actual)
+        {
+            Assert.That(actual.Count, Is.EqualTo(expected.Count));
+
+            for (int i = 0; i < actual.Count; i++)
+            {
+                AreEqual(expected[i], actual[i]);
+            }
         }
 
         public static void AreEquivalent(IReadOnlyDictionary<string, ClassifierDocumentTypeDetails> expected, IReadOnlyDictionary<string, ClassifierDocumentTypeDetails> actual)

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceClient/DocumentBatchLiveTests.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/DocumentIntelligenceClient/DocumentBatchLiveTests.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.DocumentIntelligence.Tests
+{
+    [PlaybackOnly("https://github.com/Azure/azure-sdk-for-net/issues/47557")]
+    public class DocumentBatchLiveTests : DocumentIntelligenceLiveTestBase
+    {
+        public DocumentBatchLiveTests(bool isAsync)
+            : base(isAsync)
+        {
+        }
+
+        [Test]
+        public async Task AnalyzeBatchDocuments()
+        {
+            var client = CreateDocumentIntelligenceClient();
+            var sourceContainerUri = new Uri(TestEnvironment.BatchSourceBlobSasUrl);
+            var resultContainerUri = new Uri(TestEnvironment.BatchResultBlobSasUrl);
+            var blobSource = new BlobContentSource(sourceContainerUri);
+            var options = new AnalyzeBatchDocumentsOptions("prebuilt-read", blobSource, resultContainerUri)
+            {
+                OverwriteExisting = true
+            };
+
+            var operation = await client.AnalyzeBatchDocumentsAsync(WaitUntil.Completed, options);
+
+            Assert.That(operation.HasCompleted);
+            Assert.That(operation.HasValue);
+
+            ValidateAcordAnalyzeBatchResult(operation.Value);
+        }
+
+        [Test]
+        public async Task GetAnalyzeBatchResult()
+        {
+            var client = CreateDocumentIntelligenceClient();
+            var sourceContainerUri = new Uri(TestEnvironment.BatchSourceBlobSasUrl);
+            var resultContainerUri = new Uri(TestEnvironment.BatchResultBlobSasUrl);
+            var blobSource = new BlobContentSource(sourceContainerUri);
+            var options = new AnalyzeBatchDocumentsOptions("prebuilt-read", blobSource, resultContainerUri)
+            {
+                OverwriteExisting = true
+            };
+            var startTime = Recording.UtcNow;
+
+            var operation = await client.AnalyzeBatchDocumentsAsync(WaitUntil.Completed, options);
+            var getResponse = await client.GetAnalyzeBatchResultAsync("prebuilt-read", operation.Id);
+            var operationDetails = getResponse.Value;
+
+            Assert.That(operationDetails.ResultId, Is.EqualTo(operation.Id));
+            Assert.That(operationDetails.Status, Is.EqualTo(DocumentIntelligenceOperationStatus.Succeeded));
+            Assert.That(operationDetails.CreatedOn, Is.GreaterThan(startTime - TimeSpan.FromHours(4)));
+            Assert.That(operationDetails.LastUpdatedOn, Is.GreaterThanOrEqualTo(operationDetails.CreatedOn));
+            Assert.That(operationDetails.PercentCompleted, Is.EqualTo(100));
+            Assert.That(operationDetails.Error, Is.Null);
+
+            DocumentAssert.AreEqual(operation.Value, operationDetails.Result);
+        }
+
+        [Test]
+        public async Task GetAnalyzeBatchResults()
+        {
+            var client = CreateDocumentIntelligenceClient();
+            var sourceContainerUri = new Uri(TestEnvironment.BatchSourceBlobSasUrl);
+            var resultContainerUri = new Uri(TestEnvironment.BatchResultBlobSasUrl);
+            var blobSource = new BlobContentSource(sourceContainerUri);
+            var options = new AnalyzeBatchDocumentsOptions("prebuilt-read", blobSource, resultContainerUri)
+            {
+                OverwriteExisting = true
+            };
+
+            var operation0 = await client.AnalyzeBatchDocumentsAsync(WaitUntil.Completed, options);
+            var operation1 = await client.AnalyzeBatchDocumentsAsync(WaitUntil.Completed, options);
+            var getResponse0 = await client.GetAnalyzeBatchResultAsync("prebuilt-read", operation0.Id);
+            var getResponse1 = await client.GetAnalyzeBatchResultAsync("prebuilt-read", operation1.Id);
+
+            var expectedIdMapping = new Dictionary<string, AnalyzeBatchOperationDetails>()
+            {
+                { operation0.Id, getResponse0.Value },
+                { operation1.Id, getResponse1.Value }
+            };
+            var idMapping = new Dictionary<string, AnalyzeBatchOperationDetails>();
+
+            await foreach (AnalyzeBatchOperationDetails operation in client.GetAnalyzeBatchResultsAsync("prebuilt-read"))
+            {
+                if (expectedIdMapping.ContainsKey(operation.ResultId))
+                {
+                    idMapping.Add(operation.ResultId, operation);
+                }
+
+                if (idMapping.Count == expectedIdMapping.Count)
+                {
+                    break;
+                }
+            }
+
+            Assert.That(idMapping.Count, Is.EqualTo(expectedIdMapping.Count));
+
+            foreach (string id in expectedIdMapping.Keys)
+            {
+                Assert.That(idMapping, Contains.Key(id));
+
+                AnalyzeBatchOperationDetails expected = expectedIdMapping[id];
+                AnalyzeBatchOperationDetails actual = idMapping[id];
+
+                Assert.That(actual.ResultId, Is.EqualTo(expected.ResultId));
+                Assert.That(actual.Status, Is.EqualTo(expected.Status));
+                Assert.That(actual.CreatedOn, Is.EqualTo(expected.CreatedOn));
+                Assert.That(actual.LastUpdatedOn, Is.EqualTo(expected.LastUpdatedOn));
+                Assert.That(actual.PercentCompleted, Is.Null);
+
+                DocumentAssert.AreEqual(actual.Error, expected.Error);
+            }
+        }
+
+        [Test]
+        public async Task DeleteAnalyzeBatchResult()
+        {
+            var client = CreateDocumentIntelligenceClient();
+            var sourceContainerUri = new Uri(TestEnvironment.BatchSourceBlobSasUrl);
+            var resultContainerUri = new Uri(TestEnvironment.BatchResultBlobSasUrl);
+            var blobSource = new BlobContentSource(sourceContainerUri);
+            var options = new AnalyzeBatchDocumentsOptions("prebuilt-read", blobSource, resultContainerUri)
+            {
+                OverwriteExisting = true
+            };
+
+            var operation = await client.AnalyzeBatchDocumentsAsync(WaitUntil.Completed, options);
+            var response = await client.DeleteAnalyzeBatchResultAsync("prebuilt-read", operation.Id);
+
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.NoContent));
+        }
+
+        private void ValidateAcordAnalyzeBatchResult(AnalyzeBatchResult result)
+        {
+            Assert.That(result.SucceededCount, Is.EqualTo(6));
+            Assert.That(result.FailedCount, Is.EqualTo(0));
+            Assert.That(result.SkippedCount, Is.EqualTo(0));
+
+            string expectedSourcePrefix = string.Empty;
+            string expectedResultPrefix = string.Empty;
+
+            // We can't validate this in Playback mode since these environment variables
+            // are not stored when recording.
+
+            if (Mode == RecordedTestMode.Live)
+            {
+                int sourceQueryStart = TestEnvironment.BatchSourceBlobSasUrl.IndexOf('?');
+                int resultQueryStart = TestEnvironment.BatchResultBlobSasUrl.IndexOf('?');
+
+                expectedSourcePrefix = (sourceQueryStart == -1)
+                    ? TestEnvironment.BatchSourceBlobSasUrl
+                    : TestEnvironment.BatchSourceBlobSasUrl.Substring(0, sourceQueryStart);
+
+                expectedResultPrefix = (resultQueryStart == -1)
+                    ? TestEnvironment.BatchResultBlobSasUrl
+                    : TestEnvironment.BatchResultBlobSasUrl.Substring(0, resultQueryStart);
+            }
+
+            foreach (var details in result.Details)
+            {
+                Assert.That(details.SourceUri.AbsoluteUri, Does.StartWith(expectedSourcePrefix));
+                Assert.That(details.ResultUri.AbsoluteUri, Does.StartWith(expectedResultPrefix));
+                Assert.That(details.Status, Is.EqualTo(DocumentIntelligenceOperationStatus.Succeeded));
+                Assert.That(details.Error, Is.Null);
+            }
+        }
+    }
+}

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/Infrastructure/DocumentIntelligenceLiveTestBase.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/Infrastructure/DocumentIntelligenceLiveTestBase.cs
@@ -11,11 +11,14 @@ namespace Azure.AI.DocumentIntelligence.Tests
 {
     public class DocumentIntelligenceLiveTestBase : RecordedTestBase<DocumentIntelligenceTestEnvironment>
     {
+        private const string SanitizedContainerUri = "https://sanitized.blob.core.windows.net";
+
         public DocumentIntelligenceLiveTestBase(bool isAsync, RecordedTestMode? mode = null)
             : base(isAsync, mode)
         {
             JsonPathSanitizers.Add("$..accessToken");
-            BodyKeySanitizers.Add(new BodyKeySanitizer("$..containerUrl") { Value = "https://sanitized.blob.core.windows.net" });
+            BodyKeySanitizers.Add(new BodyKeySanitizer("$..containerUrl") { Value = SanitizedContainerUri });
+            BodyKeySanitizers.Add(new BodyKeySanitizer("$..resultContainerUrl") { Value = SanitizedContainerUri });
             SanitizedHeaders.Add("Ocp-Apim-Subscription-Key");
         }
 

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/Infrastructure/DocumentIntelligenceTestEnvironment.cs
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/tests/Infrastructure/DocumentIntelligenceTestEnvironment.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
-using Azure.Identity;
 
 namespace Azure.AI.DocumentIntelligence.Tests
 {
@@ -33,6 +32,10 @@ namespace Azure.AI.DocumentIntelligence.Tests
         public string BlobContainerSasUrl => GetRecordedVariable("SINGLEPAGE_BLOB_CONTAINER_SAS_URL", options => options.IsSecret(SanitizedSasUrl));
 
         public string ClassifierTrainingSasUrl => GetRecordedVariable("CLASSIFIER_BLOB_CONTAINER_SAS_URL", options => options.IsSecret(SanitizedSasUrl));
+
+        public string BatchSourceBlobSasUrl => GetRecordedVariable("BATCH_SOURCE_BLOB_CONTAINER_SAS_URL", options => options.IsSecret(SanitizedSasUrl));
+
+        public string BatchResultBlobSasUrl => GetRecordedVariable("BATCH_RESULT_BLOB_CONTAINER_SAS_URL", options => options.IsSecret(SanitizedSasUrl));
 
         public static string CreatePath(string filename)
         {

--- a/sdk/documentintelligence/test-resources.json
+++ b/sdk/documentintelligence/test-resources.json
@@ -42,6 +42,14 @@
             "type": "string",
             "defaultValue": "training-data-classifier"
         },
+        "batchSourceContainer": {
+            "type": "string",
+            "defaultValue": "trainingdata-batch"
+        },
+        "batchResultContainer": {
+            "type": "string",
+            "defaultValue": "trainingdata-batch-result"
+        },
         "trainingDataResourceId": {
             "type": "string",
             "defaultValue": "[resourceId('static-test-resources', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
@@ -61,6 +69,24 @@
                 "canonicalizedResource": "[concat('/blob/', parameters('trainingDataAccount'), '/', parameters('classifierTrainingDataContainer'))]",
                 "signedExpiry": "[dateTimeAdd(utcNow('u'), 'PT2H')]",
                 "signedPermission": "rl",
+                "signedResource": "c"
+            }
+        },
+        "batchSourceSasProperties": {
+            "type": "object",
+            "defaultValue": {
+                "canonicalizedResource": "[concat('/blob/', parameters('trainingDataAccount'), '/', parameters('batchSourceContainer'))]",
+                "signedExpiry": "[dateTimeAdd(utcNow('u'), 'PT2H')]",
+                "signedPermission": "rwdl",
+                "signedResource": "c"
+            }
+        },
+        "batchResultSasProperties": {
+            "type": "object",
+            "defaultValue": {
+                "canonicalizedResource": "[concat('/blob/', parameters('trainingDataAccount'), '/', parameters('batchResultContainer'))]",
+                "signedExpiry": "[dateTimeAdd(utcNow('u'), 'PT2H')]",
+                "signedPermission": "rwdl",
                 "signedResource": "c"
             }
         }
@@ -118,6 +144,14 @@
         "CLASSIFIER_BLOB_CONTAINER_SAS_URL": {
             "type": "string",
             "value": "[concat(reference(parameters('trainingDataResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('classifierTrainingDataContainer'), '?', listServiceSas(parameters('trainingDataResourceId'), '2019-06-01', parameters('classifierTrainingSasProperties')).serviceSasToken)]"
+        },
+        "BATCH_SOURCE_BLOB_CONTAINER_SAS_URL": {
+            "type": "string",
+            "value": "[concat(reference(parameters('trainingDataResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('batchSourceContainer'), '?', listServiceSas(parameters('trainingDataResourceId'), '2019-06-01', parameters('batchSourceSasProperties')).serviceSasToken)]"
+        },
+        "BATCH_RESULT_BLOB_CONTAINER_SAS_URL": {
+            "type": "string",
+            "value": "[concat(reference(parameters('trainingDataResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('batchResultContainer'), '?', listServiceSas(parameters('trainingDataResourceId'), '2019-06-01', parameters('batchResultSasProperties')).serviceSasToken)]"
         }
     }
 }


### PR DESCRIPTION
Tests work as expected when running locally, but these changes are failing when deploying test resources in our live tests pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4410381&view=results

The batch-related containers were recently added to our static storage container, so I believe this could be related to their not being included in the TME storage account we use for testing yet.

These new tests have been marked with the `PlaybackOnly` attribute for the time being.

This issue is tracked by: https://github.com/Azure/azure-sdk-for-net/issues/47557

I'm getting this PR out while this issue is being investigated so we can get work parallelized.