### PR TITLE
Create minimum buffer required for OpenRead

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/LazyLoadingReadOnlyStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/LazyLoadingReadOnlyStream.cs
@@ -139,7 +139,7 @@ namespace Azure.Storage
             GetPropertiesAsync getPropertiesFunc,
             DownloadTransferValidationOptions transferValidation,
             bool allowModifications,
-            long initialLenght,
+            long initialLength,
             long position = 0,
             int? bufferSize = default,
             PredictEncryptedRangeAdjustment rangePredictionFunc = default)
@@ -148,12 +148,16 @@ namespace Azure.Storage
             _getPropertiesInternalFunc = getPropertiesFunc;
             _predictEncryptedRangeAdjustment = rangePredictionFunc ?? (range => range);
             _position = position;
-            _bufferSize = bufferSize ?? Constants.DefaultStreamingDownloadSize;
+
+            // If the blob cannot be modified and the total blob size is less than the default streaming size,
+            // the buffer size should be limited to the total blob size.
+            int maxBufferSize = allowModifications ? Constants.DefaultStreamingDownloadSize : (int)Math.Min(initialLength, Constants.DefaultStreamingDownloadSize);
+            _bufferSize = bufferSize ?? maxBufferSize;
             _buffer = ArrayPool<byte>.Shared.Rent(_bufferSize);
             _allowBlobModifications = allowModifications;
             _bufferPosition = 0;
             _bufferLength = 0;
-            _length = initialLenght;
+            _length = initialLength;
             _bufferInvalidated = false;
 
             // the caller to this stream cannot defer validation, as they cannot access a returned hash


### PR DESCRIPTION
LazyLoadingReadOnlyStream, when not specified an explicit buffer size, always selects 4MB as the buffer size. This is unnecessary if the underlying blob size (which comes in as initialLength) is smaller than that AND the blob does not allow modifications (meaning the blob will never grow any larger). In this case, the buffer size can simply be initialized to the length of the blob that will be read.

Fixes #47821 