### PR TITLE
Fix typo in CertificatePolicy.KeySize documentation

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Corrected a typo in the documentation for `CertificatePolicy.KeySize`, changing the RSA key length from "4092" to "4096".
 
 ### Other Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatePolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatePolicy.cs
@@ -178,7 +178,7 @@ namespace Azure.Security.KeyVault.Certificates
         public CertificateKeyCurveName? KeyCurveName { get; set; }
 
         /// <summary>
-        /// Gets or sets the size of the RSA key. The value must be a valid RSA key length such as 2048 or 4092.
+        /// Gets or sets the size of the RSA key. The value must be a valid RSA key length such as 2048 or 4096.
         /// </summary>
         public int? KeySize { get; set; }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/47598

There is a typo in the current documentation for the `CertificatePolicy.KeySize` property, which is documented as "[...] The value must be a valid RSA key length such as 2048 or 4092", and the 4092 should be a 4096 instead.

The live documentation on Microsoft Learn will be updated automatically following a future release of the SDK.