### PR TITLE
[Event Hubs] Handle bad offset at GeoDR failover

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,6 +10,23 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 ### Features Added
 
+- Support for the Event Hubs geographic data replication feature has been enabled. Checking for whether or not this feature is enabled for your namespace can be done by querying for Event Hub properties using `EventHubProducerClient` or `EventHubConsumerClient` and referencing the the `IsGeoReplicationEnabled` property of the result.
+
+  As part of this feature, the type of offset-related data has been changed from `long` to `string` to align with changes to the Event Hubs service API. To preserve backwards compatibility, the existing offset-related members have not been changed, and new members with names similar to `OffsetString` and string-based parameters for method overloads have been introduced.   
+  
+  The long-based offset members will continue to work for Event Hubs namespaces that do not have GeoDR replication enabled, but are discouraged for use and have been marked as obsolete.
+  
+  Obsoleted properties:
+  - [EventData.Offset](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventdata.offset?view=azure-dotnet#azure-messaging-eventhubs-eventdata-offset)
+  - [LastEnqueuedEventProperties.Offset](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.consumer.lastenqueuedeventproperties.offset?view=azure-dotnet)
+  - [PartitionProperties.LastEnqueuedOffset](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.partitionproperties.lastenqueuedoffset?view=azure-dotnet)
+
+  Obsoleted method overloads:
+  - [EventPosition.FromOffset](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.consumer.eventposition.fromoffset?view=azure-dotnet)
+  - [EventHubsModelFactory.EventData](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventhubsmodelfactory.eventdata?view=azure-dotnet)
+  - [BlobCheckpointStore.UpdateCheckpointAsync](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.primitives.blobcheckpointstore.updatecheckpointasync?view=azure-dotnet)
+  - [EventProcessorClient.UpdateCheckpointAsync](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventprocessorclient.updatecheckpointasync?view=azure-dotnet)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -10,6 +10,23 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 ### Features Added
 
+- Support for the Event Hubs geographic data replication feature has been enabled. Checking for whether or not this feature is enabled for your namespace can be done by querying for Event Hub properties using `EventHubProducerClient` or `EventHubConsumerClient` and referencing the the `IsGeoReplicationEnabled` property of the result.
+
+  As part of this feature, the type of offset-related data has been changed from `long` to `string` to align with changes to the Event Hubs service API. To preserve backwards compatibility, the existing offset-related members have not been changed, and new members with names similar to `OffsetString` and string-based parameters for method overloads have been introduced.  
+  
+  The long-based offset members will continue to work for Event Hubs namespaces that do not have GeoDR replication enabled, but are discouraged for use and have been marked as obsolete.
+  
+  Obsoleted properties:
+  - [EventData.Offset](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventdata.offset?view=azure-dotnet#azure-messaging-eventhubs-eventdata-offset)
+  - [LastEnqueuedEventProperties.Offset](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.consumer.lastenqueuedeventproperties.offset?view=azure-dotnet)
+  - [PartitionProperties.LastEnqueuedOffset](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.partitionproperties.lastenqueuedoffset?view=azure-dotnet)
+
+  Obsoleted method overloads:
+  - [EventPosition.FromOffset](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.consumer.eventposition.fromoffset?view=azure-dotnet)
+  - [EventHubsModelFactory.EventData](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventhubsmodelfactory.eventdata?view=azure-dotnet)
+  - [BlobCheckpointStore.UpdateCheckpointAsync](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.primitives.blobcheckpointstore.updatecheckpointasync?view=azure-dotnet)
+  - [EventProcessorClient.UpdateCheckpointAsync](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventprocessorclient.updatecheckpointasync?view=azure-dotnet)
+  
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.net8.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.net8.0.cs
@@ -541,6 +541,7 @@ namespace Azure.Messaging.EventHubs.Processor
     {
         private object _dummy;
         private int _dummyPrimitive;
+        public CheckpointPosition() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("The Event Hubs service does not guarantee that a sequence number-only checkpoint can access the event stream for all resource configurations.  Reading events may not work in all cases going forward. Please provide a string-based offset.", false)]
         public CheckpointPosition(long sequenceNumber) { throw null; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -541,6 +541,7 @@ namespace Azure.Messaging.EventHubs.Processor
     {
         private object _dummy;
         private int _dummyPrimitive;
+        public CheckpointPosition() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("The Event Hubs service does not guarantee that a sequence number-only checkpoint can access the event stream for all resource configurations.  Reading events may not work in all cases going forward. Please provide a string-based offset.", false)]
         public CheckpointPosition(long sequenceNumber) { throw null; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
@@ -66,6 +66,12 @@ namespace Azure.Messaging.EventHubs
         public static AmqpSymbol ProducerStolenError { get; } = AmqpConstants.Vendor + ":producer-epoch-stolen";
 
         /// <summary>
+        ///   Indicates that an offset is invalid for a GeoDR-enabled namespace.
+        /// </summary>
+        ///
+        public static AmqpSymbol InvalidGeolocationOffset { get; } = AmqpConstants.Vendor + ":georeplication:invalid-offset";
+
+        /// <summary>
         ///   The expression to test for when the service returns a "Not Found" response to determine the context.
         /// </summary>
         ///
@@ -222,6 +228,13 @@ namespace Azure.Messaging.EventHubs
             if (string.Equals(condition, SequenceOutOfOrderError.Value, StringComparison.InvariantCultureIgnoreCase))
             {
                 return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.InvalidClientState, innerException);
+            }
+
+            // An offset was rejected as invalid for a GeoDR-enabled namespace.
+
+            if (string.Equals(condition, InvalidGeolocationOffset.Value, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new FormatException(IncludeTroubleshootingGuideLink(description), innerException);
             }
 
             // Authorization was denied.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -2790,7 +2790,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has experienced an exception while processing events for a partition.
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance used an invalid offset format from a legacy checkpoint when initializing a partition for processing.
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the Event Hub partition whose processing is taking place.</param>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -2790,6 +2790,27 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has experienced an exception while processing events for a partition.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is taking place.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(131, Level = EventLevel.Error, Message = "The checkpoint data for partition '{0}' contains a legacy offset that is invalid after a geo-replication fail over has taken place.  This checkpoint will be automatically reset.  The processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3} will attempt to fall back to the default starting position for partition '{0}'.")]
+        public virtual void EventProcessorPartitionLegacyCheckpointFormat(string partitionId,
+                                                                          string identifier,
+                                                                          string eventHubName,
+                                                                          string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(141, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
         ///   Gets the current value of <see cref="DateTimeOffset.UtcNow" /> formatted
         ///   for use in logs.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/CheckpointPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/CheckpointPosition.cs
@@ -111,6 +111,17 @@ namespace Azure.Messaging.EventHubs.Processor
         }
 
         /// <summary>
+        ///   Initializes an empty <see cref="CheckpointPosition"/> which can be used
+        ///   to clear existing checkpoint data.
+        /// </summary>
+        ///
+        public CheckpointPosition()
+        {
+            SequenceNumber = long.MinValue;
+            OffsetString = null;
+        }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="CheckpointPosition"/> from an <see cref="EventData"/> instance.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/CheckpointPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/CheckpointPosition.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using System.Text;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Core;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpErrorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpErrorTests.cs
@@ -36,6 +36,7 @@ namespace Azure.Messaging.EventHubs.Tests
             yield return new object[] { AmqpError.SequenceOutOfOrderError, typeof(EventHubsException), EventHubsException.FailureReason.InvalidClientState };
             yield return new object[] { AmqpError.ArgumentError, typeof(ArgumentException), null };
             yield return new object[] { AmqpError.ArgumentOutOfRangeError, typeof(ArgumentOutOfRangeException), null };
+            yield return new object[] { AmqpError.InvalidGeolocationOffset, typeof(FormatException), null } ;
 
             // Stock conditions.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -792,28 +792,42 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
                     await SendEventsAsync(scope.EventHubName, EventGenerator.CreateEvents(50), new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                    // Begin reading though no events have been published.  This is necessary to open the connection and
-                    // ensure that the consumer is watching the partition.
+                    // Begin reading in the background, though no events should be read until the next publish.  This is necessary to open the connection and
+                    // ensure that the receiver is watching the partition.
 
-                    var readTask = ReadEventsFromPartitionAsync(consumer, partition,sourceEvents.Select(evt => evt.MessageId), cancellationSource.Token, EventPosition.Latest);
+                    var eventsRead = 0;
 
-                    // Give the consumer a moment to ensure that it is established and then send events for it to read.
+                    var readTask = Task.Run(async () =>
+                    {
+                        await Task.Yield();
+
+                        try
+                        {
+                            await foreach (var item in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, cancellationSource.Token))
+                            {
+                                // If more than one event was read, no need to keep going.
+
+                                if (++eventsRead > 1)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            // Expected
+                        }
+                    });
+
+                    // Give the receiver a moment to ensure that it is established and then send events for it to read.
 
                     await Task.Delay(250);
-                    await SendEventsAsync(scope.EventHubName, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+                    await SendEventsAsync(scope.EventHubName, EventGenerator.CreateEvents(50), new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                    // Await reading of the events and validate the resulting state.
+                    // Await reading of the events and validate that we were able to read at least one event.
 
-                    var readState = await readTask;
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-                    Assert.That(readState.Events.Count, Is.EqualTo(sourceEvents.Count), "Only the source events should have been read.");
-
-                    foreach (var sourceEvent in sourceEvents)
-                    {
-                        var sourceId = sourceEvent.MessageId;
-                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed.");
-                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
-                    }
+                    Assert.That(eventsRead, Is.GreaterThanOrEqualTo(1), "At least one event should have been read.");
                 }
 
                 cancellationSource.Cancel();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Amqp;
@@ -579,7 +577,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
                 var partition = (await QueryPartitionsAsync(scope.EventHubName, cancellationSource.Token)).First();
-                var sourceEvents = EventGenerator.CreateEvents(200).ToList();
 
                 await using (var receiver = new PartitionReceiver(
                     EventHubConsumerClient.DefaultConsumerGroupName,
@@ -593,28 +590,45 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     await SendEventsAsync(scope.EventHubName, EventGenerator.CreateEvents(50), new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                    // Begin reading though no events have been published.  This is necessary to open the connection and
+                    // Begin reading in the background, though no events should be read until the next publish.  This is necessary to open the connection and
                     // ensure that the receiver is watching the partition.
 
-                    var readTask = ReadEventsAsync(receiver, sourceEvents.Select(evt => evt.MessageId), cancellationSource.Token);
+                    var eventsRead = 0;
+
+                    var readTask = Task.Run(async () =>
+                    {
+                        await Task.Yield();
+
+                        try
+                        {
+                            while ((!cancellationSource.Token.IsCancellationRequested) && (eventsRead <= 1))
+                            {
+                                var batch = await receiver.ReceiveBatchAsync(10, TimeSpan.FromMilliseconds(250), cancellationSource.Token);
+                                eventsRead += batch.Count();
+
+                                // Avoid a tight loop if nothing was read.
+
+                                if (eventsRead <= 1)
+                                {
+                                    await Task.Delay(50);
+                                }
+                            }
+                        }
+                        catch (TaskCanceledException)
+                        {
+                          // Expected
+                        }
+                    });
 
                     // Give the receiver a moment to ensure that it is established and then send events for it to read.
 
                     await Task.Delay(250);
-                    await SendEventsAsync(scope.EventHubName, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+                    await SendEventsAsync(scope.EventHubName, EventGenerator.CreateEvents(50), new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                    // Await reading of the events and validate the resulting state.
+                    // Await reading of the events and validate that we were able to read at least one event.
 
-                    var readState = await readTask;
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-                    Assert.That(readState.Events.Count, Is.EqualTo(sourceEvents.Count), "Only the source events should have been read.");
-
-                    foreach (var sourceEvent in sourceEvents)
-                    {
-                        var sourceId = sourceEvent.MessageId;
-                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed.");
-                        Assert.That(sourceEvent.IsEquivalentTo(readEvent), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
-                    }
+                    Assert.That(eventsRead, Is.GreaterThanOrEqualTo(1), "At least one event should have been read.");
                 }
 
                 cancellationSource.Cancel();


### PR DESCRIPTION
# Summary

The focus of these changes is to handle the corner case exception that can occur when a GeoDR namespace fails over and an existing checkpoint exists with the legacy format that is now invalid.  This is a rare occurrence, but it would cause the processor to be unable to recover without manual deletion of the checkpoint blobs.  This change introduces error handling that detects the scenario based on a new service error code and automatically resets the checkpoint, falling back to the configured default position.

## References and resources

- [[Event Hubs] GeoDR Failover Error Handling (#47303)](https://github.com/Azure/azure-sdk-for-net/issues/47303)