### PR TITLE
[Storage] Add Azure.Storage.DataMovement to eng/Packages.Data.props

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -133,6 +133,7 @@
     <PackageReference Update="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Update="Azure.Storage.Queues" Version="12.21.0" />
     <PackageReference Update="Azure.Storage.Files.Shares" Version="12.21.0" />
+	<PackageReference Update="Azure.Storage.DataMovement" Version="12.0.0" />
     <PackageReference Update="Azure.ResourceManager" Version="1.13.0" />
     <PackageReference Update="Azure.ResourceManager.AppConfiguration" Version="1.3.2" />
     <PackageReference Update="Azure.ResourceManager.ApplicationInsights" Version="1.0.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -133,7 +133,7 @@
     <PackageReference Update="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Update="Azure.Storage.Queues" Version="12.21.0" />
     <PackageReference Update="Azure.Storage.Files.Shares" Version="12.21.0" />
-	<PackageReference Update="Azure.Storage.DataMovement" Version="12.0.0" />
+    <PackageReference Update="Azure.Storage.DataMovement" Version="12.0.0" />
     <PackageReference Update="Azure.ResourceManager" Version="1.13.0" />
     <PackageReference Update="Azure.ResourceManager.AppConfiguration" Version="1.3.2" />
     <PackageReference Update="Azure.ResourceManager.ApplicationInsights" Version="1.0.0" />


### PR DESCRIPTION
In preperation for our Azure.Storage.DataMovement.Blobs and Azure.Storage.DataMovement.Files.Shares GA release, we're add this to the `Packages.Data.props` file so those packages can take a dependency on the base Azure.Storage.DataMovement package.