### PR TITLE
Update usage of RemoveTrack1Packages

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -172,7 +172,6 @@ jobs:
           /p:EnableSourceLink=false
           /p:ProjectListOverrideFile=$(ProjectListOverrideFile)
           /p:EnableOverrideExclusions=true
-          /p:RemoveTrack1Projects=true
           $(AdditionalTestArguments)
           $(DiagnosticArguments)
         displayName: "Build & Test ($(TestTargetFramework))"

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -157,25 +157,44 @@ jobs:
         parameters:
           LogFilePath: $(Build.ArtifactStagingDirectory)/test.binlog
 
-      - script: >-
-          dotnet test eng/service.proj
-          --filter "(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))"
-          --framework $(TestTargetFramework)
-          --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
-          --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TestTimeoutInMinutes}}minutes
-          /p:SDKType=${{ parameters.SDKType }}
-          /p:ServiceDirectory=$(ServiceDirectory)
-          /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeIntegrationTests=false
-          /p:RunApiCompat=false /p:InheritDocEnabled=false
-          /p:Configuration=$(BuildConfiguration)
-          /p:CollectCoverage=$(CollectCoverage)
-          /p:EnableSourceLink=false
-          /p:ProjectListOverrideFile=$(ProjectListOverrideFile)
-          /p:EnableOverrideExclusions=true
-          /p:RemoveTrack1Projects=true
-          $(AdditionalTestArguments)
-          $(DiagnosticArguments)
-        displayName: "Build & Test ($(TestTargetFramework))"
+      - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+        - script: >-
+            dotnet test eng/service.proj
+            --filter "(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))"
+            --framework $(TestTargetFramework)
+            --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
+            --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TestTimeoutInMinutes}}minutes
+            /p:SDKType=${{ parameters.SDKType }}
+            /p:ServiceDirectory=$(ServiceDirectory)
+            /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeIntegrationTests=false
+            /p:RunApiCompat=false /p:InheritDocEnabled=false
+            /p:Configuration=$(BuildConfiguration)
+            /p:CollectCoverage=$(CollectCoverage)
+            /p:EnableSourceLink=false
+            /p:ProjectListOverrideFile=$(ProjectListOverrideFile)
+            /p:EnableOverrideExclusions=true
+            /p:RemoveTrack1Projects="$(RemoveTrack1)"
+            $(AdditionalTestArguments)
+            $(DiagnosticArguments)
+        displayName: "Build & Test ($(TestTargetFramework)) for PR"
+      - ${{ else }}:
+        - script: >-
+            dotnet test eng/service.proj
+            --filter "(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))"
+            --framework $(TestTargetFramework)
+            --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
+            --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TestTimeoutInMinutes}}minutes
+            /p:SDKType=${{ parameters.SDKType }}
+            /p:ServiceDirectory=$(ServiceDirectory)
+            /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeIntegrationTests=false
+            /p:RunApiCompat=false /p:InheritDocEnabled=false
+            /p:Configuration=$(BuildConfiguration)
+            /p:CollectCoverage=$(CollectCoverage)
+            /p:EnableSourceLink=false
+            /p:ProjectListOverrideFile=""
+            $(AdditionalTestArguments)
+            $(DiagnosticArguments)
+          displayName: "Build & Test ($(TestTargetFramework))"
 
       - task: PublishTestResults@2
         condition: always()

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -157,44 +157,25 @@ jobs:
         parameters:
           LogFilePath: $(Build.ArtifactStagingDirectory)/test.binlog
 
-      - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-        - script: >-
-            dotnet test eng/service.proj
-            --filter "(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))"
-            --framework $(TestTargetFramework)
-            --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
-            --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TestTimeoutInMinutes}}minutes
-            /p:SDKType=${{ parameters.SDKType }}
-            /p:ServiceDirectory=$(ServiceDirectory)
-            /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeIntegrationTests=false
-            /p:RunApiCompat=false /p:InheritDocEnabled=false
-            /p:Configuration=$(BuildConfiguration)
-            /p:CollectCoverage=$(CollectCoverage)
-            /p:EnableSourceLink=false
-            /p:ProjectListOverrideFile=$(ProjectListOverrideFile)
-            /p:EnableOverrideExclusions=true
-            /p:RemoveTrack1Projects="$(RemoveTrack1)"
-            $(AdditionalTestArguments)
-            $(DiagnosticArguments)
-          displayName: "Build & Test ($(TestTargetFramework)) for PR"
-      - ${{ else }}:
-        - script: >-
-            dotnet test eng/service.proj
-            --filter "(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))"
-            --framework $(TestTargetFramework)
-            --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
-            --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TestTimeoutInMinutes}}minutes
-            /p:SDKType=${{ parameters.SDKType }}
-            /p:ServiceDirectory=$(ServiceDirectory)
-            /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeIntegrationTests=false
-            /p:RunApiCompat=false /p:InheritDocEnabled=false
-            /p:Configuration=$(BuildConfiguration)
-            /p:CollectCoverage=$(CollectCoverage)
-            /p:EnableSourceLink=false
-            /p:ProjectListOverrideFile=""
-            $(AdditionalTestArguments)
-            $(DiagnosticArguments)
-          displayName: "Build & Test ($(TestTargetFramework))"
+      - script: >-
+          dotnet test eng/service.proj
+          --filter "(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))"
+          --framework $(TestTargetFramework)
+          --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
+          --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TestTimeoutInMinutes}}minutes
+          /p:SDKType=${{ parameters.SDKType }}
+          /p:ServiceDirectory=$(ServiceDirectory)
+          /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeIntegrationTests=false
+          /p:RunApiCompat=false /p:InheritDocEnabled=false
+          /p:Configuration=$(BuildConfiguration)
+          /p:CollectCoverage=$(CollectCoverage)
+          /p:EnableSourceLink=false
+          /p:ProjectListOverrideFile=$(ProjectListOverrideFile)
+          /p:EnableOverrideExclusions=true
+          /p:RemoveTrack1Projects="$(RemoveTrack1)"
+          $(AdditionalTestArguments)
+          $(DiagnosticArguments)
+        displayName: "Build & Test ($(TestTargetFramework)) for PR"
 
       - task: PublishTestResults@2
         condition: always()

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -175,7 +175,7 @@ jobs:
           /p:RemoveTrack1Projects="$(RemoveTrack1)"
           $(AdditionalTestArguments)
           $(DiagnosticArguments)
-        displayName: "Build & Test ($(TestTargetFramework)) for PR"
+        displayName: "Build & Test ($(TestTargetFramework))"
 
       - task: PublishTestResults@2
         condition: always()

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -176,7 +176,7 @@ jobs:
             /p:RemoveTrack1Projects="$(RemoveTrack1)"
             $(AdditionalTestArguments)
             $(DiagnosticArguments)
-        displayName: "Build & Test ($(TestTargetFramework)) for PR"
+          displayName: "Build & Test ($(TestTargetFramework)) for PR"
       - ${{ else }}:
         - script: >-
             dotnet test eng/service.proj

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -172,7 +172,7 @@ jobs:
           /p:EnableSourceLink=false
           /p:ProjectListOverrideFile=$(ProjectListOverrideFile)
           /p:EnableOverrideExclusions=true
-          /p:RemoveTrack1Projects="$(RemoveTrack1)"
+          /p:RemoveTrack1Projects=true
           $(AdditionalTestArguments)
           $(DiagnosticArguments)
         displayName: "Build & Test ($(TestTargetFramework))"

--- a/eng/scripts/splittestdependencies/set-artifact-packages.ps1
+++ b/eng/scripts/splittestdependencies/set-artifact-packages.ps1
@@ -27,6 +27,17 @@ $projectsForGeneration = ($changedProjects | ForEach-Object { "`$(RepoRoot)$_" }
 $projectGroups = @()
 $projectGroups += ,$projectsForGeneration
 
+# if we have any track 1 projects in the list, we need to set RemoveTrack1Projects to false
+# if there are not, we need to set it to true. We just want the scoping mechanism of the generate project list to not accidentally
+# include track 1 projects in the generated project list
+$track1Projects = $projectsForGeneration | Where-Object { $_.IsNewSdk -eq $false }
+if ($track1Projects) {
+    Write-Host "##vso[task.setvariable variable=RemoveTrack1;]false"
+}
+else {
+    Write-Host "##vso[task.setvariable variable=RemoveTrack1;]true"
+}
+
 # todo: refactor write-test-dependency-group to take in a list of project files only and generate a single project file
 $outputFile = (Write-Test-Dependency-Group-To-Files -ProjectFileConfigName "packages" -ProjectGroups $projectGroups -MatrixOutputFolder $OutputPath)[0]
 

--- a/eng/scripts/splittestdependencies/set-artifact-packages.ps1
+++ b/eng/scripts/splittestdependencies/set-artifact-packages.ps1
@@ -27,17 +27,6 @@ $projectsForGeneration = ($changedProjects | ForEach-Object { "`$(RepoRoot)$_" }
 $projectGroups = @()
 $projectGroups += ,$projectsForGeneration
 
-# if we have any track 1 projects in the list, we need to set RemoveTrack1Projects to false
-# if there are not, we need to set it to true. We just want the scoping mechanism of the generate project list to not accidentally
-# include track 1 projects in the generated project list
-$track1Projects = $projectsForGeneration | Where-Object { $_.IsNewSdk -eq $false }
-if ($track1Projects) {
-    Write-Host "##vso[task.setvariable variable=RemoveTrack1;]false"
-}
-else {
-    Write-Host "##vso[task.setvariable variable=RemoveTrack1;]true"
-}
-
 # todo: refactor write-test-dependency-group to take in a list of project files only and generate a single project file
 $outputFile = (Write-Test-Dependency-Group-To-Files -ProjectFileConfigName "packages" -ProjectGroups $projectGroups -MatrixOutputFolder $OutputPath)[0]
 

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -48,6 +48,7 @@
     <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Extensions.WebJobs.*\**\*.csproj" />
     <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Data.SchemaRegistry.ApacheAvro\**\*.csproj" />
     <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.NewtonsoftJson\**\*.csproj" />
+    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.Spatial\**\*.csproj" />
     <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.Spatial.NewtonsoftJson\**\*.csproj" />
   </ItemGroup>
 

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -64,12 +64,11 @@
 
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(RemoveTrack1Projects)' == 'true'">
     <!-- Remove all track1 SDKs from Regen -->
-    <Track1ProjectsToRemove Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" />
-    <ProjectReference Remove="@(Track1ProjectsToRemove)" />
+    <Track1ProjectsToRemove Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" Exclude="@(ProjectsToIncludeBySDKType)"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(RemoveTrack1Projects)' == 'true'">
-    <ProjectReference Remove="@(Track1ProjectsToRemove)" Exclude="@(ProjectsToIncludeBySDKType)"/>
+    <ProjectReference Remove="@(Track1ProjectsToRemove)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(EnableOverrideExclusions)' != ''">

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Extensions.WebJobs.*\**\*.csproj" />
+    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.WebJobs.Extensions.*\**\*.csproj" />
     <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Data.SchemaRegistry.ApacheAvro\**\*.csproj" />
     <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.NewtonsoftJson\**\*.csproj" />
     <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.Spatial\**\*.csproj" />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -44,6 +44,13 @@
       <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\hdinsight\Microsoft.Azure.HDInsight.Job\**\*.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Extensions.WebJobs.*\**\*.csproj" />
+    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Data.SchemaRegistry.ApacheAvro\**\*.csproj" />
+    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.NewtonsoftJson\**\*.csproj" />
+    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.Spatial.NewtonsoftJson\**\*.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(ProjectListOverrideFile)' == '' ">
     <TestProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\tests\**\*.csproj" />
     <SamplesProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\samples\**\*.csproj;..\sdk\$(ServiceDirectory)\samples\**\*.csproj" />
@@ -64,10 +71,7 @@
 
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(RemoveTrack1Projects)' == 'true'">
     <!-- Remove all track1 SDKs from Regen -->
-    <Track1ProjectsToRemove Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" Exclude="@(ProjectsToIncludeBySDKType)"/>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(RemoveTrack1Projects)' == 'true'">
+    <Track1ProjectsToRemove Exclude="@(BridgeProjects)" Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" Exclude="@(ProjectsToIncludeBySDKType)"/>
     <ProjectReference Remove="@(Track1ProjectsToRemove)" />
   </ItemGroup>
 

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -72,7 +72,7 @@
 
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(RemoveTrack1Projects)' == 'true'">
     <!-- Remove all track1 SDKs from Regen -->
-    <Track1ProjectsToRemove Exclude="@(BridgeProjects)" Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" Exclude="@(ProjectsToIncludeBySDKType)"/>
+    <Track1ProjectsToRemove Exclude="@(BridgeProjects)" Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" />
     <ProjectReference Remove="@(Track1ProjectsToRemove)" />
   </ItemGroup>
 

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -68,6 +68,10 @@
     <ProjectReference Remove="@(Track1ProjectsToRemove)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(RemoveTrack1Projects)' == 'true'">
+    <ProjectReference Remove="@(Track1ProjectsToRemove)" Exclude="@(ProjectsToIncludeBySDKType)"/>
+  </ItemGroup>
+
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(EnableOverrideExclusions)' != ''">
     <TestProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\tests\**\*.csproj" Exclude="@(MgmtExcludePaths)" />
     <SamplesProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\samples\**\*.csproj;..\sdk\$(ServiceDirectory)\samples\**\*.csproj" Exclude="@(MgmtExcludePaths)" />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -59,7 +59,7 @@
     <ProjectReference Include="@(SrcProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSrc)' == 'true'" />
   </ItemGroup>
 
-  <Import Project="..\sdk\$(ServiceDirectory)\*.projects" Condition="'$(ProjectListOverrideFile)' == '' "/>
+  <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
   <Import Project="$(RepoRoot)$(ProjectListOverrideFile)" Condition="'$(ProjectListOverrideFile)' != '' " />
 
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(EnableOverrideExclusions)' != ''">

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -44,14 +44,6 @@
       <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\hdinsight\Microsoft.Azure.HDInsight.Job\**\*.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.WebJobs.Extensions.*\**\*.csproj" />
-    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Data.SchemaRegistry.ApacheAvro\**\*.csproj" />
-    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.NewtonsoftJson\**\*.csproj" />
-    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.Spatial\**\*.csproj" />
-    <BridgeProjects Include="$(MSBuildThisFileDirectory)..\sdk\**\Microsoft.Azure.Core.Spatial.NewtonsoftJson\**\*.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(ProjectListOverrideFile)' == '' ">
     <TestProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\tests\**\*.csproj" />
     <SamplesProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\samples\**\*.csproj;..\sdk\$(ServiceDirectory)\samples\**\*.csproj" />
@@ -69,12 +61,6 @@
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" Condition="'$(ProjectListOverrideFile)' == '' "/>
   <Import Project="$(RepoRoot)$(ProjectListOverrideFile)" Condition="'$(ProjectListOverrideFile)' != '' " />
-
-  <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(RemoveTrack1Projects)' == 'true'">
-    <!-- Remove all track1 SDKs from Regen -->
-    <Track1ProjectsToRemove Exclude="@(BridgeProjects)" Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.Azure.*\**\*.csproj" />
-    <ProjectReference Remove="@(Track1ProjectsToRemove)" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(ProjectListOverrideFile)' != '' and '$(EnableOverrideExclusions)' != ''">
     <TestProjects Include="..\sdk\$(ServiceDirectory)\$(Project)\tests\**\*.csproj" Exclude="@(MgmtExcludePaths)" />


### PR DESCRIPTION
The primary issue is that during the dependency tests for `Azure.Core`, some track1 packages are included without the bit as I discovered while executing on the initial update to pullrequest. We still need it to be set, but in the case of actually targeting track1, we want to test those.

This PR should maintain that original behavior while still allowing others to test. 

#48506 is an example of what should be resolved by this PR. Will verify that scenario before merge.

This PR isn't mergable as-is due to all the `include by default` existing in a few service.props files.

[Evidence is most visible here](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4613241&view=logs&j=bf2461f0-018c-56e3-12cd-1c3d6735490e&t=0717a63d-b3bb-5466-a39c-92389d142c93&l=57)

As you can see, we resolved `Azure.Template` as the package that should run, but we're still include `Azure.Core.Tests` due to the [resourcemanager service.props](https://github.com/Azure/azure-sdk-for-net/blob/1b111b4bbe66608874d87d91ae60239e104c5a47/sdk/resourcemanager/service.projects#L7).

We can add a `triggeringPath` for `Azure.ResourceManager` in the `Azure.Core` artifact to get the same experience once we fix it.