### PR TITLE
[Extensions] Prepare Microsoft.Extension.Azure for release

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.10.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.10.0 (2025-02-11)
 
 ### Other Changes
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.10.0 (2025-02-11)
 
 ### Other Changes
+- Updated dependencies to ensure they are up-to-date with the latest targets and trimming from built-in dependencies.
 
 ## 1.9.0 (2024-11-26)
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Azure Client SDK integration with Microsoft.Extensions libraries</Description>
     <AssemblyTitle>Azure Client SDK integration Microsoft.Extensions</AssemblyTitle>
-    <Version>1.10.0-beta.1</Version>
+    <Version>1.10.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.9.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline AspNetCore Extensions</PackageTags>


### PR DESCRIPTION
Releasing this package will update the dependencies to new major versions centrally specified in Package.Data.Props. 

Microsoft.Extension.Azure must be the first extension to be release since it's a dependency for other extension libraries.

Part of:
- https://github.com/Azure/azure-sdk-for-net/issues/48083.