### PR TITLE
[Storage][DataMovement] Fix Blob directory copy tests

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_214325a4f9"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_ad91d92591"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobDirectoryToBlockBlobDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobDirectoryToBlockBlobDirectoryTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             string objectName = null,
             Stream contents = null,
             CancellationToken cancellationToken = default)
-            => CreateBlockBlobAsync(container, objectName, contents, cancellationToken);
+            => CreateBlockBlobAsync(container, objectLength, objectName, contents, cancellationToken);
 
         protected override Task CreateObjectInSourceAsync(
             BlobContainerClient container,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobDirectoryToAppendBlobDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobDirectoryToAppendBlobDirectoryTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Stream contents = null,
             TransferPropertiesTestType propertiesTestType = TransferPropertiesTestType.Default,
             CancellationToken cancellationToken = default)
-            => CreateBlockBlobAsync(container, objectName, contents, cancellationToken);
+            => CreateBlockBlobAsync(container, objectLength, objectName, contents, cancellationToken);
 
         protected override StorageResourceContainer GetDestinationStorageResourceContainer(
             BlobContainerClient containerClient,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobDirectoryToDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobDirectoryToDirectoryTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             string objectName = null,
             Stream contents = null,
             CancellationToken cancellationToken = default)
-            => CreateBlockBlobAsync(container, objectName, contents, cancellationToken);
+            => CreateBlockBlobAsync(container, objectLength, objectName, contents, cancellationToken);
 
         protected override Task CreateObjectInSourceAsync(
             BlobContainerClient container,
@@ -40,7 +40,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Stream contents = null,
             TransferPropertiesTestType propertiesType = default,
             CancellationToken cancellationToken = default)
-            => CreateBlockBlobAsync(container, objectName, contents, cancellationToken);
+            => CreateBlockBlobAsync(container, objectLength, objectName, contents, cancellationToken);
 
         protected override StorageResourceContainer GetDestinationStorageResourceContainer(
             BlobContainerClient containerClient,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobDirectoryToPageBlobDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobDirectoryToPageBlobDirectoryTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Stream contents = null,
             TransferPropertiesTestType propertiesTestType = TransferPropertiesTestType.Default,
             CancellationToken cancellationToken = default)
-            => CreateBlockBlobAsync(container, objectName, contents, cancellationToken);
+            => CreateBlockBlobAsync(container, objectLength, objectName, contents, cancellationToken);
 
         protected override StorageResourceContainer GetDestinationStorageResourceContainer(
             BlobContainerClient containerClient,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobDirectoryToBlockBlobDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobDirectoryToBlockBlobDirectoryTests.cs
@@ -42,7 +42,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             string objectName = null,
             Stream contents = null,
             CancellationToken cancellationToken = default)
-            => CreateBlockBlobAsync(container, objectName, contents, cancellationToken);
+            => CreateBlockBlobAsync(container, objectLength, objectName, contents, cancellationToken);
 
         protected override Task CreateObjectInSourceAsync(
             BlobContainerClient container,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/StartTransferBlobDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/StartTransferBlobDirectoryCopyTestBase.cs
@@ -39,7 +39,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
     where TDestinationObjectClient : BlobBaseClient
     {
         private readonly AccessTier _defaultAccessTier = AccessTier.Cold;
-        private const string _defaultContentType = "text/plain";
+        private const string _defaultContentType = "image/jpeg";
         private const string _defaultContentLanguage = "en-US";
         private const string _defaultContentDisposition = "inline";
         private const string _defaultCacheControl = "no-cache";
@@ -81,21 +81,22 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
 
         internal async Task CreateBlockBlobAsync(
             BlobContainerClient container,
-            string blobName,
-            Stream contents,
+            long? objectLength = null,
+            string objectName = null,
+            Stream contents = null,
             CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
-            blobName ??= GetNewObjectName();
+            objectName ??= GetNewObjectName();
 
-            BlockBlobClient blobClient = container.GetBlockBlobClient(blobName);
+            BlockBlobClient blobClient = container.GetBlockBlobClient(objectName);
             if (contents != default)
             {
                 await blobClient.UploadAsync(contents, cancellationToken: cancellationToken);
             }
             else
             {
-                var data = new byte[0];
+                byte[] data = GetRandomBuffer(objectLength.Value);
                 using (var stream = new MemoryStream(data))
                 {
                     await blobClient.UploadAsync(
@@ -163,7 +164,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             }
             else
             {
-                var data = new byte[0];
+                byte[] data = GetRandomBuffer(objectLength.Value);
                 using (var stream = new MemoryStream(data))
                 {
                     await UploadAppendBlocksAsync(
@@ -222,7 +223,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             }
             else
             {
-                var data = new byte[0];
+                byte[] data = GetRandomBuffer(objectLength.Value);
                 using (var stream = new MemoryStream(data))
                 {
                     await UploadPagesAsync(

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/StartTransferBlobDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/StartTransferBlobDirectoryCopyTestBase.cs
@@ -96,7 +96,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             }
             else
             {
-                byte[] data = GetRandomBuffer(objectLength.Value);
+                byte[] data = GetRandomBuffer(objectLength ?? 0);
                 using (var stream = new MemoryStream(data))
                 {
                     await blobClient.UploadAsync(
@@ -164,7 +164,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             }
             else
             {
-                byte[] data = GetRandomBuffer(objectLength.Value);
+                byte[] data = GetRandomBuffer(objectLength ?? 0);
                 using (var stream = new MemoryStream(data))
                 {
                     await UploadAppendBlocksAsync(
@@ -223,7 +223,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             }
             else
             {
-                byte[] data = GetRandomBuffer(objectLength.Value);
+                byte[] data = GetRandomBuffer(objectLength ?? 0);
                 using (var stream = new MemoryStream(data))
                 {
                     await UploadPagesAsync(


### PR DESCRIPTION
This change addresses a test issue where a number of our Blob->Blob directory Copy tests were incorrectly testing with empty blobs when the test was supposed to be using blobs with some data. The change makes the small change to test code and re-records the hundreds of affected tests.

Also changed the default content type to something other than `text/plain` as that causes issues with recordings when there is data present.