### PR TITLE
[DesktopVirtualization] Fix for issue #45976

### DIFF
--- a/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/CHANGELOG.md
+++ b/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Fix an issue that the `SessionHostData` can't handle empty `resourceId`.
+
 ### Other Changes
 
 ## 1.3.0 (2024-09-10)

--- a/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/src/Generated/SessionHostData.Serialization.cs
+++ b/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/src/Generated/SessionHostData.Serialization.cs
@@ -219,7 +219,7 @@ namespace Azure.ResourceManager.DesktopVirtualization
                         }
                         if (property0.NameEquals("lastHeartBeat"u8))
                         {
-                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                            if (property0.Value.ValueKind == JsonValueKind.Null || property0.Value.ValueKind == JsonValueKind.String && property0.Value.GetString().Length == 0)
                             {
                                 continue;
                             }
@@ -256,7 +256,7 @@ namespace Azure.ResourceManager.DesktopVirtualization
                         }
                         if (property0.NameEquals("resourceId"u8))
                         {
-                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                            if (property0.Value.ValueKind == JsonValueKind.Null || property0.Value.ValueKind == JsonValueKind.String && property0.Value.GetString().Length == 0)
                             {
                                 continue;
                             }
@@ -284,7 +284,7 @@ namespace Azure.ResourceManager.DesktopVirtualization
                         }
                         if (property0.NameEquals("statusTimestamp"u8))
                         {
-                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                            if (property0.Value.ValueKind == JsonValueKind.Null || property0.Value.ValueKind == JsonValueKind.String && property0.Value.GetString().Length == 0)
                             {
                                 continue;
                             }
@@ -312,7 +312,7 @@ namespace Azure.ResourceManager.DesktopVirtualization
                         }
                         if (property0.NameEquals("lastUpdateTime"u8))
                         {
-                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                            if (property0.Value.ValueKind == JsonValueKind.Null || property0.Value.ValueKind == JsonValueKind.String && property0.Value.GetString().Length == 0)
                             {
                                 continue;
                             }

--- a/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/src/autorest.md
+++ b/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/src/autorest.md
@@ -26,6 +26,9 @@ enable-bicep-serialization: true
 #mgmt-debug:
 #  show-serialized-names: true
 
+models-to-treat-empty-string-as-null:
+  - SessionHostData
+
 format-by-name-rules:
   'tenantId': 'uuid'
   'ETag': 'etag'


### PR DESCRIPTION
Fix for issue: https://github.com/Azure/azure-sdk-for-net/issues/45976
Add config in autorest.md, allow the `resourceId` in `SessionHostData` to be null

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
