### PR TITLE
[Messaging] Fix Functions test host credential use

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -242,13 +242,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     configurationBuilder.AddInMemoryCollection(new Dictionary<string, string>()
                     {
                         {"TestConnection:fullyQualifiedNamespace", EventHubsTestEnvironment.Instance.FullyQualifiedNamespace},
-                        {"TestConnection:clientId", EventHubsTestEnvironment.Instance.ClientId},
-                        {"TestConnection:clientSecret", EventHubsTestEnvironment.Instance.ClientSecret},
-                        {"TestConnection:tenantId", EventHubsTestEnvironment.Instance.TenantId},
-                        {"AzureWebJobsStorage:serviceUri", GetServiceUri()},
-                        {"AzureWebJobsStorage:clientId", EventHubsTestEnvironment.Instance.ClientId},
-                        {"AzureWebJobsStorage:clientSecret", EventHubsTestEnvironment.Instance.ClientSecret},
-                        {"AzureWebJobsStorage:tenantId", EventHubsTestEnvironment.Instance.TenantId},
+                        {"AzureWebJobsStorage:serviceUri", GetServiceUri()}
                     })));
         }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Azure.Core.Diagnostics;
 using Azure.Messaging.EventHubs.Tests;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -64,6 +64,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             var hostBuilder = new HostBuilder();
             hostBuilder
+                .ConfigureServices(services =>
+                {
+                    services.AddAzureClients(clientBuilder =>
+                    {
+                        clientBuilder.UseCredential(EventHubsTestEnvironment.Instance.Credential);
+                    });
+                })
                 .ConfigureAppConfiguration(builder =>
                 {
                     builder.AddInMemoryCollection(new Dictionary<string, string>()

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -1,6 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Azure.Core.TestFramework;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using Azure.Messaging.ServiceBus.Tests;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,17 +20,6 @@ using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using Azure.Core.TestFramework;
-using Azure.Messaging.ServiceBus;
-using Azure.Messaging.ServiceBus.Administration;
-using Azure.Messaging.ServiceBus.Tests;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
-using Microsoft.Azure.WebJobs.ServiceBus;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using NUnit.Framework;
 using static Azure.Messaging.ServiceBus.Tests.ServiceBusScope;
 
 namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
@@ -144,9 +144,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             if (useTokenCredential)
             {
                 settings.Add("AzureWebJobsServiceBus:fullyQualifiedNamespace", ServiceBusTestEnvironment.Instance.FullyQualifiedNamespace);
-                settings.Add("AzureWebJobsServiceBus:clientId", ServiceBusTestEnvironment.Instance.ClientId);
-                settings.Add("AzureWebJobsServiceBus:clientSecret", ServiceBusTestEnvironment.Instance.ClientSecret);
-                settings.Add("AzureWebJobsServiceBus:tenantId", ServiceBusTestEnvironment.Instance.TenantId);
             }
             else
             {
@@ -156,6 +153,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             var hostBuilder = new HostBuilder()
                 .ConfigureServices(s =>
                 {
+                    s.AddAzureClients(clientBuilder =>
+                    {
+                        clientBuilder.UseCredential(ServiceBusTestEnvironment.Instance.Credential);
+                    });
+
                     s.Configure<HostOptions>(opts => opts.ShutdownTimeout = HostShutdownTimeout);
                     // Configure ServiceBusEndToEndTestService before WebJobs stuff so that the ServiceBusEndToEndTestService.StopAsync will be called after
                     // the WebJobsHost.StopAsync (service that is started first will be stopped last by the IHost).


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the approach used for token credential management in the Function extensions end-to-end tests for Event Hubs and Service Bus.  The previous approach used simple logic to set in-memory configuration with assumptions about the test environment.  These assumptions are no longer accurate with the security changes in the testing pipelines.

The new approach delegates to the test environment for credential management, as it has the conditional logic for environmental factors needed for credential selection and creation.  The configuration-to-credential mapping and creation logic is part of the `Microsoft.Extensions.Azure` package and has full test coverage there; there is no benefit to duplicating test environment logic just to force Function configuration to control the credential locally for the test host.

# References and resources

- [[Microsoft.Azure.WebJobs.Extensions.ServiceBus] Fix live test pipeline (#47168)](https://github.com/Azure/azure-sdk-for-net/issues/47168)
- [Example test failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4571949&view=ms.vss-test-web.build-test-results-tab&runId=52822427&resultId=100249&paneView=debug) _(Microsoft internal)_