### PR TITLE
[EngSys] Lock Function extensions dependencies

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -223,7 +223,7 @@
     <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.Rpc" Version="3.0.37" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0" />
     <PackageReference Update="Microsoft.Spatial" Version="7.5.3" />
-    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <!-- Packages intended for Extensions libraries only -->
@@ -232,7 +232,7 @@
     <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Connections" Version="1.0.15" />
     <PackageReference Update="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.10.0" />
+    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.8.0" /> <!-- Latest confirmed as compatible by the Functions team. DO NOT BUMP-->
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.0" />


### PR DESCRIPTION
The focus of these changes is to lock the version of the `Microsoft.Extensions.Azure` version used by Azure Function extensions packages to 1.8.0, which is the latest confirmed by the Azure Functions team to be compatible with the in-process host.  Also bumping the version of `Newtonsoft.Json` used by bridge packages to the latest.
