### PR TITLE
[Service Bus] Clarify "Idle" for entities

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateQueueOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateQueueOptions.cs
@@ -143,6 +143,7 @@ namespace Azure.Messaging.ServiceBus.Administration
         /// The <see cref="TimeSpan"/> idle interval after which the queue is automatically deleted.
         /// </summary>
         /// <remarks>The minimum duration is 5 minutes. Default value is <see cref="TimeSpan.MaxValue"/>.</remarks>
+        /// <seealso href="https://learn.microsoft.com/azure/service-bus-messaging/message-expiration#idleness">Service Bus: Idleness</seealso>
         public TimeSpan AutoDeleteOnIdle
         {
             get => autoDeleteOnIdle;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateSubscriptionOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateSubscriptionOptions.cs
@@ -112,6 +112,7 @@ namespace Azure.Messaging.ServiceBus.Administration
         /// The <see cref="TimeSpan"/> idle interval after which the subscription is automatically deleted.
         /// </summary>
         /// <remarks>The minimum duration is 5 minutes. Default value is <see cref="TimeSpan.MaxValue"/>.</remarks>
+        /// <seealso href="https://learn.microsoft.com/azure/service-bus-messaging/message-expiration#idleness">Service Bus: Idleness</seealso>
         public TimeSpan AutoDeleteOnIdle
         {
             get => _autoDeleteOnIdle;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateTopicOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateTopicOptions.cs
@@ -81,6 +81,7 @@ namespace Azure.Messaging.ServiceBus.Administration
         /// The <see cref="TimeSpan"/> idle interval after which the topic is automatically deleted.
         /// </summary>
         /// <remarks>The minimum duration is 5 minutes. Default value is <see cref="TimeSpan.MaxValue"/>.</remarks>
+        /// <seealso href="https://learn.microsoft.com/azure/service-bus-messaging/message-expiration#idleness">Service Bus: Idleness</seealso>
         public TimeSpan AutoDeleteOnIdle
         {
             get => _autoDeleteOnIdle;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueueProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueueProperties.cs
@@ -138,6 +138,7 @@ namespace Azure.Messaging.ServiceBus.Administration
         /// The <see cref="TimeSpan"/> idle interval after which the queue is automatically deleted.
         /// </summary>
         /// <remarks>The minimum duration is 5 minutes. Default value is <see cref="TimeSpan.MaxValue"/>.</remarks>
+        /// <seealso href="https://learn.microsoft.com/azure/service-bus-messaging/message-expiration#idleness">Service Bus: Idleness</seealso>
         public TimeSpan AutoDeleteOnIdle
         {
             get => _autoDeleteOnIdle;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/SubscriptionProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/SubscriptionProperties.cs
@@ -107,6 +107,7 @@ namespace Azure.Messaging.ServiceBus.Administration
         /// The <see cref="TimeSpan"/> idle interval after which the subscription is automatically deleted.
         /// </summary>
         /// <remarks>The minimum duration is 5 minutes. Default value is <see cref="TimeSpan.MaxValue"/>.</remarks>
+        /// <seealso href="https://learn.microsoft.com/azure/service-bus-messaging/message-expiration#idleness">Service Bus: Idleness</seealso>
         public TimeSpan AutoDeleteOnIdle
         {
             get => _autoDeleteOnIdle;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicProperties.cs
@@ -85,6 +85,7 @@ namespace Azure.Messaging.ServiceBus.Administration
         /// The <see cref="TimeSpan"/> idle interval after which the topic is automatically deleted.
         /// </summary>
         /// <remarks>The minimum duration is 5 minutes. Default value is <see cref="TimeSpan.MaxValue"/>.</remarks>
+        /// <seealso href="https://learn.microsoft.com/azure/service-bus-messaging/message-expiration#idleness">Service Bus: Idleness</seealso>
         public TimeSpan AutoDeleteOnIdle
         {
             get => _autoDeleteOnIdle;


### PR DESCRIPTION
# Summary

The focus of these changes is link to the Service Bus docs to clarify the meaning of "idle" as applied to Service Bus entities.

## References and resources

- [Would be nice to clarify what "idle" really means in the context of AutoDeleteOnIdle (#48367)](https://github.com/Azure/azure-sdk-for-net/issues/48367)