### PR TITLE
[CODEOWNERS] Remove invalid owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -581,7 +581,7 @@
 
 # ServiceLabel: %KeyVault
 # AzureSdkOwners:                                                  @JonathanCrd
-# ServiceOwners:                                                   @RandalliLama @jlichwa
+# ServiceOwners:                                                   @RandalliLama
 
 # ServiceLabel: %Kubernetes Configuration
 # ServiceOwners:                                                   @NarayanThiru


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner who is being flagged as no longer valid by the linter.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4479672&view=results) _(Microsoft internal)_