### PR TITLE
Added post process telemetry option

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/LiveMetrics/Filtering/CollectionConfiguration.cs
@@ -118,16 +118,16 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.LiveMetrics.Filtering
 
         public string ETag => this.info.ETag;
 
-        private static void AddMetric<DocumentIngress>(
+        private static void AddMetric<TDocumentIngress>(
           DerivedMetricInfo metricInfo,
-          List<DerivedMetric<DocumentIngress>> metrics,
+          List<DerivedMetric<TDocumentIngress>> metrics,
           out CollectionConfigurationError[] errors)
         {
             errors = Array.Empty<CollectionConfigurationError>();
 
             try
             {
-                metrics.Add(new DerivedMetric<DocumentIngress>(metricInfo, out errors));
+                metrics.Add(new DerivedMetric<TDocumentIngress>(metricInfo, out errors));
             }
             catch (System.Exception e)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net6.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net6.0.cs
@@ -11,6 +11,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         public AzureMonitorExporterOptions() { }
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.v2_1) { }
+        public System.Action<Azure.Monitor.OpenTelemetry.Exporter.ITelemetryItem> BeforeTelemetrySent { get { throw null; } set { } }
         public string ConnectionString { get { throw null; } set { } }
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
@@ -27,5 +28,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
+    }
+    public partial interface ITelemetryItem
+    {
+        string Name { get; }
+        System.Collections.Generic.IDictionary<string, string> Tags { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net8.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net8.0.cs
@@ -11,6 +11,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         public AzureMonitorExporterOptions() { }
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.v2_1) { }
+        public System.Action<Azure.Monitor.OpenTelemetry.Exporter.ITelemetryItem> BeforeTelemetrySent { get { throw null; } set { } }
         public string ConnectionString { get { throw null; } set { } }
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
@@ -27,5 +28,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
+    }
+    public partial interface ITelemetryItem
+    {
+        string Name { get; }
+        System.Collections.Generic.IDictionary<string, string> Tags { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -11,6 +11,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         public AzureMonitorExporterOptions() { }
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.v2_1) { }
+        public System.Action<Azure.Monitor.OpenTelemetry.Exporter.ITelemetryItem> BeforeTelemetrySent { get { throw null; } set { } }
         public string ConnectionString { get { throw null; } set { } }
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
@@ -27,5 +28,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
+    }
+    public partial interface ITelemetryItem
+    {
+        string Name { get; }
+        System.Collections.Generic.IDictionary<string, string> Tags { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 using Azure.Core;
@@ -43,6 +44,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// The <see cref="ServiceVersion"/> of the Azure Monitor ingestion API.
         /// </summary>
         public ServiceVersion Version { get; set; } = LatestVersion;
+
+        /// <summary>
+        /// Callback to configure telemetry items before they are sent to Azure Monitor.
+        /// </summary>
+        public Action<ITelemetryItem> BeforeTelemetrySent { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureMonitorExporterOptions"/>.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -6,12 +6,11 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-
 using OpenTelemetry.Logs;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
-    internal partial class TelemetryItem
+    internal partial class TelemetryItem : ITelemetryItem
     {
         public TelemetryItem(Activity activity, ref ActivityTagsProcessor activityTagsProcessor, AzureMonitorResource? resource, string instrumentationKey, float sampleRate) :
             this(activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency", FormatUtcTimestamp(activity.StartTimeUtc))

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ITelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ITelemetryItem.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter;
+
+/// <summary> A telemetry item that will be sent to Application Insights. </summary>
+public interface ITelemetryItem
+{
+    /// <summary> Type name of telemetry data item. </summary>
+    string Name { get; }
+    /// <summary> Key/value collection of context properties.</summary>
+    IDictionary<string, string> Tags { get; }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -443,5 +443,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
 
         [Event(43, Message = "Error while adding activity tags as custom property: {0}", Level = EventLevel.Warning)]
         public void ErrorAddingActivityTagsAsCustomProperties(string errorMessage) => WriteEvent(43, errorMessage);
+
+        [NonEvent]
+        public void ErrorInvokingBeforeTelemetrySent(Exception ex)
+        {
+            if (IsEnabled(EventLevel.Warning))
+            {
+                ErrorInvokingBeforeTelemetrySent(ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(44, Message = "An exception occurred invoking BeforeTelemetrySent callback: {0}", Level = EventLevel.Warning)]
+        public void ErrorInvokingBeforeTelemetrySent(string errorMessage) => WriteEvent(44, errorMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -47,16 +47,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
         };
 
-        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource? resource, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource? resource, string instrumentationKey) =>
+            OtelToAzureMonitorLogs(batchLogRecord, resource, instrumentationKey, postProcess: null);
+
+        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource? resource, string instrumentationKey, Action<ITelemetryItem>? postProcess)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
-            TelemetryItem telemetryItem;
 
             foreach (var logRecord in batchLogRecord)
             {
                 try
                 {
-                    telemetryItem = new TelemetryItem(logRecord, resource, instrumentationKey);
+                    TelemetryItem telemetryItem = new TelemetryItem(logRecord, resource, instrumentationKey);
                     if (logRecord.Exception != null)
                     {
                         telemetryItem.Data = new MonitorBase
@@ -74,6 +76,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         };
                     }
 
+                    PostProcessTelemetryHelper.InvokePostProcess(telemetryItem, postProcess);
                     telemetryItems.Add(telemetryItem);
                 }
                 catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PostProcessTelemetryHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PostProcessTelemetryHelper.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals;
+
+/// <summary>
+/// Enables a callback to be invoked before telemetry is sent to the backend.
+/// </summary>
+internal static class PostProcessTelemetryHelper
+{
+    /// <summary>
+    /// Invokes the <paramref name="postProcess"/> callback
+    /// </summary>
+    internal static void InvokePostProcess(ITelemetryItem item, Action<ITelemetryItem>? postProcess)
+    {
+        if (postProcess == null)
+        {
+            return;
+        }
+
+        try
+        {
+            postProcess(item);
+
+            // Clear any tags that exceed the maximum length after the callback has been invoked.
+            var tags =
+                from kvp in item.Tags
+                where kvp.Key.Length > SchemaConstants.KVP_MaxKeyLength
+                      || kvp.Value.Length > SchemaConstants.KVP_MaxValueLength
+                select kvp;
+            foreach (var kvp in tags.ToList())
+            {
+                item.Tags.Remove(kvp.Key);
+            }
+        }
+        catch (Exception ex)
+        {
+            AzureMonitorExporterEventSource.Log.ErrorInvokingBeforeTelemetrySent(ex);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/PostProcessTelemetryHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/PostProcessTelemetryHelperTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Moq;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests;
+
+public class PostProcessTelemetryHelperTests
+{
+    [Fact]
+    public void InvokePostProcess()
+    {
+        var longKey = new string('k', SchemaConstants.KVP_MaxKeyLength + 1);
+        var longValue = new string('v', SchemaConstants.KVP_MaxValueLength + 1);
+
+        var tags = new Dictionary<string, string>();
+        var item = new Mock<ITelemetryItem>();
+        item.Setup(i => i.Tags).Returns(tags);
+        PostProcessTelemetryHelper.InvokePostProcess(item.Object,
+            i =>
+            {
+                i.Tags.Add("key", "value");
+                i.Tags.Add(longKey, "value");
+                i.Tags.Add("key2", longValue);
+                i.Tags.Add($"{longKey}2", longValue);
+            });
+        Assert.Single(tags);
+        Assert.Contains(tags, kvp => kvp is { Key: "key", Value: "value" });
+    }
+
+    [Fact]
+    public void InvokePostProcessNull()
+    {
+        var item = new Mock<ITelemetryItem>();
+        PostProcessTelemetryHelper.InvokePostProcess(item.Object, null);
+    }
+
+    [Fact]
+    public void InvokePostProcessException()
+    {
+        var item = new Mock<ITelemetryItem>();
+        PostProcessTelemetryHelper.InvokePostProcess(item.Object,
+            i => throw new System.Exception());
+    }
+}


### PR DESCRIPTION
## Rationale

I am currently using the application insights SDK in a desktop (wpf) application. I have initializers that set various tags (e.g. client type) that I cannot configure using Open Telemetry/Azure Monitor. This PR allows a client to configure a telemetry item.

### Changes
Added option `Action<ITelemetryItem>` to `AzureMonitorExporterOptions` to allow configuring telemetry before being sent.

`ITelemetryItem` exposes Telemetry item as:

```csharp
/// <summary> A telemetry item that will be sent to Application Insights. </summary>
public interface ITelemetryItem
{
    /// <summary> Type name of telemetry data item. </summary>
    string Name { get; }
    /// <summary> Key/value collection of context properties. </summary>
    IDictionary<string, string> Tags { get; }
}
````


