### PR TITLE
[Storage] Add single-shot Crc64.HashToUInt64(ROS<byte>) method

### DIFF
--- a/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.net6.0.cs
@@ -45,7 +45,9 @@ namespace Azure.Storage
         internal StorageCrc64HashAlgorithm() : base (default(int)) { }
         public override void Append(System.ReadOnlySpan<byte> source) { }
         public static Azure.Storage.StorageCrc64HashAlgorithm Create() { throw null; }
+        public ulong GetCurrentHashAsUInt64() { throw null; }
         protected override void GetCurrentHashCore(System.Span<byte> destination) { }
+        public static ulong HashToUInt64(System.ReadOnlySpan<byte> source) { throw null; }
         public override void Reset() { }
     }
     public static partial class StorageExtensions

--- a/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.net8.0.cs
+++ b/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.net8.0.cs
@@ -45,7 +45,9 @@ namespace Azure.Storage
         internal StorageCrc64HashAlgorithm() : base (default(int)) { }
         public override void Append(System.ReadOnlySpan<byte> source) { }
         public static Azure.Storage.StorageCrc64HashAlgorithm Create() { throw null; }
+        public ulong GetCurrentHashAsUInt64() { throw null; }
         protected override void GetCurrentHashCore(System.Span<byte> destination) { }
+        public static ulong HashToUInt64(System.ReadOnlySpan<byte> source) { throw null; }
         public override void Reset() { }
     }
     public static partial class StorageExtensions

--- a/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.netstandard2.0.cs
@@ -45,7 +45,9 @@ namespace Azure.Storage
         internal StorageCrc64HashAlgorithm() : base (default(int)) { }
         public override void Append(System.ReadOnlySpan<byte> source) { }
         public static Azure.Storage.StorageCrc64HashAlgorithm Create() { throw null; }
+        public ulong GetCurrentHashAsUInt64() { throw null; }
         protected override void GetCurrentHashCore(System.Span<byte> destination) { }
+        public static ulong HashToUInt64(System.ReadOnlySpan<byte> source) { throw null; }
         public override void Reset() { }
     }
     public static partial class StorageExtensions

--- a/sdk/storage/Azure.Storage.Common/src/StorageCrc64HashAlgorithm.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageCrc64HashAlgorithm.cs
@@ -44,5 +44,21 @@ namespace Azure.Storage
         /// <inheritdoc/>
         protected override void GetCurrentHashCore(Span<byte> destination)
             => BitConverter.GetBytes(_uCRC).CopyTo(destination);
+
+        /// <summary>
+        /// Gets the current computed hash value without modifying accumulated state.
+        /// </summary>
+        /// <returns>The hash value for the data already provided.</returns>
+        public ulong GetCurrentHashAsUInt64() => _uCRC;
+
+        /// <summary>
+        /// Computes the Azure Storage CRC-64 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The computed Azure Storage CRC-64 hash.</returns>
+        public static ulong HashToUInt64(ReadOnlySpan<byte> source)
+        {
+            return StorageCrc64Calculator.ComputeSlicedSafe(source, uCrc: 0);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/StorageCrc64NonCryptographicHashAlgorithmTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageCrc64NonCryptographicHashAlgorithmTests.cs
@@ -12,6 +12,40 @@ namespace Azure.Storage.Tests
 {
     public class StorageCrc64NonCryptographicHashAlgorithmTests
     {
+        private static readonly byte[] TestVectorBytes = Encoding.UTF8.GetBytes("Hello, World!");
+        private const ulong TestVectorExpectedCrc64 = 0xd4a9be4326add24d;
+
+        [Test]
+        public void StorageHashAlgorithm_GetCurrentHash()
+        {
+            var calculator = StorageCrc64HashAlgorithm.Create();
+            calculator.Append(TestVectorBytes);
+
+            byte[] actual = calculator.GetCurrentHash();
+            byte[] expected = BitConverter.GetBytes(TestVectorExpectedCrc64);
+
+            Assert.IsTrue(Enumerable.SequenceEqual(expected, actual));
+        }
+
+        [Test]
+        public void StorageHashAlgorithm_GetCurrentHashAsUInt64()
+        {
+            var calculator = StorageCrc64HashAlgorithm.Create();
+            calculator.Append(TestVectorBytes);
+
+            ulong actual = calculator.GetCurrentHashAsUInt64();
+
+            Assert.AreEqual(TestVectorExpectedCrc64, actual);
+        }
+
+        [Test]
+        public void StorageHashAlgorithm_HashToUInt64()
+        {
+            ulong actual = StorageCrc64HashAlgorithm.HashToUInt64(TestVectorBytes);
+
+            Assert.AreEqual(TestVectorExpectedCrc64, actual);
+        }
+
         [Test]
         public void UpdateHashManualAppends()
         {


### PR DESCRIPTION
## Introduction

This introduces a simple single-shot hashing method on the `StorageCrc64HashAlgorithm` to produce `UInt64` hashes directly:

```csharp
ulong StorageCrc64HashAlgorithm.HashToUInt64(ReadOnlySpan<byte> source);
```

This is a common pattern, first introduced and implemented in the BCL itself, designed to simplify usage of hash algorithms and improve performance for common one-shot hashing scenarios.  Implementing this pattern here in the Azure SDK makes usage more consistent with the hash algorithms available in `System.IO.Hashing`, and offers an easier mechanism for customers to compute a CRC-64 over their data.

For more context, see:
 - https://github.com/dotnet/runtime/issues/76279
 - https://github.com/dotnet/runtime/pull/78075


## Test Results

I've added basic tests to verify this functionality, covering the existing `GetCurrentHash` method and demonstrating the new simplified methods to access the accumulated `UInt64` hash.

```bash
> dotnet test Azure.Storage.Common.Tests.dll --filter "StorageCrc64NonCryptographicHashAlgorithmTests" --verbosity:normal

Starting test execution, please wait...
  Passed StorageHashAlgorithm_GetCurrentHash [46 ms]
  Passed StorageHashAlgorithm_GetCurrentHashAsUInt64 [10 ms]
  Passed StorageHashAlgorithm_HashToUInt64 [< 1 ms]
  Passed UpdateHashManualAppends [231 ms]

Test Run Successful.
Total tests: 4
     Passed: 4
 Total time: 1.5579 Seconds
```