### PR TITLE
[CODEOWNERS] Remove invalid account

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -330,7 +330,7 @@
 /sdk/communication/Azure.Communication.Identity/                   @Azure/acs-identity-sdk @AikoBB @maximrytych-ms @mjafferi-msft
 
 # PRLabel: %Communication - Phone Numbers
-/sdk/communication/Azure.Communication.PhoneNumbers/               @miguhern @whisper6284 @danielav7
+/sdk/communication/Azure.Communication.PhoneNumbers/               @whisper6284 @danielav7
 
 # PRLabel: %Communication - Programmable Connectivity
 /sdk/communication/Azure.Communication.ProgrammableConnectivity/   @Azure/azure-sdk-write-communication


### PR DESCRIPTION
# Summary

The focus of these changes is to address a linter failure flagging an owner account as invalid.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4580546&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=8c98ab76-57b2-59d0-3d3a-18dce788f3ba) _(Microsoft internal)_