### PR TITLE
Delete Resourcemanager Service.Props, trigger core tests on changes to resourcemanager

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -44,6 +44,8 @@ extends:
     Artifacts:
     - name: Azure.Core
       safeName: AzureCore
+      triggeringPaths:
+      - /sdk/resourcemanager/
     - name: Azure.Core.Experimental
       safeName: AzureCoreExperimental
     - name: Azure.Core.Expressions.DataFactory

--- a/sdk/resourcemanager/service.projects
+++ b/sdk/resourcemanager/service.projects
@@ -1,9 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!--
-      Include Azure.Core.Tests project when building Azure.ResourceManager.Tests so we can validate that
-      core management test infrastructure isn't broken.
-    -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\core\Azure.Core\tests\Azure.Core.Tests.csproj" />
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
This PR is addressing the sole service.props file that is preventing merge of #48514 

The issue is that including that service.props file will always include Azure.Core.Tests project. We want to avoid that in all cases, but not ignore the _intent_ behind the import in that service.props file.

Thoughts?