### PR TITLE
[Event Hubs] Update etag reset logic in the checkpoint store

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -223,9 +223,11 @@ namespace Azure.Messaging.EventHubs.Primitives
                         {
                             // This is an unlikely corner case that indicates that the blob was unexpectedly deleted while the
                             // processor is running.  Attempt to recover by resetting the ETag and considering it an upload scenario
-                            // to be handled by the next block.
+                            // to be handled by the next block. Additionally clear the IfMatch to ensure next block does not have
+                            // an outdated ETag.
 
                             ownership.Version = null;
+                            blobRequestConditions.IfMatch = null;
                         }
                     }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalTests.cs
@@ -309,9 +309,11 @@ namespace Azure.Messaging.EventHubs.Tests
                     setMetadataCalled = true;
                 };
 
-                client.UploadAsyncCallback = (_, _, _, _, _, _, _, _) =>
+                client.UploadAsyncCallback = (_, _, _, conditions, _, _, _, _) =>
                 {
                     uploadBlobCalled = true;
+                    Assert.That(conditions.IfNoneMatch, Is.EqualTo(new ETag("*")), "The IfNoneMatch condition should be set.");
+                    Assert.That(conditions.IfMatch, Is.Null, "The IfMatch condition should be null.");
                 };
             });
 


### PR DESCRIPTION
# Summary
- This fix addresses a corner case in the Blob checkpoint store implementation where the etag is reset without updating the `BlobRequestConditions`. An outdated `If-Match` was leading to a bad request for some Storage service versions.
- Resolves #47852
