### PR TITLE
[CODEOWNERS] Adding owners for AI Projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,11 +80,20 @@
 # ServiceLabel: %AAD
 # ServiceOwners:                                                   @adamedx
 
+# PRLabel: %AI Model Inference %AI Projects
+/sdk/ai/                                                          @trangevi @dargilco @jhakulin @glharper @nick863 @jhakulin
+
 # PRLabel: %AI Model Inference
-/sdk/ai/                                                           @trangevi @dargilco @jhakulin @glharper
+/sdk/ai/Azure.AI.Inference                                         @trangevi @dargilco @jhakulin @glharper
 
 # ServiceLabel: %AI Model Inference
 # ServiceOwners:                                                   @trangevi @dargilco @jhakulin @glharper
+
+# PRLabel: %AI Projects
+/sdk/ai/Azure.AI.Projects                                          @nick863 @jhakulin
+
+# ServiceLabel: %AI Projects
+# ServiceOwners:                                                   @nick863 @jhakulin
 
 # ServiceLabel: %AKS
 # ServiceOwners:                                                   @Azure/aks-pm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,7 +81,7 @@
 # ServiceOwners:                                                   @adamedx
 
 # PRLabel: %AI Model Inference %AI Projects
-/sdk/ai/                                                           @trangevi @dargilco @jhakulin @glharper @nick863 @jhakulin
+/sdk/ai/                                                           @trangevi @dargilco @jhakulin @glharper @jhakulin
 
 # PRLabel: %AI Model Inference
 /sdk/ai/Azure.AI.Inference                                         @trangevi @dargilco @jhakulin @glharper
@@ -90,10 +90,10 @@
 # ServiceOwners:                                                   @trangevi @dargilco @jhakulin @glharper
 
 # PRLabel: %AI Projects
-/sdk/ai/Azure.AI.Projects                                          @nick863 @jhakulin
+/sdk/ai/Azure.AI.Projects                                          @jhakulin
 
 # ServiceLabel: %AI Projects
-# ServiceOwners:                                                   @nick863 @jhakulin
+# ServiceOwners:                                                   @dargilco @jhakulin
 
 # ServiceLabel: %AKS
 # ServiceOwners:                                                   @Azure/aks-pm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,7 +81,7 @@
 # ServiceOwners:                                                   @adamedx
 
 # PRLabel: %AI Model Inference %AI Projects
-/sdk/ai/                                                          @trangevi @dargilco @jhakulin @glharper @nick863 @jhakulin
+/sdk/ai/                                                           @trangevi @dargilco @jhakulin @glharper @nick863 @jhakulin
 
 # PRLabel: %AI Model Inference
 /sdk/ai/Azure.AI.Inference                                         @trangevi @dargilco @jhakulin @glharper


### PR DESCRIPTION
# Summary

The focus of these changes is to add owners for the AI Projects library and refocus the root /sdk/ai path such that it alerts both sub-packages for changes.
