### PR TITLE
[SignalR functions bindings] Self-implemented MessagePack hub protocol

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -209,11 +209,10 @@
     <PackageReference Update="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0" />
     <PackageReference Update="Google.Protobuf" Version="3.24.3" />
     <PackageReference Update="Grpc.Tools" Version="2.51.0" PrivateAssets="all" />
-    <PackageReference Update="MessagePack" Version="1.9.11" />
-    <PackageReference Update="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="1.1.5" />
-    <PackageReference Update="Microsoft.Azure.SignalR" Version="1.25.2" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.25.2" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.25.2" />
+    <PackageReference Update="MessagePack" Version="2.5.192" />
+    <PackageReference Update="Microsoft.Azure.SignalR" Version="1.29.0" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.29.0" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.29.0" />
     <PackageReference Update="Microsoft.Azure.SignalR.Serverless.Protocols" Version="1.10.0" />
     <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.37" PrivateAssets="All"/>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Release History
 
-## 1.16.0-beta.1 (Unreleased)
+## 2.0.0-beta.1 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
+* Remove .NET 6.0 support.
 
 ### Bugs Fixed
+* Correctly support returning result for SignalR invocation in MessagePack protocol from isolated-worker process.
 
 ### Other Changes
+* Update `MessagePack` to 2.5.192
+* Update `Microsoft.Azure.SignalR`, `Microsoft.Azure.SignalR.Management`, `Microsoft.Azure.SignalR.Protocols` to 1.29.0
 
 ## 1.15.0 (2024-10-14)
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -12,14 +12,16 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />
   </ItemGroup>
 </Project>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -1,10 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks);net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
-    <Version>1.16.0-beta.1</Version>
-    <ApiCompatVersion>1.15.0</ApiCompatVersion>
+    <Version>2.0.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <SignAssembly>true</SignAssembly>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
@@ -16,7 +15,6 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.SignalR" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/BinaryMessageFormatter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/BinaryMessageFormatter.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+
+namespace Microsoft.AspNetCore.Internal;
+
+internal static class BinaryMessageFormatter
+{
+    public static void WriteLengthPrefix(long length, IBufferWriter<byte> output)
+    {
+        Span<byte> lenBuffer = stackalloc byte[5];
+
+        var lenNumBytes = WriteLengthPrefix(length, lenBuffer);
+
+        output.Write(lenBuffer.Slice(0, lenNumBytes));
+    }
+
+    public static int WriteLengthPrefix(long length, Span<byte> output)
+    {
+        // This code writes length prefix of the message as a VarInt. Read the comment in
+        // the BinaryMessageParser.TryParseMessage for details.
+        var lenNumBytes = 0;
+        do
+        {
+            ref var current = ref output[lenNumBytes];
+            current = (byte)(length & 0x7f);
+            length >>= 7;
+            if (length > 0)
+            {
+                current |= 0x80;
+            }
+            lenNumBytes++;
+        }
+        while (length > 0);
+
+        return lenNumBytes;
+    }
+
+    public static int LengthPrefixLength(long length)
+    {
+        var lenNumBytes = 0;
+        do
+        {
+            length >>= 7;
+            lenNumBytes++;
+        }
+        while (length > 0);
+
+        return lenNumBytes;
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/BinaryMessageFormatter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/BinaryMessageFormatter.cs
@@ -1,11 +1,14 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.Buffers;
 
 namespace Microsoft.AspNetCore.Internal;
 
+/// <summary>
+/// Copied from https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
+/// </summary>
 internal static class BinaryMessageFormatter
 {
     public static void WriteLengthPrefix(long length, IBufferWriter<byte> output)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/DefaultMessagePackHubProtocolWorker.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/DefaultMessagePackHubProtocolWorker.cs
@@ -1,5 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;
@@ -8,6 +8,11 @@ using MessagePack;
 
 namespace Microsoft.AspNetCore.SignalR.Protocol;
 
+#nullable enable
+
+/// <summary>
+/// Copied from https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
+/// </summary>
 internal sealed class DefaultMessagePackHubProtocolWorker : MessagePackHubProtocolWorker
 {
     private readonly MessagePackSerializerOptions _messagePackSerializerOptions;

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/DefaultMessagePackHubProtocolWorker.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/DefaultMessagePackHubProtocolWorker.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+using MessagePack;
+
+namespace Microsoft.AspNetCore.SignalR.Protocol;
+
+internal sealed class DefaultMessagePackHubProtocolWorker : MessagePackHubProtocolWorker
+{
+    private readonly MessagePackSerializerOptions _messagePackSerializerOptions;
+
+    public DefaultMessagePackHubProtocolWorker(MessagePackSerializerOptions messagePackSerializerOptions)
+    {
+        _messagePackSerializerOptions = messagePackSerializerOptions;
+    }
+
+    protected override object? DeserializeObject(ref MessagePackReader reader, Type type, string field)
+    {
+        try
+        {
+            return MessagePackSerializer.Deserialize(type, ref reader, _messagePackSerializerOptions);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Deserializing object of the `{type.Name}` type for '{field}' failed.", ex);
+        }
+    }
+
+    protected override void Serialize(ref MessagePackWriter writer, Type type, object value)
+    {
+        MessagePackSerializer.Serialize(type, ref writer, value, _messagePackSerializerOptions);
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MemoryBufferWriter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MemoryBufferWriter.cs
@@ -1,0 +1,404 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Internal;
+
+internal sealed class MemoryBufferWriter : Stream, IBufferWriter<byte>
+{
+    [ThreadStatic]
+    private static MemoryBufferWriter? _cachedInstance;
+
+#if DEBUG
+    private bool _inUse;
+#endif
+
+    private readonly int _minimumSegmentSize;
+    private int _bytesWritten;
+
+    private List<CompletedBuffer>? _completedSegments;
+    private byte[]? _currentSegment;
+    private int _position;
+
+    public MemoryBufferWriter(int minimumSegmentSize = 4096)
+    {
+        _minimumSegmentSize = minimumSegmentSize;
+    }
+
+    public override long Length => _bytesWritten;
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public static MemoryBufferWriter Get()
+    {
+        var writer = _cachedInstance;
+        if (writer == null)
+        {
+            writer = new MemoryBufferWriter();
+        }
+        else
+        {
+            // Taken off the thread static
+            _cachedInstance = null;
+        }
+#if DEBUG
+        if (writer._inUse)
+        {
+            throw new InvalidOperationException("The reader wasn't returned!");
+        }
+
+        writer._inUse = true;
+#endif
+
+        return writer;
+    }
+
+    public static void Return(MemoryBufferWriter writer)
+    {
+        _cachedInstance = writer;
+#if DEBUG
+        writer._inUse = false;
+#endif
+        writer.Reset();
+    }
+
+    public void Reset()
+    {
+        if (_completedSegments != null)
+        {
+            for (var i = 0; i < _completedSegments.Count; i++)
+            {
+                _completedSegments[i].Return();
+            }
+
+            _completedSegments.Clear();
+        }
+
+        if (_currentSegment != null)
+        {
+            ArrayPool<byte>.Shared.Return(_currentSegment);
+            _currentSegment = null;
+        }
+
+        _bytesWritten = 0;
+        _position = 0;
+    }
+
+    public void Advance(int count)
+    {
+        _bytesWritten += count;
+        _position += count;
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+
+        return _currentSegment.AsMemory(_position, _currentSegment.Length - _position);
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+
+        return _currentSegment.AsSpan(_position, _currentSegment.Length - _position);
+    }
+
+    public void CopyTo(IBufferWriter<byte> destination)
+    {
+        if (_completedSegments != null)
+        {
+            // Copy completed segments
+            var count = _completedSegments.Count;
+            for (var i = 0; i < count; i++)
+            {
+                destination.Write(_completedSegments[i].Span);
+            }
+        }
+
+        destination.Write(_currentSegment.AsSpan(0, _position));
+    }
+
+    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+    {
+        if (_completedSegments == null && _currentSegment is not null)
+        {
+            // There is only one segment so write without awaiting.
+            return destination.WriteAsync(_currentSegment, 0, _position, cancellationToken);
+        }
+
+        return CopyToSlowAsync(destination, cancellationToken);
+    }
+
+    [MemberNotNull(nameof(_currentSegment))]
+    private void EnsureCapacity(int sizeHint)
+    {
+        // This does the Right Thing. It only subtracts _position from the current segment length if it's non-null.
+        // If _currentSegment is null, it returns 0.
+        var remainingSize = _currentSegment?.Length - _position ?? 0;
+
+        // If the sizeHint is 0, any capacity will do
+        // Otherwise, the buffer must have enough space for the entire size hint, or we need to add a segment.
+        if ((sizeHint == 0 && remainingSize > 0) || (sizeHint > 0 && remainingSize >= sizeHint))
+        {
+            // We have capacity in the current segment
+#pragma warning disable CS8774 // Member must have a non-null value when exiting.
+            return;
+#pragma warning restore CS8774 // Member must have a non-null value when exiting.
+        }
+
+        AddSegment(sizeHint);
+    }
+
+    [MemberNotNull(nameof(_currentSegment))]
+    private void AddSegment(int sizeHint = 0)
+    {
+        if (_currentSegment != null)
+        {
+            // We're adding a segment to the list
+            if (_completedSegments == null)
+            {
+                _completedSegments = new List<CompletedBuffer>();
+            }
+
+            // Position might be less than the segment length if there wasn't enough space to satisfy the sizeHint when
+            // GetMemory was called. In that case we'll take the current segment and call it "completed", but need to
+            // ignore any empty space in it.
+            _completedSegments.Add(new CompletedBuffer(_currentSegment, _position));
+        }
+
+        // Get a new buffer using the minimum segment size, unless the size hint is larger than a single segment.
+        _currentSegment = ArrayPool<byte>.Shared.Rent(Math.Max(_minimumSegmentSize, sizeHint));
+        _position = 0;
+    }
+
+    private async Task CopyToSlowAsync(Stream destination, CancellationToken cancellationToken)
+    {
+        if (_completedSegments != null)
+        {
+            // Copy full segments
+            var count = _completedSegments.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var segment = _completedSegments[i];
+#if NETCOREAPP
+                await destination.WriteAsync(segment.Buffer.AsMemory(0, segment.Length), cancellationToken).ConfigureAwait(false);
+#else
+                await destination.WriteAsync(segment.Buffer, 0, segment.Length, cancellationToken).ConfigureAwait(false);
+#endif
+            }
+        }
+
+        if (_currentSegment is not null)
+        {
+#if NETCOREAPP
+            await destination.WriteAsync(_currentSegment.AsMemory(0, _position), cancellationToken).ConfigureAwait(false);
+#else
+            await destination.WriteAsync(_currentSegment, 0, _position, cancellationToken).ConfigureAwait(false);
+#endif
+        }
+    }
+
+    public byte[] ToArray()
+    {
+        if (_currentSegment == null)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var result = new byte[_bytesWritten];
+
+        var totalWritten = 0;
+
+        if (_completedSegments != null)
+        {
+            // Copy full segments
+            var count = _completedSegments.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var segment = _completedSegments[i];
+                segment.Span.CopyTo(result.AsSpan(totalWritten));
+                totalWritten += segment.Span.Length;
+            }
+        }
+
+        // Copy current incomplete segment
+        _currentSegment.AsSpan(0, _position).CopyTo(result.AsSpan(totalWritten));
+
+        return result;
+    }
+
+    public void CopyTo(Span<byte> span)
+    {
+        Debug.Assert(span.Length >= _bytesWritten);
+
+        if (_currentSegment == null)
+        {
+            return;
+        }
+
+        var totalWritten = 0;
+
+        if (_completedSegments != null)
+        {
+            // Copy full segments
+            var count = _completedSegments.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var segment = _completedSegments[i];
+                segment.Span.CopyTo(span.Slice(totalWritten));
+                totalWritten += segment.Span.Length;
+            }
+        }
+
+        // Copy current incomplete segment
+        _currentSegment.AsSpan(0, _position).CopyTo(span.Slice(totalWritten));
+
+        Debug.Assert(_bytesWritten == totalWritten + _position);
+    }
+
+    public override void Flush() { }
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void WriteByte(byte value)
+    {
+        if (_currentSegment != null && (uint)_position < (uint)_currentSegment.Length)
+        {
+            _currentSegment[_position] = value;
+        }
+        else
+        {
+            AddSegment();
+            _currentSegment[0] = value;
+        }
+
+        _position++;
+        _bytesWritten++;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        var position = _position;
+        if (_currentSegment != null && position < _currentSegment.Length - count)
+        {
+            Buffer.BlockCopy(buffer, offset, _currentSegment, position, count);
+
+            _position = position + count;
+            _bytesWritten += count;
+        }
+        else
+        {
+            BuffersExtensions.Write(this, buffer.AsSpan(offset, count));
+        }
+    }
+
+#if NETCOREAPP
+    public override void Write(ReadOnlySpan<byte> span)
+    {
+        if (_currentSegment != null && span.TryCopyTo(_currentSegment.AsSpan(_position)))
+        {
+            _position += span.Length;
+            _bytesWritten += span.Length;
+        }
+        else
+        {
+            BuffersExtensions.Write(this, span);
+        }
+    }
+#endif
+
+    public WrittenBuffers DetachAndReset()
+    {
+        _completedSegments ??= new List<CompletedBuffer>();
+
+        if (_currentSegment is not null)
+        {
+            _completedSegments.Add(new CompletedBuffer(_currentSegment, _position));
+        }
+
+        var written = new WrittenBuffers(_completedSegments, _bytesWritten);
+
+        _currentSegment = null;
+        _completedSegments = null;
+        _bytesWritten = 0;
+        _position = 0;
+
+        return written;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Reset();
+        }
+    }
+
+    /// <summary>
+    /// Holds the written segments from a MemoryBufferWriter and is no longer attached to a MemoryBufferWriter.
+    /// You are now responsible for calling Dispose on this type to return the memory to the pool.
+    /// </summary>
+    internal readonly ref struct WrittenBuffers
+    {
+        public readonly List<CompletedBuffer> Segments;
+        private readonly int _bytesWritten;
+
+        public WrittenBuffers(List<CompletedBuffer> segments, int bytesWritten)
+        {
+            Segments = segments;
+            _bytesWritten = bytesWritten;
+        }
+
+        public int ByteLength => _bytesWritten;
+
+        public void Dispose()
+        {
+            for (var i = 0; i < Segments.Count; i++)
+            {
+                Segments[i].Return();
+            }
+            Segments.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Holds a byte[] from the pool and a size value. Basically a Memory but guaranteed to be backed by an ArrayPool byte[], so that we know we can return it.
+    /// </summary>
+    internal readonly struct CompletedBuffer
+    {
+        public byte[] Buffer { get; }
+        public int Length { get; }
+
+        public ReadOnlySpan<byte> Span => Buffer.AsSpan(0, Length);
+
+        public CompletedBuffer(byte[] buffer, int length)
+        {
+            Buffer = buffer;
+            Length = length;
+        }
+
+        public void Return()
+        {
+            ArrayPool<byte>.Shared.Return(Buffer);
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MemoryBufferWriter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MemoryBufferWriter.cs
@@ -1,23 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable enable
-
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Internal;
 
+/// <summary>
+/// Copied from https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
+/// </summary>
 internal sealed class MemoryBufferWriter : Stream, IBufferWriter<byte>
 {
     [ThreadStatic]
-    private static MemoryBufferWriter? _cachedInstance;
+    private static MemoryBufferWriter _cachedInstance;
 
 #if DEBUG
     private bool _inUse;
@@ -26,8 +26,8 @@ internal sealed class MemoryBufferWriter : Stream, IBufferWriter<byte>
     private readonly int _minimumSegmentSize;
     private int _bytesWritten;
 
-    private List<CompletedBuffer>? _completedSegments;
-    private byte[]? _currentSegment;
+    private List<CompletedBuffer> _completedSegments;
+    private byte[] _currentSegment;
     private int _position;
 
     public MemoryBufferWriter(int minimumSegmentSize = 4096)
@@ -146,7 +146,6 @@ internal sealed class MemoryBufferWriter : Stream, IBufferWriter<byte>
         return CopyToSlowAsync(destination, cancellationToken);
     }
 
-    [MemberNotNull(nameof(_currentSegment))]
     private void EnsureCapacity(int sizeHint)
     {
         // This does the Right Thing. It only subtracts _position from the current segment length if it's non-null.
@@ -166,7 +165,6 @@ internal sealed class MemoryBufferWriter : Stream, IBufferWriter<byte>
         AddSegment(sizeHint);
     }
 
-    [MemberNotNull(nameof(_currentSegment))]
     private void AddSegment(int sizeHint = 0)
     {
         if (_currentSegment != null)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocol.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocol.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.SignalR.Protocol;
+
+/// <summary>
+/// Implements the SignalR Hub Protocol using MessagePack.
+/// </summary>
+public class MessagePackHubProtocol : IHubProtocol
+{
+    private const string ProtocolName = "messagepack";
+    private const int ProtocolVersion = 2;
+    private readonly DefaultMessagePackHubProtocolWorker _worker;
+
+    /// <inheritdoc />
+    public string Name => ProtocolName;
+
+    /// <inheritdoc />
+    public int Version => ProtocolVersion;
+
+    /// <inheritdoc />
+    public TransferFormat TransferFormat => TransferFormat.Binary;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagePackHubProtocol"/> class.
+    /// </summary>
+    public MessagePackHubProtocol()
+        : this(Options.Create(new MessagePackHubProtocolOptions()))
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagePackHubProtocol"/> class.
+    /// </summary>
+    /// <param name="options">The options used to initialize the protocol.</param>
+    public MessagePackHubProtocol(IOptions<MessagePackHubProtocolOptions> options)
+    {
+        ArgumentNullThrowHelper.ThrowIfNull(options);
+
+        _worker = new DefaultMessagePackHubProtocolWorker(options.Value.SerializerOptions);
+    }
+
+    /// <inheritdoc />
+    public bool IsVersionSupported(int version)
+    {
+        return version <= Version;
+    }
+
+    /// <inheritdoc />
+    public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, [NotNullWhen(true)] out HubMessage? message)
+        => _worker.TryParseMessage(ref input, binder, out message);
+
+    /// <inheritdoc />
+    public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
+        => _worker.WriteMessage(message, output);
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
+        => _worker.GetMessageBytes(message);
+
+    internal static MessagePackSerializerOptions CreateDefaultMessagePackSerializerOptions() =>
+        MessagePackSerializerOptions
+            .Standard
+            .WithResolver(SignalRResolver.Instance)
+            .WithSecurity(MessagePackSecurity.UntrustedData);
+
+    internal sealed class SignalRResolver : IFormatterResolver
+    {
+        public static readonly IFormatterResolver Instance = new SignalRResolver();
+
+        public static readonly IReadOnlyList<IFormatterResolver> Resolvers = new IFormatterResolver[]
+        {
+                DynamicEnumAsStringResolver.Instance,
+                ContractlessStandardResolver.Instance,
+        };
+
+        public IMessagePackFormatter<T>? GetFormatter<T>()
+        {
+            return Cache<T>.Formatter;
+        }
+
+        private static class Cache<T>
+        {
+            public static readonly IMessagePackFormatter<T>? Formatter = ResolveFormatter();
+
+            private static IMessagePackFormatter<T>? ResolveFormatter()
+            {
+                foreach (var resolver in Resolvers)
+                {
+                    var formatter = resolver.GetFormatter<T>();
+                    if (formatter != null)
+                    {
+                        return formatter;
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocolWorker.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocolWorker.cs
@@ -1,0 +1,718 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE0005 // This file is shared across multiple projects making it ugly to ignore unused usings
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Pipelines;
+using System.Runtime.ExceptionServices;
+using System.Text;
+
+using MessagePack;
+
+using Microsoft.AspNetCore.Internal;
+using Microsoft.Azure.SignalR.Protocol;
+
+namespace Microsoft.AspNetCore.SignalR.Protocol;
+
+/// <summary>
+/// Implements support for MessagePackHubProtocol. This code is shared between SignalR and Blazor.
+/// </summary>
+internal abstract class MessagePackHubProtocolWorker
+{
+    private const int ErrorResult = 1;
+    private const int VoidResult = 2;
+    private const int NonVoidResult = 3;
+
+    public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, [NotNullWhen(true)] out HubMessage? message)
+    {
+        if (!BinaryMessageParser.TryParseMessage(ref input, out var payload))
+        {
+            message = null;
+            return false;
+        }
+
+        var reader = new MessagePackReader(payload);
+        message = ParseMessage(ref reader, binder);
+        return message != null;
+    }
+
+    private HubMessage? ParseMessage(ref MessagePackReader reader, IInvocationBinder binder)
+    {
+        var itemCount = reader.ReadArrayHeader();
+
+        var messageType = ReadInt32(ref reader, "messageType");
+
+        switch (messageType)
+        {
+            case HubProtocolConstants.InvocationMessageType:
+                return CreateInvocationMessage(ref reader, binder, itemCount);
+            case HubProtocolConstants.StreamInvocationMessageType:
+                return CreateStreamInvocationMessage(ref reader, binder, itemCount);
+            case HubProtocolConstants.StreamItemMessageType:
+                return CreateStreamItemMessage(ref reader, binder);
+            case HubProtocolConstants.CompletionMessageType:
+                return CreateCompletionMessage(ref reader, binder);
+            case HubProtocolConstants.CancelInvocationMessageType:
+                return CreateCancelInvocationMessage(ref reader);
+            case HubProtocolConstants.PingMessageType:
+                return PingMessage.Instance;
+            case HubProtocolConstants.CloseMessageType:
+                return CreateCloseMessage(ref reader, itemCount);
+            case HubProtocolConstants.AckMessageType:
+                return CreateAckMessage(ref reader);
+            case HubProtocolConstants.SequenceMessageType:
+                return CreateSequenceMessage(ref reader);
+            default:
+                // Future protocol changes can add message types, old clients can ignore them
+                return null;
+        }
+    }
+
+    private HubMessage CreateInvocationMessage(ref MessagePackReader reader, IInvocationBinder binder, int itemCount)
+    {
+        var headers = ReadHeaders(ref reader);
+        var invocationId = ReadInvocationId(ref reader);
+
+        // For MsgPack, we represent an empty invocation ID as an empty string,
+        // so we need to normalize that to "null", which is what indicates a non-blocking invocation.
+        if (string.IsNullOrEmpty(invocationId))
+        {
+            invocationId = null;
+        }
+
+        var target = ReadString(ref reader, binder, "target");
+        ThrowIfNullOrEmpty(target, "target for Invocation message");
+
+        object?[]? arguments;
+        try
+        {
+            var parameterTypes = binder.GetParameterTypes(target);
+            arguments = BindArguments(ref reader, parameterTypes);
+        }
+        catch (Exception ex)
+        {
+            return new InvocationBindingFailureMessage(invocationId, target, ExceptionDispatchInfo.Capture(ex));
+        }
+
+        string[]? streams = null;
+        // Previous clients will send 5 items, so we check if they sent a stream array or not
+        if (itemCount > 5)
+        {
+            streams = ReadStreamIds(ref reader);
+        }
+
+        return ApplyHeaders(headers, new InvocationMessage(invocationId, target, arguments, streams));
+    }
+
+    private HubMessage CreateStreamInvocationMessage(ref MessagePackReader reader, IInvocationBinder binder, int itemCount)
+    {
+        var headers = ReadHeaders(ref reader);
+        var invocationId = ReadInvocationId(ref reader);
+        ThrowIfNullOrEmpty(invocationId, "invocation ID for StreamInvocation message");
+
+        var target = ReadString(ref reader, "target");
+        ThrowIfNullOrEmpty(target, "target for StreamInvocation message");
+
+        object?[] arguments;
+        try
+        {
+            var parameterTypes = binder.GetParameterTypes(target);
+            arguments = BindArguments(ref reader, parameterTypes);
+        }
+        catch (Exception ex)
+        {
+            return new InvocationBindingFailureMessage(invocationId, target, ExceptionDispatchInfo.Capture(ex));
+        }
+
+        string[]? streams = null;
+        // Previous clients will send 5 items, so we check if they sent a stream array or not
+        if (itemCount > 5)
+        {
+            streams = ReadStreamIds(ref reader);
+        }
+
+        return ApplyHeaders(headers, new StreamInvocationMessage(invocationId, target, arguments, streams));
+    }
+
+    private HubMessage CreateStreamItemMessage(ref MessagePackReader reader, IInvocationBinder binder)
+    {
+        var headers = ReadHeaders(ref reader);
+        var invocationId = ReadInvocationId(ref reader);
+        ThrowIfNullOrEmpty(invocationId, "invocation ID for StreamItem message");
+
+        object? value;
+        try
+        {
+            var itemType = binder.GetStreamItemType(invocationId);
+            value = DeserializeObject(ref reader, itemType, "item");
+        }
+        catch (Exception ex)
+        {
+            return new StreamBindingFailureMessage(invocationId, ExceptionDispatchInfo.Capture(ex));
+        }
+
+        return ApplyHeaders(headers, new StreamItemMessage(invocationId, value));
+    }
+
+    private CompletionMessage CreateCompletionMessage(ref MessagePackReader reader, IInvocationBinder binder)
+    {
+        var headers = ReadHeaders(ref reader);
+        var invocationId = ReadInvocationId(ref reader);
+        ThrowIfNullOrEmpty(invocationId, "invocation ID for Completion message");
+
+        var resultKind = ReadInt32(ref reader, "resultKind");
+
+        string? error = null;
+        object? result = null;
+        var hasResult = false;
+
+        switch (resultKind)
+        {
+            case ErrorResult:
+                error = ReadString(ref reader, "error");
+                break;
+            case NonVoidResult:
+                hasResult = true;
+                var itemType = ProtocolHelper.TryGetReturnType(binder, invocationId);
+                if (itemType is null)
+                {
+                    reader.Skip();
+                }
+                else
+                {
+                    if (itemType == typeof(RawResult))
+                    {
+                        result = new RawResult(reader.ReadRaw());
+                    }
+                    else
+                    {
+                        try
+                        {
+                            result = DeserializeObject(ref reader, itemType, "argument");
+                        }
+                        catch (Exception ex)
+                        {
+                            error = $"Error trying to deserialize result to {itemType.Name}. {ex.Message}";
+                            hasResult = false;
+                        }
+                    }
+                }
+                break;
+            case VoidResult:
+                hasResult = false;
+                break;
+            default:
+                throw new InvalidDataException("Invalid invocation result kind.");
+        }
+
+        return ApplyHeaders(headers, new CompletionMessage(invocationId, error, result, hasResult));
+    }
+
+    private static CancelInvocationMessage CreateCancelInvocationMessage(ref MessagePackReader reader)
+    {
+        var headers = ReadHeaders(ref reader);
+        var invocationId = ReadInvocationId(ref reader);
+        ThrowIfNullOrEmpty(invocationId, "invocation ID for CancelInvocation message");
+
+        return ApplyHeaders(headers, new CancelInvocationMessage(invocationId));
+    }
+
+    private static CloseMessage CreateCloseMessage(ref MessagePackReader reader, int itemCount)
+    {
+        var error = ReadString(ref reader, "error");
+        var allowReconnect = false;
+
+        if (itemCount > 2)
+        {
+            allowReconnect = ReadBoolean(ref reader, "allowReconnect");
+        }
+
+        // An empty string is still an error
+        if (error == null && !allowReconnect)
+        {
+            return CloseMessage.Empty;
+        }
+
+        return new CloseMessage(error, allowReconnect);
+    }
+
+    private static Dictionary<string, string>? ReadHeaders(ref MessagePackReader reader)
+    {
+        var headerCount = ReadMapLength(ref reader, "headers");
+        if (headerCount > 0)
+        {
+            var headers = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            for (var i = 0; i < headerCount; i++)
+            {
+                var key = ReadString(ref reader, $"headers[{i}].Key");
+                ThrowIfNullOrEmpty(key, "key in header");
+
+                var value = ReadString(ref reader, $"headers[{i}].Value");
+                ThrowIfNullOrEmpty(value, "value in header");
+
+                headers.Add(key, value);
+            }
+            return headers;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private static string[]? ReadStreamIds(ref MessagePackReader reader)
+    {
+        var streamIdCount = ReadArrayLength(ref reader, "streamIds");
+        List<string>? streams = null;
+
+        if (streamIdCount > 0)
+        {
+            streams = new List<string>();
+            for (var i = 0; i < streamIdCount; i++)
+            {
+                var id = reader.ReadString();
+                ThrowIfNullOrEmpty(id, "value in streamIds received");
+
+                streams.Add(id);
+            }
+        }
+
+        return streams?.ToArray();
+    }
+
+    private static AckMessage CreateAckMessage(ref MessagePackReader reader)
+    {
+        return new AckMessage(ReadInt64(ref reader, "sequenceId"));
+    }
+
+    private static SequenceMessage CreateSequenceMessage(ref MessagePackReader reader)
+    {
+        return new SequenceMessage(ReadInt64(ref reader, "sequenceId"));
+    }
+
+    private object?[] BindArguments(ref MessagePackReader reader, IReadOnlyList<Type> parameterTypes)
+    {
+        var argumentCount = ReadArrayLength(ref reader, "arguments");
+
+        if (parameterTypes.Count != argumentCount)
+        {
+            throw new InvalidDataException(
+                $"Invocation provides {argumentCount} argument(s) but target expects {parameterTypes.Count}.");
+        }
+
+        try
+        {
+            var arguments = new object?[argumentCount];
+            for (var i = 0; i < argumentCount; i++)
+            {
+                arguments[i] = DeserializeObject(ref reader, parameterTypes[i], "argument");
+            }
+
+            return arguments;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException("Error binding arguments. Make sure that the types of the provided values match the types of the hub method being invoked.", ex);
+        }
+    }
+
+    protected abstract object? DeserializeObject(ref MessagePackReader reader, Type type, string field);
+
+    private static T ApplyHeaders<T>(IDictionary<string, string>? source, T destination) where T : HubInvocationMessage
+    {
+        if (source != null && source.Count > 0)
+        {
+            destination.Headers = source;
+        }
+
+        return destination;
+    }
+
+    /// <inheritdoc />
+    public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
+    {
+        var memoryBufferWriter = MemoryBufferWriter.Get();
+
+        try
+        {
+            var writer = new MessagePackWriter(memoryBufferWriter);
+
+            // Write message to a buffer so we can get its length
+            WriteMessageCore(message, ref writer);
+
+            // Write length then message to output
+            BinaryMessageFormatter.WriteLengthPrefix(memoryBufferWriter.Length, output);
+            memoryBufferWriter.CopyTo(output);
+        }
+        finally
+        {
+            MemoryBufferWriter.Return(memoryBufferWriter);
+        }
+    }
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
+    {
+        var memoryBufferWriter = MemoryBufferWriter.Get();
+
+        try
+        {
+            var writer = new MessagePackWriter(memoryBufferWriter);
+
+            // Write message to a buffer so we can get its length
+            WriteMessageCore(message, ref writer);
+
+            var dataLength = memoryBufferWriter.Length;
+            var prefixLength = BinaryMessageFormatter.LengthPrefixLength(memoryBufferWriter.Length);
+
+            var array = new byte[dataLength + prefixLength];
+            var span = array.AsSpan();
+
+            // Write length then message to output
+            var written = BinaryMessageFormatter.WriteLengthPrefix(memoryBufferWriter.Length, span);
+            Debug.Assert(written == prefixLength);
+            memoryBufferWriter.CopyTo(span.Slice(prefixLength));
+
+            return array;
+        }
+        finally
+        {
+            MemoryBufferWriter.Return(memoryBufferWriter);
+        }
+    }
+
+    private void WriteMessageCore(HubMessage message, ref MessagePackWriter writer)
+    {
+        switch (message)
+        {
+            case InvocationMessage invocationMessage:
+                WriteInvocationMessage(invocationMessage, ref writer);
+                break;
+            case StreamInvocationMessage streamInvocationMessage:
+                WriteStreamInvocationMessage(streamInvocationMessage, ref writer);
+                break;
+            case StreamItemMessage streamItemMessage:
+                WriteStreamingItemMessage(streamItemMessage, ref writer);
+                break;
+            case CompletionMessage completionMessage:
+                WriteCompletionMessage(completionMessage, ref writer);
+                break;
+            case CancelInvocationMessage cancelInvocationMessage:
+                WriteCancelInvocationMessage(cancelInvocationMessage, ref writer);
+                break;
+            case PingMessage:
+                WritePingMessage(ref writer);
+                break;
+            case CloseMessage closeMessage:
+                WriteCloseMessage(closeMessage, ref writer);
+                break;
+            case AckMessage ackMessage:
+                WriteAckMessage(ackMessage, ref writer);
+                break;
+            case SequenceMessage sequenceMessage:
+                WriteSequenceMessage(sequenceMessage, ref writer);
+                break;
+            default:
+                throw new InvalidDataException($"Unexpected message type: {message.GetType().Name}");
+        }
+
+        writer.Flush();
+    }
+
+    private void WriteInvocationMessage(InvocationMessage message, ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(6);
+
+        writer.Write(HubProtocolConstants.InvocationMessageType);
+        PackHeaders(message.Headers, ref writer);
+        if (string.IsNullOrEmpty(message.InvocationId))
+        {
+            writer.WriteNil();
+        }
+        else
+        {
+            writer.Write(message.InvocationId);
+        }
+        writer.Write(message.Target);
+
+        if (message.Arguments is null)
+        {
+            writer.WriteArrayHeader(0);
+        }
+        else
+        {
+            writer.WriteArrayHeader(message.Arguments.Length);
+            foreach (var arg in message.Arguments)
+            {
+                WriteArgument(arg, ref writer);
+            }
+        }
+
+        WriteStreamIds(message.StreamIds, ref writer);
+    }
+
+    private void WriteStreamInvocationMessage(StreamInvocationMessage message, ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(6);
+
+        writer.Write(HubProtocolConstants.StreamInvocationMessageType);
+        PackHeaders(message.Headers, ref writer);
+        writer.Write(message.InvocationId);
+        writer.Write(message.Target);
+
+        if (message.Arguments is null)
+        {
+            writer.WriteArrayHeader(0);
+        }
+        else
+        {
+            writer.WriteArrayHeader(message.Arguments.Length);
+            foreach (var arg in message.Arguments)
+            {
+                WriteArgument(arg, ref writer);
+            }
+        }
+
+        WriteStreamIds(message.StreamIds, ref writer);
+    }
+
+    private void WriteStreamingItemMessage(StreamItemMessage message, ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(4);
+        writer.Write(HubProtocolConstants.StreamItemMessageType);
+        PackHeaders(message.Headers, ref writer);
+        writer.Write(message.InvocationId);
+        WriteArgument(message.Item, ref writer);
+    }
+
+    private void WriteArgument(object? argument, ref MessagePackWriter writer)
+    {
+        if (argument == null)
+        {
+            writer.WriteNil();
+        }
+        else if (argument is RawResult result)
+        {
+            writer.WriteRaw(result.RawSerializedData);
+        }
+        else
+        {
+            Serialize(ref writer, argument.GetType(), argument);
+        }
+    }
+
+    protected abstract void Serialize(ref MessagePackWriter writer, Type type, object value);
+
+    private static void WriteStreamIds(string[]? streamIds, ref MessagePackWriter writer)
+    {
+        if (streamIds != null)
+        {
+            writer.WriteArrayHeader(streamIds.Length);
+            foreach (var streamId in streamIds)
+            {
+                writer.Write(streamId);
+            }
+        }
+        else
+        {
+            writer.WriteArrayHeader(0);
+        }
+    }
+
+    private void WriteCompletionMessage(CompletionMessage message, ref MessagePackWriter writer)
+    {
+        var resultKind =
+            message.Error != null ? ErrorResult :
+            message.HasResult ? NonVoidResult :
+            VoidResult;
+
+        writer.WriteArrayHeader(4 + (resultKind != VoidResult ? 1 : 0));
+        writer.Write(HubProtocolConstants.CompletionMessageType);
+        PackHeaders(message.Headers, ref writer);
+        writer.Write(message.InvocationId);
+        writer.Write(resultKind);
+        switch (resultKind)
+        {
+            case ErrorResult:
+                writer.Write(message.Error);
+                break;
+            case NonVoidResult:
+                WriteArgument(message.Result, ref writer);
+                break;
+        }
+    }
+
+    private static void WriteCancelInvocationMessage(CancelInvocationMessage message, ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(3);
+        writer.Write(HubProtocolConstants.CancelInvocationMessageType);
+        PackHeaders(message.Headers, ref writer);
+        writer.Write(message.InvocationId);
+    }
+
+    private static void WriteCloseMessage(CloseMessage message, ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(3);
+        writer.Write(HubProtocolConstants.CloseMessageType);
+        if (string.IsNullOrEmpty(message.Error))
+        {
+            writer.WriteNil();
+        }
+        else
+        {
+            writer.Write(message.Error);
+        }
+
+        writer.Write(message.AllowReconnect);
+    }
+
+    private static void WritePingMessage(ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(1);
+        writer.Write(HubProtocolConstants.PingMessageType);
+    }
+
+    private static void WriteAckMessage(AckMessage message, ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(2);
+        writer.Write(HubProtocolConstants.AckMessageType);
+        writer.Write(message.SequenceId);
+    }
+
+    private static void WriteSequenceMessage(SequenceMessage message, ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(2);
+        writer.Write(HubProtocolConstants.SequenceMessageType);
+        writer.Write(message.SequenceId);
+    }
+
+    private static void PackHeaders(IDictionary<string, string>? headers, ref MessagePackWriter writer)
+    {
+        if (headers != null)
+        {
+            writer.WriteMapHeader(headers.Count);
+            if (headers.Count > 0)
+            {
+                foreach (var header in headers)
+                {
+                    writer.Write(header.Key);
+                    writer.Write(header.Value);
+                }
+            }
+        }
+        else
+        {
+            writer.WriteMapHeader(0);
+        }
+    }
+
+    private static string? ReadInvocationId(ref MessagePackReader reader) =>
+        ReadString(ref reader, "invocationId");
+
+    private static bool ReadBoolean(ref MessagePackReader reader, string field)
+    {
+        try
+        {
+            return reader.ReadBoolean();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading '{field}' as Boolean failed.", ex);
+        }
+    }
+
+    private static int ReadInt32(ref MessagePackReader reader, string field)
+    {
+        try
+        {
+            return reader.ReadInt32();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading '{field}' as Int32 failed.", ex);
+        }
+    }
+
+    private static long ReadInt64(ref MessagePackReader reader, string field)
+    {
+        try
+        {
+            return reader.ReadInt64();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading '{field}' as Int64 failed.", ex);
+        }
+    }
+
+    protected static string? ReadString(ref MessagePackReader reader, IInvocationBinder binder, string field)
+    {
+        try
+        {
+#if NETCOREAPP
+            if (reader.TryReadStringSpan(out var span))
+            {
+                return binder.GetTarget(span) ?? Encoding.UTF8.GetString(span);
+            }
+            return reader.ReadString();
+#else
+            return reader.ReadString();
+#endif
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading '{field}' as String failed.", ex);
+        }
+    }
+
+    protected static string? ReadString(ref MessagePackReader reader, string field)
+    {
+        try
+        {
+            return reader.ReadString();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading '{field}' as String failed.", ex);
+        }
+    }
+
+    private static long ReadMapLength(ref MessagePackReader reader, string field)
+    {
+        try
+        {
+            return reader.ReadMapHeader();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading map length for '{field}' failed.", ex);
+        }
+    }
+
+    private static long ReadArrayLength(ref MessagePackReader reader, string field)
+    {
+        try
+        {
+            return reader.ReadArrayHeader();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading array length for '{field}' failed.", ex);
+        }
+    }
+
+    private static void ThrowIfNullOrEmpty([NotNull] string? target, string message)
+    {
+        if (string.IsNullOrEmpty(target))
+        {
+            throw new InvalidDataException($"Null or empty {message}.");
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocolWorker.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocolWorker.cs
@@ -1,27 +1,21 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-#pragma warning disable IDE0005 // This file is shared across multiple projects making it ugly to ignore unused usings
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.IO.Pipelines;
-using System.Runtime.ExceptionServices;
-using System.Text;
 
 using MessagePack;
 
 using Microsoft.AspNetCore.Internal;
-using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.AspNetCore.SignalR.Protocol;
 
+#nullable enable
+
 /// <summary>
-/// Implements support for MessagePackHubProtocol. This code is shared between SignalR and Blazor.
+/// A trimmed version of  https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
 /// </summary>
 internal abstract class MessagePackHubProtocolWorker
 {
@@ -29,313 +23,8 @@ internal abstract class MessagePackHubProtocolWorker
     private const int VoidResult = 2;
     private const int NonVoidResult = 3;
 
-    public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, [NotNullWhen(true)] out HubMessage? message)
-    {
-        if (!BinaryMessageParser.TryParseMessage(ref input, out var payload))
-        {
-            message = null;
-            return false;
-        }
-
-        var reader = new MessagePackReader(payload);
-        message = ParseMessage(ref reader, binder);
-        return message != null;
-    }
-
-    private HubMessage? ParseMessage(ref MessagePackReader reader, IInvocationBinder binder)
-    {
-        var itemCount = reader.ReadArrayHeader();
-
-        var messageType = ReadInt32(ref reader, "messageType");
-
-        switch (messageType)
-        {
-            case HubProtocolConstants.InvocationMessageType:
-                return CreateInvocationMessage(ref reader, binder, itemCount);
-            case HubProtocolConstants.StreamInvocationMessageType:
-                return CreateStreamInvocationMessage(ref reader, binder, itemCount);
-            case HubProtocolConstants.StreamItemMessageType:
-                return CreateStreamItemMessage(ref reader, binder);
-            case HubProtocolConstants.CompletionMessageType:
-                return CreateCompletionMessage(ref reader, binder);
-            case HubProtocolConstants.CancelInvocationMessageType:
-                return CreateCancelInvocationMessage(ref reader);
-            case HubProtocolConstants.PingMessageType:
-                return PingMessage.Instance;
-            case HubProtocolConstants.CloseMessageType:
-                return CreateCloseMessage(ref reader, itemCount);
-            case HubProtocolConstants.AckMessageType:
-                return CreateAckMessage(ref reader);
-            case HubProtocolConstants.SequenceMessageType:
-                return CreateSequenceMessage(ref reader);
-            default:
-                // Future protocol changes can add message types, old clients can ignore them
-                return null;
-        }
-    }
-
-    private HubMessage CreateInvocationMessage(ref MessagePackReader reader, IInvocationBinder binder, int itemCount)
-    {
-        var headers = ReadHeaders(ref reader);
-        var invocationId = ReadInvocationId(ref reader);
-
-        // For MsgPack, we represent an empty invocation ID as an empty string,
-        // so we need to normalize that to "null", which is what indicates a non-blocking invocation.
-        if (string.IsNullOrEmpty(invocationId))
-        {
-            invocationId = null;
-        }
-
-        var target = ReadString(ref reader, binder, "target");
-        ThrowIfNullOrEmpty(target, "target for Invocation message");
-
-        object?[]? arguments;
-        try
-        {
-            var parameterTypes = binder.GetParameterTypes(target);
-            arguments = BindArguments(ref reader, parameterTypes);
-        }
-        catch (Exception ex)
-        {
-            return new InvocationBindingFailureMessage(invocationId, target, ExceptionDispatchInfo.Capture(ex));
-        }
-
-        string[]? streams = null;
-        // Previous clients will send 5 items, so we check if they sent a stream array or not
-        if (itemCount > 5)
-        {
-            streams = ReadStreamIds(ref reader);
-        }
-
-        return ApplyHeaders(headers, new InvocationMessage(invocationId, target, arguments, streams));
-    }
-
-    private HubMessage CreateStreamInvocationMessage(ref MessagePackReader reader, IInvocationBinder binder, int itemCount)
-    {
-        var headers = ReadHeaders(ref reader);
-        var invocationId = ReadInvocationId(ref reader);
-        ThrowIfNullOrEmpty(invocationId, "invocation ID for StreamInvocation message");
-
-        var target = ReadString(ref reader, "target");
-        ThrowIfNullOrEmpty(target, "target for StreamInvocation message");
-
-        object?[] arguments;
-        try
-        {
-            var parameterTypes = binder.GetParameterTypes(target);
-            arguments = BindArguments(ref reader, parameterTypes);
-        }
-        catch (Exception ex)
-        {
-            return new InvocationBindingFailureMessage(invocationId, target, ExceptionDispatchInfo.Capture(ex));
-        }
-
-        string[]? streams = null;
-        // Previous clients will send 5 items, so we check if they sent a stream array or not
-        if (itemCount > 5)
-        {
-            streams = ReadStreamIds(ref reader);
-        }
-
-        return ApplyHeaders(headers, new StreamInvocationMessage(invocationId, target, arguments, streams));
-    }
-
-    private HubMessage CreateStreamItemMessage(ref MessagePackReader reader, IInvocationBinder binder)
-    {
-        var headers = ReadHeaders(ref reader);
-        var invocationId = ReadInvocationId(ref reader);
-        ThrowIfNullOrEmpty(invocationId, "invocation ID for StreamItem message");
-
-        object? value;
-        try
-        {
-            var itemType = binder.GetStreamItemType(invocationId);
-            value = DeserializeObject(ref reader, itemType, "item");
-        }
-        catch (Exception ex)
-        {
-            return new StreamBindingFailureMessage(invocationId, ExceptionDispatchInfo.Capture(ex));
-        }
-
-        return ApplyHeaders(headers, new StreamItemMessage(invocationId, value));
-    }
-
-    private CompletionMessage CreateCompletionMessage(ref MessagePackReader reader, IInvocationBinder binder)
-    {
-        var headers = ReadHeaders(ref reader);
-        var invocationId = ReadInvocationId(ref reader);
-        ThrowIfNullOrEmpty(invocationId, "invocation ID for Completion message");
-
-        var resultKind = ReadInt32(ref reader, "resultKind");
-
-        string? error = null;
-        object? result = null;
-        var hasResult = false;
-
-        switch (resultKind)
-        {
-            case ErrorResult:
-                error = ReadString(ref reader, "error");
-                break;
-            case NonVoidResult:
-                hasResult = true;
-                var itemType = ProtocolHelper.TryGetReturnType(binder, invocationId);
-                if (itemType is null)
-                {
-                    reader.Skip();
-                }
-                else
-                {
-                    if (itemType == typeof(RawResult))
-                    {
-                        result = new RawResult(reader.ReadRaw());
-                    }
-                    else
-                    {
-                        try
-                        {
-                            result = DeserializeObject(ref reader, itemType, "argument");
-                        }
-                        catch (Exception ex)
-                        {
-                            error = $"Error trying to deserialize result to {itemType.Name}. {ex.Message}";
-                            hasResult = false;
-                        }
-                    }
-                }
-                break;
-            case VoidResult:
-                hasResult = false;
-                break;
-            default:
-                throw new InvalidDataException("Invalid invocation result kind.");
-        }
-
-        return ApplyHeaders(headers, new CompletionMessage(invocationId, error, result, hasResult));
-    }
-
-    private static CancelInvocationMessage CreateCancelInvocationMessage(ref MessagePackReader reader)
-    {
-        var headers = ReadHeaders(ref reader);
-        var invocationId = ReadInvocationId(ref reader);
-        ThrowIfNullOrEmpty(invocationId, "invocation ID for CancelInvocation message");
-
-        return ApplyHeaders(headers, new CancelInvocationMessage(invocationId));
-    }
-
-    private static CloseMessage CreateCloseMessage(ref MessagePackReader reader, int itemCount)
-    {
-        var error = ReadString(ref reader, "error");
-        var allowReconnect = false;
-
-        if (itemCount > 2)
-        {
-            allowReconnect = ReadBoolean(ref reader, "allowReconnect");
-        }
-
-        // An empty string is still an error
-        if (error == null && !allowReconnect)
-        {
-            return CloseMessage.Empty;
-        }
-
-        return new CloseMessage(error, allowReconnect);
-    }
-
-    private static Dictionary<string, string>? ReadHeaders(ref MessagePackReader reader)
-    {
-        var headerCount = ReadMapLength(ref reader, "headers");
-        if (headerCount > 0)
-        {
-            var headers = new Dictionary<string, string>(StringComparer.Ordinal);
-
-            for (var i = 0; i < headerCount; i++)
-            {
-                var key = ReadString(ref reader, $"headers[{i}].Key");
-                ThrowIfNullOrEmpty(key, "key in header");
-
-                var value = ReadString(ref reader, $"headers[{i}].Value");
-                ThrowIfNullOrEmpty(value, "value in header");
-
-                headers.Add(key, value);
-            }
-            return headers;
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    private static string[]? ReadStreamIds(ref MessagePackReader reader)
-    {
-        var streamIdCount = ReadArrayLength(ref reader, "streamIds");
-        List<string>? streams = null;
-
-        if (streamIdCount > 0)
-        {
-            streams = new List<string>();
-            for (var i = 0; i < streamIdCount; i++)
-            {
-                var id = reader.ReadString();
-                ThrowIfNullOrEmpty(id, "value in streamIds received");
-
-                streams.Add(id);
-            }
-        }
-
-        return streams?.ToArray();
-    }
-
-    private static AckMessage CreateAckMessage(ref MessagePackReader reader)
-    {
-        return new AckMessage(ReadInt64(ref reader, "sequenceId"));
-    }
-
-    private static SequenceMessage CreateSequenceMessage(ref MessagePackReader reader)
-    {
-        return new SequenceMessage(ReadInt64(ref reader, "sequenceId"));
-    }
-
-    private object?[] BindArguments(ref MessagePackReader reader, IReadOnlyList<Type> parameterTypes)
-    {
-        var argumentCount = ReadArrayLength(ref reader, "arguments");
-
-        if (parameterTypes.Count != argumentCount)
-        {
-            throw new InvalidDataException(
-                $"Invocation provides {argumentCount} argument(s) but target expects {parameterTypes.Count}.");
-        }
-
-        try
-        {
-            var arguments = new object?[argumentCount];
-            for (var i = 0; i < argumentCount; i++)
-            {
-                arguments[i] = DeserializeObject(ref reader, parameterTypes[i], "argument");
-            }
-
-            return arguments;
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException("Error binding arguments. Make sure that the types of the provided values match the types of the hub method being invoked.", ex);
-        }
-    }
-
     protected abstract object? DeserializeObject(ref MessagePackReader reader, Type type, string field);
 
-    private static T ApplyHeaders<T>(IDictionary<string, string>? source, T destination) where T : HubInvocationMessage
-    {
-        if (source != null && source.Count > 0)
-        {
-            destination.Headers = source;
-        }
-
-        return destination;
-    }
-
-    /// <inheritdoc />
     public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
     {
         var memoryBufferWriter = MemoryBufferWriter.Get();
@@ -357,7 +46,6 @@ internal abstract class MessagePackHubProtocolWorker
         }
     }
 
-    /// <inheritdoc />
     public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
     {
         var memoryBufferWriter = MemoryBufferWriter.Get();
@@ -395,35 +83,50 @@ internal abstract class MessagePackHubProtocolWorker
             case InvocationMessage invocationMessage:
                 WriteInvocationMessage(invocationMessage, ref writer);
                 break;
-            case StreamInvocationMessage streamInvocationMessage:
-                WriteStreamInvocationMessage(streamInvocationMessage, ref writer);
-                break;
-            case StreamItemMessage streamItemMessage:
-                WriteStreamingItemMessage(streamItemMessage, ref writer);
-                break;
             case CompletionMessage completionMessage:
                 WriteCompletionMessage(completionMessage, ref writer);
                 break;
-            case CancelInvocationMessage cancelInvocationMessage:
-                WriteCancelInvocationMessage(cancelInvocationMessage, ref writer);
-                break;
-            case PingMessage:
-                WritePingMessage(ref writer);
-                break;
-            case CloseMessage closeMessage:
-                WriteCloseMessage(closeMessage, ref writer);
-                break;
-            case AckMessage ackMessage:
-                WriteAckMessage(ackMessage, ref writer);
-                break;
-            case SequenceMessage sequenceMessage:
-                WriteSequenceMessage(sequenceMessage, ref writer);
-                break;
             default:
-                throw new InvalidDataException($"Unexpected message type: {message.GetType().Name}");
+                throw new NotSupportedException($"Not supported message type: {message.GetType().Name}");
         }
 
         writer.Flush();
+    }
+
+    private void WriteArgument(object? argument, ref MessagePackWriter writer)
+    {
+        if (argument == null)
+        {
+            writer.WriteNil();
+        }
+#if NET8_0_OR_GREATER
+        else if (argument is RawResult result)
+        {
+            writer.WriteRaw(result.RawSerializedData);
+        }
+#endif
+        else
+        {
+            Serialize(ref writer, argument.GetType(), argument);
+        }
+    }
+
+    protected abstract void Serialize(ref MessagePackWriter writer, Type type, object value);
+
+    private static void WriteStreamIds(string[]? streamIds, ref MessagePackWriter writer)
+    {
+        if (streamIds != null)
+        {
+            writer.WriteArrayHeader(streamIds.Length);
+            foreach (var streamId in streamIds)
+            {
+                writer.Write(streamId);
+            }
+        }
+        else
+        {
+            writer.WriteArrayHeader(0);
+        }
     }
 
     private void WriteInvocationMessage(InvocationMessage message, ref MessagePackWriter writer)
@@ -454,76 +157,9 @@ internal abstract class MessagePackHubProtocolWorker
                 WriteArgument(arg, ref writer);
             }
         }
-
+#if NET6_0_OR_GREATER
         WriteStreamIds(message.StreamIds, ref writer);
-    }
-
-    private void WriteStreamInvocationMessage(StreamInvocationMessage message, ref MessagePackWriter writer)
-    {
-        writer.WriteArrayHeader(6);
-
-        writer.Write(HubProtocolConstants.StreamInvocationMessageType);
-        PackHeaders(message.Headers, ref writer);
-        writer.Write(message.InvocationId);
-        writer.Write(message.Target);
-
-        if (message.Arguments is null)
-        {
-            writer.WriteArrayHeader(0);
-        }
-        else
-        {
-            writer.WriteArrayHeader(message.Arguments.Length);
-            foreach (var arg in message.Arguments)
-            {
-                WriteArgument(arg, ref writer);
-            }
-        }
-
-        WriteStreamIds(message.StreamIds, ref writer);
-    }
-
-    private void WriteStreamingItemMessage(StreamItemMessage message, ref MessagePackWriter writer)
-    {
-        writer.WriteArrayHeader(4);
-        writer.Write(HubProtocolConstants.StreamItemMessageType);
-        PackHeaders(message.Headers, ref writer);
-        writer.Write(message.InvocationId);
-        WriteArgument(message.Item, ref writer);
-    }
-
-    private void WriteArgument(object? argument, ref MessagePackWriter writer)
-    {
-        if (argument == null)
-        {
-            writer.WriteNil();
-        }
-        else if (argument is RawResult result)
-        {
-            writer.WriteRaw(result.RawSerializedData);
-        }
-        else
-        {
-            Serialize(ref writer, argument.GetType(), argument);
-        }
-    }
-
-    protected abstract void Serialize(ref MessagePackWriter writer, Type type, object value);
-
-    private static void WriteStreamIds(string[]? streamIds, ref MessagePackWriter writer)
-    {
-        if (streamIds != null)
-        {
-            writer.WriteArrayHeader(streamIds.Length);
-            foreach (var streamId in streamIds)
-            {
-                writer.Write(streamId);
-            }
-        }
-        else
-        {
-            writer.WriteArrayHeader(0);
-        }
+#endif
     }
 
     private void WriteCompletionMessage(CompletionMessage message, ref MessagePackWriter writer)
@@ -549,50 +185,6 @@ internal abstract class MessagePackHubProtocolWorker
         }
     }
 
-    private static void WriteCancelInvocationMessage(CancelInvocationMessage message, ref MessagePackWriter writer)
-    {
-        writer.WriteArrayHeader(3);
-        writer.Write(HubProtocolConstants.CancelInvocationMessageType);
-        PackHeaders(message.Headers, ref writer);
-        writer.Write(message.InvocationId);
-    }
-
-    private static void WriteCloseMessage(CloseMessage message, ref MessagePackWriter writer)
-    {
-        writer.WriteArrayHeader(3);
-        writer.Write(HubProtocolConstants.CloseMessageType);
-        if (string.IsNullOrEmpty(message.Error))
-        {
-            writer.WriteNil();
-        }
-        else
-        {
-            writer.Write(message.Error);
-        }
-
-        writer.Write(message.AllowReconnect);
-    }
-
-    private static void WritePingMessage(ref MessagePackWriter writer)
-    {
-        writer.WriteArrayHeader(1);
-        writer.Write(HubProtocolConstants.PingMessageType);
-    }
-
-    private static void WriteAckMessage(AckMessage message, ref MessagePackWriter writer)
-    {
-        writer.WriteArrayHeader(2);
-        writer.Write(HubProtocolConstants.AckMessageType);
-        writer.Write(message.SequenceId);
-    }
-
-    private static void WriteSequenceMessage(SequenceMessage message, ref MessagePackWriter writer)
-    {
-        writer.WriteArrayHeader(2);
-        writer.Write(HubProtocolConstants.SequenceMessageType);
-        writer.Write(message.SequenceId);
-    }
-
     private static void PackHeaders(IDictionary<string, string>? headers, ref MessagePackWriter writer)
     {
         if (headers != null)
@@ -610,109 +202,6 @@ internal abstract class MessagePackHubProtocolWorker
         else
         {
             writer.WriteMapHeader(0);
-        }
-    }
-
-    private static string? ReadInvocationId(ref MessagePackReader reader) =>
-        ReadString(ref reader, "invocationId");
-
-    private static bool ReadBoolean(ref MessagePackReader reader, string field)
-    {
-        try
-        {
-            return reader.ReadBoolean();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading '{field}' as Boolean failed.", ex);
-        }
-    }
-
-    private static int ReadInt32(ref MessagePackReader reader, string field)
-    {
-        try
-        {
-            return reader.ReadInt32();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading '{field}' as Int32 failed.", ex);
-        }
-    }
-
-    private static long ReadInt64(ref MessagePackReader reader, string field)
-    {
-        try
-        {
-            return reader.ReadInt64();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading '{field}' as Int64 failed.", ex);
-        }
-    }
-
-    protected static string? ReadString(ref MessagePackReader reader, IInvocationBinder binder, string field)
-    {
-        try
-        {
-#if NETCOREAPP
-            if (reader.TryReadStringSpan(out var span))
-            {
-                return binder.GetTarget(span) ?? Encoding.UTF8.GetString(span);
-            }
-            return reader.ReadString();
-#else
-            return reader.ReadString();
-#endif
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading '{field}' as String failed.", ex);
-        }
-    }
-
-    protected static string? ReadString(ref MessagePackReader reader, string field)
-    {
-        try
-        {
-            return reader.ReadString();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading '{field}' as String failed.", ex);
-        }
-    }
-
-    private static long ReadMapLength(ref MessagePackReader reader, string field)
-    {
-        try
-        {
-            return reader.ReadMapHeader();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading map length for '{field}' failed.", ex);
-        }
-    }
-
-    private static long ReadArrayLength(ref MessagePackReader reader, string field)
-    {
-        try
-        {
-            return reader.ReadArrayHeader();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading array length for '{field}' failed.", ex);
-        }
-    }
-
-    private static void ThrowIfNullOrEmpty([NotNull] string? target, string message)
-    {
-        if (string.IsNullOrEmpty(target))
-        {
-            throw new InvalidDataException($"Null or empty {message}.");
         }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Utils/JTokenWrapper.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Utils/JTokenWrapper.cs
@@ -3,7 +3,12 @@
 
 using System;
 using System.Text.Json;
+
+using MessagePack;
+using MessagePack.Formatters;
+
 using Microsoft.AspNetCore.SignalR.Protocol;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -15,14 +20,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService;
 /// </summary>
 
 [System.Text.Json.Serialization.JsonConverter(typeof(JTokenWrapperJsonConverter))]
-internal class JTokenWrapper
+[MessagePackFormatter(typeof(JTokenWrapperMessagePackFormatter))]
+internal class JTokenWrapper(JToken value)
 {
-    public JTokenWrapper(JToken value)
-    {
-        Value = value;
-    }
-
-    public JToken Value { get; }
+    public JToken Value { get; } = value;
 }
 
 internal class JTokenWrapperJsonConverter : System.Text.Json.Serialization.JsonConverter<JTokenWrapper>
@@ -43,5 +44,19 @@ internal class JTokenWrapperJsonConverter : System.Text.Json.Serialization.JsonC
         // Even if somehow the extensions run on .NET Framework, the JsonHubProtocol would use Newtonsoft.Json for serialization and this class would not be used.
         throw new NotImplementedException("Serializing Newtonsoft.Json.JsonToken with System.Text.Json is not implemented. ");
 #endif
+    }
+}
+
+internal class JTokenWrapperMessagePackFormatter : IMessagePackFormatter<JTokenWrapper>
+{
+    public JTokenWrapper Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Serialize(ref MessagePackWriter writer, JTokenWrapper value, MessagePackSerializerOptions options)
+    {
+        var jsonString = value.Value.ToString();
+        MessagePackSerializer.ConvertFromJson(jsonString, ref writer, options);
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/IConfigurationExtensionsFacts.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/IConfigurationExtensionsFacts.cs
@@ -3,14 +3,17 @@
 
 using System;
 using System.Linq;
+
 using Azure.Core.Serialization;
 using Azure.Identity;
+
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+
 using Xunit;
 
 namespace SignalRServiceExtension.Tests.Config
@@ -41,7 +44,7 @@ namespace SignalRServiceExtension.Tests.Config
             Assert.True(config.GetSection("eastus").TryGetEndpointFromIdentity(factory, out var endpoint));
             Assert.Equal("eastus", endpoint.Name);
             Assert.Equal(uri, endpoint.Endpoint);
-            Assert.IsType<DefaultAzureCredential>((endpoint.AccessKey as AadAccessKey).TokenCredential);
+            Assert.IsType<DefaultAzureCredential>((endpoint.AccessKey as MicrosoftEntraAccessKey).TokenCredential);
             Assert.Equal(EndpointType.Primary, endpoint.EndpointType);
         }
 
@@ -65,7 +68,7 @@ namespace SignalRServiceExtension.Tests.Config
             Assert.Equal(uri, endpoint.Endpoint);
             Assert.Equal(new Uri("https://serverEndpoint.com"), endpoint.ServerEndpoint);
             Assert.Equal(new Uri("https://clientEndpoint.com"), endpoint.ClientEndpoint);
-            Assert.IsType<ManagedIdentityCredential>((endpoint.AccessKey as AadAccessKey).TokenCredential);
+            Assert.IsType<ManagedIdentityCredential>((endpoint.AccessKey as MicrosoftEntraAccessKey).TokenCredential);
             Assert.Equal(EndpointType.Secondary, endpoint.EndpointType);
         }
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Text;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
+
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
@@ -47,10 +49,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
             {
                 parameters.IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(IssuerToken));
                 parameters.RequireSignedTokens = true;
-                parameters.ValidateAudience = false;
-                parameters.ValidateIssuer = false;
                 parameters.ValidateIssuerSigningKey = true;
                 parameters.ValidateLifetime = true;
+                parameters.ValidIssuer = "issuer";
+                parameters.ValidAudience = "audience";
             };
 
             var securityTokenValidator = new DefaultSecurityTokenValidator(configureTokenValidationParameters);

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/JobhostEndToEnd.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/JobhostEndToEnd.cs
@@ -180,10 +180,10 @@ namespace SignalRServiceExtension.Tests
             var accessKeys = new List<string> { DefaultAccessKey, DefaultAttributeAccessKey };
             var validationParameters = new TokenValidationParameters
             {
-                ValidateIssuer = false,
-                ValidateAudience = false,
                 IssuerSigningKeyResolver = (token, securityToken, kid, validationParas) => from key in accessKeys
-                                                                                           select new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+                                                                                           select new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key)),
+                ValidAudience = "http://localhostmakesurenotoneusedxxxxx/client/?hub=testhub",
+                ValidIssuer = "azure-signalr",
             };
             handler.ValidateToken(connectionInfo.AccessToken, validationParameters, out var validatedToken);
             var validatedAccessKey = Encoding.UTF8.GetString((validatedToken.SigningKey as SymmetricSecurityKey)?.Key);


### PR DESCRIPTION
As `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` 1.x relies on an unsecure `MessagePack` version 1.x, and we cannot update `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` to 2.x as we have to support .NET Standard 2.0 framework, we implement the required functionalities of `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` with `MessagePack` 2.0
* Copied `MessagePackHubProtocol` files from https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
* Self-implemented MessagePack Hub Protocol
* Fix security code alert
* Cleanup dependencies



This pull request includes several updates and improvements to the `Microsoft.Azure.WebJobs.Extensions.SignalRService` package, including dependency updates, breaking changes, and new internal implementations for MessagePack protocol support.

### Dependency updates:
* Updated `MessagePack` to version 2.5.192 and `Microsoft.Azure.SignalR` packages to version 1.29.0 in `eng/Packages.Data.props` and `CHANGELOG.md` files. [[1]](diffhunk://#diff-93a28d9569550c68624a8ad2209a6fae1d4f88237e4b5414eed2ecac4ef8c98fL212-R215) [[2]](diffhunk://#diff-4d5b0364bdfdd9ef92d9390778dc219802aaa0928538cb2cd57b68dbe0c29221L3-R15)

### Breaking changes:
* Removed .NET 6.0 support from `Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj`. [[1]](diffhunk://#diff-4d5b0364bdfdd9ef92d9390778dc219802aaa0928538cb2cd57b68dbe0c29221L3-R15) [[2]](diffhunk://#diff-d7d1fc92bb60f4162589c9d75a13093a5c1388addb9ed263f3b8269eccd623deL1-R6)

### New internal implementations for MessagePack protocol:
* Added `BinaryMessageFormatter`, `DefaultMessagePackHubProtocolWorker`, `MessagePackHubProtocol`, and `MessagePackHubProtocolWorker` classes to support MessagePack serialization and deserialization. [[1]](diffhunk://#diff-d078a537b71b42d35b0edfe9d0b29af9a4015b69a4f34c0a249eca42ee30c93fR1-R56) [[2]](diffhunk://#diff-a76e5671b348949cd69c7c0d48230ba174198702ca45b5b7e5368a8cc8cbd9e2R1-R41) [[3]](diffhunk://#diff-72c85cc1f4ff9895e501b28007e8369acfd4881c70893ee96f4a97f0dbd20debR1-R97) [[4]](diffhunk://#diff-666c7b6452ef625804593260147713eba1eb6ec088285711dfc90b6bc202b481R1-R207)

### Code improvements:
* Added `JTokenWrapperMessagePackFormatter` to `JTokenWrapper` class for MessagePack serialization support. [[1]](diffhunk://#diff-3b3afd72fe7b3ec3ff0c24b0f3d8641ba5620774ad29921f462595747e91e058L18-R26) [[2]](diffhunk://#diff-3b3afd72fe7b3ec3ff0c24b0f3d8641ba5620774ad29921f462595747e91e058R49-R62)

### Test updates:
* Updated test cases to use `MicrosoftEntraAccessKey` instead of `AadAccessKey` and added validation for issuer and audience in `DefaultSecurityTokenValidatorTests`. [[1]](diffhunk://#diff-703e2ebb42f2b10519f5f7f40dc765fba826f126042a9d5833ca6a68b4e1d32eL44-R47) [[2]](diffhunk://#diff-703e2ebb42f2b10519f5f7f40dc765fba826f126042a9d5833ca6a68b4e1d32eL68-R71) [[3]](diffhunk://#diff-87b72117be06a7d56bfa5afc7195979729da5ee25e66a63d4b86f7e3c6e27eb6L50-R55)

<details>
<summary>Details</summary>



</details>