### PR TITLE
[Storage] Update Storage Package Versions Packages.Data.props

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -290,8 +290,8 @@
     <PackageReference Update="Azure.Search.Documents" Version="11.2.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.8.0" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.23.0" />
+    <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.21.0" />
     <PackageReference Update="BenchmarkDotNet" Version="0.13.4" />
     <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.4" />
     <PackageReference Update="Castle.Core" Version="5.1.0" />
@@ -403,8 +403,8 @@
     <PackageReference Update="System.IO.Pipelines" Version="8.0.0" />
     <PackageReference Update="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Update="System.ServiceModel.Primitives" Version="6.2.0" />
-    <PackageReference Update="Azure.Storage.Files.Shares" Version="12.18.0" />
-    <PackageReference Update="Azure.Storage.Queues" Version="12.18.0" />
+    <PackageReference Update="Azure.Storage.Files.Shares" Version="12.21.0" />
+    <PackageReference Update="Azure.Storage.Queues" Version="12.21.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -124,10 +124,10 @@
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
-    <PackageReference Update="Azure.Storage.Common" Version="12.20.1" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.21.1" />
-    <PackageReference Update="Azure.Storage.Queues" Version="12.19.1" />
-    <PackageReference Update="Azure.Storage.Files.Shares" Version="12.19.1" />
+    <PackageReference Update="Azure.Storage.Common" Version="12.22.0" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.23.0" />
+    <PackageReference Update="Azure.Storage.Queues" Version="12.21.0" />
+    <PackageReference Update="Azure.Storage.Files.Shares" Version="12.21.0" />
     <PackageReference Update="Azure.AI.Inference" Version="1.0.0-beta.2" />
     <PackageReference Update="Azure.AI.OpenAI" Version="2.0.0" />
     <PackageReference Update="Azure.ResourceManager" Version="1.13.0" />


### PR DESCRIPTION
Updating storage package version within the eng/script/Packages.Data.props file.

This is in preparation for our Azure.Storage.DataMovement libraries and Microsoft.Azure.WebJobs.Extensions.Storage package releases which take a dependency on the respective packages I updated the versions of.