### PR TITLE
Fix ExcludePath filter in AdditionalValidationPackagesFromPackageSetFn

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -167,7 +167,7 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet {
   # The targetedFiles needs to filter out anything in the ExcludePaths
   # otherwise it'll end up processing things below that it shouldn't be.
   foreach ($excludePath in $diffObj.ExcludePaths) {
-    $targetedFiles = $targetedFiles | Where-Object { -not $_.StartsWith($excludePath) }
+    $targetedFiles = $targetedFiles | Where-Object { -not $_.StartsWith($excludePath.TrimEnd("/") + "/") }
   }
 
   # this section will identify


### PR DESCRIPTION
The StartsWith check should have been adding a trailing "/" when doing the match because, without it, the match is too greedy.
For example, in Java we also exclude sdk/cosmos from our pullrequest.yml but java has an sdk/cosmosdbforpostgresql directory which was also getting excluded and shouldn't have been.

This is, quite literally, [code I'd added to Package-Properties.ps1](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/scripts/Package-Properties.ps1#L194) and overlooked this when adding it in Language-Settings.ps1 earlier this week.

This is the same change I'm making in [Python right now](https://github.com/Azure/azure-sdk-for-python/pull/39726).