### PR TITLE
[Storage] Redact SAS credentials from Error.SasCredentialRequiresUriWithoutSas message

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_bf9faa9325"
+  "Tag": "net/storage/Azure.Storage.Blobs_d1a42a73c0"
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -554,6 +554,48 @@ namespace Azure.Storage.Blobs.Test
             }
         }
 
+        [RecordedTest]
+        public async Task SasCredentialRequiresUriWithoutSasError_RedactedSasUri()
+        {
+            // Arrange
+            BlobServiceClient oauthService = GetServiceClient_OAuth();
+            string containerName = GetNewContainerName();
+
+            await using DisposingContainer test = await GetTestContainerAsync(service: oauthService, containerName: containerName);
+
+            Response<UserDelegationKey> userDelegationKey = await oauthService.GetUserDelegationKeyAsync(
+                startsOn: Recording.UtcNow.AddHours(-1),
+                expiresOn: Recording.UtcNow.AddHours(1));
+
+            BlobSasBuilder blobSasBuilder = new BlobSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                BlobContainerName = containerName,
+            };
+
+            blobSasBuilder.SetPermissions(BlobSasPermissions.All);
+
+            BlobUriBuilder blobUriBuilder = new BlobUriBuilder(test.Container.Uri)
+            {
+                Sas = blobSasBuilder.ToSasQueryParameters(userDelegationKey, test.Container.AccountName)
+            };
+
+            Uri sasUri = blobUriBuilder.ToUri();
+
+            UriBuilder uriBuilder = new UriBuilder(sasUri);
+            uriBuilder.Query = "[REDACTED]";
+            string redactedUri = uriBuilder.Uri.ToString();
+
+            ArgumentException ex = Errors.SasCredentialRequiresUriWithoutSas<BlobUriBuilder>(sasUri);
+
+            // Assert
+            Assert.IsTrue(ex.Message.Contains(redactedUri));
+            Assert.IsFalse(ex.Message.Contains("st="));
+            Assert.IsFalse(ex.Message.Contains("se="));
+            Assert.IsFalse(ex.Message.Contains("sig="));
+        }
+
         private string BuildSignature(bool includeBlob, bool includeSnapshot, string containerName, string blobName, TestConstants constants)
         {
             var canonicalName = includeBlob ? $"/blob/{constants.Sas.Account}/{containerName}/{blobName}"

--- a/sdk/storage/Azure.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Common/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 - Fixed bug where in rare cases, a `NullReferenceException` could be thrown when parsing an error response from the service.
 - Fixed bug to ensure that the accumulated disposables within the internal `StorageWriteStream` are disposed properly in the event that an exception is thrown during the disposal process. (#47781)
+- Fixed bug to Redact SAS credentials from Error.SasCredentialRequiresUriWithoutSas message.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.Clients.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.Clients.cs
@@ -45,10 +45,16 @@ namespace Azure.Storage
             => new InvalidOperationException("Use of token credentials requires HTTPS");
 
         public static ArgumentException SasCredentialRequiresUriWithoutSas<TUriBuilder>(Uri uri)
-            => new ArgumentException(
-                $"You cannot use {nameof(AzureSasCredential)} when the resource URI also contains a Shared Access Signature: {uri}\n" +
+        {
+            UriBuilder uriBuilder = new UriBuilder(uri);
+            uriBuilder.Query = "[REDACTED]";
+            Uri redactedUri = uriBuilder.Uri;
+
+            return new ArgumentException(
+                $"You cannot use {nameof(AzureSasCredential)} when the resource URI also contains a Shared Access Signature: {redactedUri}\n" +
                 $"You can remove the shared access signature by creating a {typeof(TUriBuilder).Name}, setting {typeof(TUriBuilder).Name}.Sas to null," +
                 $" and calling {typeof(TUriBuilder).Name}.ToUri.");
+        }
 
         public static InvalidOperationException SasMissingData(string paramName)
             => new InvalidOperationException($"SAS is missing required parameter: {paramName}");

--- a/sdk/storage/Azure.Storage.Files.DataLake/assets.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.DataLake",
-  "Tag": "net/storage/Azure.Storage.Files.DataLake_d74597f1e3"
+  "Tag": "net/storage/Azure.Storage.Files.DataLake_a37793870a"
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.Files.Shares_92c08b30c4"
+  "Tag": "net/storage/Azure.Storage.Files.Shares_cd8d6a7947"
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -243,6 +243,45 @@ namespace Azure.Storage.Files.Shares.Tests
             Assert.AreEqual(originalUri, newUri);
         }
 
+        [RecordedTest]
+        public async Task SasCredentialRequiresUriWithoutSasError_RedactedSasUri()
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+
+            ShareSasBuilder fileSasBuilder = new ShareSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                ShareName = test.Share.Name
+            };
+
+            fileSasBuilder.SetPermissions(
+                rawPermissions: "LDWCR",
+                normalize: true);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+
+            ShareUriBuilder fileUriBuilder = new ShareUriBuilder(test.Share.Uri)
+            {
+                Sas = fileSasBuilder.ToSasQueryParameters(sharedKeyCredential)
+            };
+
+            Uri sasUri = fileUriBuilder.ToUri();
+
+            UriBuilder uriBuilder = new UriBuilder(sasUri);
+            uriBuilder.Query = "[REDACTED]";
+            string redactedUri = uriBuilder.Uri.ToString();
+
+            ArgumentException ex = Errors.SasCredentialRequiresUriWithoutSas<ShareUriBuilder>(sasUri);
+
+            // Assert
+            Assert.IsTrue(ex.Message.Contains(redactedUri));
+            Assert.IsFalse(ex.Message.Contains("st="));
+            Assert.IsFalse(ex.Message.Contains("se="));
+            Assert.IsFalse(ex.Message.Contains("sig="));
+        }
+
         private ShareSasBuilder BuildFileSasBuilder(bool includeFilePath, TestConstants constants, string shareName, string filePath)
         {
             var fileSasBuilder = new ShareSasBuilder

--- a/sdk/storage/Azure.Storage.Queues/assets.json
+++ b/sdk/storage/Azure.Storage.Queues/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Queues",
-  "Tag": "net/storage/Azure.Storage.Queues_ef3164e0b2"
+  "Tag": "net/storage/Azure.Storage.Queues_ef5347e834"
 }


### PR DESCRIPTION
Redacted the SAS credentials portion of the Uri in the Error.SasCredentialRequiresUriWithoutSas message.
