### PR TITLE
[Cloud Machine] Update Cloud Machine version and rename types for RAG app

### DIFF
--- a/sdk/cloudmachine/Azure.CloudMachine/samples/RAGMachine/Program.cs
+++ b/sdk/cloudmachine/Azure.CloudMachine/samples/RAGMachine/Program.cs
@@ -3,11 +3,11 @@ using Azure.CloudMachine.OpenAI;
 using Azure.CloudMachine;
 using OpenAI.Chat;
 
-CloudMachineInfrastructure infrastructure = new();
+ProjectInfrastructure infrastructure = new();
 infrastructure.AddFeature(new OpenAIModelFeature("gpt-35-turbo", "0125"));
 infrastructure.AddFeature(new OpenAIModelFeature("text-embedding-ada-002", "2", AIModelKind.Embedding));
 infrastructure.AddFeature(new AppServiceFeature());
-CloudMachineClient client = infrastructure.GetClient();
+ProjectClient client = infrastructure.GetClient();
 
 // the app can be called with -init switch to generate bicep and prepare for azd deployment.
 if (infrastructure.TryExecuteCommand(args)) return;

--- a/sdk/cloudmachine/Azure.CloudMachine/samples/RAGMachine/RAGMachine.csproj
+++ b/sdk/cloudmachine/Azure.CloudMachine/samples/RAGMachine/RAGMachine.csproj
@@ -15,6 +15,6 @@
     </NoWarn>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Azure.CloudMachine.All" Version="1.0.0-alpha.20241213.1" />
+		<PackageReference Include="Azure.CloudMachine.All" Version="1.0.0-alpha.20250205.1" />
 	</ItemGroup>
 </Project>

--- a/sdk/cloudmachine/Azure.Provisioning.CloudMachine/src/FeaturesBuiltIn/AIFoundryFeature.cs
+++ b/sdk/cloudmachine/Azure.Provisioning.CloudMachine/src/FeaturesBuiltIn/AIFoundryFeature.cs
@@ -65,7 +65,7 @@ namespace Azure.CloudMachine.AIFoundry
         /// <summary>
         /// Emit any necessary resources for provisioning (currently no-op).
         /// </summary>
-        /// <param name="cm">The CloudMachineInfrastructure context.</param>
+        /// <param name="cm">The ProjectInfrastructure context.</param>
         /// <returns>A placeholder or no-op resource, as provisioning is out-of-band for now.</returns>
         protected override ProvisionableResource EmitResources(ProjectInfrastructure cm)
         {


### PR DESCRIPTION
This PR updates the latest* cloud machine version for the RAG app and renames `CloudMachineInfrastructure` and `CloudMachineClient` types.