### PR TITLE
[Storage] Fix NullReferenceException when parsing error response

### DIFF
--- a/sdk/storage/Azure.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Common/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed bug where in rare cases, a `NullReferenceException` could be thrown when parsing an error response from the service.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -105,7 +105,9 @@ namespace Azure.Storage
         public const string TrueName = "true";
 
         public const string ErrorCode = "Code";
+        public const string ErrorCodeLower = "code";
         public const string ErrorMessage = "Message";
+        public const string ErrorMessageLower = "message";
 
         public const string CommaString = ",";
         public const char CommaChar = ',';

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageRequestFailedDetailsParser.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageRequestFailedDetailsParser.cs
@@ -27,10 +27,12 @@ namespace Azure.Core.Pipeline
                     if (response.Headers.ContentType.Contains(Constants.ContentTypeApplicationXml))
                     {
                         XDocument xml = XDocument.Load(contentStream);
-                        var errorCode = xml.Root!.Element(Constants.ErrorCode)!.Value;
-                        var message = xml.Root.Element(Constants.ErrorMessage)!.Value;
-                        data = new Dictionary<string, string>();
+                        var errorCode = xml.Root!.Element(Constants.ErrorCode)?.Value ??
+                            xml.Root.Element(Constants.ErrorCodeLower)?.Value;
+                        var message = xml.Root.Element(Constants.ErrorMessage)?.Value ??
+                            xml.Root.Element(Constants.ErrorMessageLower)?.Value;
 
+                        data = new Dictionary<string, string>();
                         foreach (XElement element in xml.Root.Elements())
                         {
                             switch (element.Name.LocalName)


### PR DESCRIPTION
Resolves #45427

It seems the Storage service can sometimes return the error code and message XML elements as all lowercase where our parsing logic was expecting pascal case. This change fixes that by also searching for the lowercase versions of these elements if the pascal case was not found. Additionally, it will no longer throw a `NullReferenceException` if the code or message cannot be found and instead just return an error with those elements omitted.

This applies to all packages.