### PR TITLE
Prevent max_tokens from also being written when making a call with OpenAI o-models

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatClient.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatClient.cs
@@ -135,8 +135,6 @@ internal partial class AzureChatClient : ChatClient
                 }
 
                 writer.Flush();
-
-                options.SerializedAdditionalRawData["max_tokens"] = BinaryData.FromBytes(stream.ToArray());
             }
             else
             {


### PR DESCRIPTION
Prevent max_tokens from being written and leave only max_completion_tokens when making a call with OpenAI o-models

Fix for https://github.com/Azure/azure-sdk-for-net/issues/46545