### PR TITLE
Emitter - Create scalar.test.ts

### DIFF
--- a/eng/packages/http-client-csharp/emitter/test/Unit/scalar.test.ts
+++ b/eng/packages/http-client-csharp/emitter/test/Unit/scalar.test.ts
@@ -1,0 +1,42 @@
+import { TestHost } from "@typespec/compiler/testing";
+import { strictEqual } from "assert";
+import { beforeEach, describe, it } from "vitest";
+import { createModel } from "../../src/lib/client-model-builder.js";
+import {
+  createEmitterContext,
+  createEmitterTestHost,
+  createNetSdkContext,
+  typeSpecCompile,
+} from "./utils/test-util.js";
+
+describe("Test GetInputType for scalar", () => {
+  let runner: TestHost;
+
+  beforeEach(async () => {
+    runner = await createEmitterTestHost();
+  });
+
+  it("azureLocation scalar", async () => {
+    const program = await typeSpecCompile(
+      `
+        op test(@query location: azureLocation): void;
+      `,
+      runner,
+      { IsNamespaceNeeded: true, IsAzureCoreNeeded: true },
+    );
+    const context = createEmitterContext(program);
+    const sdkContext = await createNetSdkContext(context);
+    const root = createModel(sdkContext);
+    const inputParamArray = root.Clients[0].Operations[0].Parameters.filter(
+      (p) => p.Name === "location",
+    );
+    strictEqual(1, inputParamArray.length);
+    const type = inputParamArray[0].Type;
+    strictEqual(type.kind, "string");
+    strictEqual(type.name, "azureLocation");
+    strictEqual(type.crossLanguageDefinitionId, "Azure.Core.azureLocation");
+    strictEqual(type.baseType?.kind, "string");
+    strictEqual(type.baseType.name, "string");
+    strictEqual(type.baseType.crossLanguageDefinitionId, "TypeSpec.string");
+  });
+});


### PR DESCRIPTION
Moving AzureLocation from microsoft/typespec to azure-sdk-for-net repo
PR to remove from typespec repo will follow


# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
