### PR TITLE
Handle PR changes in the root of the repository

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -180,25 +180,23 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet {
       $pathComponents = $file -split "/"
       # handle changes only in sdk/<service>/<file>.<extension>
       if ($pathComponents.Length -eq 3 -and $pathComponents[0] -eq "sdk") {
-        if (-not $changedServices.Contains($pathComponents[1])) {
-          $changedServices += $pathComponents[1]
-        }
+        $changedServices += $pathComponents[1]
       }
 
-      # handle any changes under sdk/<file>.<extension>
-      if ($pathComponents.Length -eq 2 -and $pathComponents[0] -eq "sdk") {
-        if (-not $changedServices.Contains("template")) {
-          $changedServices += "template"
-        }
+      # handle any changes under sdk/<file>.<extension> or any files
+      # in the repository root
+      if (($pathComponents.Length -eq 2 -and $pathComponents[0] -eq "sdk") -or
+          ($pathComponents.Length -eq 1)) {
+        $changedServices += "template"
       }
 
       # changes to a Azure.*.Shared within a service directory should include all packages within that service directory
       if ($file.Replace('\', '/') -match ".*sdk/.*/.*\.Shared/.*") {
-        if (-not $changedServices.Contains($pathComponents[1])) {
-          $changedServices += $pathComponents[1]
-        }
+        $changedServices += $pathComponents[1]
       }
     }
+    # dedupe the changedServices list before processing
+    $changedServices = $changedServices | Get-Unique
     foreach ($changedService in $changedServices) {
       $additionalPackages = $AllPkgProps | Where-Object { $_.ServiceDirectory -eq $changedService }
 


### PR DESCRIPTION
Two minor changes:

1. Handle changes in the root of the repository. Similar to changes in the root of the sdk directory, add template for changes in the root of the repository.
2. Remove all of the changedServices.Contains checks and just dedupe the changedServices before processing it. This is the same thing that Java and Python do. 
