### PR TITLE
Add comment to Packages.Data.Props for synchronizing SDK upgrades

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -250,6 +250,7 @@
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20250223.1" PrivateAssets="All" />
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20250227.2" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
+    <!-- Note: Upgrading the .NET SDK version needs to be synchronized with the autorest.csharp repository -->
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20467.1" PrivateAssets="All" />


### PR DESCRIPTION
Upgrades to the global.json file need to be synchronized with the autorest.csharp repo. A comment can't be added to the global.json file, but when the .NET SDK version is upgraded, the analyzers need to be upgraded too. So this package will always be upgraded when the global.json file is. This comment is just to help the person upgrading the SDK so they don't forget to coordinate the change in autorest.csharp :sweat_smile: