### PR TITLE
Handle empty yaml variable in interpolated string

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -145,11 +145,14 @@ jobs:
           displayName: "Build and Package for PR"
       - ${{ else }}:
         - pwsh: |
-            if (Test-Path "$(ProjectListOverrideFile)") {
-              Write-Host "Clearing $(ProjectListOverrideFile)"
-              rm "$(ProjectListOverrideFile)"
-              Write-Host "##vso[task.setvariable variable=ProjectListOverrideFile;]"
+            $variableSet = $env:ProjectListOverrideFile -ne "`$`(ProjectListOverrideFile`)"
+            if ($variableSet -and (Test-Path $env:ProjectListOverrideFile)) {
+              Write-Host "Clearing $env:ProjectListOverrideFile"
+              rm $env:ProjectListOverrideFile
             }
+            Write-Host '##vso[task.setvariable variable=ProjectListOverrideFile;]'
+          env:
+            ProjectListOverrideFile: $(ProjectListOverrideFile)
           displayName: Cleanup Props File
 
         - script: >-


### PR DESCRIPTION
When `$(ProjectListOverrideFile)` is empty, powershell processes the unreplaced yaml syntax `"$(ProjectListOverrideFile)"` as string interpolation with the command `ProjectListOverrideFile`.

This throws the exception "The term 'ProjectListOverrideFile' is not recognized as a name of a cmdlet..."