### PR TITLE
build: bump Azure.ClientSdk.Analyzers to 0.1.1-dev.20250227.2

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -248,7 +248,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20250223.1" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20240813.2" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20250227.2" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />


### PR DESCRIPTION
This PR bumps the `Azure.ClientSdk.Analyzers` package to version [0.1.1-dev.20250227.2](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4603682&view=results) which includes a [fix for AZC0007](https://github.com/Azure/azure-sdk-tools/pull/9934).