### PR TITLE
`net - pullrequest`

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -49,6 +49,12 @@ jobs:
       # Add a default so the job doesn't fail when the matrix is empty
       container: $[ variables['Container'] ]
 
+    variables:
+      ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+        ServiceDirectory: '*'
+      ${{ else }}:
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+
     templateContext:
       outputs:
         - output: pipelineArtifact
@@ -72,7 +78,9 @@ jobs:
       - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
-            ${{ if eq(parameters.ProjectListOverrideFilePropertyName, '') }}:
+            # we only need to checkout all sdk directories for All PR builds OR the
+            # deprecating AdditionalDependency leg of the core/resource builds. ProjectListOverrideFilePropertyName will be set in the latter case.
+            ${{ if and(ne(parameters.ServiceDirectory, 'auto'), eq(parameters.ProjectListOverrideFilePropertyName, '')) }}:
               Paths:
                 - "/*"
                 - "!SessionRecords"
@@ -82,42 +90,72 @@ jobs:
                 - "/*"
                 - "!SessionRecords"
                 - "/sdk/*/**/SessionRecords/*"
+
       - ${{ if ne(parameters.ProjectListOverrideFilePropertyName, '') }}:
         - task: DownloadPipelineArtifact@2
           inputs:
             artifact: DependencyTestProjectReferences
             patterns: "**/$(${{ parameters.ProjectListOverrideFilePropertyName }})"
             path: $(Build.SourcesDirectory)
+      - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifact: TestPackagesArtifact
+            path: $(Build.SourcesDirectory)/PackageInfo
+
       - pwsh: |
           $(Build.SourcesDirectory)/eng/common/scripts/trust-proxy-certificate.ps1
         displayName: 'Language Specific Certificate Trust'
+
       - pwsh: |
           Write-Host "##vso[task.setvariable variable=ASPNETCORE_Kestrel__Certificates__Default__Path]$(Build.SourcesDirectory)/eng/common/testproxy/dotnet-devcert.pfx"
           Write-Host "##vso[task.setvariable variable=ASPNETCORE_Kestrel__Certificates__Default__Password]password"
         displayName: 'Configure Kestrel Environment Variables'
+
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
         parameters:
           AgentImage: ${{ parameters.OSName }}
+
       - ${{ each step in parameters.TestSetupSteps }}:
         - ${{ each pair in step }}:
             ${{ pair.key }}: ${{ pair.value }}
+
+      # this section is only included when invoking with a dynamic set of packages (EG net - pullrequest)
+      - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
+        - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
+          parameters:
+            PackageInfo: '$(Build.SourcesDirectory)/PackageInfo'
+
+        - pwsh: |
+            if ("$(ProjectNames)" -like "*storage*") {
+              &"$(Build.SourcesDirectory)/eng/scripts/install_azurite.ps1" -AzuriteLocation "$(AzuriteLocation)" -AzuriteVersion "$(AzuriteVersion)"
+            }
+          displayName: Install Azurite If Necessary
+          condition: ne(variables['ProjectNames'], '')
+
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
         parameters:
           NuGetCacheKey: Test
+
+      # ProjectListOverrideFile is set by the customization within dependency.tests.yml
+      # OR it is set by the PR built to target a set of packages outside of a single target service directory.
+      # if it is unset, then we are in a traditional service directory build.
       - pwsh: |
-          if ("${{ parameters.ProjectListOverrideFilePropertyName }}" -ne '') {
-            Write-Host "##vso[task.setvariable variable=ProjectListOverrideFileName]$(${{ parameters.ProjectListOverrideFilePropertyName }})"
-            Write-Host "##vso[task.setvariable variable=CodeCoverageFilePattern]$(Build.SourcesDirectory)\sdk\**\coverage.cobertura.xml"
+          if ($env:PROJECTLISTOVERRIDEFILE) {
+            Write-Host "##vso[task.setvariable variable=CodeCoverageFilePattern]$(Build.SourcesDirectory)/sdk/**/coverage.cobertura.xml"
           }
           else
           {
-            Write-Host "##vso[task.setvariable variable=ProjectListOverrideFileName]"
-            Write-Host "##vso[task.setvariable variable=CodeCoverageFilePattern]$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**\coverage.cobertura.xml"
+            # we aren't running in net - pullrequest, so we need to ensure the value is set to empty string
+            Write-Host "##vso[task.setvariable variable=ProjectListOverrideFile]"
+            Write-Host "##vso[task.setvariable variable=CodeCoverageFilePattern]$(Build.SourcesDirectory)/sdk/$(ServiceDirectory)/**/coverage.cobertura.xml"
           }
         displayName: Set variable for the project list file and coverage directory
+
       - template: /eng/pipelines/templates/steps/dotnet-diagnostics.yml
         parameters:
           LogFilePath: $(Build.ArtifactStagingDirectory)/test.binlog
+
       - script: >-
           dotnet test eng/service.proj
           --filter "(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))"
@@ -125,16 +163,18 @@ jobs:
           --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
           --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TestTimeoutInMinutes}}minutes
           /p:SDKType=${{ parameters.SDKType }}
-          /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
+          /p:ServiceDirectory=$(ServiceDirectory)
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
           /p:RunApiCompat=false /p:InheritDocEnabled=false
           /p:Configuration=$(BuildConfiguration)
           /p:CollectCoverage=$(CollectCoverage)
           /p:EnableSourceLink=false
-          /p:ProjectListOverrideFile=$(ProjectListOverrideFileName)
+          /p:ProjectListOverrideFile=$(ProjectListOverrideFile)
+          /p:EnableOverrideExclusions=true
           $(AdditionalTestArguments)
           $(DiagnosticArguments)
         displayName: "Build & Test ($(TestTargetFramework))"
+
       - task: PublishTestResults@2
         condition: always()
         displayName: "Publish Results ($(TestTargetFramework))"
@@ -149,9 +189,9 @@ jobs:
         displayName: Generate Code Coverage Reports
         inputs:
           reports: $(CodeCoverageFilePattern)
-          targetdir: $(Build.ArtifactStagingDirectory)\coverage
+          targetdir: $(Build.ArtifactStagingDirectory)/coverage
           reporttypes: Cobertura
-          filefilters: +$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**
+          filefilters: +$(Build.SourcesDirectory)/sdk/$(ServiceDirectory)/**
           verbosity: Verbose
       - task: PublishCodeCoverageResults@2
         condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -82,9 +82,20 @@ jobs:
       - pwsh: |
           echo "##vso[task.setvariable variable=SkipDevBuildNumber]true"
         displayName: "Set SkipDevBuildNumber env variable"
-      - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+
+      # run this before setting SetDevVersion to true, so that versioning properties will be non-dev always
+      - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
         parameters:
-          ServiceDirectory: ${{parameters.ServiceDirectory}}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+
+      - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+
+      - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
+        parameters:
+          PackageInfo: '$(Build.ArtifactStagingDirectory)/PackageInfo'
+          Artifacts: ${{ parameters.Artifacts }}
+          IncludeIndirect: false
+
       - pwsh: |
           # Reset SkipDevBuildNumber as empty
           $skipDevBuildNumber = ""
@@ -99,36 +110,63 @@ jobs:
           $versioningProperties = "/p:OfficialBuildId=$(OfficialBuildId) /p:SkipDevBuildNumber=$skipDevBuildNumber";
           echo "##vso[task.setvariable variable=VersioningProperties]$versioningProperties"
         displayName: "Setup .NET specific versioning properties"
+
       - task: UsePythonVersion@0
         displayName: 'Use Python 3.11'
         inputs:
           versionSpec: '3.11'
+
       - template: /eng/pipelines/templates/steps/dotnet-diagnostics.yml
         parameters:
           LogFilePath: $(Build.ArtifactStagingDirectory)/pack.binlog
-      - script: >-
-          dotnet pack eng/service.proj -warnaserror
-          /p:ValidateRunApiCompat=true
-          /p:SDKType=${{ parameters.SDKType }}
-          /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
-          /p:IncludeTests=false
-          /p:PublicSign=false $(VersioningProperties)
-          /p:Configuration=$(BuildConfiguration)
-          /p:CommitSHA=$(Build.SourceVersion)
-          /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory)
-          $(DiagnosticArguments)
-        displayName: "Build and Package"
 
-      - task: Powershell@2
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/scripts/Save-Package-Properties.ps1
-          arguments: >
-            -ServiceDirectory ${{parameters.ServiceDirectory}}
-            -OutDirectory $(Build.ArtifactStagingDirectory)/PackageInfo
-            -AddDevVersion:$$(SetDevVersion)
-          pwsh: true
-          workingDirectory: $(Pipeline.Workspace)
-        displayName: Update package properties with dev version
+      # only use the project list override file if the service directory is not auto
+      - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+        - pwsh: |
+            if (!"$(ProjectNames)") {
+              Write-Host "No packages to build."
+              exit 0
+            }
+            dotnet pack eng/service.proj -warnaserror `
+              /p:ValidateRunApiCompat=true `
+              /p:SDKType=${{ parameters.SDKType }} `
+              /p:IncludeTests=false `
+              /p:PublicSign=false $(VersioningProperties) `
+              /p:Configuration=$(BuildConfiguration) `
+              /p:CommitSHA=$(Build.SourceVersion) `
+              /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) `
+              /p:ServiceDirectory=* `
+              /p:ProjectListOverrideFile=$(ProjectListOverrideFile) `
+              $(DiagnosticArguments)
+          displayName: "Build and Package"
+      - ${{ else }}:
+        - pwsh: |
+            if (Test-Path "$(ProjectListOverrideFile)") {
+              Write-Host "Clearing $(ProjectListOverrideFile)"
+              rm "$(ProjectListOverrideFile)"
+              Write-Host "##vso[task.setvariable variable=ProjectListOverrideFile;]"
+            }
+          displayName: Cleanup Props File
+
+        - script: >-
+            dotnet pack eng/service.proj -warnaserror
+            /p:ValidateRunApiCompat=true
+            /p:SDKType=${{ parameters.SDKType }}
+            /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
+            /p:IncludeTests=false
+            /p:PublicSign=false $(VersioningProperties)
+            /p:Configuration=$(BuildConfiguration)
+            /p:CommitSHA=$(Build.SourceVersion)
+            /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory)
+            /p:ProjectListOverrideFile=$(ProjectListOverrideFile)
+            $(DiagnosticArguments)
+          displayName: "Build and Package"
+
+      # save package properties again, this time honoring the dev version number
+      - ${{ if ne(parameters.ServiceDirectory, 'auto') }}:
+        - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
+          parameters:
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
       - task: Powershell@2
         inputs:
@@ -140,6 +178,7 @@ jobs:
           pwsh: true
           workingDirectory: $(Pipeline.Workspace)
         displayName: Update package properties with namespaces
+        condition: and(succeeded(), ne(variables['ProjectNames'], ''))
 
       - template: ../steps/archetype-sdk-docs.yml
         parameters:
@@ -147,6 +186,7 @@ jobs:
           Artifacts: ${{parameters.Artifacts}}
           DocGenerationDir: "$(Build.SourcesDirectory)/doc/ApiDocGeneration"
           LibType: 'client'
+          PackageInfoFolder: '$(Build.ArtifactStagingDirectory)/PackageInfo'
 
       - ${{ if eq(parameters.CheckAOTCompat, 'true') }}:
         - template: /eng/pipelines/templates/steps/aot-compatibility.yml
@@ -202,13 +242,24 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/cache-ps-modules.yml
 
-      - template: /eng/common/pipelines/templates/steps/verify-samples.yml
+      - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
         parameters:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
-      - template: /eng/common/pipelines/templates/steps/verify-readme.yml
+      - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
         parameters:
-          ScanPath: $(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}
+          PackageInfo: '$(Build.ArtifactStagingDirectory)/PackageInfo'
+          Artifacts: ${{ parameters.Artifacts }}
+          IncludeIndirect: false
+
+      - template: /eng/common/pipelines/templates/steps/verify-samples.yml
+        parameters:
+          ServiceDirectories: "$(ChangedServices)"
+
+      - template: /eng/common/pipelines/templates/steps/verify-readmes.yml
+        parameters:
+          PackagePropertiesFolder: '$(Build.ArtifactStagingDirectory)/PackageInfo'
+          IncludeIndirect: false
 
       - task: NodeTool@0
         inputs:
@@ -225,36 +276,62 @@ jobs:
           arguments: 'restore'
           workingDirectory: '$(Agent.BuildDirectory)'
 
-      - task: PowerShell@2
-        displayName: "Verify generated code"
+      - pwsh: |
+          $failed = $false
+          if ("$(ProjectNames)") {
+            $serviceDirectories = "$(ChangedServices)" -split ","
+            $ScanPaths = @()
+            foreach ($ServiceDirectory in $serviceDirectories) {
+              ./eng/scripts/CodeChecks.ps1 `
+                -ServiceDirectory $ServiceDirectory `
+                -SDKType ${{ parameters.SDKType }} `
+                -SpellCheckPublicApiSurface `
+
+              if ($LASTEXITCODE -ne 0) {
+                $failed = $true
+              }
+            }
+
+            if ($failed) {
+              exit 1
+            }
+          }
+          else {
+            Write-Host "No services were directly changed. Skipping code checks."
+          }
+        displayName: Verify Generated Code
         env:
           EnableSourceLink: false
-        inputs:
-          filePath: "eng/scripts/CodeChecks.ps1"
-          arguments: >
-            -ServiceDirectory ${{ parameters.ServiceDirectory }}
-            -SDKType ${{ parameters.SDKType }}
-            -SpellCheckPublicApiSurface
-          pwsh: true
-          failOnStderr: false
 
       - template: /eng/pipelines/templates/steps/dotnet-diagnostics.yml
         parameters:
           LogFilePath: $(Build.ArtifactStagingDirectory)/rebuild.binlog
 
-      - script: >-
-          dotnet build eng/service.proj -warnaserror
-          /t:rebuild
-          /p:DebugType=none
-          /p:SDKType=${{ parameters.SDKType }}
-          /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
-          /p:IncludePerf=false
-          /p:IncludeStress=false
-          /p:PublicSign=false
-          /p:Configuration=$(BuildConfiguration)
-          /p:EnableSourceLink=false
-          /p:BuildSnippets=true
-          $(DiagnosticArguments)
+      # todo, refactor to using the projectlistoverridefile
+      - pwsh: |
+          $failed = $false
+          if ("$(ProjectNames)") {
+            $services = "$(ChangedServices)" -split ","
+
+            foreach ($service in $services) {
+              Write-Host "building $service"
+              dotnet build eng/service.proj -warnaserror `
+                /t:rebuild `
+                /p:DebugType=none `
+                /p:SDKType=${{ parameters.SDKType }} `
+                /p:ServiceDirectory=$service `
+                /p:IncludePerf=false `
+                /p:IncludeStress=false `
+                /p:PublicSign=false `
+                /p:Configuration=$(BuildConfiguration) `
+                /p:EnableSourceLink=false `
+                /p:BuildSnippets=true `
+                $(DiagnosticArguments)
+            }
+          }
+          else {
+            Write-Host "No services were directly changed. Skipping snippet build."
+          }
         displayName: Build snippets
         condition: and(succeeded(), eq(${{ parameters.BuildSnippets }}, true))
 
@@ -305,44 +382,78 @@ jobs:
         MatrixReplace: ${{ parameters.MatrixReplace }}
         CloudConfig:
           Cloud: public
+        ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+          SparseCheckoutPaths:
+            - "/*"
+            - "!SessionRecords"
+          EnablePRGeneration: true
+          PRMatrixSetting: ProjectNames
+          PRJobBatchSize: 20
+          PRMatrixIndirectFilters:
+            - 'AdditionalTestArguments=.*true'
+            - 'Pool=.*LinuxPool$'
+          PreGenerationSteps:
+            - script: |
+                echo "##vso[task.setvariable variable=DISCOVER_DEPENDENT_PACKAGES]1"
+              displayName: Enable AdditionalDependency Calculation
+
+            - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
+              parameters:
+                ServiceDirectory: ${{parameters.ServiceDirectory}}
+                PackageInfoDirectory: $(Build.ArtifactStagingDirectory)/PackageInfoPublishing
+
+            # when we publish the packageinfo as an artifact, it actually cleans up the original files. Since we need them during matrix generation steps
+            # that will execute directly after the pregeneration steps here, we output them to a publishing directory, copy from there into the target PackageInfoDirectory,
+            # and then publish the originals
+            - pwsh: |
+                mkdir "$(Build.ArtifactStagingDirectory)/PackageInfo"
+                Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/PackageInfoPublishing" -File `
+                  | Copy-Item -Destination "$(Build.ArtifactStagingDirectory)/PackageInfo/$($_.Name)" -Force
+              displayName: Copy ArtifactInfo from Publishing Directory
+
+            - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+              parameters:
+                ArtifactName: 'TestPackagesArtifact'
+                ArtifactPath: '$(Build.ArtifactStagingDirectory)/PackageInfoPublishing'
+
         AdditionalParameters:
           SDKType: ${{ parameters.SDKType }}
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           TestSetupSteps: ${{ parameters.TestSetupSteps }}
           TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
 
-    - ${{ if ne(parameters.TestDependsOnDependency, 'not-specified') }}:
-      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-        parameters:
-          GenerateJobName: generate_target_dependencies_test_matrix
-          JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
-          MatrixConfigs: ${{ parameters.MatrixConfigs }}
-          MatrixFilters: ${{ parameters.MatrixFilters }}
-          MatrixReplace:
-            # Force UseProjectReferenceToAzureClients option to always be true because we only want to test with ProjectReference for dependency tests
-            - AdditionalTestArguments=\/p:UseProjectReferenceToAzureClients\=false/\/p:UseProjectReferenceToAzureClients\=true
-            - ${{ each matrixReplace in parameters.MatrixReplace }}:
-                - ${{ matrixReplace }}
-          CloudConfig:
-            Cloud: public
-          SparseCheckoutPaths:
-            - /*
-            - '!/sdk/*/**/SessionRecords/*'
-          PreGenerationSteps:
-            - ${{ each config in parameters.MatrixConfigs }}:
-                - template: /eng/pipelines/templates/steps/dependency.tests.yml
-                  parameters:
-                    TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
-                    # The value for ProjectListOverrideFilePropertyName should be the same as AdditionalParameters ProjectListOverrideFilePropertyName below
-                    ProjectListOverrideFilePropertyName: 'ProjectListOverrideFile'
-                    ProjectFilesOutputFolder: $(Build.ArtifactStagingDirectory)
-                    ExcludeTargetTestProjects: true
-                    ServiceDirectory: ${{ parameters.ServiceDirectory }}
-                    MatrixConfigsFile: ${{ config.Path }}
-          AdditionalParameters:
-            SDKType: ${{ parameters.SDKType }}
-            ServiceDirectory: ${{ parameters.ServiceDirectory }}
-            TestSetupSteps: ${{ parameters.TestSetupSteps }}
-            TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
-            # The value for ProjectListOverrideFilePropertyName should be the same as dependency.tests.yml parameter ProjectListOverrideFilePropertyName
-            ProjectListOverrideFilePropertyName: 'ProjectListOverrideFile'
+  - ${{ if ne(parameters.TestDependsOnDependency, 'not-specified') }}:
+    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+      parameters:
+        GenerateJobName: generate_target_dependencies_test_matrix
+        JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
+        MatrixConfigs: ${{ parameters.MatrixConfigs }}
+        MatrixFilters: ${{ parameters.MatrixFilters }}
+        MatrixReplace:
+          # Force UseProjectReferenceToAzureClients option to always be true because we only want to test with ProjectReference for dependency tests
+          - AdditionalTestArguments=\/p:UseProjectReferenceToAzureClients\=false/\/p:UseProjectReferenceToAzureClients\=true
+          - ${{ each matrixReplace in parameters.MatrixReplace }}:
+              - ${{ matrixReplace }}
+        CloudConfig:
+          Cloud: public
+        SparseCheckoutPaths:
+          - /*
+          - '!/sdk/*/**/SessionRecords/*'
+        PreGenerationSteps:
+          - ${{ each config in parameters.MatrixConfigs }}:
+              - template: /eng/pipelines/templates/steps/dependency.tests.yml
+                parameters:
+                  TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
+                  # The value for ProjectListOverrideFilePropertyName should be the same as AdditionalParameters ProjectListOverrideFilePropertyName below
+                  ProjectListOverrideFilePropertyName: 'ProjectListOverrideFile'
+                  ProjectFilesOutputFolder: $(Build.ArtifactStagingDirectory)
+                  ExcludeTargetTestProjects: true
+                  ServiceDirectory: ${{ parameters.ServiceDirectory }}
+                  MatrixConfigsFile: ${{ config.Path }}
+        AdditionalParameters:
+          SDKType: ${{ parameters.SDKType }}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          TestSetupSteps: ${{ parameters.TestSetupSteps }}
+          TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+          # The value for ProjectListOverrideFilePropertyName should be the same as dependency.tests.yml parameter ProjectListOverrideFilePropertyName
+          ProjectListOverrideFilePropertyName: 'ProjectListOverrideFile'

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -59,7 +59,8 @@
           "SupportsRecording": true,
           "CollectCoverage": true
         }
-      }
+      },
+      "AdditionalTestArguments": "/p:UseProjectReferenceToAzureClients=false"
     }
   ]
 }

--- a/eng/pipelines/templates/steps/archetype-sdk-docs.yml
+++ b/eng/pipelines/templates/steps/archetype-sdk-docs.yml
@@ -1,3 +1,19 @@
+parameters:
+  - name: Artifacts
+    type: object
+    default: []
+  - name: ServiceDirectory
+    type: string
+  - name: DocGenerationDir
+    type: string
+    default: "$(Build.SourcesDirectory)/doc/ApiDocGeneration"
+  - name: LibType
+    type: string
+    default: client
+  - name: PackageInfoFolder
+    type: string
+
+
 steps:
   - task: PowerShell@2
     displayName: Download and Extract Required Software
@@ -23,3 +39,42 @@ steps:
           -DocGenDir ${{parameters.DocGenerationDir}}
           -ArtifactStagingDirectory '$(Build.ArtifactStagingDirectory)'
           -verbose
+
+  # artifacts will only be blank if the template is called with no Artifact parameter,
+  # which should only happen in the case of a PR build. In this case we locate all that were directly
+  # changed and build their docs.
+  - ${{ if not(parameters.Artifacts) }}:
+    - pwsh: |
+        $failedBuild = $false
+
+        $targetedPackages = Get-ChildItem -Recurse "${{ parameters.PackageInfoFolder }}" *.json
+          | ForEach-Object { Get-Content -Raw _ | ConvertFrom-Json }
+          | Where-Object { $_.IncludedForValidation -ne $true }
+
+        if ($targetedPackages) {
+          foreach($pkg in $targetedPackages) {
+            $artifactDirectory = ($pkg.DirectoryPath -split '\\|/')[-1]
+
+            &"$(Build.SourcesDirectory)/doc/ApiDocGeneration/Generate-Api-Docs.ps1" `
+              -ArtifactName '$($pkg.name)' `
+              -ServiceDirectory '$($pkg.ServiceDirectory)' `
+              -ArtifactsDirectoryName '$artifactDirectory' `
+              -RepoRoot $(Build.SourcesDirectory) `
+              -BinDirectory $(Build.BinariesDirectory) `
+              -DocGenDir ${{parameters.DocGenerationDir}} `
+              -ArtifactStagingDirectory '$(Build.ArtifactStagingDirectory)' `
+              -verbose
+
+            if ($LASTEXITCODE -ne 0) {
+              $failedBuild = $true
+            }
+          }
+        }
+        else {
+          Write-Host "No directly targeted packages found. Skipping doc generation."
+        }
+
+        if ($failedBuild) {
+          exit 1
+        }
+      displayName: Generate Docs for Pull Request

--- a/eng/pipelines/templates/steps/dependency.tests.yml
+++ b/eng/pipelines/templates/steps/dependency.tests.yml
@@ -27,6 +27,7 @@ steps:
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
     parameters:
       EnableNuGetCache: false
+
   - pwsh: |
       dotnet build /t:ProjectDependsOn ./eng/service.proj `
         /p:TestDependsOnDependency="${{parameters.TestDependsOnDependency}}" `

--- a/eng/pipelines/templates/steps/set-artifact-packages.yml
+++ b/eng/pipelines/templates/steps/set-artifact-packages.yml
@@ -1,0 +1,51 @@
+parameters:
+  PackageInfo: ''
+  Artifacts: []
+  IncludeIndirect: true
+steps:
+  # Package-Properties folder contains the package properties for all discovered packages that were either A) affected by the PR or
+  # B) explicitly present in the service directory. This repo splits the builds into two categories: "mgmt" and "dataplane". While
+  # a given directory may contain both, there will be a separate build definition to release the management packages. Due to this
+  # we need to artificially filter the packages to ensure that only the packages targeted for THAT ci.yml are built.
+  # When we merge the PR adding net - pullrequest, this code will also merge, meaning the public - <service> - ci builds will still operate
+  # EXACTLY the same as they did before the pipelinev3 change. This is important to ensure that we don't accidentally build the wrong packages
+  # while in the integration period. After we disable all the public `net - <service> - ci` builds, only the `net - pullrequest` build WONT provide
+  # an artifact list, which will allow the expand/contract. Meanwhile the internal builds will continue to provide the artifact list from their
+  # individual ci.yml and ci.mgmt.yml files.
+  - pwsh: |
+      $artifacts = '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
+      $includeIndirect = $${{ parameters.IncludeIndirect }}
+      $knownArtifacts = @()
+      if ($artifacts) {
+        $knownArtifacts = $artifacts | ForEach-Object { $_.name }
+      }
+
+      $packageProperties = Get-ChildItem -Recurse "${{ parameters.PackageInfo }}" *.json `
+        | Where-Object { if($knownArtifacts) { $knownArtifacts -contains $_.Name.Replace(".json", "") } else { $true } }
+
+      if (-not $includeIndirect) {
+        $packageProperties = $packageProperties | Where-Object { (Get-Content -Raw $_ | ConvertFrom-Json).IncludedForValidation -eq $false }
+      }
+
+      $pkgNames = $packageProperties | ForEach-Object { $_.Name.Replace(".json", "") }
+
+      $setting = $pkgNames -join ","
+      Write-Host "Setting ProjectNames to: `n$setting"
+      Write-Host "##vso[task.setvariable variable=ProjectNames;]$setting"
+
+      if (!$pkgNames) {
+        Write-Host "No packages were identified for this build."
+      }
+    displayName: Resolve Targeted Packages
+    condition: eq(variables['ProjectNames'], '')
+
+  # this script sets $(ChangedServices) and populates a props file with the targeted set of projects
+  # for the build. This file is set to variable $(ProjectListOverrideFile).
+  - pwsh: |
+      ./eng/scripts/splittestdependencies/set-artifact-packages.ps1 `
+        -ProjectNames "$(ProjectNames)" `
+        -PackageInfoFolder "${{ parameters.PackageInfo }}" `
+        -OutputPath $(Build.SourcesDirectory)/projlist
+    displayName: Resolve Service and Project List
+    condition: ne(variables['ProjectNames'], '')
+

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -12,6 +12,8 @@ variables:
   CollectCoverage: false
   NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages/
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  AzuriteLocation: $(Pipeline.Workspace)/.storage/azurite
+  AzuriteVersion: 3.11.0
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
   Codeql.SkipTaskAutoInjection: true

--- a/eng/scripts/Install-Azurite.ps1
+++ b/eng/scripts/Install-Azurite.ps1
@@ -1,0 +1,23 @@
+<#
+.DESCRIPTION
+
+This script installs Azurite using npm to a specific location. It does not utilize the caching mechanism provided by azure devops.
+
+#>
+param (
+    [Parameter(Mandatory = $true)]
+    [string]$AzuriteLocation,
+    [Parameter(Mandatory = $true)]
+    [string]$AzuriteVersion
+)
+
+npm install --prefix $AzuriteLocation azurite@$AzuriteVersion
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to install Azurite."
+    exit $LASTEXITCODE
+}
+
+if ($env:TF_BUILD -or $env:CI) {
+    Write-Output "##vso[task.setvariable variable=Azure.Azurite.Location]$AzuriteLocation"
+}

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -46,7 +46,9 @@ if (-not (Test-Path -Path $repoRoot)) {
     exit 1
 }
 # Get all of the packageInfo files
-$packageInfoFiles = Get-ChildItem -Path $packageInfoDirectory -Filter *.json
+$packageInfoFiles = Get-ChildItem -Path $packageInfoDirectory -Filter *.json `
+    | Where-Object { (Get-Content -Raw $_ | ConvertFrom-Json).IncludedForValidation -eq $false }
+
 if ($packageInfoFiles.Length -eq 0) {
     LogWarning "packageInfoDirectory '$packageInfoDirectory' does not contain any json files. Please ensure that the packageInfo files were generated prior to running this."
     exit 0

--- a/eng/scripts/splittestdependencies/set-artifact-packages.ps1
+++ b/eng/scripts/splittestdependencies/set-artifact-packages.ps1
@@ -1,0 +1,41 @@
+param (
+    [string] $ProjectNames,
+    [string] $OutputPath,
+    [string] $PackageInfoFolder
+)
+
+. $PSScriptRoot/generate-dependency-functions.ps1
+
+$RepoRoot = Resolve-Path (Join-Path "$PSScriptRoot" ".." ".." "..")
+
+# set changed services given the set of changed packages, this will mean that
+# ChangedServices will be appropriate for the batched set of packages if that is indeed how
+# we set the targeted artifacts
+$packageProperties = Get-ChildItem -Recurse "$PackageInfoFolder" *.json `
+| Foreach-Object { Get-Content -Raw -Path $_.FullName | ConvertFrom-Json }
+
+$packageSet = "$ProjectNames" -split ","
+
+$changedServicesArray = $packageProperties | Where-Object { $packageSet -contains $_.ArtifactName }
+| ForEach-Object { $_.ServiceDirectory } | Get-Unique
+$changedServices = $changedServicesArray -join ","
+
+$changedProjects = $packageProperties | Where-Object { $packageSet -contains $_.ArtifactName }
+| ForEach-Object { "$($_.DirectoryPath)/**/*.csproj"; }
+
+$projectsForGeneration = ($changedProjects | ForEach-Object { "`$(RepoRoot)$_" } | Sort-Object)
+$projectGroups = @()
+$projectGroups += ,$projectsForGeneration
+
+# todo: refactor write-test-dependency-group to take in a list of project files only and generate a single project file
+$outputFile = (Write-Test-Dependency-Group-To-Files -ProjectFileConfigName "packages" -ProjectGroups $projectGroups -MatrixOutputFolder $OutputPath)[0]
+
+# debug, will remove
+Get-ChildItem -Recurse $OutputPath | ForEach-Object { Write-Host "Dumping $($_.FullName)"; Get-Content -Raw -Path $_.FullName | Write-Host }
+
+# the projectlistoverride file must be provided as a relative path
+$relativeOutputPath = [System.IO.Path]::GetRelativePath($RepoRoot, "$OutputPath/$outputFile")
+
+Write-Host "##vso[task.setvariable variable=ProjectListOverrideFile;]$relativeOutputPath"
+Write-Host "##vso[task.setvariable variable=ChangedServices;]$changedServices"
+Write-Host "This run is targeting: $ProjectNames in [$changedServices]"

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -13,34 +13,37 @@
     <IncludeSamplesApplications Condition="'$(ServiceDirectory)' != '*' or '$(IncludeSamples)' == 'false'">false</IncludeSamplesApplications>
   </PropertyGroup>
 
+  <ItemGroup>
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj" />
+      <!-- because this project is using the project below -->
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitivelanguage\Azure.AI.Language.QuestionAnswering\tests\Azure.AI.Language.QuestionAnswering.Tests.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Knowledge.QnAMaker\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.CustomVision.Prediction\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingWebSearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.ComputerVision\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.ContentModerator\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingNewsSearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingLocalSearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingImageSearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingVisualSearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingVideoSearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingAutoSuggest\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingEntitySearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingCustomSearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingCustomImageSearch\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\AnomalyDetector\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Language.LUIS.Authoring\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Language.LUIS.Runtime\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Language.TextAnalytics\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Language.SpellCheck\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\FormRecognizer\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.Face\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.CustomVision.Training\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Personalizer\**\*.csproj" />
+      <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\hdinsight\Microsoft.Azure.HDInsight.Job\**\*.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(ProjectListOverrideFile)' == '' ">
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj" />
-    <!-- because this project is using the project below -->
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitivelanguage\Azure.AI.Language.QuestionAnswering\tests\Azure.AI.Language.QuestionAnswering.Tests.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Knowledge.QnAMaker\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.CustomVision.Prediction\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingWebSearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.ComputerVision\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.ContentModerator\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingNewsSearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingLocalSearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingImageSearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingVisualSearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingVideoSearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingAutoSuggest\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingEntitySearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingCustomSearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Search.BingCustomImageSearch\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\AnomalyDetector\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Language.LUIS.Authoring\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Language.LUIS.Runtime\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Language.TextAnalytics\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Language.SpellCheck\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\FormRecognizer\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.Face\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Vision.CustomVision.Training\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\cognitiveservices\Personalizer\**\*.csproj" />
-    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\hdinsight\Microsoft.Azure.HDInsight.Job\**\*.csproj" />
     <TestProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\tests\**\*.csproj" />
     <SamplesProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\samples\**\*.csproj;..\sdk\$(ServiceDirectory)\samples\**\*.csproj" />
     <PerfProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\perf\**\*.csproj" />
@@ -62,6 +65,25 @@
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' ">
     <Track1ProjectsToRemove Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" />
     <ProjectReference Remove="@(Track1ProjectsToRemove)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(EnableOverrideExclusions)' != ''">
+    <TestProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\tests\**\*.csproj" Exclude="@(MgmtExcludePaths)" />
+    <SamplesProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\samples\**\*.csproj;..\sdk\$(ServiceDirectory)\samples\**\*.csproj" Exclude="@(MgmtExcludePaths)" />
+    <PerfProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\perf\**\*.csproj" Exclude="@(MgmtExcludePaths)" />
+    <StressProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\stress\**\*.csproj" Exclude="@(MgmtExcludePaths)"/>
+    <IntegrationTestProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\integration\**\*.csproj" Exclude="@(MgmtExcludePaths)"/>
+    <SampleApplications Include="..\samples\**\*.csproj" Exclude="@(MgmtExcludePaths)"/>
+    <SharedProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\shared\**\*.csproj" Exclude="@(MgmtExcludePaths)"/>
+    <SrcProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\src\**\*.csproj" Exclude="@(TestProjects);@(SamplesProjects);@(PerfProjects);@(StressProjects)" />
+    <ProjectReference Remove="@(TestProjects)" Condition="'$(IncludeTests)' == 'false'" />
+    <ProjectReference Remove="@(SamplesProjects)" Condition="'$(IncludeSamples)' == 'false'" />
+    <ProjectReference Remove="@(PerfProjects)" Condition="'$(IncludePerf)' == 'false'" />
+    <ProjectReference Remove="@(StressProjects)" Condition="'$(IncludeStress)' == 'false'" />
+    <ProjectReference Remove="@(SampleApplications)" Condition="'$(IncludeSamplesApplications)' == 'false'"/>
+    <ProjectReference Remove="@(SrcProjects)" Condition="'$(IncludeSrc)' == 'false'" />
+    <ProjectReference Remove="@(IntegrationTestProjects)" Condition="'$(IncludeSrc)' == 'false'" />
+    <ProjectReference Remove="@(SharedProjects)" Condition="'$(IncludeSrc)' == 'false'" />
   </ItemGroup>
 
   <!-- Remove all projects except the ones included by the SDKType filter -->

--- a/sdk/pullrequest.yml
+++ b/sdk/pullrequest.yml
@@ -22,5 +22,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: ${{ parameters.Service }}
-    ExcludePaths:
-      - eng/packages/http-client-csharp

--- a/sdk/pullrequest.yml
+++ b/sdk/pullrequest.yml
@@ -1,0 +1,26 @@
+pr:
+  branches:
+    include:
+    - main
+    - feature/*
+    - hotfix/*
+    - release/*
+    - pipelinev3*
+  paths:
+    include:
+    - "*"
+
+    exclude:
+    - eng/packages/http-client-csharp
+
+parameters:
+  - name: Service
+    type: string
+    default: auto
+
+extends:
+  template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: ${{ parameters.Service }}
+    ExcludePaths:
+      - eng/packages/http-client-csharp


### PR DESCRIPTION
This PR...

- [x] Adds a new `net - pullrequest` build.
  - This PR dynamically expands/contracts to only build and test the changed packages.  
  - If `Azure.Core` or `Azure.ResourceManager` are present in the set of packages that have been changed, their dependencies are **also** discovered and distributed sparsely to test runs. This completely replaces the static `AdditionalDependency` leg that currently exists only on `net - core` and `net - resourcemanager`. It utilizes _exactly_ the same dependency discovery that original leg utilized. (`eng/service.proj` `ProjectDependsOn` target)
  - The dependency discovery is fairly slow still, so it's limited to `Azure.Core`/`Azure.ResourceManager`. That can be adjusted.

Todo:

- [x] Add language-settings function to handle which packages should be build/tested if a PR is purely non-sdk changes.
- [x] Fix the docs generation to honor the changed packages
- [ ] ~~Re-add dev versioning save of save-package-props~~
  - This doesn't exist in main that I can tell anymore.
- [x] Fix broken pkg props `build` stage in original net CI builds
- [x] Fix existing build legs which are broken by the change to propertyoverridefile usage in build-test.
  - [x] `resourcemanager`
  - [x] `core`
- [ ] ~~Invoke the $eachService steps in static analysis (where Ben commented effectively) to at least attempt to shift these to pshell job.~~ Going to make this entire job parallel.
- [x] Run nightly core to ensure I make absolutely certain we're all good
- [x] One last cleanup rebase.

 