### PR TITLE
DeID test failure on deidServiceName length

### DIFF
--- a/sdk/healthdataaiservices/test-resources.bicep
+++ b/sdk/healthdataaiservices/test-resources.bicep
@@ -26,7 +26,10 @@ var storageBlobDataContributor = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
 
 var blobStorageName = take(toLower(replace('blob-${baseName}', '-', '')), 24)
 var blobContainerName = 'container-${baseName}'
-var deidServiceName = 'deid-${baseName}-${deidLocationShort}'
+
+var maxBaseNameLength = 24 - 5 - length(deidLocationShort) // 5 characters for 'deid-' and 1 for '-'
+var truncatedBaseName = take(baseName, maxBaseNameLength)
+var deidServiceName = 'deid-${truncatedBaseName}-${deidLocationShort}'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   name: blobStorageName

--- a/sdk/healthdataaiservices/test-resources.bicep
+++ b/sdk/healthdataaiservices/test-resources.bicep
@@ -15,8 +15,8 @@ param baseName string
 param location string = resourceGroup().location
 
 @description('The location of the resource. By default, this is the same as the resource group.')
-param deidLocation string = 'eastus2euap'
-param deidLocationShort string = 'eup'
+param deidLocation string = 'eastus2'
+param deidLocationShort string = 'eus2'
 
 param deploymentTime string = utcNow('u')
 


### PR DESCRIPTION
deidServiceName was over 24 chars now truncating baseName to insure max length does not go over 24 chars

**Error references:**
- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3992050&view=logs&j=76b7f760-7857-5526-9942-d88b580eb83a&t=0b78fc45-a08b-5d1a-bcae-155a32f152dd&l=159
- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4567682&view=logs&j=76b7f760-7857-5526-9942-d88b580eb83a&t=da4c1fd9-22df-5093-9ae3-3cb8bcacc5a9&l=73

