### PR TITLE
[Event Hubs] Processor Release Prep: Feb, 2025

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.12.0-beta.2 (Unreleased)
+## 5.12.0-beta.2 (2025-02-11)
 
 ### Acknowledgments
 
@@ -26,11 +26,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
   - [EventHubsModelFactory.EventData](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventhubsmodelfactory.eventdata?view=azure-dotnet)
   - [BlobCheckpointStore.UpdateCheckpointAsync](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.primitives.blobcheckpointstore.updatecheckpointasync?view=azure-dotnet)
   - [EventProcessorClient.UpdateCheckpointAsync](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventprocessorclient.updatecheckpointasync?view=azure-dotnet)
-
-### Breaking Changes
-
-### Bugs Fixed
-
+  
 ### Other Changes
 
 - Added annotations to make the package compatible with trimming and native AOT compilation.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -16,9 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- TEMP TEMP -->
-    <ProjectReference Include="../../Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj" />
-    <!-- PackageReference Include="Azure.Messaging.EventHubs" /-->
+    <!-- Using a local override to avoid moving the central reference to a beta.  Tracked by #47302-->
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.12.0-beta.2" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -12,9 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- TEMP TEMP -->
-    <ProjectReference Include="../../Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj" />
-    <!-- PackageReference Include="Azure.Messaging.EventHubs" /-->
+    <!-- Using a local override to avoid moving the central reference to a beta.  Tracked by #47302-->
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.12.0-beta.2" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Hubs processor package for the February 2025 release.