### PR TITLE
[Storage][Batch] Fix Blob batch with TokenCredential from BlobContainerClient

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/CHANGELOG.md
@@ -7,8 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Fixed an issue where batch subrequests would not authenticate properly if using `TokenCredential` authentication
-when the `BlobBatchClient` was created from `BlobContianerClient.GetBlobBatchClient`.
+- Fixed an issue where batch subrequests would not authenticate properly if using `TokenCredential` authentication when the `BlobBatchClient` was created from `BlobContianerClient.GetBlobBatchClient`.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Blobs.Batch/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue where batch subrequests would not authenticate properly if using `TokenCredential` authentication
+when the `BlobBatchClient` was created from `BlobContianerClient.GetBlobBatchClient`.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Blobs.Batch/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs.Batch",
-  "Tag": "net/storage/Azure.Storage.Blobs.Batch_91b5e838a2"
+  "Tag": "net/storage/Azure.Storage.Blobs.Batch_9b2222572d"
 }

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
@@ -389,6 +389,21 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
+        public async Task Delete_Basic_Convenience_OAuth()
+        {
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_OAuth(TestEnvironment.Credential);
+            await using TestScenario scenario = Scenario(service);
+            BlobClient[] blobs = await scenario.CreateBlobsAsync(3);
+            Uri[] uris = blobs.Select(b => b.Uri).ToArray();
+
+            BlobBatchClient client = scenario.GetBlobBatchClient();
+            Response[] responses = await client.DeleteBlobsAsync(uris);
+
+            scenario.AssertStatus(202, responses);
+            await scenario.AssertDeleted(blobs);
+        }
+
+        [RecordedTest]
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task Delete_Basic_Convenience_AccountSas()
         {
@@ -409,6 +424,22 @@ namespace Azure.Storage.Blobs.Test
         public async Task Delete_ContainerScoped_Basic_Convenience()
         {
             await using TestScenario scenario = Scenario();
+            BlobClient[] blobs = await scenario.CreateBlobsAsync(3);
+            Uri[] uris = blobs.Select(b => b.Uri).ToArray();
+
+            BlobBatchClient client = scenario.GetBlobBatchClient(scenario.Containers[0].Container.Name);
+            Response[] responses = await client.DeleteBlobsAsync(uris);
+
+            scenario.AssertStatus(202, responses);
+            await scenario.AssertDeleted(blobs);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_04_08)]
+        public async Task Delete_ContainerScoped_Basic_Convenience_OAuth()
+        {
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_OAuth(TestEnvironment.Credential);
+            await using TestScenario scenario = Scenario(service);
             BlobClient[] blobs = await scenario.CreateBlobsAsync(3);
             Uri[] uris = blobs.Select(b => b.Uri).ToArray();
 
@@ -797,6 +828,21 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
+        public async Task SetBlobAccessTier_Basic_Convenience_OAuth()
+        {
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_OAuth(TestEnvironment.Credential);
+            await using TestScenario scenario = Scenario(service);
+            BlobClient[] blobs = await scenario.CreateBlobsAsync(3);
+            Uri[] uris = blobs.Select(b => b.Uri).ToArray();
+
+            BlobBatchClient client = scenario.GetBlobBatchClient();
+            Response[] responses = await client.SetBlobsAccessTierAsync(uris, AccessTier.Cool);
+
+            scenario.AssertStatus(200, responses);
+            await scenario.AssertTiers(AccessTier.Cool, blobs);
+        }
+
+        [RecordedTest]
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task SetBlobAccessTier_Basic_Convenience_AccountSas()
         {
@@ -817,6 +863,22 @@ namespace Azure.Storage.Blobs.Test
         public async Task SetBlobAccessTier_ContainerScoped_Basic_Convenience()
         {
             await using TestScenario scenario = Scenario();
+            BlobClient[] blobs = await scenario.CreateBlobsAsync(3);
+            Uri[] uris = blobs.Select(b => b.Uri).ToArray();
+
+            BlobBatchClient client = scenario.GetBlobBatchClient(scenario.Containers[0].Container.Name);
+            Response[] responses = await client.SetBlobsAccessTierAsync(uris, AccessTier.Cool);
+
+            scenario.AssertStatus(200, responses);
+            await scenario.AssertTiers(AccessTier.Cool, blobs);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_04_08)]
+        public async Task SetBlobAccessTier_ContainerScoped_Basic_Convenience_OAuth()
+        {
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_OAuth(TestEnvironment.Credential);
+            await using TestScenario scenario = Scenario(service);
             BlobClient[] blobs = await scenario.CreateBlobsAsync(3);
             Uri[] uris = blobs.Select(b => b.Uri).ToArray();
 

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -415,6 +415,22 @@ namespace Azure.Storage.Blobs
             BlobErrors.VerifyCpkAndEncryptionScopeNotBothSet(_clientConfiguration.CustomerProvidedKey, _clientConfiguration.EncryptionScope);
         }
 
+        internal BlobContainerClient(
+            Uri containerUri,
+            BlobClientConfiguration clientConfiguration,
+            HttpPipelinePolicy authentication,
+            ClientSideEncryptionOptions clientSideEncryption)
+        {
+            _uri = containerUri;
+            _clientConfiguration = clientConfiguration;
+            _authenticationPolicy = authentication;
+            _clientSideEncryption = clientSideEncryption?.Clone();
+            _containerRestClient = BuildContainerRestClient(containerUri);
+
+            BlobErrors.VerifyHttpsCustomerProvidedKey(_uri, _clientConfiguration.CustomerProvidedKey);
+            BlobErrors.VerifyCpkAndEncryptionScopeNotBothSet(_clientConfiguration.CustomerProvidedKey, _clientConfiguration.EncryptionScope);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobContainerClient"/>
         /// class with Blob Container URI, <see cref="BlobClientOptions"/>, and <see cref="HttpPipeline"/>.
@@ -3374,6 +3390,7 @@ namespace Azure.Storage.Blobs
                     BlobContainerClient destContainerClient = new BlobContainerClient(
                         uriBuilder.ToUri(),
                         ClientConfiguration,
+                        AuthenticationPolicy,
                         ClientSideEncryption);
 
                     ResponseWithHeaders<ContainerRenameHeaders> response;

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -574,6 +574,7 @@ namespace Azure.Storage.Blobs
             new BlobContainerClient(
                 Uri.AppendToPath(blobContainerName),
                 ClientConfiguration,
+                AuthenticationPolicy,
                 ClientSideEncryption);
 
         #region protected static accessors for Azure.Storage.Blobs.Batch


### PR DESCRIPTION
Resolves #45632
Resolves #45469

This change addresses an issue with Blob Batch authentication when using a `TokenCredential` and creating the batch client from a `BlobContainerClient` which was created from `BlobServiceCleint.GetBlobContainerClient`.

The root of the issue is that `GetBlobContainerClient` did not properly pass the authentication policy that was stored on the `BlobServiceClient` which is then passed to the batch client to use when creating the batch pipeline. this issue did not affect anything other than batch however since batch is the only thing that uses the stored `_authenticationPolicy`.

I created a new internal constructor instead of modifying the existing one since there were some callers of the existing one existing one that would not have an auth policy to pass. They probably could have passed `null` but i didn't want to risk breaking something.