### PR TITLE
Update Microsoft.Extensions.Azure dependency version

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -232,7 +232,7 @@
     <PackageReference Update="Microsoft.AspNetCore.Http.Connections" Version="1.0.15" />
     <PackageReference Update="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Update="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.7.6" />
+    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.0" />
@@ -341,7 +341,7 @@
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Update="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.3" />
-    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.7.6" />
+    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.10" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />


### PR DESCRIPTION
Released version 1.10.0 of `Microsoft.Extensions.Azure` in https://github.com/Azure/azure-sdk-for-net/pull/48133 to pull the latest dependencies versions specified in Package.Data.Props

Updating this file to include the latest version of `Microsoft.Extensions.Azure`

This PR is related to: 
- https://github.com/Azure/azure-sdk-for-net/issues/48083