### PR TITLE
VisualStudioCredential falls through to next chained cred when no account is found

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- `VisualStudioCredential` will now correctly fall through to the next credential in the chain when no account is found by Visual Studio. ([#48464](https://github.com/Azure/azure-sdk-for-net/issues/48464))
 
 ### Other Changes
 - Marked `UsernamePasswordCredential` as obsolete because Resource Owner Password Credentials (ROPC) token grant flow is incompatible with multifactor authentication (MFA), which Microsoft Entra ID requires for all tenants. See https://aka.ms/azsdk/identity/mfa for details about MFA enforcement and migration guidance.

--- a/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
@@ -26,6 +26,7 @@ namespace Azure.Identity
         private static readonly string TokenProviderFilePath = Path.Combine(".IdentityService", "AzureServiceAuth", "tokenprovider.json");
         private const string ResourceArgumentName = "--resource";
         private const string TenantArgumentName = "--tenant";
+        private string[] UnavailableErrorStrings => new[] { "TS005" };
 
         private readonly CredentialPipeline _pipeline;
         internal string TenantId { get; }
@@ -119,7 +120,16 @@ namespace Azure.Identity
             }
             catch (Exception e)
             {
-                throw scope.FailWrapAndThrow(e, isCredentialUnavailable: _isChainedCredential);
+                bool containsUnavailableError = false;
+                foreach (string errorString in UnavailableErrorStrings)
+                {
+                    if (e.Message.Contains(errorString))
+                    {
+                        containsUnavailableError = true;
+                        break;
+                    }
+                }
+                throw scope.FailWrapAndThrow(e, isCredentialUnavailable: _isChainedCredential || containsUnavailableError);
             }
         }
 

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
@@ -338,5 +338,17 @@ namespace Azure.Identity.Tests
             Assert.ThrowsAsync<CredentialUnavailableException>(
                 async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/" }), CancellationToken.None));
         }
+
+         [Test]
+         [TestCase("TS003: Error, TS005: No accounts found.  Please go to Tools->Options->Azure Services Authentication, and add an account to be authenticated to Azure services during development.")]
+        public void GeneralExceptions_With_CertainErrors_throws_CredentialUnavailableException(string exceptionMessage)
+        {
+            var testProcess = new TestProcess() { ExceptionOnStartHandler = p => throw new InvalidOperationException(exceptionMessage) };
+            var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudio();
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess), new VisualStudioCredentialOptions { IsChainedCredential = false }));
+
+            Assert.ThrowsAsync<CredentialUnavailableException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/" }), CancellationToken.None));
+        }
     }
 }


### PR DESCRIPTION
fixes #48464