### PR TITLE
Remove unnecessary custom targets from AOAI

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/Directory.Build.props
+++ b/sdk/openai/Azure.AI.OpenAI/Directory.Build.props
@@ -21,7 +21,7 @@
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
   
-  <PropertyGroup>
-    <RequiredTargetFrameworks Condition="$(IsTestProject) != 'true'">netstandard2.0</RequiredTargetFrameworks>
-  </PropertyGroup>
+  <!-- <PropertyGroup>
+    <RequiredTargetFrameworks Condition="$(IsTestProject) != 'true'">net8.0;netstandard2.0</RequiredTargetFrameworks>
+  </PropertyGroup> -->
 </Project>

--- a/sdk/openai/Azure.AI.OpenAI/Directory.Build.props
+++ b/sdk/openai/Azure.AI.OpenAI/Directory.Build.props
@@ -20,8 +20,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  
-  <!-- <PropertyGroup>
-    <RequiredTargetFrameworks Condition="$(IsTestProject) != 'true'">net8.0;netstandard2.0</RequiredTargetFrameworks>
-  </PropertyGroup> -->
 </Project>


### PR DESCRIPTION
This custom `RequiredTargetFrameworks` appears to be unnecessarily overriding the common definition, preventing AOAI from building for .NET 8.