### PR TITLE
[Storage] [Doc] BlobItem.Tags returns null for blobs with no tags

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobItem.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobItem.cs
@@ -51,6 +51,8 @@ namespace Azure.Storage.Blobs.Models
 
         /// <summary>
         /// Tags.
+        ///
+        /// Note: this will return null if there are no tags associated with the blob.
         /// </summary>
         public IDictionary<string, string> Tags { get; internal set; }
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/47001