### PR TITLE
[Storage][DataMovement] Make extension methods follow LRO pattern

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/README.md
+++ b/sdk/storage/Azure.Storage.Blobs/README.md
@@ -194,14 +194,14 @@ For more advanced scenarios like transferring blob virtual directories, we recom
 
 Upload a local directory to the root of the `BlobContainerClient`.
 ```C# Snippet:ExtensionMethodSimpleUploadToRoot
-TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath);
+TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath);
 
 await transfer.WaitForCompletionAsync();
 ```
 
 Upload a local directory to a virtual blob directory in the `BlobContainerClient` by specifying a directory prefix
 ```C# Snippet:ExtensionMethodSimpleUploadToDirectoryPrefix
-TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath, blobDirectoryPrefix);
+TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath, blobDirectoryPrefix);
 
 await transfer.WaitForCompletionAsync();
 ```
@@ -220,21 +220,21 @@ BlobContainerClientTransferOptions options = new BlobContainerClientTransferOpti
     }
 };
 
-TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath, options);
+TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath, options);
 
 await transfer.WaitForCompletionAsync();
 ```
 
 Download the entire `BlobContainerClient` to a local directory
 ```C# Snippet:ExtensionMethodSimpleDownloadContainer
-TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath);
+TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath);
 
 await transfer.WaitForCompletionAsync();
 ```
 
 Download a virtual blob directory in the `BlobContainerClient` by specifying a directory prefix
 ```C# Snippet:ExtensionMethodSimpleDownloadContainerDirectory
-TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath2, blobDirectoryPrefix);
+TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath2, blobDirectoryPrefix);
 
 await transfer.WaitForCompletionAsync();
 ```
@@ -253,7 +253,7 @@ BlobContainerClientTransferOptions options = new BlobContainerClientTransferOpti
     }
 };
 
-TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath2, options);
+TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath2, options);
 
 await transfer.WaitForCompletionAsync();
 ```

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 ### Breaking Changes
+- Changed `BlobContainerClient.StartUploadDirectoryAsync` to `BlobContainerClient.UploadDirectoryAsync` and added a required `waitUntil` parameter.
+- Changed `BlobContainerClient.StartDownloadToDirectoryAsync` to `BlobContainerClient.DownloadToDirectoryAsync` and added a required `waitUntil` parameter.
 
 ### Bugs Fixed
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/README.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/README.md
@@ -239,14 +239,14 @@ BlobContainerClient container = service.GetBlobContainerClient(containerName);
 
 Upload a local directory to the root of the container
 ```C# Snippet:ExtensionMethodSimpleUploadToRoot
-TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath);
+TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath);
 
 await transfer.WaitForCompletionAsync();
 ```
 
 Upload a local directory to a virtual directory in the container by specifying a directory prefix
 ```C# Snippet:ExtensionMethodSimpleUploadToDirectoryPrefix
-TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath, blobDirectoryPrefix);
+TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath, blobDirectoryPrefix);
 
 await transfer.WaitForCompletionAsync();
 ```
@@ -265,21 +265,21 @@ BlobContainerClientTransferOptions options = new BlobContainerClientTransferOpti
     }
 };
 
-TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath, options);
+TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath, options);
 
 await transfer.WaitForCompletionAsync();
 ```
 
 Download the entire container to a local directory
 ```C# Snippet:ExtensionMethodSimpleDownloadContainer
-TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath);
+TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath);
 
 await transfer.WaitForCompletionAsync();
 ```
 
 Download a directory in the container by specifying a directory prefix
 ```C# Snippet:ExtensionMethodSimpleDownloadContainerDirectory
-TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath2, blobDirectoryPrefix);
+TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath2, blobDirectoryPrefix);
 
 await transfer.WaitForCompletionAsync();
 ```
@@ -298,7 +298,7 @@ BlobContainerClientTransferOptions options = new BlobContainerClientTransferOpti
     }
 };
 
-TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath2, options);
+TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath2, options);
 
 await transfer.WaitForCompletionAsync();
 ```

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net6.0.cs
@@ -2,10 +2,10 @@ namespace Azure.Storage.Blobs
 {
     public static partial class BlobContainerClientExtensions
     {
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartDownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartDownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, string blobDirectoryPrefix = null) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartUploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartUploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, string blobDirectoryPrefix = null) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> DownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> DownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, string blobDirectoryPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> UploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> UploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, string blobDirectoryPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace Azure.Storage.DataMovement.Blobs

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net8.0.cs
@@ -2,10 +2,10 @@ namespace Azure.Storage.Blobs
 {
     public static partial class BlobContainerClientExtensions
     {
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartDownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartDownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, string blobDirectoryPrefix = null) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartUploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartUploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, string blobDirectoryPrefix = null) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> DownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> DownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, string blobDirectoryPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> UploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> UploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, string blobDirectoryPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace Azure.Storage.DataMovement.Blobs

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.0.cs
@@ -2,10 +2,10 @@ namespace Azure.Storage.Blobs
 {
     public static partial class BlobContainerClientExtensions
     {
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartDownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartDownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, string blobDirectoryPrefix = null) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartUploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartUploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, string localDirectoryPath, string blobDirectoryPrefix = null) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> DownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> DownloadToDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, string blobDirectoryPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> UploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, Azure.Storage.DataMovement.Blobs.BlobContainerClientTransferOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> UploadDirectoryAsync(this Azure.Storage.Blobs.BlobContainerClient client, Azure.WaitUntil waitUntil, string localDirectoryPath, string blobDirectoryPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace Azure.Storage.DataMovement.Blobs

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_3132ba5d1c"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_ce7e1f61c3"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/samples/Sample01b_HelloWorldAsync.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/samples/Sample01b_HelloWorldAsync.cs
@@ -1006,7 +1006,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 {
                     // upload files to the root of the container
                     #region Snippet:ExtensionMethodSimpleUploadToRoot
-                    TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath);
+                    TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath);
 
                     await transfer.WaitForCompletionAsync();
                     #endregion
@@ -1014,7 +1014,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 {
                     // upload files with to a specific directory prefix
                     #region Snippet:ExtensionMethodSimpleUploadToDirectoryPrefix
-                    TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath, blobDirectoryPrefix);
+                    TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath, blobDirectoryPrefix);
 
                     await transfer.WaitForCompletionAsync();
                     #endregion
@@ -1033,7 +1033,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                         }
                     };
 
-                    TransferOperation transfer = await container.StartUploadDirectoryAsync(localPath, options);
+                    TransferOperation transfer = await container.UploadDirectoryAsync(WaitUntil.Started, localPath, options);
 
                     await transfer.WaitForCompletionAsync();
                     #endregion
@@ -1076,7 +1076,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 {
                     // download the entire container to the local directory
                     #region Snippet:ExtensionMethodSimpleDownloadContainer
-                    TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath);
+                    TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath);
 
                     await transfer.WaitForCompletionAsync();
                     #endregion
@@ -1084,7 +1084,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 {
                     // download a virtual directory, with a specific prefix, within the container
                     #region Snippet:ExtensionMethodSimpleDownloadContainerDirectory
-                    TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath2, blobDirectoryPrefix);
+                    TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath2, blobDirectoryPrefix);
 
                     await transfer.WaitForCompletionAsync();
                     #endregion
@@ -1103,7 +1103,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                         }
                     };
 
-                    TransferOperation transfer = await container.StartDownloadToDirectoryAsync(localDirectoryPath2, options);
+                    TransferOperation transfer = await container.DownloadToDirectoryAsync(WaitUntil.Started, localDirectoryPath2, options);
 
                     await transfer.WaitForCompletionAsync();
                     #endregion

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientExtensions.cs
@@ -24,7 +24,17 @@ namespace Azure.Storage.Blobs
         /// <param name="waitUntil">Indicates whether this invocation should wait until the transfer is complete to return or return immediately.</param>
         /// <param name="localDirectoryPath">The full path to the local directory to be uploaded.</param>
         /// <param name="blobDirectoryPrefix">Optionally specifies the directory prefix to be prepended to all uploaded files.</param>
-        /// <returns>A <see cref="TransferOperation"/> instance which can be used track progress and wait for completion with <see cref="TransferOperation.WaitForCompletionAsync"/>.</returns>
+        /// <returns>
+        /// A <see cref="TransferOperation"/> instance which contains information about the transfer and its status.
+        /// If <paramref name="waitUntil"/> was set to <see cref="WaitUntil.Started"/>, this method will return immediately
+        /// and <see cref="TransferOperation.WaitForCompletionAsync"/> can be used to wait for the transfer to complete.
+        /// </returns>
+        /// <remarks>
+        /// This is an async long-running operation which means once the transfer is complete, regardless of the value of <paramref name="waitUntil"/>,
+        /// the caller should check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
+        /// completed successfully or not.
+        /// This will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
+        /// </remarks>
         public static Task<TransferOperation> UploadDirectoryAsync(
             this BlobContainerClient client,
             WaitUntil waitUntil,
@@ -49,7 +59,17 @@ namespace Azure.Storage.Blobs
         /// <param name="waitUntil">Indicates whether this invocation should wait until the transfer is complete to return or return immediately.</param>
         /// <param name="localDirectoryPath">The full path to the local directory to be uploaded.</param>
         /// <param name="options">Options which control the directory upload.</param>
-        /// <returns>A <see cref="TransferOperation"/> instance which can be used track progress and wait for completion with <see cref="TransferOperation.WaitForCompletionAsync"/>.</returns>
+        /// <returns>
+        /// A <see cref="TransferOperation"/> instance which contains information about the transfer and its status.
+        /// If <paramref name="waitUntil"/> was set to <see cref="WaitUntil.Started"/>, this method will return immediately
+        /// and <see cref="TransferOperation.WaitForCompletionAsync"/> can be used to wait for the transfer to complete.
+        /// </returns>
+        /// <remarks>
+        /// This is an async long-running operation which means once the transfer is complete, regardless of the value of <paramref name="waitUntil"/>,
+        /// the caller should check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
+        /// completed successfully or not.
+        /// This will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
+        /// </remarks>
         public static async Task<TransferOperation> UploadDirectoryAsync(this BlobContainerClient client, WaitUntil waitUntil, string localDirectoryPath, BlobContainerClientTransferOptions options)
         {
             StorageResource localDirectory = s_filesProvider.Value.FromDirectory(localDirectoryPath);
@@ -74,7 +94,17 @@ namespace Azure.Storage.Blobs
         /// <param name="waitUntil">Indicates whether this invocation should wait until the transfer is complete to return or return immediately.</param>
         /// <param name="localDirectoryPath">The full path to the local directory where files will be dowloaded.</param>
         /// <param name="blobDirectoryPrefix">Optionally restricts the downloaded content to blobs with the specified directory prefix.</param>
-        /// <returns></returns>
+        /// <returns>
+        /// A <see cref="TransferOperation"/> instance which contains information about the transfer and its status.
+        /// If <paramref name="waitUntil"/> was set to <see cref="WaitUntil.Started"/>, this method will return immediately
+        /// and <see cref="TransferOperation.WaitForCompletionAsync"/> can be used to wait for the transfer to complete.
+        /// </returns>
+        /// <remarks>
+        /// This is an async long-running operation which means once the transfer is complete, regardless of the value of <paramref name="waitUntil"/>,
+        /// the caller should check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
+        /// completed successfully or not.
+        /// This will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
+        /// </remarks>
         public static Task<TransferOperation> DownloadToDirectoryAsync(
             this BlobContainerClient client,
             WaitUntil waitUntil,
@@ -99,7 +129,17 @@ namespace Azure.Storage.Blobs
         /// <param name="waitUntil">Indicates whether this invocation should wait until the transfer is complete to return or return immediately.</param>
         /// <param name="localDirectoryPath">The full path to the local directory where files will be dowloaded.</param>
         /// <param name="options">Options which control the container download.</param>
-        /// <returns></returns>
+        /// <returns>
+        /// A <see cref="TransferOperation"/> instance which contains information about the transfer and its status.
+        /// If <paramref name="waitUntil"/> was set to <see cref="WaitUntil.Started"/>, this method will return immediately
+        /// and <see cref="TransferOperation.WaitForCompletionAsync"/> can be used to wait for the transfer to complete.
+        /// </returns>
+        /// <remarks>
+        /// This is an async long-running operation which means once the transfer is complete, regardless of the value of <paramref name="waitUntil"/>,
+        /// the caller should check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
+        /// completed successfully or not.
+        /// This will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
+        /// </remarks>
         public static async Task<TransferOperation> DownloadToDirectoryAsync(this BlobContainerClient client, WaitUntil waitUntil, string localDirectoryPath, BlobContainerClientTransferOptions options)
         {
             StorageResource localDirectory = s_filesProvider.Value.FromDirectory(localDirectoryPath);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientExtensions.cs
@@ -26,14 +26,14 @@ namespace Azure.Storage.Blobs
         /// <param name="blobDirectoryPrefix">Optionally specifies the directory prefix to be prepended to all uploaded files.</param>
         /// <returns>
         /// A <see cref="TransferOperation"/> instance which contains information about the transfer and its status.
-        /// If <paramref name="waitUntil"/> was set to <see cref="WaitUntil.Started"/>, this method will return immediately
-        /// and <see cref="TransferOperation.WaitForCompletionAsync"/> can be used to wait for the transfer to complete.
         /// </returns>
         /// <remarks>
-        /// This is an async long-running operation which means once the transfer is complete, regardless of the value of <paramref name="waitUntil"/>,
-        /// the caller should check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
-        /// completed successfully or not.
-        /// This will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
+        /// This is an async long-running operation which means the operation may not be complete when this methods returns. If <paramref name="waitUntil"/>
+        /// is set to <see cref="WaitUntil.Started"/>, the method will return as soon as a transfer is started and <see cref="TransferOperation.WaitForCompletionAsync"/>
+        /// can be used to wait for the transfer to complete. If <paramref name="waitUntil"/> is set to <see cref="WaitUntil.Completed"/>, the method will wait
+        /// for the entire transfer to complete.
+        /// In either case, the caller must check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
+        /// completed successfully or not. This method will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
         /// </remarks>
         public static Task<TransferOperation> UploadDirectoryAsync(
             this BlobContainerClient client,
@@ -61,14 +61,14 @@ namespace Azure.Storage.Blobs
         /// <param name="options">Options which control the directory upload.</param>
         /// <returns>
         /// A <see cref="TransferOperation"/> instance which contains information about the transfer and its status.
-        /// If <paramref name="waitUntil"/> was set to <see cref="WaitUntil.Started"/>, this method will return immediately
-        /// and <see cref="TransferOperation.WaitForCompletionAsync"/> can be used to wait for the transfer to complete.
         /// </returns>
         /// <remarks>
-        /// This is an async long-running operation which means once the transfer is complete, regardless of the value of <paramref name="waitUntil"/>,
-        /// the caller should check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
-        /// completed successfully or not.
-        /// This will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
+        /// This is an async long-running operation which means the operation may not be complete when this methods returns. If <paramref name="waitUntil"/>
+        /// is set to <see cref="WaitUntil.Started"/>, the method will return as soon as a transfer is started and <see cref="TransferOperation.WaitForCompletionAsync"/>
+        /// can be used to wait for the transfer to complete. If <paramref name="waitUntil"/> is set to <see cref="WaitUntil.Completed"/>, the method will wait
+        /// for the entire transfer to complete.
+        /// In either case, the caller must check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
+        /// completed successfully or not. This method will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
         /// </remarks>
         public static async Task<TransferOperation> UploadDirectoryAsync(this BlobContainerClient client, WaitUntil waitUntil, string localDirectoryPath, BlobContainerClientTransferOptions options)
         {
@@ -96,14 +96,14 @@ namespace Azure.Storage.Blobs
         /// <param name="blobDirectoryPrefix">Optionally restricts the downloaded content to blobs with the specified directory prefix.</param>
         /// <returns>
         /// A <see cref="TransferOperation"/> instance which contains information about the transfer and its status.
-        /// If <paramref name="waitUntil"/> was set to <see cref="WaitUntil.Started"/>, this method will return immediately
-        /// and <see cref="TransferOperation.WaitForCompletionAsync"/> can be used to wait for the transfer to complete.
         /// </returns>
         /// <remarks>
-        /// This is an async long-running operation which means once the transfer is complete, regardless of the value of <paramref name="waitUntil"/>,
-        /// the caller should check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
-        /// completed successfully or not.
-        /// This will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
+        /// This is an async long-running operation which means the operation may not be complete when this methods returns. If <paramref name="waitUntil"/>
+        /// is set to <see cref="WaitUntil.Started"/>, the method will return as soon as a transfer is started and <see cref="TransferOperation.WaitForCompletionAsync"/>
+        /// can be used to wait for the transfer to complete. If <paramref name="waitUntil"/> is set to <see cref="WaitUntil.Completed"/>, the method will wait
+        /// for the entire transfer to complete.
+        /// In either case, the caller must check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
+        /// completed successfully or not. This method will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
         /// </remarks>
         public static Task<TransferOperation> DownloadToDirectoryAsync(
             this BlobContainerClient client,
@@ -131,14 +131,14 @@ namespace Azure.Storage.Blobs
         /// <param name="options">Options which control the container download.</param>
         /// <returns>
         /// A <see cref="TransferOperation"/> instance which contains information about the transfer and its status.
-        /// If <paramref name="waitUntil"/> was set to <see cref="WaitUntil.Started"/>, this method will return immediately
-        /// and <see cref="TransferOperation.WaitForCompletionAsync"/> can be used to wait for the transfer to complete.
         /// </returns>
         /// <remarks>
-        /// This is an async long-running operation which means once the transfer is complete, regardless of the value of <paramref name="waitUntil"/>,
-        /// the caller should check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
-        /// completed successfully or not.
-        /// This will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
+        /// This is an async long-running operation which means the operation may not be complete when this methods returns. If <paramref name="waitUntil"/>
+        /// is set to <see cref="WaitUntil.Started"/>, the method will return as soon as a transfer is started and <see cref="TransferOperation.WaitForCompletionAsync"/>
+        /// can be used to wait for the transfer to complete. If <paramref name="waitUntil"/> is set to <see cref="WaitUntil.Completed"/>, the method will wait
+        /// for the entire transfer to complete.
+        /// In either case, the caller must check the status of the transfer using the returned <see cref="TransferOperation"/> instance to determine if the transfer
+        /// completed successfully or not. This method will not throw an exception if the transfer fails, but the <see cref="TransferOperation.Status"/> will indicate a failure.
         /// </remarks>
         public static async Task<TransferOperation> DownloadToDirectoryAsync(this BlobContainerClient client, WaitUntil waitUntil, string localDirectoryPath, BlobContainerClientTransferOptions options)
         {

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientTransferOptions.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading;
 using Azure.Storage.Blobs;
 
 namespace Azure.Storage.DataMovement.Blobs
 {
     /// <summary>
     /// Options applying to data transfer uploads and downloads using the <see cref="BlobContainerClient"/> extension methods
-    /// <see cref="BlobContainerClientExtensions.DownloadToDirectoryAsync(BlobContainerClient, WaitUntil, string, BlobContainerClientTransferOptions)"/> and
-    /// <see cref="BlobContainerClientExtensions.UploadDirectoryAsync(BlobContainerClient, WaitUntil, string, BlobContainerClientTransferOptions)"/>.
+    /// <see cref="BlobContainerClientExtensions.DownloadToDirectoryAsync(BlobContainerClient, WaitUntil, string, BlobContainerClientTransferOptions, CancellationToken)"/> and
+    /// <see cref="BlobContainerClientExtensions.UploadDirectoryAsync(BlobContainerClient, WaitUntil, string, BlobContainerClientTransferOptions, CancellationToken)"/>.
     /// </summary>
     public class BlobContainerClientTransferOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientTransferOptions.cs
@@ -7,8 +7,8 @@ namespace Azure.Storage.DataMovement.Blobs
 {
     /// <summary>
     /// Options applying to data transfer uploads and downloads using the <see cref="BlobContainerClient"/> extension methods
-    /// <see cref="BlobContainerClientExtensions.StartDownloadToDirectoryAsync(BlobContainerClient, string, BlobContainerClientTransferOptions)"/> and
-    /// <see cref="BlobContainerClientExtensions.StartUploadDirectoryAsync(BlobContainerClient, string, BlobContainerClientTransferOptions)"/>.
+    /// <see cref="BlobContainerClientExtensions.DownloadToDirectoryAsync(BlobContainerClient, WaitUntil, string, BlobContainerClientTransferOptions)"/> and
+    /// <see cref="BlobContainerClientExtensions.UploadDirectoryAsync(BlobContainerClient, WaitUntil, string, BlobContainerClientTransferOptions)"/>.
     /// </summary>
     public class BlobContainerClientTransferOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobContainerClientExtensionsIntegrationTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobContainerClientExtensionsIntegrationTests.cs
@@ -69,7 +69,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             bool createFailedCondition = false,
             TransferOptions options = default,
             int size = Constants.KB,
-            WaitUntil waitUntil = WaitUntil.Started)
+            WaitUntil waitUntil = WaitUntil.Started,
+            CancellationToken cancellationToken = default)
         {
             await CreateTempDirectoryStructureAsync(directoryPath, size);
             BlobContainerClientTransferOptions transferOptions = new BlobContainerClientTransferOptions
@@ -86,7 +87,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
                     size: size);
             }
 
-            return await containerClient.UploadDirectoryAsync(waitUntil, directoryPath, transferOptions);
+            return await containerClient.UploadDirectoryAsync(waitUntil, directoryPath, transferOptions, cancellationToken);
         }
 
         private async Task<TransferOperation> CreateStartUploadDirectoryAsync_WithDirectoryPrefix(
@@ -259,11 +260,13 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             TestEventsRaised testEventsRaised = new(options);
 
             // Act
+            CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(30));
             TransferOperation transferOperation = await CreateStartUploadDirectoryAsync_WithOptions(
                 directoryPath,
                 containerClient,
                 options: options,
-                waitUntil: WaitUntil.Completed);
+                waitUntil: WaitUntil.Completed,
+                cancellationToken: cancellationTokenSource.Token);
 
             // Assert
             Assert.IsNotNull(transferOperation);
@@ -301,7 +304,8 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             BlobContainerClient containerClient,
             TransferOptions options = default,
             int size = Constants.KB,
-            WaitUntil waitUntil = WaitUntil.Started)
+            WaitUntil waitUntil = WaitUntil.Started,
+            CancellationToken cancellationToken = default)
         {
             string sourceBlobPrefix = "sourceFolder";
             string sourceLocalFolderPath = CreateRandomDirectory(Path.GetTempPath(), sourceBlobPrefix);
@@ -312,7 +316,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
                 TransferOptions = options,
             };
 
-            return await containerClient.DownloadToDirectoryAsync(waitUntil, directoryPath, transferOptions);
+            return await containerClient.DownloadToDirectoryAsync(waitUntil, directoryPath, transferOptions, cancellationToken);
         }
 
         private async Task<TransferOperation> CreateStartDownloadToDirectoryAsync_WithDirectoryPrefix(
@@ -487,11 +491,13 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             TestEventsRaised testEventsRaised = new(options);
 
             // Act
+            CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(30));
             TransferOperation transferOperation = await CreateStartDownloadToDirectoryAsync_WithOptions(
                 directoryPath,
                 containerClient,
                 options: options,
-                waitUntil: WaitUntil.Completed);
+                waitUntil: WaitUntil.Completed,
+                cancellationToken: cancellationTokenSource.Token);
 
             // Assert
             Assert.NotNull(transferOperation);

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobContainerClientExtensionsTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobContainerClientExtensionsTests.cs
@@ -66,7 +66,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
 
             if (addTransferOptions)
             {
-                await client.StartUploadDirectoryAsync(directoryPath, new BlobContainerClientTransferOptions
+                await client.UploadDirectoryAsync(WaitUntil.Started, directoryPath, new BlobContainerClientTransferOptions
                 {
                     BlobContainerOptions = new() { BlobDirectoryPrefix = blobDirectoryPrefix },
                     TransferOptions = options
@@ -74,7 +74,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             }
             else
             {
-                await client.StartUploadDirectoryAsync(directoryPath, blobDirectoryPrefix);
+                await client.UploadDirectoryAsync(WaitUntil.Started, directoryPath, blobDirectoryPrefix);
             }
 
             Assert.IsTrue(assertionComplete);
@@ -113,7 +113,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
 
             if (addTransferOptions)
             {
-                await client.StartDownloadToDirectoryAsync(directoryPath, new BlobContainerClientTransferOptions
+                await client.DownloadToDirectoryAsync(WaitUntil.Started, directoryPath, new BlobContainerClientTransferOptions
                 {
                     BlobContainerOptions = new() { BlobDirectoryPrefix = blobDirectoryPrefix },
                     TransferOptions = options
@@ -121,7 +121,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             }
             else
             {
-                await client.StartDownloadToDirectoryAsync(directoryPath, blobDirectoryPrefix);
+                await client.DownloadToDirectoryAsync(WaitUntil.Started, directoryPath, blobDirectoryPrefix);
             }
 
             Assert.IsTrue(assertionComplete);

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
@@ -139,7 +139,7 @@ namespace Azure.Storage.DataMovement
                 FailedCount = _failedCount,
                 InProgressCount = _inProgressCount,
                 QueuedCount = _queuedCount,
-                BytesTransferred = _options.TrackBytesTransferred ? _bytesTransferred : null
+                BytesTransferred = _options?.TrackBytesTransferred == true ? _bytesTransferred : null
             };
             _options?.ProgressHandler?.Report(progress);
 


### PR DESCRIPTION
This change makes the `BlobContainerClient` extension methods follow the LRO pattern established by Azure.Core by including a `WaitUntil` parameter and having the method not return until the transfer is complete if the user passes `WaitUntil.Completed`. Also added an optional cancellation token since the method can now wait for entire transfers.

Also fixes a bug in `TransferProgressTracker`.