### PR TITLE
[Event Hubs] Add Id to suggested processor logs

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
@@ -418,6 +418,7 @@ When filing GitHub issues, the following details are requested for all scenarios
   - 45 (EventProcessorClaimOwnershipError)
   - 103 (EventProcessorLoadBalancingCycleSlowWarning)
   - 104 (EventProcessorHighPartitionOwnershipWarning)
+  - 105 (EventProcessorPartitionProcessingEventPositionDetermined)
   - 123 (EventProcessorProcessingHandlerStart)
   - 124 (EventProcessorProcessingHandlerComplete)
   - 125 (EventProcessorProcessingHandlerError)


### PR DESCRIPTION
# Summary

The focus of these changes is to add the "processor position determined" log to the set of suggested ETW Ids to capture for troubleshooting event processor issues.
