### PR TITLE
[Event Hubs] Fixed producer semaphore release

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -16,6 +16,8 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Querying runtime data and other management operations will now correctly guards against the race condition where an AMQP link is in the process of closing as the operation attempts to use it.  These errors will now properly be classified as retriable as they are for producer and consumer operations.
 
+- Fixed an obscure edge case in the `EventHubBufferedProducer` client where an obscure race condition when flushing/enqueuing events concurrently with disposing the producer could cause a semaphore to be released inappropriately.  This error superseded the `TaskCanceledException` that should have been surfaced.
+
 ### Other Changes
 
 - Added annotations to make the package compatible with trimming and native AOT compilation.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -196,7 +196,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   The total number of events that are currently buffered and waiting to be published, across all partitions.
         /// </summary>
         ///
-        public virtual int TotalBufferedEventCount => _totalBufferedEventCount;
+        public virtual int TotalBufferedEventCount => Volatile.Read(ref _totalBufferedEventCount);
 
         /// <summary>
         ///   The instance of <see cref="EventHubsEventSource" /> which can be mocked for testing.
@@ -603,7 +603,7 @@ namespace Azure.Messaging.EventHubs.Producer
             {
                 TokenCredential tokenCred => new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, tokenCred, options),
                 AzureSasCredential sasCred => new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, sasCred, options),
-                AzureNamedKeyCredential keyCred =>  new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, keyCred, options),
+                AzureNamedKeyCredential keyCred => new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, keyCred, options),
                 _ => throw new ArgumentException(Resources.UnsupportedCredential, nameof(credential))
             };
 
@@ -772,13 +772,13 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if ((!IsPublishing) || (_producerManagementTask?.IsCompleted ?? false))
                 {
+                    if (!_stateGuard.Wait(0, cancellationToken))
+                    {
+                        await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
                     try
                     {
-                        if (!_stateGuard.Wait(0, cancellationToken))
-                        {
-                            await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
-                        }
-
                         Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
 
                         // StartPublishingAsync will verify that publishing is not already taking
@@ -935,13 +935,13 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if ((!IsPublishing) || (_producerManagementTask?.IsCompleted ?? false))
                 {
+                    if (!_stateGuard.Wait(0, cancellationToken))
+                    {
+                        await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
                     try
                     {
-                        if (!_stateGuard.Wait(0, cancellationToken))
-                        {
-                            await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
-                        }
-
                         Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
 
                         // StartPublishingAsync will verify that publishing is not already taking
@@ -1059,6 +1059,15 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 await StopPublishingAsync(cancelActiveSendOperations: false, cancellationToken).ConfigureAwait(false);
                 await FlushInternalAsync(cancellationToken).ConfigureAwait(false);
+
+                // There's an unlikely race condition where it is possible that an event batch was being enqueued before publishing
+                // stopped and was not written to the partition buffer until after the flush for that partition completed.  To guard
+                // against this, restart publishing if any events are pending.
+
+                if (Volatile.Read(ref _totalBufferedEventCount) > 0)
+                {
+                    await StartPublishingAsync(cancellationToken).ConfigureAwait(false);
+                }
             }
             finally
             {
@@ -1092,15 +1101,13 @@ namespace Azure.Messaging.EventHubs.Producer
 
             var capturedExceptions = default(List<Exception>);
 
+            if (!_stateGuard.Wait(0, cancellationToken))
+            {
+                await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             try
             {
-                if (!_stateGuard.Wait(0, cancellationToken))
-                {
-                    await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
-                }
-
-                // If we've reached this point without an exception, the guard is held.
-
                 if (_isClosed)
                 {
                     return;
@@ -1531,7 +1538,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if (releaseGuard)
                 {
-                    partitionState.PartitionGuard.Release();
+                    partitionState.SafeReleaseGuard();
                 }
 
                 var duration = publishWatch.IsActive ? publishWatch.GetElapsedTime().TotalSeconds : 0;
@@ -1675,7 +1682,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 }
 
                 var partitionStateDelta = (partitionState.BufferedEventCount * -1);
-                var totalDeltaZero = (_totalBufferedEventCount * -1);
+                var totalDeltaZero = (Volatile.Read(ref _totalBufferedEventCount) * -1);
 
                 Interlocked.Add(ref _totalBufferedEventCount, Math.Max(totalDeltaZero, partitionStateDelta));
                 Interlocked.Exchange(ref partitionState.BufferedEventCount, 0);
@@ -1840,7 +1847,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 // If there is already a task running for the background management process,
                 // then no further initialization is needed.
 
-                if ((IsPublishing) && (!_producerManagementTask.IsCompleted))
+                if ((IsPublishing) && (!_producerManagementTask.IsCompleted) || (_isClosed))
                 {
                     return;
                 }
@@ -1954,13 +1961,12 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 _producerManagementTask = null;
             }
+            catch (OperationCanceledException ex) when (ex is not TaskCanceledException)
+            {
+                throw new TaskCanceledException(ex.Message, ex);
+            }
             catch (Exception ex)
             {
-                if (ex is OperationCanceledException opEx)
-                {
-                    throw new TaskCanceledException(opEx.Message, opEx);
-                }
-
                 Logger.BufferedProducerBackgroundProcessingStopError(Identifier, EventHubName, ex.Message);
                 (capturedExceptions ??= new List<Exception>()).Add(ex);
             }
@@ -2247,7 +2253,7 @@ namespace Azure.Messaging.EventHubs.Producer
                             if ((!cancellationToken.IsCancellationRequested)
                                 && (_activePartitionStateMap.TryGetValue(partition, out var partitionState))
                                 && (partitionState.BufferedEventCount > 0)
-                                && ((partitionState.PartitionGuard.Wait(0, cancellationToken)) || (await partitionState.PartitionGuard.WaitAsync(PartitionPublishingGuardAcquireLimitMilliseconds, cancellationToken).ConfigureAwait((false)))))
+                                && ((partitionState.PartitionGuard.Wait(0, cancellationToken)) || (await partitionState.PartitionGuard.WaitAsync(PartitionPublishingGuardAcquireLimitMilliseconds, cancellationToken).ConfigureAwait(false))))
                             {
                                 // Responsibility for releasing the guard semaphore is passed to the task.
 
@@ -2257,7 +2263,7 @@ namespace Azure.Messaging.EventHubs.Producer
                             // If there are no events in the buffer, avoid a tight loop by blocking to wait for events to be enqueued
                             // after a small delay.
 
-                            if (_totalBufferedEventCount == 0)
+                            if (Volatile.Read(ref _totalBufferedEventCount) == 0)
                             {
                                 // If completion source doesn't exist or was already set, then swap in a new completion source to be
                                 // set when an event is enqueued.  Allow the publishing loop to tick for one additional check of the
@@ -2281,10 +2287,15 @@ namespace Azure.Messaging.EventHubs.Producer
 
                                     var idleWatch = ValueStopwatch.StartNew();
 
-                                    await _eventEnqueuedCompletionSource.Task.AwaitWithCancellation(cancellationToken);
-                                    _eventEnqueuedCompletionSource = null;
-
-                                    Logger.BufferedProducerIdleComplete(Identifier, EventHubName, operationId, idleWatch.GetElapsedTime().TotalSeconds);
+                                    try
+                                    {
+                                        await _eventEnqueuedCompletionSource.Task.AwaitWithCancellation(cancellationToken);
+                                        _eventEnqueuedCompletionSource = null;
+                                    }
+                                    finally
+                                    {
+                                        Logger.BufferedProducerIdleComplete(Identifier, EventHubName, operationId, idleWatch.GetElapsedTime().TotalSeconds);
+                                    }
                                 }
                             }
                         }
@@ -2332,7 +2343,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///    set of Event Hub partitions has changed since they were last queried.
         /// </summary>
         ///
-        /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// v
         ///
         /// <remarks>
         ///   This method will potentially modify class state, overwriting the tracked set of partitions.
@@ -2468,11 +2479,11 @@ namespace Azure.Messaging.EventHubs.Producer
             /// <summary>The writer to use for enqueuing events to be published.</summary>
             public ChannelWriter<EventData> PendingEventsWriter => _pendingEvents.Writer;
 
-            /// <summary>The identifier of the partition that is being published.</summary>
-            public readonly string PartitionId;
-
             /// <summary>The primitive for synchronizing access for publishing to the partition.</summary>
             public readonly SemaphoreSlim PartitionGuard;
+
+            /// <summary>The identifier of the partition that is being published.</summary>
+            public readonly string PartitionId;
 
             /// <summary>The number of events that are currently buffered and waiting to be published for this partition.</summary>
             public int BufferedEventCount;
@@ -2482,6 +2493,9 @@ namespace Azure.Messaging.EventHubs.Producer
 
             /// <summary>The events that have been enqueued and are pending publishing.</summary>
             private readonly Channel<EventData> _pendingEvents;
+
+            /// <summary>The events that have been enqueued and are pending publishing.</summary>
+            private readonly int _partitionGuardMaximumCount;
 
             /// <summary>
             ///   Initializes a new instance of the <see cref="PartitionPublishingState"/> class.
@@ -2496,6 +2510,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 PartitionId = partitionId;
                 PartitionGuard = new(options.MaximumConcurrentSendsPerPartition, options.MaximumConcurrentSendsPerPartition);
 
+                _partitionGuardMaximumCount = options.MaximumConcurrentSendsPerPartition;
                 _pendingEvents = CreatePendingEventChannel(options.MaximumEventBufferLengthPerPartition);
                 _stashedEvents = new();
             }
@@ -2527,6 +2542,19 @@ namespace Azure.Messaging.EventHubs.Producer
             /// <param name="eventData">The event to stash.</param>
             ///
             public void StashEvent(EventData eventData) => _stashedEvents.Enqueue(eventData);
+
+            /// <summary>
+            ///   Releases the partition guard after checking the state to ensure
+            ///   there is capacity remaining and a release is necessary.
+            /// </summary>
+            ///
+            public void SafeReleaseGuard()
+            {
+                if (PartitionGuard.CurrentCount < _partitionGuardMaximumCount)
+                {
+                    PartitionGuard.Release();
+                }
+            }
 
             /// <summary>
             ///   Performs tasks needed to clean-up the disposable resources used by the publisher.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -1339,46 +1339,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCannotReadWithInvalidProxy()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
-
-                var clientOptions = new EventHubConsumerClientOptions();
-                clientOptions.RetryOptions.MaximumRetries = 0;
-                clientOptions.RetryOptions.MaximumDelay = TimeSpan.FromMilliseconds(5);
-                clientOptions.RetryOptions.TryTimeout = TimeSpan.FromSeconds(45);
-                clientOptions.ConnectionOptions.Proxy = new WebProxy("http://1.2.3.4:9999");
-                clientOptions.ConnectionOptions.TransportType = EventHubsTransportType.AmqpWebSockets;
-
-                await using (var producer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.FullyQualifiedNamespace, scope.EventHubName, EventHubsTestEnvironment.Instance.Credential))
-                await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.FullyQualifiedNamespace, scope.EventHubName, EventHubsTestEnvironment.Instance.Credential, clientOptions))
-                {
-                    var partition = (await producer.GetPartitionIdsAsync(cancellationSource.Token)).First();
-
-                    // The sockets implementation in .NET Core on some platforms, such as Linux, does not trigger a specific socket exception and
-                    // will, instead, hang indefinitely.  The try timeout is intentionally set to a value smaller than the cancellation token to
-                    // invoke a timeout exception in these cases.
-
-                    Assert.That(async () => await ReadNothingAsync(invalidProxyConsumer, partition, cancellationSource.Token, iterationCount: 25),
-                        Throws
-                            .InstanceOf<WebSocketException>()
-                            .Or.InstanceOf<TimeoutException>()
-                            .Or.InstanceOf<OperationCanceledException>());
-
-                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
         public async Task ConsumerCannotReadAsNonExclusiveWhenAnExclusiveReaderIsActive()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
@@ -2200,68 +2160,6 @@ namespace Azure.Messaging.EventHubs.Tests
                     EventHubsTestEnvironment.Instance.Credential))
                 {
                     Assert.That(async () => await consumer.GetPartitionPropertiesAsync(invalidPartition, cancellationSource.Token), Throws.TypeOf<ArgumentOutOfRangeException>());
-                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCannotRetrieveMetadataWithInvalidProxy()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
-
-                var invalidProxyOptions = new EventHubConsumerClientOptions();
-                invalidProxyOptions.RetryOptions.MaximumRetries = 0;
-                invalidProxyOptions.RetryOptions.MaximumDelay = TimeSpan.FromMilliseconds(5);
-                invalidProxyOptions.RetryOptions.TryTimeout = TimeSpan.FromSeconds(45);
-                invalidProxyOptions.ConnectionOptions.Proxy = new WebProxy("http://1.2.3.4:9999");
-                invalidProxyOptions.ConnectionOptions.TransportType = EventHubsTransportType.AmqpWebSockets;
-
-                await using (var consumer = new EventHubConsumerClient(
-                    EventHubConsumerClient.DefaultConsumerGroupName,
-                    EventHubsTestEnvironment.Instance.FullyQualifiedNamespace,
-                    scope.EventHubName,
-                    EventHubsTestEnvironment.Instance.Credential))
-
-                await using (var invalidProxyConsumer = new EventHubConsumerClient(
-                    EventHubConsumerClient.DefaultConsumerGroupName,
-                    EventHubsTestEnvironment.Instance.FullyQualifiedNamespace,
-                    scope.EventHubName,
-                    EventHubsTestEnvironment.Instance.Credential,
-                    invalidProxyOptions))
-                {
-                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
-
-                    // The sockets implementation in .NET Core on some platforms, such as Linux, does not trigger a specific socket exception and
-                    // will, instead, hang indefinitely.  The try timeout is intentionally set to a value smaller than the cancellation token to
-                    // invoke a timeout exception in these cases.
-
-                    Assert.That(async () => await invalidProxyConsumer.GetPartitionIdsAsync(cancellationSource.Token),
-                        Throws
-                            .InstanceOf<WebSocketException>()
-                            .Or.InstanceOf<TimeoutException>()
-                            .Or.InstanceOf<OperationCanceledException>());
-
-                    Assert.That(async () => await invalidProxyConsumer.GetEventHubPropertiesAsync(cancellationSource.Token),
-                        Throws
-                            .InstanceOf<WebSocketException>()
-                            .Or.InstanceOf<TimeoutException>()
-                            .Or.InstanceOf<OperationCanceledException>());
-
-                    Assert.That(async () => await invalidProxyConsumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token),
-                        Throws
-                            .InstanceOf<WebSocketException>()
-                            .Or.InstanceOf<TimeoutException>()
-                            .Or.InstanceOf<OperationCanceledException>());
-
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -1362,7 +1362,12 @@ namespace Azure.Messaging.EventHubs.Tests
                     // will, instead, hang indefinitely.  The try timeout is intentionally set to a value smaller than the cancellation token to
                     // invoke a timeout exception in these cases.
 
-                    Assert.That(async () => await ReadNothingAsync(invalidProxyConsumer, partition, cancellationSource.Token, iterationCount: 25), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await ReadNothingAsync(invalidProxyConsumer, partition, cancellationSource.Token, iterationCount: 25),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
+
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                 }
             }
@@ -2239,9 +2244,24 @@ namespace Azure.Messaging.EventHubs.Tests
                     // will, instead, hang indefinitely.  The try timeout is intentionally set to a value smaller than the cancellation token to
                     // invoke a timeout exception in these cases.
 
-                    Assert.That(async () => await invalidProxyConsumer.GetPartitionIdsAsync(cancellationSource.Token), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
-                    Assert.That(async () => await invalidProxyConsumer.GetEventHubPropertiesAsync(cancellationSource.Token), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
-                    Assert.That(async () => await invalidProxyConsumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await invalidProxyConsumer.GetPartitionIdsAsync(cancellationSource.Token),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
+
+                    Assert.That(async () => await invalidProxyConsumer.GetEventHubPropertiesAsync(cancellationSource.Token),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
+
+                    Assert.That(async () => await invalidProxyConsumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
+
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
@@ -987,7 +987,12 @@ namespace Azure.Messaging.EventHubs.Tests
                     // will, instead, hang indefinitely.  The try timeout is intentionally set to a value smaller than the cancellation token to
                     // invoke a timeout exception in these cases.
 
-                    Assert.That(async () => await ReadNothingAsync(invalidProxyReceiver, cancellationSource.Token, iterationCount: 25), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await ReadNothingAsync(invalidProxyReceiver, cancellationSource.Token, iterationCount: 25),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
+
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                 }
             }
@@ -2511,7 +2516,12 @@ namespace Azure.Messaging.EventHubs.Tests
                     // will, instead, hang indefinitely.  The try timeout is intentionally set to a value smaller than the cancellation token to
                     // invoke a timeout exception in these cases.
 
-                    Assert.That(async () => await receiver.GetPartitionPropertiesAsync(cancellationSource.Token), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await receiver.GetPartitionPropertiesAsync(cancellationSource.Token),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
+
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
@@ -1667,50 +1667,6 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to
-        ///   connect to the Event Hubs service.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ProducerCannotRetrieveMetadataWhenProxyIsInvalid()
-        {
-            var invalidProxyOptions = new EventHubBufferedProducerClientOptions
-            {
-                RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
-
-                ConnectionOptions = new EventHubConnectionOptions
-                {
-                    Proxy = new WebProxy("http://1.2.3.4:9999"),
-                    TransportType = EventHubsTransportType.AmqpWebSockets
-                }
-            };
-
-            await using var scope = await EventHubScope.CreateAsync(1);
-            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.FullyQualifiedNamespace, scope.EventHubName, EventHubsTestEnvironment.Instance.Credential);
-            await using var invalidProxyProducer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.FullyQualifiedNamespace, scope.EventHubName, EventHubsTestEnvironment.Instance.Credential, invalidProxyOptions);
-
-            var partition = (await producer.GetPartitionIdsAsync()).First();
-
-            Assert.That(async () => await invalidProxyProducer.GetPartitionIdsAsync(),
-                Throws
-                    .InstanceOf<WebSocketException>().Or
-                    .InstanceOf<TimeoutException>()
-                    .Or.InstanceOf<OperationCanceledException>());
-
-            Assert.That(async () => await invalidProxyProducer.GetEventHubPropertiesAsync(),
-                Throws
-                    .InstanceOf<WebSocketException>()
-                    .Or.InstanceOf<TimeoutException>()
-                    .Or.InstanceOf<OperationCanceledException>());
-
-            Assert.That(async () => await invalidProxyProducer.GetPartitionPropertiesAsync(partition),
-                Throws
-                    .InstanceOf<WebSocketException>()
-                    .Or.InstanceOf<TimeoutException>()
-                    .Or.InstanceOf<OperationCanceledException>());
-        }
-
-        /// <summary>
         ///   Polls the count of buffered events for a producer until it has been updated to
         ///   0 or the maximum number of iterations has been reached.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
@@ -1691,9 +1691,23 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var partition = (await producer.GetPartitionIdsAsync()).First();
 
-            Assert.That(async () => await invalidProxyProducer.GetPartitionIdsAsync(), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
-            Assert.That(async () => await invalidProxyProducer.GetEventHubPropertiesAsync(), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
-            Assert.That(async () => await invalidProxyProducer.GetPartitionPropertiesAsync(partition), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+            Assert.That(async () => await invalidProxyProducer.GetPartitionIdsAsync(),
+                Throws
+                    .InstanceOf<WebSocketException>().Or
+                    .InstanceOf<TimeoutException>()
+                    .Or.InstanceOf<OperationCanceledException>());
+
+            Assert.That(async () => await invalidProxyProducer.GetEventHubPropertiesAsync(),
+                Throws
+                    .InstanceOf<WebSocketException>()
+                    .Or.InstanceOf<TimeoutException>()
+                    .Or.InstanceOf<OperationCanceledException>());
+
+            Assert.That(async () => await invalidProxyProducer.GetPartitionPropertiesAsync(partition),
+                Throws
+                    .InstanceOf<WebSocketException>()
+                    .Or.InstanceOf<TimeoutException>()
+                    .Or.InstanceOf<OperationCanceledException>());
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
@@ -5298,7 +5298,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.PartitionGuard.Release();
+                        state.SafeReleaseGuard();
                     }
 
                     completionSource.TrySetResult(true);
@@ -5366,7 +5366,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.PartitionGuard.Release();
+                        state.SafeReleaseGuard();
                     }
 
                     if (Interlocked.Increment(ref publishCount) >= validPartitions.Length)
@@ -5452,7 +5452,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.PartitionGuard.Release();
+                        state.SafeReleaseGuard();
                     }
 
                     if (Interlocked.Increment(ref publishCount) >= expectedPublishCount)
@@ -5542,7 +5542,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.PartitionGuard.Release();
+                        state.SafeReleaseGuard();
                     }
 
                     if (Interlocked.Increment(ref publishCount) >= expectedPublishCount)
@@ -5633,7 +5633,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.PartitionGuard.Release();
+                        state.SafeReleaseGuard();
                     }
 
                     if (Interlocked.Increment(ref publishCount) >= expectedPublishCount)
@@ -5735,7 +5735,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.PartitionGuard.Release();
+                        state.SafeReleaseGuard();
                     }
 
                     if (Interlocked.Increment(ref publishCount) == expectedPublishCount)
@@ -5857,7 +5857,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.PartitionGuard.Release();
+                        state.SafeReleaseGuard();
                     }
 
                     if (Interlocked.Increment(ref finishCount) >= validPartitions.Length)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
@@ -5298,7 +5298,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.SafeReleaseGuard();
+                        state.PartitionGuard.Release();
                     }
 
                     completionSource.TrySetResult(true);
@@ -5366,7 +5366,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.SafeReleaseGuard();
+                        state.PartitionGuard.Release();
                     }
 
                     if (Interlocked.Increment(ref publishCount) >= validPartitions.Length)
@@ -5452,7 +5452,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.SafeReleaseGuard();
+                        state.PartitionGuard.Release();
                     }
 
                     if (Interlocked.Increment(ref publishCount) >= expectedPublishCount)
@@ -5542,7 +5542,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.SafeReleaseGuard();
+                        state.PartitionGuard.Release();
                     }
 
                     if (Interlocked.Increment(ref publishCount) >= expectedPublishCount)
@@ -5633,7 +5633,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.SafeReleaseGuard();
+                        state.PartitionGuard.Release();
                     }
 
                     if (Interlocked.Increment(ref publishCount) >= expectedPublishCount)
@@ -5735,7 +5735,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.SafeReleaseGuard();
+                        state.PartitionGuard.Release();
                     }
 
                     if (Interlocked.Increment(ref publishCount) == expectedPublishCount)
@@ -5857,7 +5857,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     if (releaseFlag)
                     {
-                        state.SafeReleaseGuard();
+                        state.PartitionGuard.Release();
                     }
 
                     if (Interlocked.Increment(ref finishCount) >= validPartitions.Length)
@@ -6062,7 +6062,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task DrainAndPublishPartitionEventsPublishshesOneBatch()
+        public async Task DrainAndPublishPartitionEventsPublishesOneBatch()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
@@ -6130,7 +6130,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task DrainAndPublishPartitionEventsPublishshesMultipleBatches()
+        public async Task DrainAndPublishPartitionEventsPublishesMultipleBatches()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
@@ -6259,7 +6259,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task DrainAndPublishPartitionEventsIvokesTheHandlerWhenPublishingFails()
+        public async Task DrainAndPublishPartitionEventsInvokesTheHandlerWhenPublishingFails()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
@@ -1207,7 +1207,11 @@ namespace Azure.Messaging.EventHubs.Tests
                     EventHubsTestEnvironment.Instance.Credential,
                     producerOptions))
                 {
-                    Assert.That(async () => await invalidProxyProducer.SendAsync(new[] { new EventData(new byte[1]) }), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await invalidProxyProducer.SendAsync(new[] { new EventData(new byte[1]) }),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
                 }
             }
         }
@@ -1478,9 +1482,23 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await producer.GetPartitionIdsAsync()).First();
 
-                    Assert.That(async () => await invalidProxyProducer.GetPartitionIdsAsync(), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
-                    Assert.That(async () => await invalidProxyProducer.GetEventHubPropertiesAsync(), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
-                    Assert.That(async () => await invalidProxyProducer.GetPartitionPropertiesAsync(partition), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await invalidProxyProducer.GetPartitionIdsAsync(),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
+
+                    Assert.That(async () => await invalidProxyProducer.GetEventHubPropertiesAsync(),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
+
+                    Assert.That(async () => await invalidProxyProducer.GetPartitionPropertiesAsync(partition),
+                        Throws
+                            .InstanceOf<WebSocketException>()
+                            .Or.InstanceOf<TimeoutException>()
+                            .Or.InstanceOf<OperationCanceledException>());
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
@@ -1186,42 +1186,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ProducerCannotSendWhenProxyIsInvalid()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var producerOptions = new EventHubProducerClientOptions
-                {
-                    RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
-
-                    ConnectionOptions = new EventHubConnectionOptions
-                    {
-                        Proxy = new WebProxy("http://1.2.3.4:9999"),
-                        TransportType = EventHubsTransportType.AmqpWebSockets
-                    }
-                };
-
-                await using (var invalidProxyProducer = new EventHubProducerClient(
-                    EventHubsTestEnvironment.Instance.FullyQualifiedNamespace,
-                    scope.EventHubName,
-                    EventHubsTestEnvironment.Instance.Credential,
-                    producerOptions))
-                {
-                    Assert.That(async () => await invalidProxyProducer.SendAsync(new[] { new EventData(new byte[1]) }),
-                        Throws
-                            .InstanceOf<WebSocketException>()
-                            .Or.InstanceOf<TimeoutException>()
-                            .Or.InstanceOf<OperationCanceledException>());
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
         public async Task ProducerCanSendEventsWithAFullyPopulatedAmqpMessage()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
@@ -1452,53 +1416,6 @@ namespace Azure.Messaging.EventHubs.Tests
                await using (var producer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.FullyQualifiedNamespace, scope.EventHubName, EventHubsTestEnvironment.Instance.Credential))
                 {
                     Assert.That(async () => await producer.GetPartitionPropertiesAsync(invalidPartition), Throws.TypeOf<ArgumentOutOfRangeException>());
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
-        ///   connect to the Event Hubs service.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ProducerCannotRetrieveMetadataWhenProxyIsInvalid()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var invalidProxyOptions = new EventHubProducerClientOptions
-                {
-                    RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
-
-                    ConnectionOptions = new EventHubConnectionOptions
-                    {
-                        Proxy = new WebProxy("http://1.2.3.4:9999"),
-                        TransportType = EventHubsTransportType.AmqpWebSockets
-                    }
-                };
-
-                await using (var producer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.FullyQualifiedNamespace, scope.EventHubName, EventHubsTestEnvironment.Instance.Credential))
-                await using (var invalidProxyProducer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.FullyQualifiedNamespace, scope.EventHubName, EventHubsTestEnvironment.Instance.Credential, invalidProxyOptions))
-                {
-                    var partition = (await producer.GetPartitionIdsAsync()).First();
-
-                    Assert.That(async () => await invalidProxyProducer.GetPartitionIdsAsync(),
-                        Throws
-                            .InstanceOf<WebSocketException>()
-                            .Or.InstanceOf<TimeoutException>()
-                            .Or.InstanceOf<OperationCanceledException>());
-
-                    Assert.That(async () => await invalidProxyProducer.GetEventHubPropertiesAsync(),
-                        Throws
-                            .InstanceOf<WebSocketException>()
-                            .Or.InstanceOf<TimeoutException>()
-                            .Or.InstanceOf<OperationCanceledException>());
-
-                    Assert.That(async () => await invalidProxyProducer.GetPartitionPropertiesAsync(partition),
-                        Throws
-                            .InstanceOf<WebSocketException>()
-                            .Or.InstanceOf<TimeoutException>()
-                            .Or.InstanceOf<OperationCanceledException>());
                 }
             }
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to fox an obscure edge case in the `EventHubBufferedProducer` client where an obscure race condition when flushing/enqueuing events concurrently with disposing the producer could cause a semaphore to be released inappropriately.  This error superseded the `TaskCanceledException` that should have been surfaced.  Also moved to volatile reads for the total buffer count when making state-related decisions, to ensure that the most recent value is used.

Also included is removal of the invalid proxy tests.  These have long been flaky due to behavioral differences between platforms and target runtimes.  At this point, the assertions have become very loose and allow for an expanded set of conditions to compensate.  After review, I don't believe that they're offering any real value in their current form and are really testing network/platform behavior rather than the Azure clients.   