### PR TITLE
[Event Hubs] Fix Ownership Claim Test Cases

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalLiveTests.cs
@@ -573,9 +573,10 @@ namespace Azure.Messaging.EventHubs.Tests
                     Version = firstOwnership.Version
                 };
 
-                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default), Throws.InstanceOf<RequestFailedException>());
+                await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default);
                 var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup1", default);
 
+                Assert.That(firstOwnership.Version, Is.Not.EqualTo(secondOwnership.Version));
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
                 Assert.That(storedOwnershipList.Single().IsEquivalentTo(firstOwnership), Is.True);
@@ -619,9 +620,10 @@ namespace Azure.Messaging.EventHubs.Tests
                     Version = firstOwnership.Version
                 };
 
-                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default), Throws.InstanceOf<RequestFailedException>());
+                await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default);
                 var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName1", "consumerGroup", default);
 
+                Assert.That(firstOwnership.Version, Is.Not.EqualTo(secondOwnership.Version));
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
                 Assert.That(storedOwnershipList.Single().IsEquivalentTo(firstOwnership), Is.True);
@@ -665,9 +667,10 @@ namespace Azure.Messaging.EventHubs.Tests
                     Version = firstOwnership.Version
                 };
 
-                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default), Throws.InstanceOf<RequestFailedException>());
+                await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default);
                 var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace1", "eventHubName", "consumerGroup", default);
 
+                Assert.That(firstOwnership.Version, Is.Not.EqualTo(secondOwnership.Version));
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
                 Assert.That(storedOwnershipList.Single().IsEquivalentTo(firstOwnership), Is.True);


### PR DESCRIPTION
# Summary
- In PR #48244 I reset an etag that broke these test cases. After offline discussion with Jesse we determined that the test cases were incorrect. 
- The test was designed to expect a failure when calling `ClaimOwnershipAsync` on an `EventProcessorPartitionOwnership` with an existing Version etag. However, the second ownership claim should actually clear the etag and set `IfNoneMatch` for the upload, as corrected in the aforementioned PR. 
