### PR TITLE
Prepare release of data protection backup

### DIFF
--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/CHANGELOG.md
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/CHANGELOG.md
@@ -1,18 +1,14 @@
 # Release History
 
-## 1.6.0-beta.1 (2025-02-07)
+## 1.6.0-beta.1 (2025-02-11)
 
 ### Features Added
 
 - Exposed `JsonModelWriteCore` for model serialization procedure.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Added a new property `UserAssignedIdentityId` in `DataProtectionIdentityDetails` to replace the old property `UserAssignedIdentityArmUri` with wrong type (https://github.com/Azure/azure-sdk-for-net/issues/47031).
-
-### Other Changes
 
 ## 1.5.0 (2024-06-17)
 

--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/CHANGELOG.md
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
+## 1.6.0-beta.1 (2025-02-07)
 
 ### Features Added
 
@@ -10,7 +10,7 @@
 
 ### Bugs Fixed
 
-Convert properties of type Uri to type string in DataProtectionIdentityDetails. Issue at https://github.com/Azure/azure-sdk-for-net/issues/47031
+- Added a new property `UserAssignedIdentityId` in `DataProtectionIdentityDetails` to replace the old property `UserAssignedIdentityArmUri` with wrong type (https://github.com/Azure/azure-sdk-for-net/issues/47031).
 
 ### Other Changes
 

--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/api/Azure.ResourceManager.DataProtectionBackup.net8.0.cs
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/api/Azure.ResourceManager.DataProtectionBackup.net8.0.cs
@@ -1992,9 +1992,9 @@ namespace Azure.ResourceManager.DataProtectionBackup.Models
     {
         public DataProtectionIdentityDetails() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This property has been replaced by UserAssignedIdentityArmUriString", false)]
+        [System.ObsoleteAttribute("This property has been replaced by UserAssignedIdentityId", false)]
         public System.Uri UserAssignedIdentityArmUri { get { throw null; } set { } }
-        public string UserAssignedIdentityArmUriString { get { throw null; } set { } }
+        public Azure.Core.ResourceIdentifier UserAssignedIdentityId { get { throw null; } set { } }
         public bool? UseSystemAssignedIdentity { get { throw null; } set { } }
         protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataProtectionBackup.Models.DataProtectionIdentityDetails System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataProtectionBackup.Models.DataProtectionIdentityDetails>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/api/Azure.ResourceManager.DataProtectionBackup.netstandard2.0.cs
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/api/Azure.ResourceManager.DataProtectionBackup.netstandard2.0.cs
@@ -1992,9 +1992,9 @@ namespace Azure.ResourceManager.DataProtectionBackup.Models
     {
         public DataProtectionIdentityDetails() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This property has been replaced by UserAssignedIdentityArmUriString", false)]
+        [System.ObsoleteAttribute("This property has been replaced by UserAssignedIdentityId", false)]
         public System.Uri UserAssignedIdentityArmUri { get { throw null; } set { } }
-        public string UserAssignedIdentityArmUriString { get { throw null; } set { } }
+        public Azure.Core.ResourceIdentifier UserAssignedIdentityId { get { throw null; } set { } }
         public bool? UseSystemAssignedIdentity { get { throw null; } set { } }
         protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         Azure.ResourceManager.DataProtectionBackup.Models.DataProtectionIdentityDetails System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.DataProtectionBackup.Models.DataProtectionIdentityDetails>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/src/Customized/Models/DataProtectionIdentityDetails.cs
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/src/Customized/Models/DataProtectionIdentityDetails.cs
@@ -4,10 +4,7 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using Azure.Core;
-using Azure.ResourceManager.Models;
 
 namespace Azure.ResourceManager.DataProtectionBackup.Models
 {
@@ -16,12 +13,12 @@ namespace Azure.ResourceManager.DataProtectionBackup.Models
         /// <summary>
         /// ARM URL for User Assigned Identity.
         /// </summary>
-        [EditorBrowsableAttribute(EditorBrowsableState.Never)]
-        [ObsoleteAttribute("This property has been replaced by UserAssignedIdentityArmUriString", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("This property has been replaced by UserAssignedIdentityId", false)]
         public Uri UserAssignedIdentityArmUri
         {
-            get => string.IsNullOrEmpty(UserAssignedIdentityArmUriString) ? null : new Uri(UserAssignedIdentityArmUriString);
-            set => UserAssignedIdentityArmUriString = value?.AbsoluteUri;
+            get => string.IsNullOrEmpty(UserAssignedIdentityId) ? null : new Uri(UserAssignedIdentityId);
+            set => UserAssignedIdentityId = new(value?.AbsoluteUri);
         }
     }
 }

--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/src/Generated/Models/DataProtectionIdentityDetails.Serialization.cs
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/src/Generated/Models/DataProtectionIdentityDetails.Serialization.cs
@@ -39,10 +39,10 @@ namespace Azure.ResourceManager.DataProtectionBackup.Models
                 writer.WritePropertyName("useSystemAssignedIdentity"u8);
                 writer.WriteBooleanValue(UseSystemAssignedIdentity.Value);
             }
-            if (Optional.IsDefined(UserAssignedIdentityArmUriString))
+            if (Optional.IsDefined(UserAssignedIdentityId))
             {
                 writer.WritePropertyName("userAssignedIdentityArmUrl"u8);
-                writer.WriteStringValue(UserAssignedIdentityArmUriString);
+                writer.WriteStringValue(UserAssignedIdentityId);
             }
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
@@ -82,7 +82,7 @@ namespace Azure.ResourceManager.DataProtectionBackup.Models
                 return null;
             }
             bool? useSystemAssignedIdentity = default;
-            string userAssignedIdentityArmUrl = default;
+            ResourceIdentifier userAssignedIdentityArmUrl = default;
             IDictionary<string, BinaryData> serializedAdditionalRawData = default;
             Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
             foreach (var property in element.EnumerateObject())
@@ -98,7 +98,11 @@ namespace Azure.ResourceManager.DataProtectionBackup.Models
                 }
                 if (property.NameEquals("userAssignedIdentityArmUrl"u8))
                 {
-                    userAssignedIdentityArmUrl = property.Value.GetString();
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    userAssignedIdentityArmUrl = new ResourceIdentifier(property.Value.GetString());
                     continue;
                 }
                 if (options.Format != "W")

--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/src/Generated/Models/DataProtectionIdentityDetails.cs
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/src/Generated/Models/DataProtectionIdentityDetails.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Core;
 
 namespace Azure.ResourceManager.DataProtectionBackup.Models
 {
@@ -52,18 +53,18 @@ namespace Azure.ResourceManager.DataProtectionBackup.Models
 
         /// <summary> Initializes a new instance of <see cref="DataProtectionIdentityDetails"/>. </summary>
         /// <param name="useSystemAssignedIdentity"> Specifies if the BI is protected by System Identity. </param>
-        /// <param name="userAssignedIdentityArmUriString"> ARM URL for User Assigned Identity. </param>
+        /// <param name="userAssignedIdentityId"> ARM URL for User Assigned Identity. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        internal DataProtectionIdentityDetails(bool? useSystemAssignedIdentity, string userAssignedIdentityArmUriString, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal DataProtectionIdentityDetails(bool? useSystemAssignedIdentity, ResourceIdentifier userAssignedIdentityId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             UseSystemAssignedIdentity = useSystemAssignedIdentity;
-            UserAssignedIdentityArmUriString = userAssignedIdentityArmUriString;
+            UserAssignedIdentityId = userAssignedIdentityId;
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
         /// <summary> Specifies if the BI is protected by System Identity. </summary>
         public bool? UseSystemAssignedIdentity { get; set; }
         /// <summary> ARM URL for User Assigned Identity. </summary>
-        public string UserAssignedIdentityArmUriString { get; set; }
+        public ResourceIdentifier UserAssignedIdentityId { get; set; }
     }
 }

--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/src/autorest.md
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/src/autorest.md
@@ -257,7 +257,7 @@ rename-mapping:
   SecureScoreLevel: BackupVaultSecureScoreLevel
   FeatureSettings: BackupVaultFeatureSettings
   IdentityDetails: DataProtectionIdentityDetails
-  IdentityDetails.userAssignedIdentityArmUrl: UserAssignedIdentityArmUriString
+  IdentityDetails.userAssignedIdentityArmUrl: UserAssignedIdentityId|arm-id
   NamespacedNameResource: NamespacedName
   CrossRegionRestoreDetails.sourceBackupInstanceId : -|arm-id
   CrossRegionRestoreDetails.sourceRegion  : -|azure-location


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/47031

`UserAssignedIdentityArmUriString` is really a bad name - the issue discovers the real value of this property is not a URI, but actually they are arm-ids. In some RPs, they use the term `ArmUri` to represent `arm-id`, therefore in this PR I changed the property name to a more reasonable name and its type to `ResourceIdentifier`.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
