### PR TITLE
[ACS][Common] OPS - Added Routing Logic Based on Scopes

### DIFF
--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.0-beta.1 (Unreleased)
 
 ### Features Added
+- Introduced support for `Azure.Core.TokenCredential` with `EntraCommunicationTokenCredentialOptions`, enabling Entra users to authorize Communication Services and allowing Azure Communication Services to receive calls from Teams resource accounts.
 
 ### Breaking Changes
 

--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.4.0-beta.1 (Unreleased)
 
 ### Features Added
-- Introduced support for `Azure.Core.TokenCredential` with `EntraCommunicationTokenCredentialOptions`, enabling Entra users to authorize Communication Services and allowing Azure Communication Services to receive calls from Teams resource accounts.
+- Introduced support for `Azure.Core.TokenCredential` with `EntraCommunicationTokenCredentialOptions`, enabling Entra users to authorize Communication Services and allowing an Entra user with a Teams license to use Teams Phone Extensibility features through the Azure Communication Services resource.
 
 ### Breaking Changes
 

--- a/sdk/communication/Azure.Communication.Common/README.md
+++ b/sdk/communication/Azure.Communication.Common/README.md
@@ -105,23 +105,23 @@ using var tokenCredential = new CommunicationTokenCredential(
 ### Create a credential with a token credential capable of obtaining an Entra user token
 
 For scenarios where an Entra user can be used with Communication Services, you need to initialize any implementation of [Azure.Core.TokenCredential](https://docs.microsoft.com/dotnet/api/azure.core.tokencredential?view=azure-dotnet) and provide it to the ``EntraCommunicationTokenCredentialOptions``.
-Along with this, you must provide the URI of the Azure Communication Services resource and the scopes required for the Entra user token. These scopes determine the permissions granted to the token:
-
+Along with this, you must provide the URI of the Azure Communication Services resource and the scopes required for the Entra user token. These scopes determine the permissions granted to the token.
+If the scopes are not provided, by default, it sets the scopes to `https://communication.azure.com/clients/.default`.
 ```C# 
 var options = new InteractiveBrowserCredentialOptions
     {
         TenantId = "<your-tenant-id>",
         ClientId = "<your-client-id>",
-        RedirectUri = new Uri("<your-redirect-uri>"),
-        AuthorityHost = new Uri("https://login.microsoftonline.com/<your-tenant-id>")
+        RedirectUri = new Uri("<your-redirect-uri>")
     };
 var entraTokenCredential = new InteractiveBrowserCredential(options);
 
 var entraTokenCredentialOptions = new EntraCommunicationTokenCredentialOptions(
     resourceEndpoint: "https://<your-resource>.communication.azure.com",
-    entraTokenCredential: entraTokenCredential,
-    scopes: new[] { "https://communication.azure.com/clients/VoIP" }
-);
+    entraTokenCredential: entraTokenCredential)
+    {
+      Scopes = new[] { "https://communication.azure.com/clients/VoIP" }
+    };
 
 var credential = new CommunicationTokenCredential(entraTokenCredentialOptions);
 
@@ -134,16 +134,17 @@ var options = new InteractiveBrowserCredentialOptions
     {
         TenantId = "<your-tenant-id>",
         ClientId = "<your-client-id>",
-        RedirectUri = new Uri("<your-redirect-uri>"),
-        AuthorityHost = new Uri("https://login.microsoftonline.com/<your-tenant-id>")
+        RedirectUri = new Uri("<your-redirect-uri>")
     };
 var entraTokenCredential = new InteractiveBrowserCredential(options);
 
 var entraTokenCredentialOptions = new EntraCommunicationTokenCredentialOptions(
     resourceEndpoint: "https://<your-resource>.communication.azure.com",
-    entraTokenCredential: entraTokenCredential,
-    scopes: new[] { "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls" }
-);
+    entraTokenCredential: entraTokenCredential)
+    )
+    {
+      Scopes = new[] { "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls" }
+    };
 
 var credential = new CommunicationTokenCredential(entraTokenCredentialOptions);
 

--- a/sdk/communication/Azure.Communication.Common/README.md
+++ b/sdk/communication/Azure.Communication.Common/README.md
@@ -119,10 +119,31 @@ var entraTokenCredential = new InteractiveBrowserCredential(options);
 
 var entraTokenCredentialOptions = new EntraCommunicationTokenCredentialOptions(
     resourceEndpoint: "https://<your-resource>.communication.azure.com",
-    entraTokenCredential: entraTokenCredential
-){
-      Scopes = new[] { "https://communication.azure.com/clients/VoIP" }
-};
+    entraTokenCredential: entraTokenCredential,
+    scopes: new[] { "https://communication.azure.com/clients/VoIP" }
+);
+
+var credential = new CommunicationTokenCredential(entraTokenCredentialOptions);
+
+```
+
+The same approach can be used to authorize your Azure Communication Services resource to receive calls from the Teams resource account.
+This requires providing the `https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls` scope
+```C# 
+var options = new InteractiveBrowserCredentialOptions
+    {
+        TenantId = "<your-tenant-id>",
+        ClientId = "<your-client-id>",
+        RedirectUri = new Uri("<your-redirect-uri>"),
+        AuthorityHost = new Uri("https://login.microsoftonline.com/<your-tenant-id>")
+    };
+var entraTokenCredential = new InteractiveBrowserCredential(options);
+
+var entraTokenCredentialOptions = new EntraCommunicationTokenCredentialOptions(
+    resourceEndpoint: "https://<your-resource>.communication.azure.com",
+    entraTokenCredential: entraTokenCredential,
+    scopes: new[] { "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls" }
+);
 
 var credential = new CommunicationTokenCredential(entraTokenCredentialOptions);
 

--- a/sdk/communication/Azure.Communication.Common/README.md
+++ b/sdk/communication/Azure.Communication.Common/README.md
@@ -127,7 +127,7 @@ var credential = new CommunicationTokenCredential(entraTokenCredentialOptions);
 
 ```
 
-The same approach can be used to authorize your Azure Communication Services resource to receive calls from the Teams resource account.
+The same approach can be used for authorizing an Entra user with a Teams license to use Teams Phone Extensibility features through your Azure Communication Services resource.
 This requires providing the `https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls` scope
 ```C# 
 var options = new InteractiveBrowserCredentialOptions

--- a/sdk/communication/Azure.Communication.Common/src/EntraCommunicationTokenCredentialOptions.cs
+++ b/sdk/communication/Azure.Communication.Common/src/EntraCommunicationTokenCredentialOptions.cs
@@ -11,7 +11,6 @@ namespace Azure.Communication
     /// </summary>
     public class EntraCommunicationTokenCredentialOptions
     {
-        private static string[] DefaultScopes = { "https://communication.azure.com/clients/.default" };
         /// <summary>
         /// The URI of the Azure Communication Services resource.
         /// </summary>
@@ -25,23 +24,25 @@ namespace Azure.Communication
         /// <summary>
         /// The scopes required for the Entra user token. These scopes determine the permissions granted to the token. For example, ["https://communication.azure.com/clients/VoIP"].
         /// </summary>
-        public string[] Scopes { get; set; }
+        public string[] Scopes { get; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="EntraCommunicationTokenCredentialOptions"/>.
         /// </summary>
         /// <param name="resourceEndpoint">The URI of the Azure Communication Services resource.For example, https://myResource.communication.azure.com.</param>
         /// <param name="entraTokenCredential">The credential capable of fetching an Entra user token.</param>
+        /// <param name="scopes">The scopes required for the Entra user token.</param>
         public EntraCommunicationTokenCredentialOptions(
             string resourceEndpoint,
-            TokenCredential entraTokenCredential)
+            TokenCredential entraTokenCredential,
+            string[] scopes)
         {
             Argument.AssertNotNullOrEmpty(resourceEndpoint, nameof(resourceEndpoint));
             Argument.AssertNotNull(entraTokenCredential, nameof(entraTokenCredential));
 
             this.ResourceEndpoint = resourceEndpoint;
             this.TokenCredential = entraTokenCredential;
-            this.Scopes = DefaultScopes;
+            this.Scopes = scopes;
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/src/EntraCommunicationTokenCredentialOptions.cs
+++ b/sdk/communication/Azure.Communication.Common/src/EntraCommunicationTokenCredentialOptions.cs
@@ -11,6 +11,7 @@ namespace Azure.Communication
     /// </summary>
     public class EntraCommunicationTokenCredentialOptions
     {
+        private static string[] DefaultScopes = { "https://communication.azure.com/clients/.default" };
         /// <summary>
         /// The URI of the Azure Communication Services resource.
         /// </summary>
@@ -24,25 +25,23 @@ namespace Azure.Communication
         /// <summary>
         /// The scopes required for the Entra user token. These scopes determine the permissions granted to the token. For example, ["https://communication.azure.com/clients/VoIP"].
         /// </summary>
-        public string[] Scopes { get; }
+        public string[] Scopes { get; set; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="EntraCommunicationTokenCredentialOptions"/>.
         /// </summary>
         /// <param name="resourceEndpoint">The URI of the Azure Communication Services resource.For example, https://myResource.communication.azure.com.</param>
         /// <param name="entraTokenCredential">The credential capable of fetching an Entra user token.</param>
-        /// <param name="scopes">The scopes required for the Entra user token.</param>
         public EntraCommunicationTokenCredentialOptions(
             string resourceEndpoint,
-            TokenCredential entraTokenCredential,
-            string[] scopes)
+            TokenCredential entraTokenCredential)
         {
             Argument.AssertNotNullOrEmpty(resourceEndpoint, nameof(resourceEndpoint));
             Argument.AssertNotNull(entraTokenCredential, nameof(entraTokenCredential));
 
             this.ResourceEndpoint = resourceEndpoint;
             this.TokenCredential = entraTokenCredential;
-            this.Scopes = scopes;
+            this.Scopes = DefaultScopes;
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/src/EntraTokenCredential.cs
+++ b/sdk/communication/Azure.Communication.Common/src/EntraTokenCredential.cs
@@ -16,8 +16,12 @@ namespace Azure.Communication
     /// </summary>
     internal sealed class EntraTokenCredential : ICommunicationTokenCredential
     {
-        private const string TeamsExtentionsScopePrefix = "https://auth.msft.communication.azure.com/";
-        private const string EntraScopePrefix = "https://communication.azure.com/clients/";
+        private const string TeamsExtensionScopePrefix = "https://auth.msft.communication.azure.com/";
+        private const string ComunicationClientsScopePrefix = "https://communication.azure.com/clients/";
+        private const string TeamsExtensionEndpoint = "/access/teamsPhone/:exchangeTeamsAccessToken";
+        private const string TeamsExtensionApiVersion = "2025-03-02-preview";
+        private const string ComunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
+        private const string ComunicationClientsApiVersion = "2024-04-01-preview";
 
         private HttpPipeline _pipeline;
         private string _resourceEndpoint;
@@ -131,19 +135,19 @@ namespace Azure.Communication
         {
             if (_scopes == null || !_scopes.Any())
             {
-                throw new ArgumentException($"Scopes validation failed. Ensure all scopes start with either {TeamsExtentionsScopePrefix} or {EntraScopePrefix}.", nameof(_scopes));
+                throw new ArgumentException($"Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {ComunicationClientsScopePrefix}.", nameof(_scopes));
             }
-            else if (_scopes.All(item => item.StartsWith(TeamsExtentionsScopePrefix)))
+            else if (_scopes.All(item => item.StartsWith(TeamsExtensionScopePrefix)))
             {
-                return ("/access/teamsPhone/:exchangeTeamsAccessToken", "2025-03-02-preview");
+                return (TeamsExtensionEndpoint, TeamsExtensionApiVersion);
             }
-            else if (_scopes.All(item => item.StartsWith(EntraScopePrefix)))
+            else if (_scopes.All(item => item.StartsWith(ComunicationClientsScopePrefix)))
             {
-                return ("/access/entra/:exchangeAccessToken", "2024-04-01-preview");
+                return (ComunicationClientsEndpoint, ComunicationClientsApiVersion);
             }
             else
             {
-                throw new ArgumentException($"Scopes validation failed. Ensure all scopes start with either {TeamsExtentionsScopePrefix} or {EntraScopePrefix}.", nameof(_scopes));
+                throw new ArgumentException($"Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {ComunicationClientsScopePrefix}.", nameof(_scopes));
             }
         }
 

--- a/sdk/communication/Azure.Communication.Common/src/EntraTokenCredential.cs
+++ b/sdk/communication/Azure.Communication.Common/src/EntraTokenCredential.cs
@@ -18,7 +18,7 @@ namespace Azure.Communication
     {
         private const string TeamsExtensionScopePrefix = "https://auth.msft.communication.azure.com/";
         private const string ComunicationClientsScopePrefix = "https://communication.azure.com/clients/";
-        private const string TeamsExtensionEndpoint = "/access/teamsPhone/:exchangeTeamsAccessToken";
+        private const string TeamsExtensionEndpoint = "/access/teamsPhone/:exchangeAccessToken";
         private const string TeamsExtensionApiVersion = "2025-03-02-preview";
         private const string ComunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
         private const string ComunicationClientsApiVersion = "2024-04-01-preview";

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
@@ -24,8 +24,8 @@ namespace Azure.Communication.Identity
         protected string TokenResponse = string.Format(TokenResponseTemplate, SampleToken, SampleTokenExpiry);
 
         private Mock<TokenCredential> _mockTokenCredential = null!;
-        private const string entraScope = "https://communication.azure.com/clients/VoIP";
-        private const string opsScope = "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls";
+        private const string communicationClientsScope = "https://communication.azure.com/clients/VoIP";
+        private const string teamsExtensionScope = "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls";
         private string _resourceEndpoint = "https://myResource.communication.azure.com";
 
         [SetUp]
@@ -39,8 +39,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(new string[] { entraScope }, typeof(ArgumentException))]
-        [TestCase(new string[] { opsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { communicationClientsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { teamsExtensionScope }, typeof(ArgumentException))]
         public void EntraTokenCredential_Init_ThrowsErrorWithNulls(string[] scopes, Type exception)
         {
             Assert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
@@ -60,8 +60,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(new string[] { entraScope }, typeof(ArgumentException))]
-        [TestCase(new string[] { opsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { communicationClientsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { teamsExtensionScope }, typeof(ArgumentException))]
         public void EntraTokenCredential_Init_FetchesTokenImmediately(string[] scopes, Type exception)
         {
             // Arrange
@@ -74,8 +74,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase("/access/entra/:exchangeAccessToken", new string[] { entraScope }, typeof(ArgumentException))]
-        [TestCase("/access/teamsPhone/:exchangeTeamsAccessToken", new string[] { opsScope }, typeof(ArgumentException))]
+        [TestCase("/access/entra/:exchangeAccessToken", new string[] { communicationClientsScope }, typeof(ArgumentException))]
+        [TestCase("/access/teamsPhone/:exchangeTeamsAccessToken", new string[] { teamsExtensionScope }, typeof(ArgumentException))]
         public async Task EntraTokenCredential_GetToken_ReturnsToken(string expectedEndpoint, string[] scopes, Type exception)
         {
             // Arrange
@@ -95,8 +95,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(new string[] { entraScope }, typeof(ArgumentException))]
-        [TestCase(new string[] { opsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { communicationClientsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { teamsExtensionScope }, typeof(ArgumentException))]
         public async Task EntraTokenCredential_GetToken_InternalEntraTokenChangeInvalidatesCachedToken(string[] scopes, Type exception)
         {
             // Arrange
@@ -121,8 +121,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(new string[] { entraScope }, typeof(ArgumentException))]
-        [TestCase(new string[] { opsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { communicationClientsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { teamsExtensionScope }, typeof(ArgumentException))]
         public async Task EntraTokenCredential_GetToken_MultipleCallsReturnsCachedToken(string[] scopes, Type exception)
         {
             // Arrange
@@ -142,8 +142,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(new string[] { entraScope }, typeof(ArgumentException))]
-        [TestCase(new string[] { opsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { communicationClientsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { teamsExtensionScope }, typeof(ArgumentException))]
         public void EntraTokenCredential_GetToken_ThrowsFailedResponse(string[] scopes, Type exception)
         {
             // Arrange
@@ -162,8 +162,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(new string[] { entraScope }, typeof(ArgumentException))]
-        [TestCase(new string[] { opsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { communicationClientsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { teamsExtensionScope }, typeof(ArgumentException))]
         public void EntraTokenCredential_GetToken_ThrowsInvalidJson(string[] scopes, Type exception)
         {
             // Arrange
@@ -183,8 +183,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(new string[] { entraScope }, typeof(ArgumentException))]
-        [TestCase(new string[] { opsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { communicationClientsScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { teamsExtensionScope }, typeof(ArgumentException))]
         public void EntraTokenCredential_GetToken_RetriesThreeTimesOnTransientError(string[] scopes, Type exception)
         {
             // Arrange
@@ -212,8 +212,8 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(new string[] { entraScope, opsScope }, typeof(ArgumentException))]
-        [TestCase(new string[] { opsScope, entraScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { communicationClientsScope, teamsExtensionScope }, typeof(ArgumentException))]
+        [TestCase(new string[] { teamsExtensionScope, communicationClientsScope }, typeof(ArgumentException))]
         [TestCase(new string[] { "invalidScope" }, typeof(ArgumentException))]
         [TestCase(new string[] { "" }, typeof(ArgumentException))]
         [TestCase(new string[] { }, typeof(ArgumentException))]


### PR DESCRIPTION
# Contributing to the Azure SDK
* Modified the `EntraTokenCredential` class to route requests to the appropriate endpoint based on the provided scopes
*  Added unit tests to verify the new routing logic and ensure its correctness.
* Updated the md files to reflect the changes

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
