### PR TITLE
[Governance] Fix outdated references

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -98,7 +98,7 @@
     <PackageReference Update="System.Security.Cryptography.Cose" Version="7.0.0" />
     <PackageReference Update="System.Threading.Channels" Version="6.0.0" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Update="System.Text.Json" Version="6.0.10" />
+    <PackageReference Update="System.Text.Json" Version="6.0.11" />
     <PackageReference Update="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -99,7 +99,7 @@
     <PackageReference Update="System.Threading.Channels" Version="6.0.0" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Update="System.Text.Json" Version="6.0.11" />
-    <PackageReference Update="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="6.0.1" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Update="Microsoft.CSharp" Version="4.7.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -89,7 +89,7 @@
     <PackageReference Update="System.ClientModel" Version="1.2.1" />
     <PackageReference Update="System.IO.Hashing" Version="6.0.0" />
     <PackageReference Update="System.Memory" Version="4.5.5" />
-    <PackageReference Update="System.Memory.Data" Version="6.0.0" />
+    <PackageReference Update="System.Memory.Data" Version="6.0.1" />
     <PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
@@ -383,7 +383,7 @@
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />
     <PackageReference Update="System.Linq.Async" Version="5.0.0" />
-    <PackageReference Update="System.Memory.Data" Version="6.0.0" />
+    <PackageReference Update="System.Memory.Data" Version="6.0.1" />
     <PackageReference Update="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Update="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Update="System.Runtime.InteropServices" Version="4.3.0" />
@@ -411,9 +411,11 @@
     <PackageReference Update="System.ServiceModel.Primitives" Version="6.2.0" />
     <PackageReference Update="Azure.Storage.Files.Shares" Version="12.21.0" />
     <PackageReference Update="Azure.Storage.Queues" Version="12.21.0" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Update="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Configuration" Version="8.0.1" />
+    <PackageReference Update="System.Formats.Asn1" Version="6.0.1" />
+    <PackageReference Update="System.Security.Cryptography.Pkcs" Version="6.0.5" />
   </ItemGroup>
   <ItemGroup Condition="('$(IsWcfLibrary)' == 'true') AND ($(TargetFramework.StartsWith('net4')))">
     <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
@@ -424,5 +426,4 @@
   <PropertyGroup>
     <TestProxyVersion>1.0.0-dev.20250221.1</TestProxyVersion>
   </PropertyGroup>
-
 </Project>

--- a/sdk/cloudmachine/Azure.CloudMachine.OpenAI/src/Azure.CloudMachine.OpenAI.csproj
+++ b/sdk/cloudmachine/Azure.CloudMachine.OpenAI/src/Azure.CloudMachine.OpenAI.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Bcl.Numerics" />
-    <PackageReference Include="System.Memory.Data" VersionOverride="8.0.0"/>
+    <PackageReference Include="System.Memory.Data" VersionOverride="8.0.1"/>
   </ItemGroup>
 
 </Project>

--- a/sdk/cloudmachine/Azure.CloudMachine.Web/src/Azure.CloudMachine.Web.csproj
+++ b/sdk/cloudmachine/Azure.CloudMachine.Web/src/Azure.CloudMachine.Web.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory.Data" VersionOverride="8.0.0" />
+    <PackageReference Include="System.Memory.Data" VersionOverride="8.0.1" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/sdk/cloudmachine/Azure.CloudMachine/src/Azure.CloudMachine.csproj
+++ b/sdk/cloudmachine/Azure.CloudMachine/src/Azure.CloudMachine.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Search.Documents" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions"/>
-    <PackageReference Include="System.Memory.Data" VersionOverride="8.0.0"/>
+    <PackageReference Include="System.Memory.Data" VersionOverride="8.0.1"/>
   </ItemGroup>
 
 </Project>

--- a/sdk/extension-wcf/Microsoft.WCF.Azure.StorageQueues/src/Microsoft.WCF.Azure.StorageQueues.csproj
+++ b/sdk/extension-wcf/Microsoft.WCF.Azure.StorageQueues/src/Microsoft.WCF.Azure.StorageQueues.csproj
@@ -19,6 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Queues" />
+    <PackageReference Include="System.Formats.Asn1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
     <PackageReference Include="System.ServiceModel.Primitives" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/sdk/extension-wcf/Microsoft.WCF.Azure.StorageQueues/tests/Microsoft.WCF.Azure.StorageQueues.Tests.csproj
+++ b/sdk/extension-wcf/Microsoft.WCF.Azure.StorageQueues/tests/Microsoft.WCF.Azure.StorageQueues.Tests.csproj
@@ -25,6 +25,8 @@
   <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.ServiceModel.Primitives" />
+    <PackageReference Include="System.Formats.Asn1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
     <ProjectReference Include="..\src\Microsoft.WCF.Azure.StorageQueues.csproj" />
   </ItemGroup>
 

--- a/sdk/extension-wcf/samples/Microsoft.WCF.Azure.StorageQueues.Samples/Microsoft.WCF.Azure.StorageQueues.Samples.csproj
+++ b/sdk/extension-wcf/samples/Microsoft.WCF.Azure.StorageQueues.Samples/Microsoft.WCF.Azure.StorageQueues.Samples.csproj
@@ -13,6 +13,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="System.ServiceModel.Primitives" />
+    <PackageReference Include="System.Formats.Asn1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
 	</ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.WCF.Azure.StorageQueues\src\Microsoft.WCF.Azure.StorageQueues.csproj" />

--- a/sdk/keyvault/samples/sharelink/ShareLink.csproj
+++ b/sdk/keyvault/samples/sharelink/ShareLink.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Azure.Security.KeyVault.Storage</RootNamespace>
     <NoWarn>
       $(NoWarn);
@@ -16,7 +16,7 @@
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
-  <ItemGroup>    
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="System.CommandLine" VersionOverride="2.0.0-beta1.21216.1" />
@@ -29,11 +29,11 @@
 
   <ItemGroup Condition="'$(IsSample)' != 'true'">
     <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
-    <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230427.2" PrivateAssets="All" />    
-    <PackageReference Update="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230427.2" PrivateAssets="All" />
+    <PackageReference Update="Azure.Identity" Version="1.13.2" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Update="System.CommandLine" Version="%(VersionOverride)" />
-    <PackageReference Update="System.Text.Json" Version="8.0.4" />
+    <PackageReference Update="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsSample)' == 'true'">

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/README.md
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/README.md
@@ -28,13 +28,9 @@ Since the Workflow service uses an Azure Active Directory (AAD) bearer token for
 
 ```C# Snippet:Azure_Analytics_Purview_Workflows_CreateClient
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-string clientId = Environment.GetEnvironmentVariable("ClientId");
-string tenantId = Environment.GetEnvironmentVariable("TenantId");
-string username = Environment.GetEnvironmentVariable("Username");
-string password = Environment.GetEnvironmentVariable("Password");
+TokenCredential credential = new DefaultAzureCredential();
 
-TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
-var client = new WorkflowsClient(endpoint, usernamePasswordCredential);
+var client = new WorkflowsClient(endpoint, credential);
 ```
 
 ## Examples

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/samples/Sample1_Workflows.md
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/samples/Sample1_Workflows.md
@@ -9,13 +9,9 @@ You can set `endpoint`, `username`, `password` etc. based on an environment vari
 
 ```C# Snippet:Azure_Analytics_Purview_Workflows_CreateClient
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-string clientId = Environment.GetEnvironmentVariable("ClientId");
-string tenantId = Environment.GetEnvironmentVariable("TenantId");
-string username = Environment.GetEnvironmentVariable("Username");
-string password = Environment.GetEnvironmentVariable("Password");
+TokenCredential credential = new DefaultAzureCredential();
 
-TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
-var client = new WorkflowsClient(endpoint, usernamePasswordCredential);
+var client = new WorkflowsClient(endpoint, credential);
 ```
 
 ## Create a Workflow

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/samples/Sample2_SubmitUserRequests.md
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/samples/Sample2_SubmitUserRequests.md
@@ -9,13 +9,9 @@ You can set `endpoint`, `username`, `password` etc. based on an environment vari
 
 ```C# Snippet:Azure_Analytics_Purview_Workflows_CreateClient
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-string clientId = Environment.GetEnvironmentVariable("ClientId");
-string tenantId = Environment.GetEnvironmentVariable("TenantId");
-string username = Environment.GetEnvironmentVariable("Username");
-string password = Environment.GetEnvironmentVariable("Password");
+TokenCredential credential = new DefaultAzureCredential();
 
-TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
-var client = new WorkflowsClient(endpoint, usernamePasswordCredential);
+var client = new WorkflowsClient(endpoint, credential);
 ```
 
 ## Submit a user request

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/samples/Sample3_WorkflowTasks.md
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/samples/Sample3_WorkflowTasks.md
@@ -9,13 +9,9 @@ You can set `endpoint`, `username`, `password` etc. based on an environment vari
 
 ```C# Snippet:Azure_Analytics_Purview_Workflows_CreateClient
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-string clientId = Environment.GetEnvironmentVariable("ClientId");
-string tenantId = Environment.GetEnvironmentVariable("TenantId");
-string username = Environment.GetEnvironmentVariable("Username");
-string password = Environment.GetEnvironmentVariable("Password");
+TokenCredential credential = new DefaultAzureCredential();
 
-TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
-var client = new WorkflowsClient(endpoint, usernamePasswordCredential);
+var client = new WorkflowsClient(endpoint, credential);
 ```
 
 ## Approve workflow task

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/samples/Sample4_WorkflowRuns.md
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/samples/Sample4_WorkflowRuns.md
@@ -9,13 +9,9 @@ You can set `endpoint`, `username`, `password` etc. based on an environment vari
 
 ```C# Snippet:Azure_Analytics_Purview_Workflows_CreateClient
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-string clientId = Environment.GetEnvironmentVariable("ClientId");
-string tenantId = Environment.GetEnvironmentVariable("TenantId");
-string username = Environment.GetEnvironmentVariable("Username");
-string password = Environment.GetEnvironmentVariable("Password");
+TokenCredential credential = new DefaultAzureCredential();
 
-TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
-var client = new WorkflowsClient(endpoint, usernamePasswordCredential);
+var client = new WorkflowsClient(endpoint, credential);
 ```
 
 ## Cancel a workflow run

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample1_HelloWorld.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample1_HelloWorld.cs
@@ -27,7 +27,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
             TokenCredential credential = TestEnvironment.Credential;
 #endif
 
-            var client = new WorkflowsClient(endpoint, usernamePasswordCredential);
+            var client = new WorkflowsClient(endpoint, credential);
 #endregion
 
             //Perform an operation

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample1_HelloWorld.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample1_HelloWorld.cs
@@ -47,13 +47,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
         public async Task CreateWorkflow()
         {
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-            string clientId = Environment.GetEnvironmentVariable("ClientId");
-            string tenantId = Environment.GetEnvironmentVariable("TenantId");
-            string username = Environment.GetEnvironmentVariable("Username");
-            string password = Environment.GetEnvironmentVariable("Password");
-
-            TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId, tenantId, username, password, null);
-            var client = new WorkflowClient(endpoint, usernamePasswordCredential);
+            var client = new WorkflowClient(endpoint, TestEnvironment.Credential);
 
             #region Snippet:Azure_Analytics_Purview_Workflows_CreateWorkflow
             Guid workflowId = Guid.NewGuid();
@@ -74,13 +68,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
         public async Task GetWorkflow()
         {
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-            string clientId = Environment.GetEnvironmentVariable("ClientId");
-            string tenantId = Environment.GetEnvironmentVariable("TenantId");
-            string username = Environment.GetEnvironmentVariable("Username");
-            string password = Environment.GetEnvironmentVariable("Password");
-
-            TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId, tenantId, username, password, null);
-            var client = new WorkflowClient(endpoint, usernamePasswordCredential);
+            var client = new WorkflowClient(endpoint, TestEnvironment.Credential);
 
             #region Snippet:Azure_Analytics_Purview_Workflows_GetWorkflow
             // This workflowId represents an existing workflow. The id can be obtained by calling CreateOrReplaceWorkflowAsync API or list workflows by calling GetWorkflowsAsync API.

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample1_HelloWorld.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample1_HelloWorld.cs
@@ -21,14 +21,14 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
         {
             #region Snippet:Azure_Analytics_Purview_Workflows_CreateClient
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-            string clientId = Environment.GetEnvironmentVariable("ClientId");
-            string tenantId = Environment.GetEnvironmentVariable("TenantId");
-            string username = Environment.GetEnvironmentVariable("Username");
-            string password = Environment.GetEnvironmentVariable("Password");
+#if SNIPPET
+            TokenCredential credential = new DefaultAzureCredential();
+#else
+            TokenCredential credential = TestEnvironment.Credential;
+#endif
 
-            TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
             var client = new WorkflowsClient(endpoint, usernamePasswordCredential);
-            #endregion
+#endregion
 
             //Perform an operation
             AsyncPageable<BinaryData> workflowList = client.GetWorkflowsAsync(new RequestContext());

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample2_SubmitUserRequests.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample2_SubmitUserRequests.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
-using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
-using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Analytics.Purview.Workflows.Tests.Samples
@@ -20,13 +16,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
         public async Task SubmitUserRequest()
         {
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-            string clientId = Environment.GetEnvironmentVariable("ClientId");
-            string tenantId = Environment.GetEnvironmentVariable("TenantId");
-            string username = Environment.GetEnvironmentVariable("Username");
-            string password = Environment.GetEnvironmentVariable("Password");
-
-            TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
-            var client = new UserRequestsClient(endpoint, usernamePasswordCredential);
+            var client = new UserRequestsClient(endpoint, TestEnvironment.Credential);
 
             #region Snippet:Azure_Analytics_Purview_Workflows_SubmitUserRequests
 

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample3_WorkflowTasks.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample3_WorkflowTasks.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
-using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
-using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Analytics.Purview.Workflows.Tests.Samples
@@ -20,13 +16,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
         public async Task ApproveWorkflowTask()
         {
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-            string clientId = Environment.GetEnvironmentVariable("ClientId");
-            string tenantId = Environment.GetEnvironmentVariable("TenantId");
-            string username = Environment.GetEnvironmentVariable("Username");
-            string password = Environment.GetEnvironmentVariable("Password");
-
-            TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
-            var client = new ApprovalClient(endpoint, usernamePasswordCredential);
+            var client = new ApprovalClient(endpoint, TestEnvironment.Credential);
 
             #region Snippet:Azure_Analytics_Purview_Workflows_ApproveWorkflowTask
 

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample4_WorkflowRuns.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample4_WorkflowRuns.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
-using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
-using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Analytics.Purview.Workflows.Tests.Samples
@@ -20,13 +16,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
         public async Task CancelWorkflowRun()
         {
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("WORKFLOW_ENDPOINT"));
-            string clientId = Environment.GetEnvironmentVariable("ClientId");
-            string tenantId = Environment.GetEnvironmentVariable("TenantId");
-            string username = Environment.GetEnvironmentVariable("Username");
-            string password = Environment.GetEnvironmentVariable("Password");
-
-            TokenCredential usernamePasswordCredential = new UsernamePasswordCredential(clientId,tenantId, username,password, null);
-            var client = new WorkflowRunClient(endpoint, usernamePasswordCredential);
+            var client = new WorkflowRunClient(endpoint, TestEnvironment.Credential);
 
             #region Snippet:Azure_Analytics_Purview_Workflows_CancelWorkflowRun
             // This workflowRunId represents an existing workflow run. The id can be obtained by calling GetWorkflowRunsAsync API.

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/WorkflowsClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/WorkflowsClientTestBase.cs
@@ -24,7 +24,7 @@ namespace Azure.Analytics.Purview.Workflow.Tests
                 return true;
             };
             var options = new PurviewWorkflowServiceClientOptions { Transport = new HttpClientTransport(httpHandler) };
-            return InstrumentClient(new WorkflowClient(TestEnvironment.Endpoint, TestEnvironment.UsernamePasswordCredential, InstrumentClientOptions(options)));
+            return InstrumentClient(new WorkflowClient(TestEnvironment.Endpoint, TestEnvironment.Credential, InstrumentClientOptions(options)));
         }
 
         public WorkflowsClient GetWorkflowsClient()
@@ -35,7 +35,7 @@ namespace Azure.Analytics.Purview.Workflow.Tests
                 return true;
             };
             var options = new PurviewWorkflowServiceClientOptions { Transport = new HttpClientTransport(httpHandler) };
-            return InstrumentClient(new WorkflowsClient(TestEnvironment.Endpoint, TestEnvironment.UsernamePasswordCredential, InstrumentClientOptions(options)));
+            return InstrumentClient(new WorkflowsClient(TestEnvironment.Endpoint, TestEnvironment.Credential, InstrumentClientOptions(options)));
         }
 
         public UserRequestsClient GetUserRequestsClient()
@@ -46,7 +46,7 @@ namespace Azure.Analytics.Purview.Workflow.Tests
                 return true;
             };
             var options = new PurviewWorkflowServiceClientOptions { Transport = new HttpClientTransport(httpHandler) };
-            return InstrumentClient(new UserRequestsClient(TestEnvironment.Endpoint, TestEnvironment.UsernamePasswordCredential, InstrumentClientOptions(options)));
+            return InstrumentClient(new UserRequestsClient(TestEnvironment.Endpoint, TestEnvironment.Credential, InstrumentClientOptions(options)));
         }
 
         public WorkflowRunClient GetWorkflowRunClient()
@@ -57,7 +57,7 @@ namespace Azure.Analytics.Purview.Workflow.Tests
                 return true;
             };
             var options = new PurviewWorkflowServiceClientOptions { Transport = new HttpClientTransport(httpHandler) };
-            return InstrumentClient(new WorkflowRunClient(TestEnvironment.Endpoint, TestEnvironment.UsernamePasswordCredential, InstrumentClientOptions(options)));
+            return InstrumentClient(new WorkflowRunClient(TestEnvironment.Endpoint, TestEnvironment.Credential, InstrumentClientOptions(options)));
         }
 
         public ApprovalClient GetApprovalClient()
@@ -68,7 +68,7 @@ namespace Azure.Analytics.Purview.Workflow.Tests
                 return true;
             };
             var options = new PurviewWorkflowServiceClientOptions { Transport = new HttpClientTransport(httpHandler) };
-            return InstrumentClient(new ApprovalClient(TestEnvironment.Endpoint, TestEnvironment.UsernamePasswordCredential, InstrumentClientOptions(options)));
+            return InstrumentClient(new ApprovalClient(TestEnvironment.Endpoint, TestEnvironment.Credential, InstrumentClientOptions(options)));
         }
     }
 }

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/WorkflowsClientTestEnvironment.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/WorkflowsClientTestEnvironment.cs
@@ -2,46 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Core;
 using Azure.Core.TestFramework;
-using Azure.Identity;
 
 namespace Azure.Analytics.Purview.Workflows.Tests
 {
     public class WorkflowsClientTestEnvironment : TestEnvironment
     {
-        private TokenCredential _usernamePasswordcredential;
-
-        public WorkflowsClientTestEnvironment()
-        {
-        }
         public Uri Endpoint => new(GetRecordedVariable("WORKFLOW_ENDPOINT"));
-
-        public TokenCredential UsernamePasswordCredential
-        {
-            get
-            {
-                if (_usernamePasswordcredential != null)
-                {
-                    return _usernamePasswordcredential;
-                }
-
-                if (Mode == RecordedTestMode.Playback)
-                {
-                    _usernamePasswordcredential = new MockCredential();
-                }
-                else
-                {
-                    _usernamePasswordcredential = new UsernamePasswordCredential(
-                        GetVariable("Username"),
-                        GetVariable("Password"),
-                        GetVariable("TenantId"),
-                        GetVariable("ClientId")
-                    );
-                }
-
-                return _usernamePasswordcredential;
-            }
-        }
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/samples/SampleDev-JavaScript/package-lock.json
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/samples/SampleDev-JavaScript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sampledev-javascript",
       "version": "1.0.0",
       "dependencies": {
-        "@azure/functions": "^4.0.0"
+        "@azure/functions": "^4.6.1"
       },
       "devDependencies": {
         "@types/node": "^20.x",
@@ -18,11 +18,12 @@
       }
     },
     "node_modules/@azure/functions": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.5.0.tgz",
-      "integrity": "sha512-WNCiOHMQEZpezxgThD3o2McKEjUEljtQBvdw4X4oE5714eTw76h33kIj0660ZJGEnxYSx4dx18oAbg5kLMs9iQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.6.1.tgz",
+      "integrity": "sha512-Py2Az29yk+A21vHES/rL6iU3ptKB+vVz3sGTjm0jSPFjG4kPbhFLi5vFI7YkCPMGeoD4WMIjHqTAeXvnFrBUBA==",
+      "license": "MIT",
       "dependencies": {
-        "cookie": "^0.6.0",
+        "cookie": "^0.7.0",
         "long": "^4.0.0",
         "undici": "^5.13.0"
       },
@@ -222,9 +223,10 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -298,10 +300,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -782,9 +785,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/samples/SampleDev-JavaScript/package.json
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/samples/SampleDev-JavaScript/package.json
@@ -12,7 +12,7 @@
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {
-    "@azure/functions": "^4.0.0"
+    "@azure/functions": "^4.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.x",


### PR DESCRIPTION
# Summary

The focus of these changes is to bump outdated references for packages and in code samples that were being flagged by governance and/or as obsolete during runs.

## References and resources

- [[Azure.Analytics.Purview.Workflows] Purview test failures causing Azure.Core CI pipeline to fail, blocking PRs (#48456)](https://github.com/Azure/azure-sdk-for-net/issues/48456)