### PR TITLE
Add `az.namespace` to Azure AI Inference spans

### DIFF
--- a/sdk/ai/Azure.AI.Inference/src/Telemetry/OpenTelemetryConstants.cs
+++ b/sdk/ai/Azure.AI.Inference/src/Telemetry/OpenTelemetryConstants.cs
@@ -11,6 +11,8 @@ namespace Azure.AI.Inference.Telemetry
         // https://github.com/open-telemetry/semantic-conventions/tree/v1.27.0/docs/gen-ai
 
         public const string ErrorTypeKey = "error.type";
+
+        public const string AzNamespaceKey = "az.namespace";
         public const string ServerAddressKey = "server.address";
         public const string ServerPortKey = "server.port";
 
@@ -38,6 +40,8 @@ namespace Azure.AI.Inference.Telemetry
 
         public const string GenAiEventContent = "gen_ai.event.content";
         public const string GenAiChoice = "gen_ai.choice";
+
+        public const string AzureRpNamespaceValue = "Microsoft.CognitiveServices";
 
         public const string ClientName = "Azure.AI.Inference.ChatCompletionsClient";
         public const string EnableOpenTelemetrySwitch = "Azure.Experimental.EnableActivitySource";

--- a/sdk/ai/Azure.AI.Inference/src/Telemetry/OpenTelemetryScope.cs
+++ b/sdk/ai/Azure.AI.Inference/src/Telemetry/OpenTelemetryScope.cs
@@ -88,6 +88,7 @@ namespace Azure.AI.Inference.Telemetry
             {
                 _activity?.SetTag(kv.Key, kv.Value);
             }
+            _activity?.SetTag(AzNamespaceKey, AzureRpNamespaceValue);
             SetTagMaybe(GenAiRequestMaxTokensKey, requestOptions.MaxTokens);
             SetTagMaybe(GenAiRequestTemperatureKey, requestOptions.Temperature);
             SetTagMaybe(GenAiRequestTopPKey, requestOptions.NucleusSamplingFactor);

--- a/sdk/ai/Azure.AI.Inference/tests/Utilities/ValidatingActivityListener.cs
+++ b/sdk/ai/Azure.AI.Inference/tests/Utilities/ValidatingActivityListener.cs
@@ -93,6 +93,7 @@ namespace Azure.AI.Inference.Tests.Utilities
             ValidateTag(activity, GenAiResponseFinishReasonsKey, response.FinishReasons);
             ValidateIntTag(activity, GenAiUsageOutputTokensKey, response.CompletionTokens);
             ValidateIntTag(activity, GenAiUsageInputTokensKey, response.PromptTokens);
+            ValidateTag(activity, AzNamespaceKey, AzureRpNamespaceValue);
 
             HashSet<string> expectedChoices = new HashSet<string>(response.Choices.Select(c => JsonSerializer.Serialize(c, options: s_jsonOptions)));
             for (int i = 0; i < actualChoices.Count; i++)


### PR DESCRIPTION
This attribute is part of azure sdk semantic conventions and should be populated by all SDKs - https://azure.github.io/azure-sdk/distributed_tracing_conventions.html

We usually populate it in 

https://github.com/Azure/azure-sdk-for-net/blob/fe16c3a518753dab58f71fbbe8e2b03a9d04d022/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs#L76

but inference uses `Activity` directly and we forgot to add this attribute.

It's used by Azure Monitor to show icons and enable navigation to resource.