### PR TITLE
[Service Bus] Fix error parsing logic

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where an error response from the Service Bus administration service without a body was incorrectly parsed, resulting in a null argument exception obscuring the actual failure response. ([#47517](https://github.com/Azure/azure-sdk-for-net/issues/47517))
+
 ### Other Changes
 
 ## 7.18.3 (2025-01-17)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusRequestFailedDetailsParser.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusRequestFailedDetailsParser.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Pipeline
         public override bool TryParse(Response response, out ResponseError? error, out IDictionary<string, string>? data)
         {
             data = default;
-            if (response.ContentStream is { CanSeek: true })
+            if (response.ContentStream is { CanSeek: true, Length: >0})
             {
                 var position = response.ContentStream.Position;
                 try

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusRequestFailedDetailsParser.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusRequestFailedDetailsParser.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Pipeline
         public override bool TryParse(Response response, out ResponseError? error, out IDictionary<string, string>? data)
         {
             data = default;
-            if (response.ContentStream is { CanSeek: true, Length: >0})
+            if (response.ContentStream is { CanSeek: true, Length: > 0})
             {
                 var position = response.ContentStream.Position;
                 try

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusRequestFailedDetailsParserTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusRequestFailedDetailsParserTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.ServiceBus.Tests.Administration
+{
+    [TestFixture]
+    public class ServiceBusRequestFailedDetailsParserTests
+    {
+        [Test]
+        public void ZeroLengthStreamReturnsDefaultErrorDetails()
+        {
+            var response = new MockResponse(401);
+            response.SetIsError(true);
+            response.SetContent(Array.Empty<byte>());
+
+            var parser = new ServiceBusRequestFailedDetailsParser();
+            parser.TryParse(response, out var error, out var data);
+
+            Assert.AreSame(default(ResponseError), error);
+        }
+
+        [Test]
+        public void NonSeekingStreamReturnsDefaultErrorDetails()
+        {
+            var mockStream = new Mock<Stream>();
+            var response = new MockResponse(401) { ContentStream = mockStream.Object };
+
+            mockStream
+                .Setup(stream => stream.CanSeek)
+                .Returns(false);
+
+            mockStream
+                .Setup(stream => stream.Length)
+                .Returns(1);
+
+            response.SetIsError(true);
+
+            var parser = new ServiceBusRequestFailedDetailsParser();
+            parser.TryParse(response, out var error, out var data);
+
+            Assert.AreSame(default(ResponseError), error);
+        }
+
+        [Test]
+        public void XmlBodyReturnsErrorDetails()
+        {
+            var subcCode = "40100";
+            var message = $"SubCode={subcCode}. Failed to authenticate";
+
+            var errorContent =
+                @$"<?xml version=""1.0"" encoding=""UTF-8""?>
+                <Error>
+                  <Code>401</Code>
+                  <Detail>{message}</Detail>
+                </Error>";
+
+            var response = new MockResponse(401);
+            response.SetIsError(true);
+            response.SetContent(errorContent);
+
+            var parser = new ServiceBusRequestFailedDetailsParser();
+            parser.TryParse(response, out var error, out var data);
+
+            Assert.NotNull(error);
+            Assert.AreNotSame(error, default(ResponseError));
+            Assert.AreEqual(subcCode, error.Code);
+            Assert.AreEqual(message, error.Message);
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the logic for parsing error codes from the Service Bus administration service.  The implementation assumes that all error responses will have a content body, which is not always the case.  For example, an HTTP 401 is returned without a body. In this scenario, the error detail parsing faults and surfaces an exception, obscuring the original 401 status code.

## References and resources

- [[BUG] ArgumentNullException when parsing RequestFailedException while resolving AsyncPageable for RuleProperties on a Subscription (#47517)](https://github.com/Azure/azure-sdk-for-net/issues/47517)