### PR TITLE
[SignalR] Fixed transitive version conflict

### DIFF
--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -19,6 +19,13 @@
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+
+    <!--
+        Adding as a local override, as packages should not generally take this dependency.  It is
+        needed here due to a transitive version conflict due to the Microsoft.Azure.Functions.Extensions
+        reference.
+    -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride ="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a transitive version conflict in the SignalR extension, arising from the legacy `Microsoft.Azure.Functions.Extensions` package and its dependency on an old version of `Microsoft.Extensions.DependencyInjection` which conflicts with the 8.x package line that the repository is moving to.  This was added as a local override, as SignalR is the only Functions extension package in the repository which uses the legacy package.

# References and resources

- [[BUG]Microsoft.Extensions.DependencyInjection.Abstractions version conflict due to the update of Microsoft.Extensions.Azure (#48163)](https://github.com/Azure/azure-sdk-for-net/issues/48163)
