### PR TITLE
Reduce async overhead in Azure.Storage.Blobs

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -411,10 +411,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContentInfo>> CreateAsync(
+        public virtual Task<Response<BlobContentInfo>> CreateAsync(
             AppendBlobCreateOptions options,
             CancellationToken cancellationToken = default) =>
-            await CreateInternal(
+            CreateInternal(
                 httpHeaders: options?.HttpHeaders,
                 metadata: options?.Metadata,
                 tags: options?.Tags,
@@ -422,8 +422,7 @@ namespace Azure.Storage.Blobs.Specialized
                 immutabilityPolicy: options?.ImmutabilityPolicy,
                 legalHold: options?.HasLegalHold,
                 async: true,
-                cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// The <see cref="Create(BlobHttpHeaders, Metadata, AppendBlobRequestConditions, CancellationToken)"/>
@@ -509,12 +508,12 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContentInfo>> CreateAsync(
+        public virtual Task<Response<BlobContentInfo>> CreateAsync(
             BlobHttpHeaders httpHeaders = default,
             Metadata metadata = default,
             AppendBlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await CreateInternal(
+            CreateInternal(
                 httpHeaders: httpHeaders,
                 metadata: metadata,
                 tags: default,
@@ -522,8 +521,7 @@ namespace Azure.Storage.Blobs.Specialized
                 async: true,
                 immutabilityPolicy: default,
                 legalHold: default,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExists(AppendBlobCreateOptions, CancellationToken)"/>
@@ -588,18 +586,17 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContentInfo>> CreateIfNotExistsAsync(
+        public virtual Task<Response<BlobContentInfo>> CreateIfNotExistsAsync(
             AppendBlobCreateOptions options,
             CancellationToken cancellationToken = default) =>
-            await CreateIfNotExistsInternal(
+            CreateIfNotExistsInternal(
                 httpHeaders: options?.HttpHeaders,
                 metadata: options?.Metadata,
                 tags: options?.Tags,
                 immutabilityPolicy: options?.ImmutabilityPolicy,
                 legalHold: options?.HasLegalHold,
                 async: true,
-                cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExists(BlobHttpHeaders, Metadata, CancellationToken)"/>
@@ -675,19 +672,18 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContentInfo>> CreateIfNotExistsAsync(
+        public virtual Task<Response<BlobContentInfo>> CreateIfNotExistsAsync(
             BlobHttpHeaders httpHeaders = default,
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            await CreateIfNotExistsInternal(
+            CreateIfNotExistsInternal(
                 httpHeaders: httpHeaders,
                 metadata: metadata,
                 tags: default,
                 immutabilityPolicy: default,
                 legalHold: default,
                 async: true,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExistsInternal"/> operation creates a new 0-length
@@ -1065,7 +1061,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
-        public virtual async Task<Response<BlobAppendInfo>> AppendBlockAsync(
+        public virtual Task<Response<BlobAppendInfo>> AppendBlockAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             Stream content,
             byte[] transactionalContentHash,
@@ -1073,14 +1069,13 @@ namespace Azure.Storage.Blobs.Specialized
             IProgress<long> progressHandler,
             CancellationToken cancellationToken)
         {
-            return await AppendBlockInternal(
+            return AppendBlockInternal(
                 content,
                 transactionalContentHash.ToValidationOptions(),
                 conditions,
                 progressHandler,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
         }
 
         /// <summary>
@@ -1156,18 +1151,17 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobAppendInfo>> AppendBlockAsync(
+        public virtual Task<Response<BlobAppendInfo>> AppendBlockAsync(
             Stream content,
             AppendBlobAppendBlockOptions options = default,
             CancellationToken cancellationToken = default) =>
-            await AppendBlockInternal(
+            AppendBlockInternal(
                 content,
                 options?.TransferValidation,
                 options?.Conditions,
                 options?.ProgressHandler,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="AppendBlockInternal"/> operation commits a new block
@@ -1398,11 +1392,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobAppendInfo>> AppendBlockFromUriAsync(
+        public virtual Task<Response<BlobAppendInfo>> AppendBlockFromUriAsync(
             Uri sourceUri,
             AppendBlobAppendBlockFromUriOptions options = default,
             CancellationToken cancellationToken = default) =>
-            await AppendBlockFromUriInternal(
+            AppendBlockFromUriInternal(
                 sourceUri,
                 options?.SourceRange ?? default,
                 options?.SourceContentHash,
@@ -1410,8 +1404,7 @@ namespace Azure.Storage.Blobs.Specialized
                 options?.SourceConditions,
                 options?.SourceAuthentication,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="AppendBlockFromUriAsync(Uri, HttpRange, byte[], AppendBlobRequestConditions, AppendBlobRequestConditions, CancellationToken)"/>
@@ -1544,7 +1537,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
-        public virtual async Task<Response<BlobAppendInfo>> AppendBlockFromUriAsync(
+        public virtual Task<Response<BlobAppendInfo>> AppendBlockFromUriAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             Uri sourceUri,
             HttpRange sourceRange,
@@ -1552,7 +1545,7 @@ namespace Azure.Storage.Blobs.Specialized
             AppendBlobRequestConditions conditions,
             AppendBlobRequestConditions sourceConditions,
             CancellationToken cancellationToken) =>
-            await AppendBlockFromUriInternal(
+            AppendBlockFromUriInternal(
                 sourceUri,
                 sourceRange,
                 sourceContentHash,
@@ -1560,8 +1553,7 @@ namespace Azure.Storage.Blobs.Specialized
                 sourceConditions,
                 sourceAuthentication: default,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="AppendBlockFromUriInternal"/> operation commits a new
@@ -1787,14 +1779,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobInfo>> SealAsync(
+        public virtual Task<Response<BlobInfo>> SealAsync(
             AppendBlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default)
-            => await SealInternal(
+            => SealInternal(
                 conditions,
                 async: true,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// Seals the append blob, making it read only.
@@ -1938,17 +1929,16 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
-        public virtual async Task<Stream> OpenWriteAsync(
+        public virtual Task<Stream> OpenWriteAsync(
 #pragma warning restore AZC0015 // Unexpected client method return type.
             bool overwrite,
             AppendBlobOpenWriteOptions options = default,
             CancellationToken cancellationToken = default)
-            => await OpenWriteInternal(
+            => OpenWriteInternal(
                 overwrite: overwrite,
                 options: options,
                 async: true,
-                cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// Opens a stream for writing to the blob.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideDecryptor.cs
@@ -70,7 +70,7 @@ namespace Azure.Storage.Blobs
             return await TrimStreamInternal(plaintext, originalRange, contentRange, alreadyTrimmedOffset, async, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<Stream> DecryptWholeBlobWriteInternal(
+        public Task<Stream> DecryptWholeBlobWriteInternal(
             Stream plaintextDestination,
             Metadata metadata,
             bool async,
@@ -79,14 +79,14 @@ namespace Azure.Storage.Blobs
             EncryptionData encryptionData = GetAndValidateEncryptionDataOrDefault(metadata);
             if (encryptionData == default)
             {
-                return plaintextDestination;
+                return Task.FromResult(plaintextDestination);
             }
 
-            return await _decryptor.DecryptWholeContentWriteInternal(
+            return _decryptor.DecryptWholeContentWriteInternal(
                 plaintextDestination,
                 encryptionData,
                 async,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
         }
 
         private static async Task<Stream> TrimStreamInternal(

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideEncryptor.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideEncryptor.cs
@@ -76,29 +76,27 @@ namespace Azure.Storage.Blobs
         /// <returns>
         /// Content transform write stream and metadata.
         /// </returns>
-        public async Task<Stream> ClientSideEncryptionOpenWriteInternal(
+        public Task<Stream> ClientSideEncryptionOpenWriteInternal(
             BlockBlobClient blobClient,
             bool overwrite,
             BlockBlobOpenWriteOptions options,
             bool async,
             CancellationToken cancellationToken)
         {
-            Stream encryptionWriteStream = await _encryptor.EncryptedOpenWriteInternal(
-                async (encryptiondata, funcAsync, funcCancellationToken) =>
+            return _encryptor.EncryptedOpenWriteInternal(
+                (encryptiondata, funcAsync, funcCancellationToken) =>
                 {
                     options ??= new BlockBlobOpenWriteOptions();
                     options.Metadata = TransformMetadata(options.Metadata, encryptiondata);
 
-                    return await blobClient.OpenWriteInternal(
+                    return blobClient.OpenWriteInternal(
                             overwrite,
                             options,
                             funcAsync,
-                            funcCancellationToken).ConfigureAwait(false);
+                            funcCancellationToken);
                 },
                 async,
-                cancellationToken).ConfigureAwait(false);
-
-            return encryptionWriteStream;
+                cancellationToken);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -759,18 +759,17 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContainerInfo>> CreateAsync(
+        public virtual Task<Response<BlobContainerInfo>> CreateAsync(
             PublicAccessType publicAccessType = PublicAccessType.None,
             Metadata metadata = default,
             BlobContainerEncryptionScopeOptions encryptionScopeOptions = default,
             CancellationToken cancellationToken = default) =>
-            await CreateInternal(
+            CreateInternal(
                 publicAccessType,
                 metadata,
                 encryptionScopeOptions,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateAsync(PublicAccessType, Metadata, CancellationToken)"/> operation creates a new container
@@ -811,18 +810,17 @@ namespace Azure.Storage.Blobs
         /// </remarks>
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContainerInfo>> CreateAsync(
+        public virtual Task<Response<BlobContainerInfo>> CreateAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             PublicAccessType publicAccessType,
             Metadata metadata,
             CancellationToken cancellationToken) =>
-            await CreateInternal(
+            CreateInternal(
                 publicAccessType,
                 metadata,
                 encryptionScopeOptions: default,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExists(PublicAccessType, Metadata, BlobContainerEncryptionScopeOptions, CancellationToken)"/>
@@ -969,18 +967,17 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContainerInfo>> CreateIfNotExistsAsync(
+        public virtual Task<Response<BlobContainerInfo>> CreateIfNotExistsAsync(
             PublicAccessType publicAccessType = PublicAccessType.None,
             Metadata metadata = default,
             BlobContainerEncryptionScopeOptions encryptionScopeOptions = default,
             CancellationToken cancellationToken = default) =>
-            await CreateIfNotExistsInternal(
+            CreateIfNotExistsInternal(
                 publicAccessType,
                 metadata,
                 encryptionScopeOptions,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExists(PublicAccessType, Metadata, CancellationToken)"/> operation creates a new container
@@ -1021,18 +1018,17 @@ namespace Azure.Storage.Blobs
         /// </remarks>
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContainerInfo>> CreateIfNotExistsAsync(
+        public virtual Task<Response<BlobContainerInfo>> CreateIfNotExistsAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             PublicAccessType publicAccessType,
             Metadata metadata,
             CancellationToken cancellationToken) =>
-            await CreateIfNotExistsInternal(
+            CreateIfNotExistsInternal(
                 publicAccessType,
                 metadata,
                 encryptionScopeOptions: default,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExistsInternal(PublicAccessType, Metadata, BlobContainerEncryptionScopeOptions, bool, CancellationToken)"/>
@@ -1299,14 +1295,13 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response> DeleteAsync(
+        public virtual Task<Response> DeleteAsync(
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await DeleteInternal(
+            DeleteInternal(
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified
@@ -1369,14 +1364,13 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<bool>> DeleteIfExistsAsync(
+        public virtual Task<Response<bool>> DeleteIfExistsAsync(
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await DeleteIfExistsInternal(
+            DeleteIfExistsInternal(
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="DeleteIfExistsInternal"/> operation marks the specified
@@ -1603,11 +1597,11 @@ namespace Azure.Storage.Blobs
         /// <see cref="CreateIfNotExists(PublicAccessType, Metadata, BlobContainerEncryptionScopeOptions, CancellationToken)"/>
         /// instead.
         /// </remarks>
-        public virtual async Task<Response<bool>> ExistsAsync(
+        public virtual Task<Response<bool>> ExistsAsync(
             CancellationToken cancellationToken = default) =>
-            await ExistsInternal(
+            ExistsInternal(
                 async: true,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="ExistsInternal"/> operation can be called on a
@@ -1734,14 +1728,13 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContainerProperties>> GetPropertiesAsync(
+        public virtual Task<Response<BlobContainerProperties>> GetPropertiesAsync(
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await GetPropertiesInternal(
+            GetPropertiesInternal(
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetPropertiesAsync"/> operation returns all
@@ -1899,16 +1892,15 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContainerInfo>> SetMetadataAsync(
+        public virtual Task<Response<BlobContainerInfo>> SetMetadataAsync(
             Metadata metadata,
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await SetMetadataInternal(
+            SetMetadataInternal(
                 metadata,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="SetMetadataInternal"/> operation sets one or more
@@ -2067,14 +2059,13 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContainerAccessPolicy>> GetAccessPolicyAsync(
+        public virtual Task<Response<BlobContainerAccessPolicy>> GetAccessPolicyAsync(
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await GetAccessPolicyInternal(
+            GetAccessPolicyInternal(
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetAccessPolicyAsync"/> operation gets the
@@ -2267,18 +2258,17 @@ namespace Azure.Storage.Blobs
         /// a failure occurs.
         /// </remarks>
         [CallerShouldAudit("https://aka.ms/azsdk/callershouldaudit/storage-blobs")]
-        public virtual async Task<Response<BlobContainerInfo>> SetAccessPolicyAsync(
+        public virtual Task<Response<BlobContainerInfo>> SetAccessPolicyAsync(
             PublicAccessType accessType = PublicAccessType.None,
             IEnumerable<BlobSignedIdentifier> permissions = default,
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await SetAccessPolicyInternal(
+            SetAccessPolicyInternal(
                 accessType,
                 permissions,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="SetAccessPolicyAsync"/> operation sets the
@@ -2985,15 +2975,14 @@ namespace Azure.Storage.Blobs
         /// with the override parameter set to true.
         /// </remarks>
         [ForwardsClientCalls]
-        public virtual async Task<Response<BlobContentInfo>> UploadBlobAsync(
+        public virtual Task<Response<BlobContentInfo>> UploadBlobAsync(
             string blobName,
             Stream content,
             CancellationToken cancellationToken = default) =>
-            await GetBlobClient(blobName)
+            GetBlobClient(blobName)
                 .UploadAsync(
                     content,
-                    cancellationToken)
-                    .ConfigureAwait(false);
+                    cancellationToken);
 
         /// <summary>
         /// The <see cref="UploadBlob(string, BinaryData, CancellationToken)"/> operation creates a new block
@@ -3070,15 +3059,14 @@ namespace Azure.Storage.Blobs
         /// with the override parameter set to true.
         /// </remarks>
         [ForwardsClientCalls]
-        public virtual async Task<Response<BlobContentInfo>> UploadBlobAsync(
+        public virtual Task<Response<BlobContentInfo>> UploadBlobAsync(
             string blobName,
             BinaryData content,
             CancellationToken cancellationToken = default) =>
-            await GetBlobClient(blobName)
+            GetBlobClient(blobName)
                 .UploadAsync(
                     content,
-                    cancellationToken)
-                    .ConfigureAwait(false);
+                    cancellationToken);
         #endregion UploadBlob
 
         #region DeleteBlob
@@ -3159,17 +3147,16 @@ namespace Azure.Storage.Blobs
         /// a failure occurs.
         /// </remarks>
         [ForwardsClientCalls]
-        public virtual async Task<Response> DeleteBlobAsync(
+        public virtual Task<Response> DeleteBlobAsync(
             string blobName,
             DeleteSnapshotsOption snapshotsOption = default,
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await GetBlobClient(blobName)
+            GetBlobClient(blobName)
                 .DeleteAsync(
                     snapshotsOption,
                     conditions,
-                    cancellationToken)
-                    .ConfigureAwait(false);
+                    cancellationToken);
 
         /// <summary>
         /// The <see cref="DeleteBlobIfExists"/> operation marks the specified
@@ -3248,16 +3235,15 @@ namespace Azure.Storage.Blobs
         /// a failure occurs.
         /// </remarks>
         [ForwardsClientCalls]
-        public virtual async Task<Response<bool>> DeleteBlobIfExistsAsync(
+        public virtual Task<Response<bool>> DeleteBlobIfExistsAsync(
             string blobName,
             DeleteSnapshotsOption snapshotsOption = default,
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await GetBlobClient(blobName).DeleteIfExistsAsync(
+            GetBlobClient(blobName).DeleteIfExistsAsync(
                     snapshotsOption,
                     conditions ?? default,
-                    cancellationToken)
-                    .ConfigureAwait(false);
+                    cancellationToken);
 
         #endregion DeleteBlob
 
@@ -3319,16 +3305,15 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal virtual async Task<Response<BlobContainerClient>> RenameAsync(
+        internal virtual Task<Response<BlobContainerClient>> RenameAsync(
             string destinationContainerName,
             BlobRequestConditions sourceConditions = default,
             CancellationToken cancellationToken = default)
-            => await RenameInternal(
+            => RenameInternal(
                 destinationContainerName,
                 sourceConditions,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// Renames an existing Blob Container.
@@ -3597,12 +3582,11 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<AccountInfo>> GetAccountInfoAsync(
+        public virtual Task<Response<AccountInfo>> GetAccountInfoAsync(
             CancellationToken cancellationToken = default) =>
-            await GetAccountInfoInternal(
+            GetAccountInfoInternal(
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetAccountInfoInternal"/> operation returns the sku

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
@@ -338,17 +338,16 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
-        public virtual async Task<Response> AcquireAsync(
+        public virtual Task<Response> AcquireAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             TimeSpan duration,
             RequestConditions conditions,
             RequestContext context) =>
-            (await AcquireInternal(
+            AcquireInternal(
                 duration,
                 conditions,
                 async: true,
-                context)
-                .ConfigureAwait(false));
+                context);
 
         /// <summary>
         /// The <see cref="AcquireInternal"/> operation acquires a lease on
@@ -561,14 +560,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobLease>> RenewAsync(
+        public virtual Task<Response<BlobLease>> RenewAsync(
             RequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await RenewInternal(
+            RenewInternal(
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="RenewInternal"/> operation renews the blob or
@@ -780,14 +778,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<ReleasedObjectInfo>> ReleaseAsync(
+        public virtual Task<Response<ReleasedObjectInfo>> ReleaseAsync(
             RequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await ReleaseInternal(
+            ReleaseInternal(
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="ReleaseInternal"/> operation releases the
@@ -1004,16 +1001,15 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobLease>> ChangeAsync(
+        public virtual Task<Response<BlobLease>> ChangeAsync(
             string proposedId,
             RequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await ChangeInternal(
+            ChangeInternal(
                 proposedId,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="ChangeInternal"/> operation changes the lease
@@ -1272,16 +1268,15 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobLease>> BreakAsync(
+        public virtual Task<Response<BlobLease>> BreakAsync(
             TimeSpan? breakPeriod = default,
             RequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await BreakInternal(
+            BreakInternal(
                 breakPeriod,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="BreakInternal"/> operation breaks the blob or

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobQuickQueryStream.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobQuickQueryStream.cs
@@ -70,8 +70,8 @@ namespace Azure.Storage.Blobs
             => ReadInternal(async: false, buffer, offset, count).EnsureCompleted();
 
         /// <inheritdoc cref="Stream.ReadAsync(byte[],int,int)"/>
-        public new async Task<int> ReadAsync(byte[] buffer, int offset, int count)
-            => await ReadInternal(async: true, buffer, offset, count).ConfigureAwait(false);
+        public new Task<int> ReadAsync(byte[] buffer, int offset, int count)
+            => ReadInternal(async: true, buffer, offset, count);
 
         // Note - offset is with respect to buffer.
         private async Task<int> ReadInternal(bool async, byte[] buffer, int offset, int count)

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -952,12 +952,11 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<AccountInfo>> GetAccountInfoAsync(
+        public virtual Task<Response<AccountInfo>> GetAccountInfoAsync(
             CancellationToken cancellationToken = default) =>
-            await GetAccountInfoInternal(
+            GetAccountInfoInternal(
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetAccountInfoInternal"/> operation returns the sku
@@ -1077,12 +1076,11 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobServiceProperties>> GetPropertiesAsync(
+        public virtual Task<Response<BlobServiceProperties>> GetPropertiesAsync(
             CancellationToken cancellationToken = default) =>
-            await GetPropertiesInternal(
+            GetPropertiesInternal(
                 true, //async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetPropertiesInternal"/> operation gets the properties
@@ -1216,14 +1214,13 @@ namespace Azure.Storage.Blobs
         /// a failure occurs.
         /// </remarks>
         [CallerShouldAudit("https://aka.ms/azsdk/callershouldaudit/storage-blobs")]
-        public virtual async Task<Response> SetPropertiesAsync(
+        public virtual Task<Response> SetPropertiesAsync(
             BlobServiceProperties properties,
             CancellationToken cancellationToken = default) =>
-            await SetPropertiesInternal(
+            SetPropertiesInternal(
                 properties,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="SetPropertiesInternal"/> operation sets properties for
@@ -1358,12 +1355,11 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobServiceStatistics>> GetStatisticsAsync(
+        public virtual Task<Response<BlobServiceStatistics>> GetStatisticsAsync(
             CancellationToken cancellationToken = default) =>
-            await GetStatisticsInternal(
+            GetStatisticsInternal(
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetStatisticsInternal"/> operation retrieves
@@ -1501,16 +1497,15 @@ namespace Azure.Storage.Blobs
         /// a failure occurs.
         /// </remarks>
         [CallerShouldAudit("https://aka.ms/azsdk/callershouldaudit/storage-blobs")]
-        public virtual async Task<Response<UserDelegationKey>> GetUserDelegationKeyAsync(
+        public virtual Task<Response<UserDelegationKey>> GetUserDelegationKeyAsync(
             DateTimeOffset? startsOn,
             DateTimeOffset expiresOn,
             CancellationToken cancellationToken = default) =>
-            await GetUserDelegationKeyInternal(
+            GetUserDelegationKeyInternal(
                 startsOn,
                 expiresOn,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetUserDelegationKeyInternal"/> operation retrieves a
@@ -1847,17 +1842,16 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContainerClient>> UndeleteBlobContainerAsync(
+        public virtual Task<Response<BlobContainerClient>> UndeleteBlobContainerAsync(
             string deletedContainerName,
             string deletedContainerVersion,
             CancellationToken cancellationToken = default)
-            => await UndeleteBlobContainerInternal(
+            => UndeleteBlobContainerInternal(
                 deletedContainerName,
                 deletedContainerVersion,
                 deletedContainerName,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// Restores a previously deleted container.
@@ -1926,18 +1920,17 @@ namespace Azure.Storage.Blobs
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContainerClient>> UndeleteBlobContainerAsync(
+        public virtual Task<Response<BlobContainerClient>> UndeleteBlobContainerAsync(
             string deletedContainerName,
             string deletedContainerVersion,
             string destinationContainerName,
             CancellationToken cancellationToken = default)
-            => await UndeleteBlobContainerInternal(
+            => UndeleteBlobContainerInternal(
                 deletedContainerName,
                 deletedContainerVersion,
                 destinationContainerName,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// Restores a previously deleted container.
@@ -2100,18 +2093,17 @@ namespace Azure.Storage.Blobs
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal virtual async Task<Response<BlobContainerClient>> RenameBlobContainerAsync(
+        internal virtual Task<Response<BlobContainerClient>> RenameBlobContainerAsync(
             string sourceContainerName,
             string destinationContainerName,
             BlobRequestConditions sourceConditions = default,
             CancellationToken cancellationToken = default)
-            => await RenameBlobContainerInternal(
+            => RenameBlobContainerInternal(
                 sourceContainerName,
                 destinationContainerName,
                 sourceConditions,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// Renames an existing Blob Container.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -589,7 +589,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContentInfo>> UploadAsync(
+        public virtual Task<Response<BlobContentInfo>> UploadAsync(
             Stream content,
             BlobUploadOptions options,
             CancellationToken cancellationToken = default)
@@ -599,14 +599,13 @@ namespace Azure.Storage.Blobs.Specialized
                 options?.TransferValidation ?? ClientConfiguration.TransferValidation.Upload,
                 operationName: $"{nameof(BlockBlobClient)}.{nameof(Upload)}");
 
-            return await uploader.UploadInternal(
+            return uploader.UploadInternal(
                 content,
                 expectedContentLength: default,
                 options,
                 options?.ProgressHandler,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
         }
 
         /// <summary>
@@ -739,7 +738,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContentInfo>> UploadAsync(
+        public virtual Task<Response<BlobContentInfo>> UploadAsync(
             Stream content,
             BlobHttpHeaders httpHeaders = default,
             Metadata metadata = default,
@@ -747,7 +746,7 @@ namespace Azure.Storage.Blobs.Specialized
             AccessTier? accessTier = default,
             IProgress<long> progressHandler = default,
             CancellationToken cancellationToken = default)
-            => await UploadAsync(
+            => UploadAsync(
                 content,
                 new BlobUploadOptions
                 {
@@ -757,7 +756,7 @@ namespace Azure.Storage.Blobs.Specialized
                     AccessTier = accessTier,
                     ProgressHandler = progressHandler,
                 },
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="UploadInternal"/>
@@ -1100,7 +1099,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
-        public virtual async Task<Response<BlockInfo>> StageBlockAsync(
+        public virtual Task<Response<BlockInfo>> StageBlockAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             string base64BlockId,
             Stream content,
@@ -1109,15 +1108,14 @@ namespace Azure.Storage.Blobs.Specialized
             IProgress<long> progressHandler,
             CancellationToken cancellationToken)
         {
-            return await StageBlockInternal(
+            return StageBlockInternal(
                 base64BlockId,
                 content,
                 transactionalContentHash.ToValidationOptions(),
                 conditions,
                 progressHandler,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
         }
 
         /// <summary>
@@ -1207,20 +1205,19 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlockInfo>> StageBlockAsync(
+        public virtual Task<Response<BlockInfo>> StageBlockAsync(
             string base64BlockId,
             Stream content,
             BlockBlobStageBlockOptions options = default,
             CancellationToken cancellationToken = default) =>
-            await StageBlockInternal(
+            StageBlockInternal(
                 base64BlockId,
                 content,
                 options?.TransferValidation,
                 options?.Conditions,
                 options?.ProgressHandler,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="StageBlockInternal"/> operation creates a new block
@@ -1463,12 +1460,12 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlockInfo>> StageBlockFromUriAsync(
+        public virtual Task<Response<BlockInfo>> StageBlockFromUriAsync(
             Uri sourceUri,
             string base64BlockId,
             StageBlockFromUriOptions options = default,
             CancellationToken cancellationToken = default) =>
-            await StageBlockFromUriInternal(
+            StageBlockFromUriInternal(
                 sourceUri,
                 base64BlockId,
                 options?.SourceRange ?? default,
@@ -1477,8 +1474,7 @@ namespace Azure.Storage.Blobs.Specialized
                 options?.DestinationConditions,
                 options?.SourceAuthentication,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="StageBlockFromUri(Uri, string, HttpRange, byte[], RequestConditions, BlobRequestConditions, CancellationToken)"/>
@@ -1625,7 +1621,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
-        public virtual async Task<Response<BlockInfo>> StageBlockFromUriAsync(
+        public virtual Task<Response<BlockInfo>> StageBlockFromUriAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             Uri sourceUri,
             string base64BlockId,
@@ -1634,7 +1630,7 @@ namespace Azure.Storage.Blobs.Specialized
             RequestConditions sourceConditions,
             BlobRequestConditions conditions,
             CancellationToken cancellationToken) =>
-            await StageBlockFromUriInternal(
+            StageBlockFromUriInternal(
                 sourceUri,
                 base64BlockId,
                 sourceRange,
@@ -1643,8 +1639,7 @@ namespace Azure.Storage.Blobs.Specialized
                 conditions,
                 sourceAuthentication: default,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="StageBlockFromUriInternal"/> operation creates a new
@@ -1988,11 +1983,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContentInfo>> CommitBlockListAsync(
+        public virtual Task<Response<BlobContentInfo>> CommitBlockListAsync(
             IEnumerable<string> base64BlockIds,
             CommitBlockListOptions options,
             CancellationToken cancellationToken = default) =>
-            await CommitBlockListInternal(
+            CommitBlockListInternal(
                 base64BlockIds,
                 options?.HttpHeaders,
                 options?.Metadata,
@@ -2002,8 +1997,7 @@ namespace Azure.Storage.Blobs.Specialized
                 options?.ImmutabilityPolicy,
                 options?.LegalHold,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="CommitBlockListAsync(IEnumerable{string}, BlobHttpHeaders, Metadata, BlobRequestConditions, AccessTier?, CancellationToken)"/>
@@ -2058,14 +2052,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContentInfo>> CommitBlockListAsync(
+        public virtual Task<Response<BlobContentInfo>> CommitBlockListAsync(
             IEnumerable<string> base64BlockIds,
             BlobHttpHeaders httpHeaders = default,
             Metadata metadata = default,
             BlobRequestConditions conditions = default,
             AccessTier? accessTier = default,
             CancellationToken cancellationToken = default) =>
-            await CommitBlockListInternal(
+            CommitBlockListInternal(
                 base64BlockIds: base64BlockIds,
                 blobHttpHeaders: httpHeaders,
                 metadata: metadata,
@@ -2075,8 +2069,7 @@ namespace Azure.Storage.Blobs.Specialized
                 immutabilityPolicy: default,
                 legalHold: default,
                 async: true,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// The <see cref="CommitBlockListInternal"/> operation writes a blob by
@@ -2356,18 +2349,17 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlockList>> GetBlockListAsync(
+        public virtual Task<Response<BlockList>> GetBlockListAsync(
             BlockListTypes blockListTypes = BlockListTypes.All,
             string snapshot = default,
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await GetBlockListInternal(
+            GetBlockListInternal(
                 blockListTypes,
                 snapshot,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetBlockListInternal"/> operation operation retrieves
@@ -2544,16 +2536,15 @@ namespace Azure.Storage.Blobs.Specialized
         /// <returns>
         /// A <see cref="Response{BlobDownloadInfo}"/>.
         /// </returns>
-        public virtual async Task<Response<BlobDownloadInfo>> QueryAsync(
+        public virtual Task<Response<BlobDownloadInfo>> QueryAsync(
             string querySqlExpression,
             BlobQueryOptions options = default,
             CancellationToken cancellationToken = default) =>
-            await QueryInternal(
+            QueryInternal(
                 querySqlExpression,
                 options,
                 async: true,
-                cancellationToken)
-            .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="QueryInternal"/> API returns the
@@ -2724,17 +2715,16 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
-        public virtual async Task<Stream> OpenWriteAsync(
+        public virtual Task<Stream> OpenWriteAsync(
 #pragma warning restore AZC0015 // Unexpected client method return type.
             bool overwrite,
             BlockBlobOpenWriteOptions options = default,
             CancellationToken cancellationToken = default)
-            => await OpenWriteInternal(
+            => OpenWriteInternal(
                 overwrite: overwrite,
                 options: options,
                 async: true,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// Opens a stream for writing to the blob.  If the blob exists,
@@ -2904,17 +2894,16 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContentInfo>> SyncUploadFromUriAsync(
+        public virtual Task<Response<BlobContentInfo>> SyncUploadFromUriAsync(
             Uri copySource,
             bool overwrite = false,
             CancellationToken cancellationToken = default)
-            => await SyncUploadFromUriInternal(
+            => SyncUploadFromUriInternal(
                 copySource,
                 overwrite ? null : new BlobSyncUploadFromUriOptions { DestinationConditions = new BlobRequestConditions
                     { IfNoneMatch = new ETag(Constants.Wildcard) } },
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The Upload from Uri operation creates a new Block Blob where the contents of the
@@ -2989,16 +2978,15 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContentInfo>> SyncUploadFromUriAsync(
+        public virtual Task<Response<BlobContentInfo>> SyncUploadFromUriAsync(
             Uri copySource,
             BlobSyncUploadFromUriOptions options,
             CancellationToken cancellationToken = default)
-            => await SyncUploadFromUriInternal(
+            => SyncUploadFromUriInternal(
                 copySource,
                 options,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The Upload from Uri operation creates a new Block Blob where the contents of the
@@ -3175,8 +3163,8 @@ namespace Azure.Storage.Blobs.Specialized
         {
             return new PartitionedUploader<BlobUploadOptions, BlobContentInfo>.Behaviors
             {
-                SingleUploadStreaming = async (stream, args, progressHandler, validationOptions, operationName, async, cancellationToken)
-                    => await client.UploadInternal(
+                SingleUploadStreaming = (stream, args, progressHandler, validationOptions, operationName, async, cancellationToken)
+                    => client.UploadInternal(
                         stream,
                         args?.HttpHeaders,
                         args?.Metadata,
@@ -3189,9 +3177,9 @@ namespace Azure.Storage.Blobs.Specialized
                         validationOptions,
                         operationName,
                         async,
-                        cancellationToken).ConfigureAwait(false),
-                SingleUploadBinaryData = async (content, args, progressHandler, validationOptions, operationName, async, cancellationToken)
-                    => await client.UploadInternal(
+                        cancellationToken),
+                SingleUploadBinaryData = (content, args, progressHandler, validationOptions, operationName, async, cancellationToken)
+                    => client.UploadInternal(
                         content.ToStream(),
                         args?.HttpHeaders,
                         args?.Metadata,
@@ -3204,8 +3192,8 @@ namespace Azure.Storage.Blobs.Specialized
                         validationOptions,
                         operationName,
                         async,
-                        cancellationToken).ConfigureAwait(false),
-                UploadPartitionStreaming = async (stream, offset, args, progressHandler, validationOptions, async, cancellationToken)
+                        cancellationToken),
+                UploadPartitionStreaming = (stream, offset, args, progressHandler, validationOptions, async, cancellationToken)
                     =>
                 {
                     // Stage Block only accepts LeaseId.
@@ -3217,16 +3205,16 @@ namespace Azure.Storage.Blobs.Specialized
                             LeaseId = args.Conditions.LeaseId
                         };
                     }
-                    await client.StageBlockInternal(
+                    return client.StageBlockInternal(
                             Shared.StorageExtensions.GenerateBlockId(offset),
                             stream,
                             validationOptions,
                             conditions,
                             progressHandler,
                             async,
-                            cancellationToken).ConfigureAwait(false);
+                            cancellationToken);
                 },
-                UploadPartitionBinaryData = async (content, offset, args, progressHandler, validationOptions, async, cancellationToken)
+                UploadPartitionBinaryData = (content, offset, args, progressHandler, validationOptions, async, cancellationToken)
                     =>
                 {
                     // Stage Block only accepts LeaseId.
@@ -3239,20 +3227,17 @@ namespace Azure.Storage.Blobs.Specialized
                         };
                     }
 
-                    using (var stream = content.ToStream())
-                    {
-                        await client.StageBlockInternal(
-                                Shared.StorageExtensions.GenerateBlockId(offset),
-                                stream,
-                                validationOptions,
-                                conditions,
-                                progressHandler,
-                                async,
-                                cancellationToken).ConfigureAwait(false);
-                    }
+                    return client.StageBlockInternal(
+                            Shared.StorageExtensions.GenerateBlockId(offset),
+                            content.ToStream(),
+                            validationOptions,
+                            conditions,
+                            progressHandler,
+                            async,
+                            cancellationToken);
                 },
-                CommitPartitionedUpload = async (partitions, args, async, cancellationToken)
-                    => await client.CommitBlockListInternal(
+                CommitPartitionedUpload = (partitions, args, async, cancellationToken)
+                    => client.CommitBlockListInternal(
                         partitions.Select(partition => Shared.StorageExtensions.GenerateBlockId(partition.Offset)),
                         args?.HttpHeaders,
                         args?.Metadata,
@@ -3262,7 +3247,7 @@ namespace Azure.Storage.Blobs.Specialized
                         args?.ImmutabilityPolicy,
                         args?.LegalHold,
                         async,
-                        cancellationToken).ConfigureAwait(false),
+                        cancellationToken),
                 Scope = operationName => client.ClientConfiguration.ClientDiagnostics.CreateScope(operationName
                     ?? $"{nameof(Azure)}.{nameof(Storage)}.{nameof(Blobs)}.{nameof(BlobClient)}.{nameof(Storage.Blobs.BlobClient.Upload)}")
             };

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/CopyFromUriOperation.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/CopyFromUriOperation.cs
@@ -139,9 +139,9 @@ namespace Azure.Storage.Blobs.Models
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>The <see cref="Response"/> with the status update.</returns>
-        public override async ValueTask<Response> UpdateStatusAsync(
+        public override ValueTask<Response> UpdateStatusAsync(
             CancellationToken cancellationToken = default) =>
-            await UpdateStatusAsync(true, cancellationToken).ConfigureAwait(false);
+            UpdateStatusAsync(true, cancellationToken);
 
         /// <summary>
         /// Check for the latest status of the copy operation.
@@ -152,7 +152,7 @@ namespace Azure.Storage.Blobs.Models
         /// </param>
         /// <param name="async" />
         /// <returns>The <see cref="Response"/> with the status update.</returns>
-        private async Task<Response> UpdateStatusAsync(bool async, CancellationToken cancellationToken)
+        private async ValueTask<Response> UpdateStatusAsync(bool async, CancellationToken cancellationToken)
         {
             // Short-circuit when already completed (which improves mocking
             // scenarios that won't have a client).

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -425,11 +425,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContentInfo>> CreateAsync(
+        public virtual Task<Response<BlobContentInfo>> CreateAsync(
             long size,
             PageBlobCreateOptions options,
             CancellationToken cancellationToken = default) =>
-            await CreateInternal(
+            CreateInternal(
                 size,
                 options?.SequenceNumber,
                 options?.HttpHeaders,
@@ -439,8 +439,7 @@ namespace Azure.Storage.Blobs.Specialized
                 options?.ImmutabilityPolicy,
                 options?.LegalHold,
                 async: true,
-                cancellationToken)
-            .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="Create(long, long?, BlobHttpHeaders, Metadata, PageBlobRequestConditions, CancellationToken)"/>
@@ -546,14 +545,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContentInfo>> CreateAsync(
+        public virtual Task<Response<BlobContentInfo>> CreateAsync(
             long size,
             long? sequenceNumber = default,
             BlobHttpHeaders httpHeaders = default,
             Metadata metadata = default,
             PageBlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await CreateInternal(
+            CreateInternal(
                 size: size,
                 sequenceNumber: sequenceNumber,
                 httpHeaders: httpHeaders,
@@ -563,8 +562,7 @@ namespace Azure.Storage.Blobs.Specialized
                 immutabilityPolicy: default,
                 legalHold: default,
                 async: true,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExists(long, PageBlobCreateOptions, CancellationToken)"/>
@@ -638,11 +636,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<BlobContentInfo>> CreateIfNotExistsAsync(
+        public virtual Task<Response<BlobContentInfo>> CreateIfNotExistsAsync(
             long size,
             PageBlobCreateOptions options,
             CancellationToken cancellationToken = default) =>
-            await CreateIfNotExistsInternal(
+            CreateIfNotExistsInternal(
                 size,
                 options?.SequenceNumber,
                 options?.HttpHeaders,
@@ -651,8 +649,7 @@ namespace Azure.Storage.Blobs.Specialized
                 options?.ImmutabilityPolicy,
                 options?.LegalHold,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExists(long, long?, BlobHttpHeaders, Metadata, CancellationToken)"/>
@@ -748,13 +745,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<BlobContentInfo>> CreateIfNotExistsAsync(
+        public virtual Task<Response<BlobContentInfo>> CreateIfNotExistsAsync(
             long size,
             long? sequenceNumber = default,
             BlobHttpHeaders httpHeaders = default,
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            await CreateIfNotExistsInternal(
+            CreateIfNotExistsInternal(
                 size: size,
                 sequenceNumber: sequenceNumber,
                 httpHeaders: httpHeaders,
@@ -763,8 +760,7 @@ namespace Azure.Storage.Blobs.Specialized
                 immutabilityPolicy: default,
                 legalHold: default,
                 async: true,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// The <see cref="CreateIfNotExistsInternal"/> operation creates a new page blob
@@ -1172,7 +1168,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
-        public virtual async Task<Response<PageInfo>> UploadPagesAsync(
+        public virtual Task<Response<PageInfo>> UploadPagesAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             Stream content,
             long offset,
@@ -1181,15 +1177,14 @@ namespace Azure.Storage.Blobs.Specialized
             IProgress<long> progressHandler,
             CancellationToken cancellationToken)
         {
-            return await UploadPagesInternal(
+            return UploadPagesInternal(
                 content,
                 offset,
                 transactionalContentHash.ToValidationOptions(),
                 conditions,
                 progressHandler,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
         }
 
         /// <summary>
@@ -1273,20 +1268,19 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<PageInfo>> UploadPagesAsync(
+        public virtual Task<Response<PageInfo>> UploadPagesAsync(
             Stream content,
             long offset,
             PageBlobUploadPagesOptions options = default,
             CancellationToken cancellationToken = default) =>
-            await UploadPagesInternal(
+            UploadPagesInternal(
                 content,
                 offset,
                 options?.TransferValidation,
                 options?.Conditions,
                 options?.ProgressHandler,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="UploadPagesInternal"/> operation writes
@@ -1520,16 +1514,15 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<PageInfo>> ClearPagesAsync(
+        public virtual Task<Response<PageInfo>> ClearPagesAsync(
             HttpRange range,
             PageBlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await ClearPagesInternal(
+            ClearPagesInternal(
                 range,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="ClearPagesInternal"/> operation clears one or more
@@ -1951,18 +1944,17 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<PageRangesInfo>> GetPageRangesAsync(
+        public virtual Task<Response<PageRangesInfo>> GetPageRangesAsync(
             HttpRange? range = null,
             string snapshot = null,
             PageBlobRequestConditions conditions = null,
             CancellationToken cancellationToken = default) =>
-            await GetPageRangesInternal(
+            GetPageRangesInternal(
                 range,
                 snapshot,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetPageRangesInternal"/> operation returns the list
@@ -2436,13 +2428,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<PageRangesInfo>> GetPageRangesDiffAsync(
+        public virtual Task<Response<PageRangesInfo>> GetPageRangesDiffAsync(
             HttpRange? range = null,
             string snapshot = null,
             string previousSnapshot = null,
             PageBlobRequestConditions conditions = null,
             CancellationToken cancellationToken = default) =>
-            await GetPageRangesDiffInternal(
+            GetPageRangesDiffInternal(
                 range,
                 snapshot,
                 previousSnapshot,
@@ -2450,8 +2442,7 @@ namespace Azure.Storage.Blobs.Specialized
                 conditions,
                 async: true,
                 operationName: $"{nameof(PageBlobClient)}.{nameof(GetPageRangesDiff)}",
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="GetPageRangesDiffInternal"/> operation returns the
@@ -2709,13 +2700,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<PageRangesInfo>> GetManagedDiskPageRangesDiffAsync(
+        public virtual Task<Response<PageRangesInfo>> GetManagedDiskPageRangesDiffAsync(
             HttpRange? range = default,
             string snapshot = default,
             Uri previousSnapshotUri = default,
             PageBlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await GetPageRangesDiffInternal(
+            GetPageRangesDiffInternal(
                 range,
                 snapshot,
                 previousSnapshot: default,
@@ -2723,8 +2714,7 @@ namespace Azure.Storage.Blobs.Specialized
                 conditions,
                 async: true,
                 operationName: $"{nameof(PageBlobClient)}.{nameof(GetManagedDiskPageRangesDiff)}",
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         #endregion GetManagedDiskPageRangesDiff
 
@@ -2804,16 +2794,15 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<PageBlobInfo>> ResizeAsync(
+        public virtual Task<Response<PageBlobInfo>> ResizeAsync(
             long size,
             PageBlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await ResizeInternal(
+            ResizeInternal(
                 size,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="ResizeAsync"/> operation resizes the page blob to
@@ -3037,18 +3026,17 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<PageBlobInfo>> UpdateSequenceNumberAsync(
+        public virtual Task<Response<PageBlobInfo>> UpdateSequenceNumberAsync(
             SequenceNumberAction action,
             long? sequenceNumber = default,
             PageBlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default) =>
-            await UpdateSequenceNumberInternal(
+            UpdateSequenceNumberInternal(
                 action,
                 sequenceNumber,
                 conditions,
                 true, // async
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="UpdateSequenceNumberInternal"/> operation changes the
@@ -3677,13 +3665,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<PageInfo>> UploadPagesFromUriAsync(
+        public virtual Task<Response<PageInfo>> UploadPagesFromUriAsync(
             Uri sourceUri,
             HttpRange sourceRange,
             HttpRange range,
             PageBlobUploadPagesFromUriOptions options = default,
             CancellationToken cancellationToken = default) =>
-            await UploadPagesFromUriInternal(
+            UploadPagesFromUriInternal(
                 sourceUri,
                 sourceRange,
                 range,
@@ -3692,8 +3680,7 @@ namespace Azure.Storage.Blobs.Specialized
                 options?.SourceConditions,
                 options?.SourceAuthentication,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="UploadPagesFromUri(Uri, HttpRange, HttpRange, byte[], PageBlobRequestConditions, PageBlobRequestConditions, CancellationToken)"/>
@@ -3836,7 +3823,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
-        public virtual async Task<Response<PageInfo>> UploadPagesFromUriAsync(
+        public virtual Task<Response<PageInfo>> UploadPagesFromUriAsync(
 #pragma warning restore AZC0002 // DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.
             Uri sourceUri,
             HttpRange sourceRange,
@@ -3845,7 +3832,7 @@ namespace Azure.Storage.Blobs.Specialized
             PageBlobRequestConditions conditions,
             PageBlobRequestConditions sourceConditions,
             CancellationToken cancellationToken) =>
-            await UploadPagesFromUriInternal(
+            UploadPagesFromUriInternal(
                 sourceUri,
                 sourceRange,
                 range,
@@ -3854,8 +3841,7 @@ namespace Azure.Storage.Blobs.Specialized
                 sourceConditions,
                 sourceAuthentication: default,
                 async: true,
-                cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken);
 
         /// <summary>
         /// The <see cref="UploadPagesFromUriInternal"/> operation writes a
@@ -4103,19 +4089,18 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
-        public virtual async Task<Stream> OpenWriteAsync(
+        public virtual Task<Stream> OpenWriteAsync(
 #pragma warning restore AZC0015 // Unexpected client method return type.
             bool overwrite,
             long position,
             PageBlobOpenWriteOptions options = default,
             CancellationToken cancellationToken = default)
-            => await OpenWriteInternal(
+            => OpenWriteInternal(
                 overwrite: overwrite,
                 position: position,
                 options: options,
                 async: true,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken);
 
         /// <summary>
         /// Opens a stream for writing to the blob.

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -477,7 +477,7 @@ namespace Azure.Storage.Blobs
         /// <returns>
         /// Task for completion status of the operation.
         /// </returns>
-        private async Task FlushFinalIfNecessaryInternal(Stream destination, bool async, CancellationToken cancellationToken)
+        private Task FlushFinalIfNecessaryInternal(Stream destination, bool async, CancellationToken cancellationToken)
         {
             if (_client.UsingClientSideEncryption)
             {
@@ -487,9 +487,10 @@ namespace Azure.Storage.Blobs
                 }
                 else if (destination is Azure.Storage.Cryptography.AuthenticatedRegionCryptoStream authRegionCryptoStream)
                 {
-                    await authRegionCryptoStream.FlushFinalInternal(async: async, cancellationToken).ConfigureAwait(false);
+                    return authRegionCryptoStream.FlushFinalInternal(async: async, cancellationToken);
                 }
             }
+            return Task.CompletedTask;
         }
 
         private void ValidateFinalCrc(ReadOnlySpan<byte> composedCrc)

--- a/sdk/storage/Azure.Storage.Blobs/src/SpecializedBlobExtensions.ClientSideEncryption.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/SpecializedBlobExtensions.ClientSideEncryption.cs
@@ -72,17 +72,17 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="cancellationToken">
         /// Cancellation token for the operation.
         /// </param>
-        public static async Task UpdateClientSideKeyEncryptionKeyAsync(
+        public static Task UpdateClientSideKeyEncryptionKeyAsync(
             this BlobClient client,
             ClientSideEncryptionOptions encryptionOptionsOverride = default,
             BlobRequestConditions conditions = default,
             CancellationToken cancellationToken = default)
-            => await UpdateClientsideKeyEncryptionKeyInternal(
+            => UpdateClientsideKeyEncryptionKeyInternal(
                 client,
                 encryptionOptionsOverride,
                 conditions,
                 async: true,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
 
         private static async Task UpdateClientsideKeyEncryptionKeyInternal(
             BlobClient client,
@@ -181,17 +181,17 @@ namespace Azure.Storage.Blobs.Specialized
                     cancellationToken);
         }
 
-        private static async Task<byte[]> WrapKeyInternal(ReadOnlyMemory<byte> contentEncryptionKey, string keyWrapAlgorithm, IKeyEncryptionKey key, bool async, CancellationToken cancellationToken)
+        private static Task<byte[]> WrapKeyInternal(ReadOnlyMemory<byte> contentEncryptionKey, string keyWrapAlgorithm, IKeyEncryptionKey key, bool async, CancellationToken cancellationToken)
         {
             return async
-                ? await key.WrapKeyAsync(
+                ? key.WrapKeyAsync(
                     keyWrapAlgorithm,
                     contentEncryptionKey,
-                    cancellationToken).ConfigureAwait(false)
-                : key.WrapKey(
+                    cancellationToken)
+                : Task.FromResult(key.WrapKey(
                     keyWrapAlgorithm,
                     contentEncryptionKey,
-                    cancellationToken);
+                    cancellationToken));
         }
     }
 }


### PR DESCRIPTION
This removes a lot of unnecessary `async` state machines that add runtime overhead (and also decreases the assembly size by about 100KB).