### PR TITLE
[CODEOWNERS] Remove legacy service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -592,9 +592,6 @@
 # ServiceLabel: %Logic App
 # ServiceOwners:                                                   @Azure/azure-logicapps-team
 
-# ServiceLabel: %LOUIS
-# ServiceOwners:                                                   @minamnmik
-
 # ServiceLabel: %Managed Identity
 # ServiceOwners:                                                   @varunkch
 


### PR DESCRIPTION
# Summary 

The focus of these changes is to remove a block tied to a legacy label.
