### PR TITLE
[Event Hubs] Fix trigger data label

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a misspelling of "PartitionId" in the trigger input data passed to the function executor.  This caused function logs and metrics reported by AppInsights and the portal to reflect the wrong label.  To ensure that applications that rely on the misspelling are not impacted, a new member with the correct spelling was added.
+
 ### Other Changes
 
 ## 6.3.5 (2024-08-01)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerInput.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerInput.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Azure.Messaging.EventHubs;
 using System.Collections.Generic;
 using System.Globalization;
-using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Primitives;
 using Microsoft.Azure.WebJobs.EventHubs.Processor;
 
@@ -83,11 +82,15 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
             return new Dictionary<string, string>()
             {
-                { "PartionId", context.PartitionId },
+                { "PartitionId", context.PartitionId },
                 { "Offset", offset },
                 { "EnqueueTimeUtc", enqueueTimeUtc },
                 { "SequenceNumber", sequenceNumber },
-                { "Count", Events.Length.ToString(CultureInfo.InvariantCulture)}
+                { "Count", Events.Length.ToString(CultureInfo.InvariantCulture)},
+
+                // Preserve a misspelling that existed in the original code, as
+                // there may be applications relying on this.
+                { "PartionId", context.PartitionId }
             };
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a misspelling of "PartitionId" in the trigger input data passed to the function executor.  This caused function logs and metrics reported by AppInsights and the portal to reflect the wrong label.  
Because the misspelling was introduced with the original migration to the repository via [#16645](https://github.com/Azure/azure-sdk-for-net/pull/16645/files#diff-7a605143d10590e40cf3721fd71ac56c689a78098eb27f1f1052f9479b49dc73R84) in 2020 and has existed in GA releases for 5 years,  the misspelling cannot be removed without the risk of breaking existing applications.  To ensure current consumers are not impacted, a new member with the correct spelling was added. 

## References and related

- [[BUG] "PartitionId" is misspelled as "PartionId" in EventHubTriggerInput logs (#48460)](https://github.com/Azure/azure-sdk-for-net/issues/48460)