### PR TITLE
⬆️ Packages.Data.props - Update Azure.ResourceManager.PostgreSql to 1.2.0

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -145,7 +145,7 @@
     <PackageReference Update="Azure.ResourceManager.KeyVault" Version="1.2.3" />
     <PackageReference Update="Azure.ResourceManager.ManagedServiceIdentities" Version="1.2.3" />
     <PackageReference Update="Azure.ResourceManager.OperationalInsights" Version="1.2.2" />
-    <PackageReference Update="Azure.ResourceManager.PostgreSql" Version="1.2.0-beta.6" />
+    <PackageReference Update="Azure.ResourceManager.PostgreSql" Version="1.2.0" />
     <PackageReference Update="Azure.ResourceManager.Redis" Version="1.4.0" />
     <PackageReference Update="Azure.ResourceManager.Resources" Version="1.7.3" />
     <PackageReference Update="Azure.ResourceManager.Search" Version="1.3.0-beta.3" />


### PR DESCRIPTION
Updates the referenced Azure.ResourceManager.PostgreSql version in Packages.Data.props

Once this is updated, we can then run the Azure.Provisioning Generator to get up to date models.

This PR unblocks #48251, #48249 and #48246
