### PR TITLE
Update Data Movement Blobs package install command

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/README.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/README.md
@@ -15,11 +15,9 @@ Azure Storage client libraries.
 
 ### Install the package
 
-Install the Azure Storage client library for .NET you'd like to use with
-[NuGet][nuget] and the `Azure.Storage.DataMovement.Blobs` client library will be included:
+Install the Azure Storage Data Movement Blobs client library for .NET with [NuGet][nuget]:
 
 ```dotnetcli
-dotnet add package Azure.Storage.DataMovement
 dotnet add package Azure.Storage.DataMovement.Blobs
 ```
 


### PR DESCRIPTION
Remove the package installation command for the transitive dependency. `Azure.Storage.DataMovement` comes along for the ride when `Azure.Storage.DataMovement.Blobs` is installed.

![image](https://github.com/user-attachments/assets/dd41dfc2-dd09-473c-8c1d-ad1c8496ea49)

