### PR TITLE
Improve Azure Identity credential env var docs

### DIFF
--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -272,7 +272,11 @@ Not all credentials require this configuration. Credentials that authenticate th
 
 [`DefaultAzureCredential`][ref_DefaultAzureCredential] and [`EnvironmentCredential`][ref_EnvironmentCredential] can be configured with environment variables. Each type of authentication requires values for specific variables.
 
-### Service principal with secret
+### EnvironmentCredential
+
+Configuration is attempted in the order in which these environment variables are listed. For example, if values for a client secret and certificate are both present, the client secret is used by `EnvironmentCredential`.
+
+#### Service principal with secret
 
 |Variable name|Value
 |-|-
@@ -280,7 +284,7 @@ Not all credentials require this configuration. Credentials that authenticate th
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_SECRET`|one of the application's client secrets
 
-### Service principal with certificate
+#### Service principal with certificate
 
 |Variable name|Value
 |-|-
@@ -290,7 +294,7 @@ Not all credentials require this configuration. Credentials that authenticate th
 |`AZURE_CLIENT_CERTIFICATE_PASSWORD`|(optional) the password protecting the certificate file (currently only supported for PFX (PKCS12) certificates)
 |`AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`|(optional) send certificate chain in x5c header to support subject name / issuer based authentication
 
-### Username and password
+#### Username and password
 
 |Variable name|Value
 |-|-
@@ -299,13 +303,21 @@ Not all credentials require this configuration. Credentials that authenticate th
 |`AZURE_USERNAME`|a username (usually an email address)
 |`AZURE_PASSWORD`|that user's password
 
-### Managed identity (`DefaultAzureCredential`)
+### DefaultAzureCredential
 
-|Variable name|Value
+When the following environment variables are set, `DefaultAzureCredentialOptions` uses them as default values for the corresponding properties.
+
+#### Managed identity
+
+|Variable name|Value|Property
 |-|-
-|`AZURE_CLIENT_ID`|The client ID for the user-assigned managed identity. If defined, used as the default value for `ManagedIdentityClientId` in `DefaultAzureCredentialOptions`
+|`AZURE_CLIENT_ID`|The client ID for the user-assigned managed identity.|`ManagedIdentityClientId`
 
-Configuration is attempted in the order in which these environment variables are listed. For example, if values for a client secret and certificate are both present, the client secret is used.
+#### Workload identity
+
+|Variable name|Value|Property
+|-|-
+|`AZURE_CLIENT_ID`|The client ID of the application the workload identity will authenticate.|`WorkloadIdentityClientId`
 
 ## Continuous Access Evaluation
 

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -270,13 +270,9 @@ Not all credentials require this configuration. Credentials that authenticate th
 
 ## Environment variables
 
-[`DefaultAzureCredential`][ref_DefaultAzureCredential] and [`EnvironmentCredential`][ref_EnvironmentCredential] can be configured with environment variables. Each type of authentication requires values for specific variables.
+[`DefaultAzureCredential`][ref_DefaultAzureCredential] and [`EnvironmentCredential`][ref_EnvironmentCredential] can be configured with environment variables. Each type of authentication requires values for specific variables. Configuration is attempted in the order in which these environment variables are listed. For example, if values for a client secret and certificate are both present, the client secret is used by `EnvironmentCredential`.
 
-### EnvironmentCredential
-
-Configuration is attempted in the order in which these environment variables are listed. For example, if values for a client secret and certificate are both present, the client secret is used by `EnvironmentCredential`.
-
-#### Service principal with secret
+### Service principal with secret
 
 |Variable name|Value
 |-|-
@@ -284,7 +280,7 @@ Configuration is attempted in the order in which these environment variables are
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_SECRET`|one of the application's client secrets
 
-#### Service principal with certificate
+### Service principal with certificate
 
 |Variable name|Value
 |-|-
@@ -294,7 +290,7 @@ Configuration is attempted in the order in which these environment variables are
 |`AZURE_CLIENT_CERTIFICATE_PASSWORD`|(optional) the password protecting the certificate file (currently only supported for PFX (PKCS12) certificates)
 |`AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`|(optional) send certificate chain in x5c header to support subject name / issuer based authentication
 
-#### Username and password
+### Username and password
 
 |Variable name|Value
 |-|-
@@ -303,21 +299,17 @@ Configuration is attempted in the order in which these environment variables are
 |`AZURE_USERNAME`|a username (usually an email address)
 |`AZURE_PASSWORD`|that user's password
 
-### DefaultAzureCredential
+### Workload identity (`DefaultAzureCredential`)
 
-When the following environment variables are set, `DefaultAzureCredentialOptions` uses them as default values for the corresponding properties.
-
-#### Managed identity
-
-|Variable name|Value|Property
+|Variable name|Value
 |-|-
-|`AZURE_CLIENT_ID`|The client ID for the user-assigned managed identity.|`ManagedIdentityClientId`
+|`AZURE_CLIENT_ID`|The client ID of the application the workload identity will authenticate. If defined, used as the default value for `WorkloadIdentityClientId` in `DefaultAzureCredentialOptions`.
 
-#### Workload identity
+### Managed identity (`DefaultAzureCredential`)
 
-|Variable name|Value|Property
+|Variable name|Value
 |-|-
-|`AZURE_CLIENT_ID`|The client ID of the application the workload identity will authenticate.|`WorkloadIdentityClientId`
+|`AZURE_CLIENT_ID`|The client ID for the user-assigned managed identity. If defined, used as the default value for `ManagedIdentityClientId` in `DefaultAzureCredentialOptions`.
 
 ## Continuous Access Evaluation
 

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -48,6 +48,9 @@ namespace Azure.Identity
         /// <summary>
         /// The ID of the tenant to which the credential will authenticate by default. If not specified, the credential will authenticate to any requested tenant, and will default to the tenant to which the chosen authentication method was originally authenticated.
         /// </summary>
+        /// <remarks>
+        /// This value can alternatively be set via environment variable <c>AZURE_TENANT_ID</c>.
+        /// </remarks>
         public string TenantId
         {
             get => _tenantId.Value;

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -49,7 +49,7 @@ namespace Azure.Identity
         /// The ID of the tenant to which the credential will authenticate by default. If not specified, the credential will authenticate to any requested tenant, and will default to the tenant to which the chosen authentication method was originally authenticated.
         /// </summary>
         /// <remarks>
-        /// This value can alternatively be set via environment variable <c>AZURE_TENANT_ID</c>.
+        /// Defaults to the value of environment variable <c>AZURE_TENANT_ID</c>.
         /// </remarks>
         public string TenantId
         {
@@ -172,7 +172,7 @@ namespace Azure.Identity
         /// If no value is specified for <see cref="TenantId"/>, this option will have no effect on that authentication method, and the credential will acquire tokens for any requested tenant when using that method.
         /// </summary>
         /// <remarks>
-        /// This value can alternatively be set via environment variable <c>AZURE_ADDITIONALLY_ALLOWED_TENANTS</c>.
+        /// Defaults to the value of environment variable <c>AZURE_ADDITIONALLY_ALLOWED_TENANTS</c>.
         /// </remarks>
         public IList<string> AdditionallyAllowedTenants { get; internal set; } = EnvironmentVariables.AdditionallyAllowedTenants;
 
@@ -183,7 +183,7 @@ namespace Azure.Identity
         /// <remarks>
         /// If multiple accounts are found in the shared token cache and no value is specified, or the specified value matches no accounts in
         /// the cache, the SharedTokenCacheCredential won't be used for authentication.
-        /// This value can alternatively be set via environment variable <c>AZURE_USERNAME</c>.
+        /// Defaults to the value of environment variable <c>AZURE_USERNAME</c>.
         /// </remarks>
         public string SharedTokenCacheUsername { get; set; } = EnvironmentVariables.Username;
 
@@ -196,7 +196,7 @@ namespace Azure.Identity
         /// Specifies the client ID of the application the workload identity will authenticate.
         /// </summary>
         /// <remarks>
-        /// This value can alternatively be set via environment variable <c>AZURE_CLIENT_ID</c>.
+        /// Defaults to the value of environment variable <c>AZURE_CLIENT_ID</c>.
         /// </remarks>
         public string WorkloadIdentityClientId { get; set; } = EnvironmentVariables.ClientId;
 
@@ -205,7 +205,7 @@ namespace Azure.Identity
         /// </summary>
         /// <remarks>
         /// If neither the <see cref="ManagedIdentityClientId"/> nor the <see cref="ManagedIdentityResourceId"/> property is set, then a system-assigned managed identity is used.
-        /// This value can alternatively be set via environment variable <c>AZURE_CLIENT_ID</c>.
+        /// Defaults to the value of environment variable <c>AZURE_CLIENT_ID</c>.
         /// </remarks>
         public string ManagedIdentityClientId { get; set; } = EnvironmentVariables.ClientId;
 
@@ -223,13 +223,13 @@ namespace Azure.Identity
         public TimeSpan? CredentialProcessTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// Specifies whether the <see cref="EnvironmentCredential"/> will be excluded from the authentication flow. Setting to true disables reading
+        /// Specifies whether the <see cref="EnvironmentCredential"/> will be excluded from the authentication flow. Setting to <c>true</c> disables reading
         /// authentication details from the process' environment variables.
         /// </summary>
         public bool ExcludeEnvironmentCredential { get; set; }
 
         /// <summary>
-        /// Specifies whether the <see cref="WorkloadIdentityCredential"/> will be excluded from the authentication flow. Setting to true disables reading
+        /// Specifies whether the <see cref="WorkloadIdentityCredential"/> will be excluded from the authentication flow. Setting to <c>true</c> disables reading
         /// authentication details from the process' environment variables.
         /// </summary>
         public bool ExcludeWorkloadIdentityCredential { get; set; }
@@ -247,7 +247,7 @@ namespace Azure.Identity
 
         /// <summary>
         /// Specifies whether the <see cref="SharedTokenCacheCredential"/> will be excluded from the <see cref="DefaultAzureCredential"/> authentication flow.
-        /// Setting to <c>true</c> disables single sign on authentication with development tools which write to the shared token cache.
+        /// Setting to <c>true</c> disables single sign-on authentication with development tools which write to the shared token cache.
         /// The default is <c>true</c>.
         /// </summary>
         public bool ExcludeSharedTokenCacheCredential { get; set; } = true;

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -81,12 +81,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// The tenant ID of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
+        /// The tenant id of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
         /// <see cref="InteractiveBrowserCredential"/>. The default is null and will authenticate users to their default tenant.
+        /// The value can also be set by setting the environment variable AZURE_TENANT_ID.
         /// </summary>
-        /// <remarks>
-        /// This value can alternatively be set via environment variable <c>AZURE_TENANT_ID</c>.
-        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string InteractiveBrowserTenantId
         {
@@ -126,12 +124,10 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// The tenant ID of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
+        /// The tenant id of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
         /// <see cref="VisualStudioCredential"/>. The default is null and will authenticate users to their default tenant.
+        /// The value can also be set by setting the environment variable AZURE_TENANT_ID.
         /// </summary>
-        /// <remarks>
-        /// This value can alternatively be set via environment variable <c>AZURE_TENANT_ID</c>.
-        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string VisualStudioTenantId
         {
@@ -150,10 +146,8 @@ namespace Azure.Identity
         /// <summary>
         /// The tenant ID of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
         /// <see cref="VisualStudioCodeCredential"/>. The default is null and will authenticate users to their default tenant.
+        /// The value can also be set by setting the environment variable AZURE_TENANT_ID.
         /// </summary>
-        /// <remarks>
-        /// This value can alternatively be set via environment variable <c>AZURE_TENANT_ID</c>.
-        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string VisualStudioCodeTenantId
         {

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -81,10 +81,12 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// The tenant id of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
+        /// The tenant ID of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
         /// <see cref="InteractiveBrowserCredential"/>. The default is null and will authenticate users to their default tenant.
-        /// The value can also be set by setting the environment variable AZURE_TENANT_ID.
         /// </summary>
+        /// <remarks>
+        /// This value can alternatively be set via environment variable <c>AZURE_TENANT_ID</c>.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string InteractiveBrowserTenantId
         {
@@ -101,7 +103,7 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Specifies the tenant id of the preferred authentication account, to be retrieved from the shared token cache for single sign on authentication with
+        /// Specifies the tenant ID of the preferred authentication account, to be retrieved from the shared token cache for single sign on authentication with
         /// development tools, in the case multiple accounts are found in the shared token.
         /// </summary>
         /// <remarks>
@@ -124,10 +126,12 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// The tenant id of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
+        /// The tenant ID of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
         /// <see cref="VisualStudioCredential"/>. The default is null and will authenticate users to their default tenant.
-        /// The value can also be set by setting the environment variable AZURE_TENANT_ID.
         /// </summary>
+        /// <remarks>
+        /// This value can alternatively be set via environment variable <c>AZURE_TENANT_ID</c>.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string VisualStudioTenantId
         {
@@ -146,8 +150,10 @@ namespace Azure.Identity
         /// <summary>
         /// The tenant ID of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
         /// <see cref="VisualStudioCodeCredential"/>. The default is null and will authenticate users to their default tenant.
-        /// The value can also be set by setting the environment variable AZURE_TENANT_ID.
         /// </summary>
+        /// <remarks>
+        /// This value can alternatively be set via environment variable <c>AZURE_TENANT_ID</c>.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string VisualStudioCodeTenantId
         {
@@ -167,8 +173,10 @@ namespace Azure.Identity
         /// Specifies tenants in addition to the specified <see cref="TenantId"/> for which the credential may acquire tokens.
         /// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant the logged in account can access.
         /// If no value is specified for <see cref="TenantId"/>, this option will have no effect on that authentication method, and the credential will acquire tokens for any requested tenant when using that method.
-        /// This value can also be set by setting the environment variable AZURE_ADDITIONALLY_ALLOWED_TENANTS.
         /// </summary>
+        /// <remarks>
+        /// This value can alternatively be set via environment variable <c>AZURE_ADDITIONALLY_ALLOWED_TENANTS</c>.
+        /// </remarks>
         public IList<string> AdditionallyAllowedTenants { get; internal set; } = EnvironmentVariables.AdditionallyAllowedTenants;
 
         /// <summary>
@@ -177,18 +185,22 @@ namespace Azure.Identity
         /// </summary>
         /// <remarks>
         /// If multiple accounts are found in the shared token cache and no value is specified, or the specified value matches no accounts in
-        /// the cache the SharedTokenCacheCredential will not be used for authentication.
+        /// the cache, the SharedTokenCacheCredential won't be used for authentication.
+        /// This value can alternatively be set via environment variable <c>AZURE_USERNAME</c>.
         /// </remarks>
         public string SharedTokenCacheUsername { get; set; } = EnvironmentVariables.Username;
 
         /// <summary>
-        /// Specifies the client id of the selected credential
+        /// Specifies the client ID of the selected credential.
         /// </summary>
         public string InteractiveBrowserCredentialClientId { get; set; }
 
         /// <summary>
-        /// Specifies the client id of the application the workload identity will authenticate.
+        /// Specifies the client ID of the application the workload identity will authenticate.
         /// </summary>
+        /// <remarks>
+        /// This value can alternatively be set via environment variable <c>AZURE_CLIENT_ID</c>.
+        /// </remarks>
         public string WorkloadIdentityClientId { get; set; } = EnvironmentVariables.ClientId;
 
         /// <summary>
@@ -196,6 +208,7 @@ namespace Azure.Identity
         /// </summary>
         /// <remarks>
         /// If neither the <see cref="ManagedIdentityClientId"/> nor the <see cref="ManagedIdentityResourceId"/> property is set, then a system-assigned managed identity is used.
+        /// This value can alternatively be set via environment variable <c>AZURE_CLIENT_ID</c>.
         /// </remarks>
         public string ManagedIdentityClientId { get; set; } = EnvironmentVariables.ClientId;
 
@@ -226,7 +239,7 @@ namespace Azure.Identity
 
         /// <summary>
         /// Specifies whether the <see cref="ManagedIdentityCredential"/> will be excluded from the <see cref="DefaultAzureCredential"/> authentication flow.
-        /// Setting to true disables authenticating with managed identity endpoints.
+        /// Setting to <c>true</c> disables authenticating with managed identity endpoints.
         /// </summary>
         public bool ExcludeManagedIdentityCredential { get; set; }
 
@@ -237,14 +250,14 @@ namespace Azure.Identity
 
         /// <summary>
         /// Specifies whether the <see cref="SharedTokenCacheCredential"/> will be excluded from the <see cref="DefaultAzureCredential"/> authentication flow.
-        /// Setting to true disables single sign on authentication with development tools which write to the shared token cache.
+        /// Setting to <c>true</c> disables single sign on authentication with development tools which write to the shared token cache.
         /// The default is <c>true</c>.
         /// </summary>
         public bool ExcludeSharedTokenCacheCredential { get; set; } = true;
 
         /// <summary>
         /// Specifies whether the <see cref="InteractiveBrowserCredential"/> will be excluded from the <see cref="DefaultAzureCredential"/> authentication flow.
-        /// Setting to true disables launching the default system browser to authenticate in development environments.
+        /// Setting to <c>true</c> disables launching the default system browser to authenticate in development environments.
         /// The default is <c>true</c>.
         /// </summary>
         public bool ExcludeInteractiveBrowserCredential { get; set; } = true;

--- a/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredentialOptions.cs
@@ -41,7 +41,7 @@ namespace Azure.Identity
         internal bool SendCertificateChain { get; set; } = EnvironmentVariables.ClientSendCertificateChain;
 
         /// <summary>
-        /// The username of the user account the credeential will authenticate. This value defaults to the value of the environment variable AZURE_USERNAME.
+        /// The username of the user account the credential will authenticate. This value defaults to the value of the environment variable AZURE_USERNAME.
         /// </summary>
         internal string Username { get; set; } = EnvironmentVariables.Username;
 
@@ -67,8 +67,10 @@ namespace Azure.Identity
         /// Specifies tenants in addition to the specified <see cref="TenantId"/> for which the credential may acquire tokens.
         /// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant the logged in account can access.
         /// If no value is specified for <see cref="TenantId"/>, this option will have no effect on that authentication method, and the credential will acquire tokens for any requested tenant when using that method.
-        /// This value defaults to the value of the environment variable AZURE_ADDITIONALLY_ALLOWED_TENANTS.
         /// </summary>
+        /// <remarks>
+        /// Defaults to the value of environment variable <c>AZURE_ADDITIONALLY_ALLOWED_TENANTS</c>.
+        /// </remarks>
         public IList<string> AdditionallyAllowedTenants { get; internal set; } = EnvironmentVariables.AdditionallyAllowedTenants;
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredentialOptions.cs
@@ -69,7 +69,7 @@ namespace Azure.Identity
         /// If no value is specified for <see cref="TenantId"/>, this option will have no effect on that authentication method, and the credential will acquire tokens for any requested tenant when using that method.
         /// </summary>
         /// <remarks>
-        /// Defaults to the value of environment variable <c>AZURE_ADDITIONALLY_ALLOWED_TENANTS</c>.
+        /// Defaults to the value of environment variable <c>AZURE_ADDITIONALLY_ALLOWED_TENANTS</c>. Values can be a semi-colon delimited list of tenant IDs , or '*' to denote any tenant ID.
         /// </remarks>
         public IList<string> AdditionallyAllowedTenants { get; internal set; } = EnvironmentVariables.AdditionallyAllowedTenants;
     }

--- a/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredentialOptions.cs
@@ -11,7 +11,7 @@ namespace Azure.Identity
     public class UsernamePasswordCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
     {
         /// <summary>
-        /// Specifies the <see cref="TokenCachePersistenceOptions"/> to be used by the credential. If not options are specified, the token cache will not be persisted to disk.
+        /// Specifies the <see cref="TokenCachePersistenceOptions"/> to be used by the credential. If no options are specified, the token cache will not be persisted to disk.
         /// </summary>
         public TokenCachePersistenceOptions TokenCachePersistenceOptions { get; set; }
 

--- a/sdk/identity/Azure.Identity/src/Credentials/WorkloadIdentityCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/WorkloadIdentityCredentialOptions.cs
@@ -13,18 +13,27 @@ namespace Azure.Identity
     public class WorkloadIdentityCredentialOptions : TokenCredentialOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
     {
         /// <summary>
-        /// The tenant ID of the service principal. Defaults to the value of the environment variable AZURE_TENANT_ID.
+        /// The tenant ID of the service principal.
         /// </summary>
+        /// <remarks>
+        /// Defaults to the value of environment variable <c>AZURE_TENANT_ID</c>.
+        /// </remarks>
         public string TenantId { get; set; } = EnvironmentVariables.TenantId;
 
         /// <summary>
-        /// The client (application) ID of the service principal. Defaults to the value of the environment variable AZURE_CLIENT_ID.
+        /// The client (application) ID of the service principal.
         /// </summary>
+        /// <remarks>
+        /// Defaults to the value of environment variable <c>AZURE_CLIENT_ID</c>.
+        /// </remarks>
         public string ClientId { get; set; } = EnvironmentVariables.ClientId;
 
         /// <summary>
-        /// The path to a file containing the workload identity token. Defaults to the value of the environment variable AZURE_FEDERATED_TOKEN_FILE.
+        /// The path to a file containing the workload identity token.
         /// </summary>
+        /// <remarks>
+        /// Defaults to the value of environment variable <c>AZURE_FEDERATED_TOKEN_FILE</c>.
+        /// </remarks>
         public string TokenFilePath { get; set; } = EnvironmentVariables.AzureFederatedTokenFile;
 
         /// <inheritdoc />
@@ -34,8 +43,10 @@ namespace Azure.Identity
         /// Specifies tenants in addition to the specified <see cref="TenantId"/> for which the credential may acquire tokens.
         /// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant the logged in account can access.
         /// If no value is specified for <see cref="TenantId"/>, this option will have no effect, and the credential will acquire tokens for any requested tenant.
-        /// Defaults to the value of the environment variable AZURE_ADDITIONALLY_ALLOWED_TENANTS.
         /// </summary>
+        /// <remarks>
+        /// Defaults to the value of environment variable <c>AZURE_ADDITIONALLY_ALLOWED_TENANTS</c>.
+        /// </remarks>
         public IList<string> AdditionallyAllowedTenants { get; internal set; } = EnvironmentVariables.AdditionallyAllowedTenants;
 
         internal CredentialPipeline Pipeline { get; set; }


### PR DESCRIPTION
**Summary of changes**
- Update XML docs for public properties in relevant credential options classes so customers know the env var alternative to setting these values. Standardize how alternative env vars are documented in property XML docs (moved to `<remarks>` element).
- Add section for workload identity in the env vars README section.