### PR TITLE
Update triggers for azure plugin

### DIFF
--- a/eng/packages/http-client-csharp/ci.yml
+++ b/eng/packages/http-client-csharp/ci.yml
@@ -5,6 +5,7 @@ trigger:
   paths:
     include:
       - eng/packages/http-client-csharp
+      - eng/scripts/typespec
 pr:
   branches:
     include:
@@ -15,6 +16,7 @@ pr:
   paths:
     include:
       - eng/packages/http-client-csharp
+      - eng/scripts/typespec
 
 parameters:
   - name: BuildPrereleaseVersion

--- a/eng/scripts/ci.yml
+++ b/eng/scripts/ci.yml
@@ -1,4 +1,6 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+# Excludes eng/scripts/typespec as these are only used in the eng/packages/http-client-csharp/ci.yml pipeline.
+
 trigger:
   branches:
     include:
@@ -9,6 +11,8 @@ trigger:
   paths:
     include:
       - eng/scripts/*
+    exclude:
+      - eng/scripts/typespec
 
 pr:
   branches:
@@ -20,6 +24,8 @@ pr:
   paths:
     include:
       - eng/scripts/*
+    exclude:
+      - eng/scripts/typespec
 
 extends:
   template: /eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/48006 where `net - eng-script-tests` was running even though we only touched the folder with the scripts that control `branded - http-client-csharp - ci`

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
