### PR TITLE
Add trailing slash exclude paths

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -167,7 +167,7 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet {
   # The targetedFiles needs to filter out anything in the ExcludePaths
   # otherwise it'll end up processing things below that it shouldn't be.
   foreach ($excludePath in $diffObj.ExcludePaths) {
-    $targetedFiles = $targetedFiles | Where-Object { -not $_.StartsWith($excludePath.TrimEnd("/") + "/") }
+    $targetedFiles = $targetedFiles | Where-Object { -not $_.StartsWith($excludePath) }
   }
 
   # this section will identify

--- a/sdk/pullrequest.yml
+++ b/sdk/pullrequest.yml
@@ -11,7 +11,7 @@ pr:
     - "*"
 
     exclude:
-    - eng/packages/http-client-csharp
+    - eng/packages/http-client-csharp/
 
 parameters:
   - name: Service


### PR DESCRIPTION
This PR is in preparation for an upcoming change that'll allow us to exclude specific files. Right now, we were always adding a trailing "/" if one wasn't there and this was done to ensure that things didn't overmatch. For example, if you had sdk/foo and sdk/foobar with an exclude of sdk/foo, without the slash, it would overmatch sdk/foo and sdk/foobar. We were adding the trailing the slash to ensure that this didn't happen. Because always have a need to exclude specific files, adding the trailing slash won't allow this case to work.

This is the first change and it's a safe. Adding the trailing slash allows the removal of where we were doing this in Language-Settings.ps1. Note: There's still a place in eng/common Package-Properties.ps1 where this also has to be done before specific file excludes can be added.
