### PR TITLE
[Cloud Machine] Fix code to generate correct Bicep for Storage and OpenAI

### DIFF
--- a/sdk/cloudmachine/Azure.CloudMachine.OpenAI/src/OpenAIModelFeature.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine.OpenAI/src/OpenAIModelFeature.cs
@@ -118,7 +118,7 @@ public class OpenAIModelFeature : CloudMachineFeature
             },
             Sku = new CognitiveServicesSku
             {
-                Capacity = 120,
+                Capacity = 10,
                 Name = "Standard"
             },
         };

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/src/FeaturesBuiltIn/StorageAccountFeature.cs
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/src/FeaturesBuiltIn/StorageAccountFeature.cs
@@ -30,6 +30,7 @@ internal class StorageAccountFeature : CloudMachineFeature
             Sku = new StorageSku { Name = _skuName },
             IsHnsEnabled = true,
             AllowBlobPublicAccess = false,
+            AllowSharedKeyAccess = false,
             Identity = new()
             {
                 ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned,

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/GenerateBicep.bicep
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/GenerateBicep.bicep
@@ -18,8 +18,8 @@ resource cm_storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   properties: {
     allowBlobPublicAccess: false
-    isHnsEnabled: true
     allowSharedKeyAccess: false
+    isHnsEnabled: true
   }
   identity: {
     type: 'UserAssigned'
@@ -329,7 +329,7 @@ resource openai_cm0c420d2f21084cd_chat 'Microsoft.CognitiveServices/accounts/dep
   }
   sku: {
     name: 'Standard'
-    capacity: 120
+    capacity: 10
   }
   parent: openai
 }
@@ -347,7 +347,7 @@ resource openai_cm0c420d2f21084cd_embedding 'Microsoft.CognitiveServices/account
   }
   sku: {
     name: 'Standard'
-    capacity: 120
+    capacity: 10
   }
   parent: openai
   dependsOn: [

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/GenerateBicep.bicep
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/GenerateBicep.bicep
@@ -19,6 +19,7 @@ resource cm_storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   properties: {
     allowBlobPublicAccess: false
     isHnsEnabled: true
+    allowSharedKeyAccess: false
   }
   identity: {
     type: 'UserAssigned'

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/JustCloudMachine.bicep
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/JustCloudMachine.bicep
@@ -18,8 +18,8 @@ resource cm_storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   properties: {
     allowBlobPublicAccess: false
-    isHnsEnabled: true
     allowSharedKeyAccess: false
+    isHnsEnabled: true
   }
   identity: {
     type: 'UserAssigned'

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/JustCloudMachine.bicep
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/JustCloudMachine.bicep
@@ -19,6 +19,7 @@ resource cm_storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   properties: {
     allowBlobPublicAccess: false
     isHnsEnabled: true
+    allowSharedKeyAccess: false
   }
   identity: {
     type: 'UserAssigned'

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/OpenAI.bicep
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/OpenAI.bicep
@@ -19,6 +19,7 @@ resource cm_storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   properties: {
     allowBlobPublicAccess: false
     isHnsEnabled: true
+    allowSharedKeyAccess: false
   }
   identity: {
     type: 'UserAssigned'
@@ -283,7 +284,7 @@ resource openai_cm0c420d2f21084cd_chat 'Microsoft.CognitiveServices/accounts/dep
   }
   sku: {
     name: 'Standard'
-    capacity: 120
+    capacity: 10
   }
   parent: openai
 }
@@ -301,7 +302,7 @@ resource openai_cm0c420d2f21084cd_embedding 'Microsoft.CognitiveServices/account
   }
   sku: {
     name: 'Standard'
-    capacity: 120
+    capacity: 10
   }
   parent: openai
   dependsOn: [

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/OpenAI.bicep
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/tests/Data/OpenAI.bicep
@@ -18,8 +18,8 @@ resource cm_storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   properties: {
     allowBlobPublicAccess: false
-    isHnsEnabled: true
     allowSharedKeyAccess: false
+    isHnsEnabled: true
   }
   identity: {
     type: 'UserAssigned'


### PR DESCRIPTION
Fixing the below issues in the bicep
* Storage -
>Deployment Error Details:
InvalidTemplateDeployment: The template deployment failed because of policy violation. Please see details for more information.
RequestDisallowedByPolicy: Resource 'ResourceName' was disallowed by policy. Policy identifiers: '[{"policyAssignment":{"name":"Storage accounts should prevent shared key access","id":"/subscriptions/[SubscriptionsId]/providers/Microsoft.Authorization/policyAssignments/6c0a51d8da734301903f967a"},"policyDefinition":{"name":"Storage accounts should prevent shared key access","id":"/providers/Microsoft.Authorization/policyDefinitions/8c6a50c6-9ffd-4ae7-986f-5fa6111f9a54"}}]'.

* OpenAI -
>Deployment Error Details:
InvalidTemplateDeployment: The template deployment 'cm' is not valid according to the validation procedure. The tracking id is '[ID]'. See inner errors for details.
InsufficientQuota: This operation require 120 new capacity in quota Tokens Per Minute (thousands) - gpt-4o-mini, which is bigger than the current available capacity 10. The current quota usage is 440 and the quota limit is 450 for quota Tokens Per Minute (thousands) - gpt-4o-mini.