### PR TITLE
Improve Identity NuGet package descriptions

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>This is the implementation of the Azure SDK Client Library for Azure Identity</Description>
+    <Description>Provides authentication broker APIs for authenticating to Microsoft Entra ID</Description>
     <AssemblyTitle>Microsoft Azure.Identity.Broker Component</AssemblyTitle>
     <Version>1.3.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>This is the implementation of the Azure SDK Client Library for Azure Identity</Description>
+    <Description>Provides APIs for authenticating to Microsoft Entra ID</Description>
     <AssemblyTitle>Microsoft Azure.Identity Component</AssemblyTitle>
     <Version>1.14.0-beta.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->


### PR DESCRIPTION
Disambiguates the package descriptions used for the 2 Azure.Identity packages. The goal is to use text that's meaningful to someone browsing on nuget.org or in VS' NuGet Package Manager. When I look at the current text, I have no idea what the package does for me:

![image](https://github.com/user-attachments/assets/11b1ca30-4574-47f9-8439-7737f241ad36)
