### PR TITLE
Queue Listener fixes: Drain Mode and Message Deletion

### DIFF
--- a/eng/nunit.runsettings
+++ b/eng/nunit.runsettings
@@ -19,7 +19,7 @@
 		<!-- <Parameter name="DisableAutoRecording" value="true" /> -->
 
 		<!-- Change the test mode -->
-		<!-- <Parameter name="TestMode" value="Record" /> -->
+		<Parameter name="TestMode" value="Live" />
 
 		<!-- Enable running Fiddler -->
 		<!-- <Parameter name="EnableFiddler" value="true" /> -->

--- a/eng/nunit.runsettings
+++ b/eng/nunit.runsettings
@@ -19,7 +19,7 @@
 		<!-- <Parameter name="DisableAutoRecording" value="true" /> -->
 
 		<!-- Change the test mode -->
-		<Parameter name="TestMode" value="Live" />
+		<!-- <Parameter name="TestMode" value="Record" /> -->
 
 		<!-- Enable running Fiddler -->
 		<!-- <Parameter name="EnableFiddler" value="true" /> -->

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -73,9 +73,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             ConcurrencyManager concurrencyManager = null,
             string functionId = null,
             TimeSpan? maxPollingInterval = null,
-            IDrainModeManager drainModeManager = null,
-            CancellationTokenSource shutdownCancellationTokenSource = null, // for testing only
-            CancellationTokenSource executionCancellationTokenSource = null) // for testing only
+            IDrainModeManager drainModeManager = null)
         {
             if (queueOptions == null)
             {
@@ -135,8 +133,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
             _delayStrategy = new RandomizedExponentialBackoffStrategy(QueuePollingIntervals.Minimum, maximumInterval);
 
-            _shutdownCancellationTokenSource = shutdownCancellationTokenSource ?? new CancellationTokenSource();
-            _executionCancellationTokenSource = executionCancellationTokenSource ?? new CancellationTokenSource();
+            _shutdownCancellationTokenSource = new CancellationTokenSource();
+            _executionCancellationTokenSource = new CancellationTokenSource();
 
             _concurrencyManager = concurrencyManager;
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
         {
             if (!_drainModeManager?.IsDrainModeEnabled ?? true)
             {
-                // Cancel execution only if drain mode is explicitly disabled
+                // Cancel the execution token when drain mode is not enabled or drain mode manager is not set.
                 _executionCancellationTokenSource.Cancel();
             }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
-            if (_drainModeManager?.IsDrainModeEnabled ?? false)
+            if (!_drainModeManager?.IsDrainModeEnabled ?? true)
             {
                 _executionCancellationTokenSource.Cancel();
             }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             string functionId = null,
             TimeSpan? maxPollingInterval = null,
             IDrainModeManager drainModeManager = null,
-            CancellationTokenSource shutdownCancellationTokenSource = null)
+            CancellationTokenSource shutdownCancellationTokenSource = null,
+            CancellationTokenSource executionCancellationTokenSource = null)
         {
             if (queueOptions == null)
             {
@@ -135,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             _delayStrategy = new RandomizedExponentialBackoffStrategy(QueuePollingIntervals.Minimum, maximumInterval);
 
             _shutdownCancellationTokenSource = shutdownCancellationTokenSource ?? new CancellationTokenSource();
-            _executionCancellationTokenSource = new CancellationTokenSource();
+            _executionCancellationTokenSource = executionCancellationTokenSource ?? new CancellationTokenSource();
 
             _concurrencyManager = concurrencyManager;
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             ConcurrencyManager concurrencyManager = null,
             string functionId = null,
             TimeSpan? maxPollingInterval = null,
-            IDrainModeManager drainModeManager = null)
+            IDrainModeManager drainModeManager = null,
+            CancellationTokenSource shutdownCancellationTokenSource = null)
         {
             if (queueOptions == null)
             {
@@ -133,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
             _delayStrategy = new RandomizedExponentialBackoffStrategy(QueuePollingIntervals.Minimum, maximumInterval);
 
-            _shutdownCancellationTokenSource = new CancellationTokenSource();
+            _shutdownCancellationTokenSource = shutdownCancellationTokenSource ?? new CancellationTokenSource();
             _executionCancellationTokenSource = new CancellationTokenSource();
 
             _concurrencyManager = concurrencyManager;
@@ -169,9 +170,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
-            if (!_drainModeManager?.IsDrainModeEnabled ?? false)
+            if (!_drainModeManager?.IsDrainModeEnabled ?? true)
             {
-                // Cancel execution if drain mode unless drain mode is disabled
+                // Cancel execution only if drain mode is explicitly disabled
                 _executionCancellationTokenSource.Cancel();
             }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -61,7 +61,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             _targetScaler = new Lazy<QueueTargetScaler>(() => new QueueTargetScaler());
         }
 
-        public QueueListener(QueueClient queue,
+        public QueueListener(
+            QueueClient queue,
+            QueueClient poisonQueue,
+            ITriggerExecutor<QueueMessage> triggerExecutor,
+            IWebJobsExceptionHandler exceptionHandler,
+            ILoggerFactory loggerFactory,
+            SharedQueueWatcher sharedWatcher,
+            QueuesOptions queueOptions,
+            QueueProcessor queueProcessor,
+            FunctionDescriptor functionDescriptor,
+            ConcurrencyManager concurrencyManager = null,
+            string functionId = null,
+            TimeSpan? maxPollingInterval = null,
+            IDrainModeManager drainModeManager = null)
+            : this(queue, poisonQueue, triggerExecutor, exceptionHandler, loggerFactory, sharedWatcher, queueOptions,
+                  queueProcessor, functionDescriptor, concurrencyManager, functionId, maxPollingInterval, drainModeManager, null, null)
+        { }
+
+        // Internal constructor (used for testing)
+        internal QueueListener(QueueClient queue,
             QueueClient poisonQueue,
             ITriggerExecutor<QueueMessage> triggerExecutor,
             IWebJobsExceptionHandler exceptionHandler,

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -61,26 +61,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             _targetScaler = new Lazy<QueueTargetScaler>(() => new QueueTargetScaler());
         }
 
-        public QueueListener(
-            QueueClient queue,
-            QueueClient poisonQueue,
-            ITriggerExecutor<QueueMessage> triggerExecutor,
-            IWebJobsExceptionHandler exceptionHandler,
-            ILoggerFactory loggerFactory,
-            SharedQueueWatcher sharedWatcher,
-            QueuesOptions queueOptions,
-            QueueProcessor queueProcessor,
-            FunctionDescriptor functionDescriptor,
-            ConcurrencyManager concurrencyManager = null,
-            string functionId = null,
-            TimeSpan? maxPollingInterval = null,
-            IDrainModeManager drainModeManager = null)
-            : this(queue, poisonQueue, triggerExecutor, exceptionHandler, loggerFactory, sharedWatcher, queueOptions,
-                  queueProcessor, functionDescriptor, concurrencyManager, functionId, maxPollingInterval, drainModeManager, null, null)
-        { }
-
-        // Internal constructor (used for testing)
-        internal QueueListener(QueueClient queue,
+        public QueueListener(QueueClient queue,
             QueueClient poisonQueue,
             ITriggerExecutor<QueueMessage> triggerExecutor,
             IWebJobsExceptionHandler exceptionHandler,
@@ -93,8 +74,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             string functionId = null,
             TimeSpan? maxPollingInterval = null,
             IDrainModeManager drainModeManager = null,
-            CancellationTokenSource shutdownCancellationTokenSource = null,
-            CancellationTokenSource executionCancellationTokenSource = null)
+            CancellationTokenSource shutdownCancellationTokenSource = null, // for testing only
+            CancellationTokenSource executionCancellationTokenSource = null) // for testing only
         {
             if (queueOptions == null)
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -169,10 +169,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
-            if (!_drainModeManager?.IsDrainModeEnabled ?? true)
+            if (!_drainModeManager?.IsDrainModeEnabled ?? false)
             {
+                // Cancel execution if drain mode unless drain mode is disabled
                 _executionCancellationTokenSource.Cancel();
             }
+
             using (cancellationToken.Register(() => _shutdownCancellationTokenSource.Cancel()))
             {
                 ThrowIfDisposed();
@@ -417,7 +419,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                     // Use a different cancellation token for shutdown to allow graceful shutdown.
                     // Specifically, don't cancel the completion or update of the message itself during graceful shutdown.
                     // Only cancel completion or update of the message if a non-graceful shutdown is requested via _shutdownCancellationTokenSource.
-                    await _queueProcessor.CompleteProcessingMessageAsync(message, result, linkedCts.Token).ConfigureAwait(false);
+                    await _queueProcessor.CompleteProcessingMessageAsync(message, result, _shutdownCancellationTokenSource.Token).ConfigureAwait(false);
                 }
             }
             catch (TaskCanceledException)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -8,8 +8,7 @@
 
 ### Bugs Fixed
 - Fixed bug where calling StopAsync in QueueListener while drain mode was enabled would cancel the execution cancellation token.
-- In QueueListener When ProcessMessageAsync calls QueueProcessor.CompleteProcessingMessageAsync, pass in only the shutdown cancellation token only and not the caller's cancellation token in order to allow for graceful shutdown.
-- Fixed bug where the cancellation token passed to QueueListener.ProcessMessageAsync was being passed into the QueueProcessor.CompleteProcessingMessageAsync call. If this token was cancelled it would not allow the message to be deleted.
+- Fixed bug where the cancellation token passed to QueueListener.ProcessMessageAsync was being propagated to the QueueProcessor.CompleteProcessingMessageAsync call. Since this token is always canceled when QueueListener.StopAsync is invoked, it caused messages to be processed but not deleted.
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- When DrainMode is enabled, calling StopAsync in QueueListener.cs will not cancel the execution cancellation token.
-- In QueueListener.cs When ProcessMessageAsync calls QueueProcessor.CompleteProcessingMessageAsync, pass in only the shutdown cancellation token only and not the caller's cancellation token in order to allow for graceful shutdown.
+- Fixed bug where calling StopAsync in QueueListener while drain mode was enabled would cancel the execution cancellation token.
+- In QueueListener When ProcessMessageAsync calls QueueProcessor.CompleteProcessingMessageAsync, pass in only the shutdown cancellation token only and not the caller's cancellation token in order to allow for graceful shutdown.
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- When DrainMode is enabled, calling StopAsync in QueueListener.cs will not cancel the execution cancellation token.
+- In QueueListener.cs When ProcessMessageAsync calls QueueProcessor.CompleteProcessingMessageAsync, pass in only the shutdown cancellation token only and not the caller's cancellation token in order to allow for graceful shutdown.
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 - Fixed bug where calling StopAsync in QueueListener while drain mode was enabled would cancel the execution cancellation token.
 - In QueueListener When ProcessMessageAsync calls QueueProcessor.CompleteProcessingMessageAsync, pass in only the shutdown cancellation token only and not the caller's cancellation token in order to allow for graceful shutdown.
+- Fixed bug where the cancellation token passed to QueueListener.ProcessMessageAsync was being passed into the QueueProcessor.CompleteProcessingMessageAsync call. If this token was cancelled it would not allow the message to be deleted.
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueListenerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueListenerTests.cs
@@ -46,17 +46,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         private TestLoggerProvider _loggerProvider;
         private QueuesOptions _queuesOptions;
 
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            Fixture = new TestFixture();
-        }
+        //[OneTimeSetUp]
+        //public void OneTimeSetUp()
+        //{
+        //    Fixture = new TestFixture();
+        //}
 
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            Fixture.Dispose();
-        }
+        //[OneTimeTearDown]
+        //public void OneTimeTearDown()
+        //{
+        //    Fixture.Dispose();
+        //}
 
         [SetUp]
         public void SetUp()
@@ -687,11 +687,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         {
             // Arrange
             var (listener, processor, callerCts, shutdownCts) = CreateListenerAndMocks();
-            var message = new Mock<QueueMessage>().Object;
 
             // Act
             // Neither token is canceled
-            await listener.ProcessMessageAsync(message, TimeSpan.FromMinutes(2), callerCts.Token);
+            await listener.ProcessMessageAsync(_queueMessage, TimeSpan.FromMinutes(2), callerCts.Token);
 
             // TODO verify that the message was processed and deleted
             Assert.AreEqual(shutdownCts.Token, processor.CapturedDeleteToken);
@@ -702,13 +701,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         {
             // Arrange
             var (listener, processor, callerCts, shutdownCts) = CreateListenerAndMocks();
-            var message = new Mock<QueueMessage>().Object;
 
             // Act
             // Cancel the caller token
             callerCts.Cancel();
 
-            await listener.ProcessMessageAsync(message, TimeSpan.FromMinutes(2), callerCts.Token);
+            await listener.ProcessMessageAsync(_queueMessage, TimeSpan.FromMinutes(2), callerCts.Token);
 
             // TODO verify that the message was processed and deleted
             Assert.AreEqual(shutdownCts.Token, processor.CapturedDeleteToken);
@@ -719,13 +717,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         {
             // Arrange
             var (listener, processor, callerCts, shutdownCts) = CreateListenerAndMocks();
-            var message = new Mock<QueueMessage>().Object;
 
             // Act
             // Cancel the shutdown token
             shutdownCts.Cancel();
 
-            await listener.ProcessMessageAsync(message, TimeSpan.FromMinutes(2), callerCts.Token);
+            await listener.ProcessMessageAsync(_queueMessage, TimeSpan.FromMinutes(2), callerCts.Token);
 
             // TODO verify that the message was not deleted because this is a forced shutdown
             Assert.AreEqual(shutdownCts.Token, processor.CapturedDeleteToken);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueListenerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueListenerTests.cs
@@ -46,17 +46,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         private TestLoggerProvider _loggerProvider;
         private QueuesOptions _queuesOptions;
 
-        //[OneTimeSetUp]
-        //public void OneTimeSetUp()
-        //{
-        //    Fixture = new TestFixture();
-        //}
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Fixture = new TestFixture();
+        }
 
-        //[OneTimeTearDown]
-        //public void OneTimeTearDown()
-        //{
-        //    Fixture.Dispose();
-        //}
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            Fixture.Dispose();
+        }
 
         [SetUp]
         public void SetUp()

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueListenerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueListenerTests.cs
@@ -765,8 +765,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
                 Times.Never);
         }
 
-
-
         [Test]
         public async Task StopAsync_DisablesCancellation_WhenDrainModeEnabled()
         {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/TestQueueProcessor .cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/TestQueueProcessor .cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Host.Queues;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
+{
+    public class TestQueueProcessor : QueueProcessor
+    {
+        public bool DeleteCalled { get; private set; }
+        public CancellationToken CapturedDeleteToken { get; private set; }
+
+        public TestQueueProcessor(QueueProcessorOptions options)
+            : base(options)
+        {
+        }
+
+        protected override async Task DeleteMessageAsync(QueueMessage message, CancellationToken cancellationToken)
+        {
+            DeleteCalled = true;
+            CapturedDeleteToken = cancellationToken; // store the exact token used
+            await base.DeleteMessageAsync(message, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
Two changes to the queue listener:

1. When drain mode is enabled, we should not trigger the execution cancellation token in StopAsync
2. `_queueProcessor.CompleteProcessingMessageAsync` should only pass in the shutdown cancellation token, not the linked cancellation token. This way the message will be successfully deleted even if the cancellation token is canceled. 