### PR TITLE
[AzureMonitor] simplify preprocessors

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An OpenTelemetry .NET distro that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry ASP.NET Core Distro</AssemblyTitle>
@@ -6,7 +6,7 @@
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.0</ApiCompatVersion>
     <PackageTags>Azure Monitor OpenTelemetry Exporter Distro ApplicationInsights</PackageTags>
-    <TargetFrameworks>net6.0;$(RequiredTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <NoWarn>SA1636;AZC0011</NoWarn>
     <DefineConstants>$(DefineConstants);ASP_NET_CORE_DISTRO;</DefineConstants>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.AspNetCoreTestApp/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.AspNetCoreTestApp/Program.cs
@@ -3,7 +3,7 @@
 
 // This is an ASP.NET Core test app used in unit tests.
 // Unit Tests are expected to define their own routes and middleware.
-#if !NETFRAMEWORK
+#if NET
 using Microsoft.AspNetCore.Builder;
 
 namespace Azure.Monitor.AspNetCoreTestApp

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/Program.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if NET6_0_OR_GREATER
+#if NET
 using System.Diagnostics;
 using System.Net.Http;
 using Azure.Monitor.OpenTelemetry.AspNetCore;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/ProgramNet461Compat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/ProgramNet461Compat.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if NET462
+#if NETFRAMEWORK
 
 namespace Azure.Monitor.OpenTelemetry.AspNetCore.Demo
 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/BaseLiveTest.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/BaseLiveTest.cs
@@ -13,7 +13,7 @@ using Azure.Monitor.Query.Models;
 using NUnit.Framework;
 using static Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests.TelemetryValidationHelper;
 
-#if !NETFRAMEWORK
+#if NET
 namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
 {
     public abstract class BaseLiveTest : RecordedTestBase<AzureMonitorTestEnvironment>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/DistroWebAppLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/DistroWebAppLiveTests.cs
@@ -22,7 +22,7 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using static Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests.TelemetryValidationHelper;
 
-#if NET6_0_OR_GREATER
+#if NET
 namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
 {
     public class DistroWebAppLiveTests : BaseLiveTest

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/TelemetryValidationHelper.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-#if NET6_0_OR_GREATER
+#if NET
 using System.Text.Json.Nodes;
 #endif
 using Azure.Monitor.Query.Models;
@@ -51,7 +51,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
 
         private static void ValidateProperties(string description, string jsonString, List<KeyValuePair<string, string>> expectedProperties)
         {
-#if NET6_0_OR_GREATER
+#if NET
             var jsonNode = JsonNode.Parse(jsonString);
             Assert.IsNotNull(jsonNode, $"({description}) Expected a non-null JSON node.");
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureSdkLoggingTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if NET6_0_OR_GREATER
+#if NET
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             Assert.Null(azureMonitorOptions.StorageDirectory);
         }
 
-#if !NETFRAMEWORK
+#if NET
         [Fact]
         public void VerifyConfigure_ViaJson()
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/AspNetCoreInstrumentationTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/AspNetCoreInstrumentationTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if !NETFRAMEWORK
+#if NET
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/SqlClientInstrumentationTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/SqlClientInstrumentationTests.cs
@@ -4,7 +4,7 @@
 // The following tests were originally copied from OpenTelemetry and modified for Azure Monitor.
 // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.SqlClient-1.9.0-beta.1/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
 
-#if !NETFRAMEWORK
+#if NET
 
 using System;
 using System.Collections.Generic;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/TestHttpServer.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/TestHttpServer.cs
@@ -13,7 +13,7 @@ namespace OpenTelemetry.Tests;
 
 internal static class TestHttpServer
 {
-#if !NET6_0_OR_GREATER
+#if NETFRAMEWORK
     private static readonly Random GlobalRandom = new();
 #endif
 
@@ -28,7 +28,7 @@ internal static class TestHttpServer
         {
             try
             {
-#if NET6_0_OR_GREATER
+#if NET
                 port = RandomNumberGenerator.GetInt32(2000, 5000);
 #else
 #pragma warning disable CA5394 // Do not use insecure randomness

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/HttpClientDependecyTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/HttpClientDependecyTests.cs
@@ -77,7 +77,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.LiveMetrics.DocumentTests
             Assert.True(dependencyDocument.Extension_IsSuccess);
         }
 
-#if !NET462
+#if NET
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/RequestTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/LiveMetrics/DocumentTests/RequestTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if !NETFRAMEWORK
+#if NET
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/OpenTelemetryBuilderExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/OpenTelemetryBuilderExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 {
     public class OpenTelemetryBuilderExtensionsTests
     {
-#if !NETFRAMEWORK
+#if NET
         private const string ConnectionStringEnvironmentVariable = "APPLICATIONINSIGHTS_CONNECTION_STRING";
 
         [Theory]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An OpenTelemetry .NET exporter that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry Exporter</AssemblyTitle>
@@ -6,8 +6,7 @@
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageTags>Azure Monitor OpenTelemetry Exporter ApplicationInsights</PackageTags>
-    <!--NET6 is added here for trimming compatibility. This includes necessary annotations and System.Text.Json's "Source Generation" feature.-->
-    <TargetFrameworks>net6.0;$(RequiredTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <DefineConstants>$(DefineConstants);AZURE_MONITOR_EXPORTER;</DefineConstants>
   </PropertyGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/IngestionResponseHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/IngestionResponseHelper.cs
@@ -25,7 +25,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
                 ResponseObject? responseObj;
 
-#if NET6_0_OR_GREATER
+#if NET
                 responseObj = JsonSerializer.Deserialize<ResponseObject>(responseContent, SourceGenerationContext.Default.ResponseObject);
 #else
                 responseObj = JsonSerializer.Deserialize<ResponseObject>(responseContent);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SourceGenerationContext.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SourceGenerationContext.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals;
 
-#if NET6_0_OR_GREATER
+#if NET
 // "Source Generation" is feature added to System.Text.Json in .NET 6.0.
 // This is a performance optimization that avoids runtime reflection when performing serialization.
 // Serialization metadata will be computed at compile-time and included in the assembly.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
@@ -134,7 +134,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
                         httpClient.DefaultRequestHeaders.Add("Metadata", "True");
                         var responseString = httpClient.GetStringAsync(StatsbeatConstants.AMS_Url);
                         VmMetadataResponse? vmMetadata;
-#if NET6_0_OR_GREATER
+#if NET
                         vmMetadata = JsonSerializer.Deserialize<VmMetadataResponse>(responseString.Result, SourceGenerationContext.Default.VmMetadataResponse);
 #else
                         vmMetadata = JsonSerializer.Deserialize<VmMetadataResponse>(responseString.Result);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -101,7 +101,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             {
                 // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
                 // In case of duplicate keys, only the first occurence will be exported.
-#if NET6_0_OR_GREATER
+#if NET
                 destination.TryAdd(keyValuePair.Key, Convert.ToString(keyValuePair.Value, CultureInfo.InvariantCulture).Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null");
 #else
                 if (!destination.ContainsKey(keyValuePair.Key))
@@ -119,7 +119,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             {
                 // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
                 // In case of duplicate keys, only the first occurence will be exported.
-#if NET6_0_OR_GREATER
+#if NET
                 destination.TryAdd(key, value.Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null");
 #else
                 if (!destination.ContainsKey(key))


### PR DESCRIPTION
This repo just removed NET6 and added NET9. #48424
Taking this opportunity to simplify the preprocessor tags that we use and remove the explicit net6 target frameworks.