### PR TITLE
Exception messages for file share clients when for emulator connection string

### DIFF
--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -158,6 +158,7 @@ namespace Azure.Storage.Files.Shares
             Argument.AssertNotNullOrWhiteSpace(shareName, nameof(shareName));
             options ??= new ShareClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
+            ShareErrors.AssertNotDevelopment(conn, nameof(connectionString));
             ShareUriBuilder uriBuilder = new ShareUriBuilder(conn.FileEndpoint) { ShareName = shareName };
             _uri = uriBuilder.ToUri();
             _clientConfiguration = new ShareClientConfiguration(

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -193,6 +193,7 @@ namespace Azure.Storage.Files.Shares
             Argument.AssertNotNullOrWhiteSpace(shareName, nameof(shareName));
             options ??= new ShareClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
+            ShareErrors.AssertNotDevelopment(conn, nameof(connectionString));
             ShareUriBuilder uriBuilder =
                 new ShareUriBuilder(conn.FileEndpoint)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareErrors.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareErrors.cs
@@ -37,7 +37,7 @@ namespace Azure.Storage.Files.Shares
         {
             if (conn.IsDevStoreAccount)
             {
-                throw new ArgumentException("Connection string for emulator is not valid for Azure File Shares", nameof(argumentName));
+                throw new ArgumentException("Connection string for emulator is not valid for Azure File Shares", argumentName);
             }
         }
     }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareErrors.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareErrors.cs
@@ -32,5 +32,13 @@ namespace Azure.Storage.Files.Shares
                     throw new ArgumentException($"{nameof(StorageChecksumAlgorithm)} does not support value {Enum.GetName(typeof(StorageChecksumAlgorithm), resolved) ?? ((int)resolved).ToString(CultureInfo.InvariantCulture)}.");
             }
         }
+
+        public static void AssertNotDevelopment(StorageConnectionString conn, string argumentName)
+        {
+            if (conn.IsDevStoreAccount)
+            {
+                throw new ArgumentException("Connection string for emulator is not valid for Azure File Shares", nameof(argumentName));
+            }
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -203,6 +203,7 @@ namespace Azure.Storage.Files.Shares
             Argument.AssertNotNullOrWhiteSpace(filePath, nameof(filePath));
             options ??= new ShareClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
+            ShareErrors.AssertNotDevelopment(conn, nameof(connectionString));
             ShareUriBuilder uriBuilder =
                 new ShareUriBuilder(conn.FileEndpoint)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -129,6 +129,7 @@ namespace Azure.Storage.Files.Shares
         {
             options ??= new ShareClientOptions();
             var conn = StorageConnectionString.Parse(connectionString);
+            ShareErrors.AssertNotDevelopment(conn, nameof(connectionString));
             _uri = conn.FileEndpoint;
             _clientConfiguration = new ShareClientConfiguration(
                 pipeline: options.Build(conn.Credentials),

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -159,7 +159,7 @@ namespace Azure.Storage.Files.Shares.Tests
             Assert.IsNotNull(exists);
         }
 
-        [RecordedTest]
+        [Test]
         public void Ctor_DevelopmentThrows()
         {
             var shareName = GetNewShareName();

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -162,7 +162,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Test]
         public void Ctor_DevelopmentThrows()
         {
-            var ex = Assert.Throws<ArgumentException>(() => new ShareDirectoryClient("Development=true", "share", "dir"));
+            var ex = Assert.Throws<ArgumentException>(() => new ShareDirectoryClient("UseDevelopmentStorage=true", "share", "dir"));
             Assert.AreEqual("connectionString", ex.ParamName);
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -160,6 +160,15 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         [RecordedTest]
+        public void Ctor_DevelopmentThrows()
+        {
+            var shareName = GetNewShareName();
+            var path = GetNewDirectoryName();
+            var ex = Assert.Throws<ArgumentException>(() => new ShareDirectoryClient("Development=true", shareName, path));
+            Assert.AreEqual("connectionString", ex.ParamName);
+        }
+
+        [RecordedTest]
         public async Task Ctor_StorageAccountAudience()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -162,9 +162,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Test]
         public void Ctor_DevelopmentThrows()
         {
-            var shareName = GetNewShareName();
-            var path = GetNewDirectoryName();
-            var ex = Assert.Throws<ArgumentException>(() => new ShareDirectoryClient("Development=true", shareName, path));
+            var ex = Assert.Throws<ArgumentException>(() => new ShareDirectoryClient("Development=true", "share", "dir"));
             Assert.AreEqual("connectionString", ex.ParamName);
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -139,7 +139,7 @@ namespace Azure.Storage.Files.Shares.Tests
             Assert.IsNotNull(exists);
         }
 
-        [RecordedTest]
+        [Test]
         public void Ctor_DevelopmentThrows()
         {
             var shareName = GetNewShareName();

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -140,6 +140,15 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         [RecordedTest]
+        public void Ctor_DevelopmentThrows()
+        {
+            var shareName = GetNewShareName();
+            var path = $"{GetNewDirectoryName()}/{GetNewFileName()}";
+            var ex = Assert.Throws<ArgumentException>(() => new ShareFileClient("Development=true", shareName, path));
+            Assert.AreEqual("connectionString", ex.ParamName);
+        }
+
+        [RecordedTest]
         public async Task Ctor_CustomAudience()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -142,7 +142,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Test]
         public void Ctor_DevelopmentThrows()
         {
-            var ex = Assert.Throws<ArgumentException>(() => new ShareFileClient("Development=true", "share", "dir/file"));
+            var ex = Assert.Throws<ArgumentException>(() => new ShareFileClient("UseDevelopmentStorage=true", "share", "dir/file"));
             Assert.AreEqual("connectionString", ex.ParamName);
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -142,9 +142,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Test]
         public void Ctor_DevelopmentThrows()
         {
-            var shareName = GetNewShareName();
-            var path = $"{GetNewDirectoryName()}/{GetNewFileName()}";
-            var ex = Assert.Throws<ArgumentException>(() => new ShareFileClient("Development=true", shareName, path));
+            var ex = Assert.Throws<ArgumentException>(() => new ShareFileClient("Development=true", "share", "dir/file"));
             Assert.AreEqual("connectionString", ex.ParamName);
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -73,6 +73,13 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         [RecordedTest]
+        public void Ctor_DevelopmentThrows()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new ShareServiceClient("Development=true"));
+            Assert.AreEqual("connectionString", ex.ParamName);
+        }
+
+        [RecordedTest]
         public async Task GetPropertiesAsync()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -72,7 +72,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 e => e.Message.Contains($"You cannot use {nameof(AzureSasCredential)} when the resource URI also contains a Shared Access Signature"));
         }
 
-        [RecordedTest]
+        [Test]
         public void Ctor_DevelopmentThrows()
         {
             var ex = Assert.Throws<ArgumentException>(() => new ShareServiceClient("Development=true"));

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -75,7 +75,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Test]
         public void Ctor_DevelopmentThrows()
         {
-            var ex = Assert.Throws<ArgumentException>(() => new ShareServiceClient("Development=true"));
+            var ex = Assert.Throws<ArgumentException>(() => new ShareServiceClient("UseDevelopmentStorage=true"));
             Assert.AreEqual("connectionString", ex.ParamName);
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -268,6 +268,14 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         [RecordedTest]
+        public void Ctor_DevelopmentThrows()
+        {
+            var shareName = GetNewShareName();
+            var ex = Assert.Throws<ArgumentException>(() => new ShareClient("Development=true", shareName));
+            Assert.AreEqual("connectionString", ex.ParamName);
+        }
+
+        [RecordedTest]
         public void WithSnapshot()
         {
             var shareName = GetNewShareName();

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -270,7 +270,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Test]
         public void Ctor_DevelopmentThrows()
         {
-            var ex = Assert.Throws<ArgumentException>(() => new ShareClient("Development=true", "share"));
+            var ex = Assert.Throws<ArgumentException>(() => new ShareClient("UseDevelopmentStorage=true", "share"));
             Assert.AreEqual("connectionString", ex.ParamName);
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -270,8 +270,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Test]
         public void Ctor_DevelopmentThrows()
         {
-            var shareName = GetNewShareName();
-            var ex = Assert.Throws<ArgumentException>(() => new ShareClient("Development=true", shareName));
+            var ex = Assert.Throws<ArgumentException>(() => new ShareClient("Development=true", "share"));
             Assert.AreEqual("connectionString", ex.ParamName);
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -267,7 +267,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 e => Assert.AreEqual("InvalidAuthenticationInfo", e.ErrorCode));
         }
 
-        [RecordedTest]
+        [Test]
         public void Ctor_DevelopmentThrows()
         {
             var shareName = GetNewShareName();


### PR DESCRIPTION
Throw `ArgumentException` with a better message instead of `NullReferenceException` or `NullArgumentException` (no arguments were null)