### PR TITLE
Update dependencies of SignalR extensions

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -231,7 +231,6 @@
     <PackageReference Update="Microsoft.AspNetCore.DataProtection" Version="3.1.32" />
     <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Connections" Version="1.0.15" />
-    <PackageReference Update="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Update="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
     <PackageReference Update="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
@@ -318,6 +317,7 @@
     <PackageReference Update="Microsoft.Azure.Devices.Client" Version="1.41.3" />
     <PackageReference Update="Microsoft.Azure.EventHubs" Version="4.3.2" />
     <PackageReference Update="Microsoft.Azure.EventHubs.Processor" Version="4.3.2" />
+    <PackageReference Update="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Update="Microsoft.Azure.Graph.RBAC" Version="2.2.2-preview" />
     <PackageReference Update="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Update="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Features Added
 
 ### Breaking Changes
-* Remove .NET 6.0 support.
 * Modify `AddDefaultAuth` method in `SignalRFunctionsHostBuilderExtensions.cs` to use `IServiceCollection` instead of `IFunctionsHostBuilder` to remove the dependency for legacy package `Microsoft.Azure.Functions.Extensions`.
 
 ### Bugs Fixed

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 * Remove .NET 6.0 support.
-* Modify `AddDefaultAuth` method in `SignalRFunctionsHostBuilderExtensions.cs` to use `IServiceCollection` instead of `IFunctionsHostBuilder` to remove the dependency for legacy pacakge `Microsoft.Azure.Functions.Extensions`.
+* Modify `AddDefaultAuth` method in `SignalRFunctionsHostBuilderExtensions.cs` to use `IServiceCollection` instead of `IFunctionsHostBuilder` to remove the dependency for legacy package `Microsoft.Azure.Functions.Extensions`.
 
 ### Bugs Fixed
 * Correctly support returning result for SignalR invocation in MessagePack protocol from isolated-worker process.
@@ -34,7 +34,7 @@
 
 ## 1.12.0 (2023-11-07)
 ### Features Added
-* Added `RetryOptions` to `SignalROptions` to configure retry policy for SignalR Service REST API calls. For more infomation about cutomize retry options, see samples.
+* Added `RetryOptions` to `SignalROptions` to configure retry policy for SignalR Service REST API calls. For more infomation about customize retry options, see samples.
 * Added `HttpClientTimeout` to `SignalROptions` to configure HTTP client timeout for SignalR Service REST API calls. The default value is 100 seconds. User can also set "AzureSignalRHttpClientTimeout" in the app settings to override the default value.
 
 ### Bugs Fixed
@@ -85,7 +85,7 @@
 
 ### Bugs Fixed
 * Fixed the message order problem.
-* Fixed the ackable message timeout problem when multiple SignalR endpoints exist.
+* Fixed the ack-able message timeout problem when multiple SignalR endpoints exist.
 
 ## 1.7.0 (2022-02-22)
 **Following are the all changes in 1.7.0-beta.2 and 1.7.0-beta.1 versions.**

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Breaking Changes
 * Remove .NET 6.0 support.
+* Modify `AddDefaultAuth` method in `SignalRFunctionsHostBuilderExtensions.cs` to use `IServiceCollection` instead of `IFunctionsHostBuilder` to remove the dependency for legacy pacakge `Microsoft.Azure.Functions.Extensions`.
 
 ### Bugs Fixed
 * Correctly support returning result for SignalR invocation in MessagePack protocol from isolated-worker process.

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net8.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net8.0.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     }
     public static partial class SignalRFunctionsHostBuilderExtensions
     {
-        public static Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder AddDefaultAuth(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder builder, System.Action<Microsoft.IdentityModel.Tokens.TokenValidationParameters> configureTokenValidationParameters, System.Func<Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult, Microsoft.AspNetCore.Http.HttpRequest, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail> configurer = null) { throw null; }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDefaultAuth(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.IdentityModel.Tokens.TokenValidationParameters> configureTokenValidationParameters, System.Func<Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult, Microsoft.AspNetCore.Http.HttpRequest, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail> configurer = null) { throw null; }
     }
     [Newtonsoft.Json.JsonObjectAttribute]
     public partial class SignalRGroupAction

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     }
     public static partial class SignalRFunctionsHostBuilderExtensions
     {
-        public static Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder AddDefaultAuth(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder builder, System.Action<Microsoft.IdentityModel.Tokens.TokenValidationParameters> configureTokenValidationParameters, System.Func<Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult, Microsoft.AspNetCore.Http.HttpRequest, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail> configurer = null) { throw null; }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDefaultAuth(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.IdentityModel.Tokens.TokenValidationParameters> configureTokenValidationParameters, System.Func<Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult, Microsoft.AspNetCore.Http.HttpRequest, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail, Microsoft.Azure.WebJobs.Extensions.SignalRService.SignalRConnectionDetail> configurer = null) { throw null; }
     }
     [Newtonsoft.Json.JsonObjectAttribute]
     public partial class SignalRGroupAction

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/SignalRFunctionsHostBuilderExtensions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/SignalRFunctionsHostBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         /// <summary>
         /// Adds security token validation parameters' configuration and SignalR connection's configuration.
         /// </summary>
-        /// <param name="services"></param>
+        /// <param name="services">The service collections to add default auth.</param>
         /// <param name="configureTokenValidationParameters">Token validation parameters to validate security token</param>
         /// <param name="configurer">SignalR connection configuration to be used in generating Azure SignalR service's access token</param>
         public static IServiceCollection AddDefaultAuth(this IServiceCollection services, Action<TokenValidationParameters> configureTokenValidationParameters, SignalRConnectionInfoConfigureFunc configurer = null)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRFunctionsHostBuilderExtensions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRFunctionsHostBuilderExtensions.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Linq;
+
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Tokens;
@@ -21,15 +21,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         /// <summary>
         /// Adds security token validation parameters' configuration and SignalR connection's configuration.
         /// </summary>
-        /// <param name="builder">Azure function host builder</param>
+        /// <param name="services"></param>
         /// <param name="configureTokenValidationParameters">Token validation parameters to validate security token</param>
         /// <param name="configurer">SignalR connection configuration to be used in generating Azure SignalR service's access token</param>
-        /// <returns><see cref="IFunctionsHostBuilder"/>Azure function host builder</returns>
-        public static IFunctionsHostBuilder AddDefaultAuth(this IFunctionsHostBuilder builder, Action<TokenValidationParameters> configureTokenValidationParameters, SignalRConnectionInfoConfigureFunc configurer = null)
+        public static IServiceCollection AddDefaultAuth(this IServiceCollection services, Action<TokenValidationParameters> configureTokenValidationParameters, SignalRConnectionInfoConfigureFunc configurer = null)
         {
-            if (builder == null)
+            if (services == null)
             {
-                throw new ArgumentNullException(nameof(builder));
+                throw new ArgumentNullException(nameof(services));
             }
 
             if (configureTokenValidationParameters == null)
@@ -39,20 +38,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
             var internalSignalRConnectionInfoConfigurer = new InternalSignalRConnectionInfoConfigurer(configurer);
 
-            if (builder.Services.Any(d => d.ServiceType == typeof(ISecurityTokenValidator)))
+            if (services.Any(d => d.ServiceType == typeof(ISecurityTokenValidator)))
             {
                 throw new NotSupportedException($"{nameof(ISecurityTokenValidator)} already injected.");
             }
 
-            builder.Services
+            services
                 .AddSingleton<ISecurityTokenValidator>(s =>
                     new DefaultSecurityTokenValidator(configureTokenValidationParameters));
 
-            builder.Services.
+            services.
                 TryAddSingleton<ISignalRConnectionInfoConfigurer>(s =>
                     internalSignalRConnectionInfoConfigurer);
 
-            return builder;
+            return services;
         }
 
         private class InternalSignalRConnectionInfoConfigurer : ISignalRConnectionInfoConfigurer

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="MessagePack" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -13,13 +13,13 @@
   <ItemGroup>
     <!--Pin the versions of packages that may be upgraded during the process of Azure SDK moving all dependencies to the 8.x line to avoid incompatibility, until a compatible dependency gragh is figured out and finalized.-->
     <PackageReference Include="MessagePack" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" VersionOverride="3.0.37"/>
+    <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
-    <PackageReference Include="Microsoft.Extensions.Azure" VersionOverride="1.10.0"/>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="6.35.0"/>
+    <PackageReference Include="Microsoft.Extensions.Azure" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -11,24 +11,24 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--Pin the versions of packages that may be upgraded during the process of Azure SDK moving all dependencies to the 8.x line to avoid incompatibility, until a compatible dependency gragh is figured out and finalized.-->
     <PackageReference Include="MessagePack" />
-    <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" VersionOverride="3.0.37"/>
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-
-    <!--
-        Adding as a local override, as packages should not generally take this dependency.  It is
-        needed here due to a transitive version conflict due to the Microsoft.Azure.Functions.Extensions
-        reference.
-    -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride ="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Azure" VersionOverride="1.10.0"/>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="6.35.0"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />
+    <!--
+        Adding as a local override, as packages should not generally take this dependency.  It is
+        needed here due to a transitive version conflict due to the 2.x version of Microsoft.* packages.
+        reference.
+    -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride ="8.0.1" />
   </ItemGroup>
 </Project>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
-    <!--Pin the following version to avoid issue https://github.com/Azure/azure-functions-host/issues/10575 in the short term.-->
-    <PackageReference Include="Microsoft.Extensions.Azure" VersionOverride="1.7.5"/>
+    <!--According to https://github.com/Azure/azure-sdk-for-net/pull/48280#discussion_r1972339492, 1.8.0 is the latest safe version.-->
+    <PackageReference Include="Microsoft.Extensions.Azure" VersionOverride="1.8.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
     <!--Pin the following version to avoid issue https://github.com/Azure/azure-functions-host/issues/10575 in the short term.-->
-    <PackageReference Include="Microsoft.Extensions.Azure" VersionOverride="1.7.3"/>
+    <PackageReference Include="Microsoft.Extensions.Azure" VersionOverride="1.7.5"/>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -11,24 +11,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--Pin the versions of packages that may be upgraded during the process of Azure SDK moving all dependencies to the 8.x line to avoid incompatibility, until a compatible dependency gragh is figured out and finalized.-->
     <PackageReference Include="MessagePack" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
-    <PackageReference Include="Microsoft.Extensions.Azure" />
+    <!--Pin the following version to avoid issue https://github.com/Azure/azure-functions-host/issues/10575 in the short term.-->
+    <PackageReference Include="Microsoft.Extensions.Azure" VersionOverride="1.7.3"/>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />
-    <!--
-        Adding as a local override, as packages should not generally take this dependency.  It is
-        needed here due to a transitive version conflict due to the 2.x version of Microsoft.* packages.
-        reference.
-    -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride ="8.0.1" />
   </ItemGroup>
 </Project>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
* Modified `AddDefaultAuth` method in `SignalRFunctionsHostBuilderExtensions.cs` to use `IServiceCollection` instead of `IFunctionsHostBuilder` to remove the dependency for legacy pacakge `Microsoft.Azure.Functions.Extensions`.
* Removed and relocated `Microsoft.Azure.Functions.Extensions` package references in various project files.