### PR TITLE
Updated types supported by ApplicationProperties

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CorrelationRuleFilter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CorrelationRuleFilter.cs
@@ -153,10 +153,30 @@ namespace Azure.Messaging.ServiceBus.Administration
         /// </summary>
         /// <value>The application specific properties of the message.</value>
         /// <remarks>
-        /// Only following value types are supported:
-        /// byte, sbyte, char, short, ushort, int, uint, long, ulong, float, double, decimal,
-        /// bool, Guid, string, Uri, DateTime, DateTimeOffset, TimeSpan, Stream, byte[],
-        /// and IList / IDictionary of supported types
+        ///   <list type="bullet">
+        ///     <listheader><description>The following types are supported:</description></listheader>
+        ///     <item><description>byte</description></item>
+        ///     <item><description>sbyte</description></item>
+        ///     <item><description>char</description></item>
+        ///     <item><description>short</description></item>
+        ///     <item><description>ushort</description></item>
+        ///     <item><description>int</description></item>
+        ///     <item><description>uint</description></item>
+        ///     <item><description>long</description></item>
+        ///     <item><description>ulong</description></item>
+        ///     <item><description>float</description></item>
+        ///     <item><description>double</description></item>
+        ///     <item><description>decimal</description></item>
+        ///     <item><description>bool</description></item>
+        ///     <item><description>Guid</description></item>
+        ///     <item><description>string</description></item>
+        ///     <item><description>Uri</description></item>
+        ///     <item><description>DateTime</description></item>
+        ///     <item><description>DateTimeOffset</description></item>
+        ///     <item><description>TimeSpan</description></item>
+        ///     <item><description>Stream</description></item>
+        ///     <item><description>byte[]</description></item>
+        ///   </list>
         /// </remarks>
         public IDictionary<string, object> ApplicationProperties { get; internal set; } = new PropertyDictionary();
 


### PR DESCRIPTION
- Resolves #47205
- `ApplicationProperties` stated in documentation to support IList and IDictionary, but it is always implemented by `PropertyDictionary`, which does not support Collection types. 
- Improved readability in `Remarks` section.
