### PR TITLE
[Storage] [DataMovement] Add Datamovement to Storage CI

### DIFF
--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -9,11 +9,11 @@ trigger:
   paths:
     include:
     - sdk/storage/
-    exclude:
-    - sdk/storage/Azure.ResourceManager.Storage/
     - sdk/storage/Azure.Storage.DataMovement/
     - sdk/storage/Azure.Storage.DataMovement.Blobs/
     - sdk/storage/Azure.Storage.DataMovement.Files/
+    exclude:
+    - sdk/storage/Azure.ResourceManager.Storage/
     - sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/
     - sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/
     - sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -12,6 +12,7 @@ trigger:
     - sdk/storage/Azure.Storage.DataMovement/
     - sdk/storage/Azure.Storage.DataMovement.Blobs/
     - sdk/storage/Azure.Storage.DataMovement.Files/
+    - sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/
     exclude:
     - sdk/storage/Azure.ResourceManager.Storage/
     - sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/
@@ -34,6 +35,7 @@ pr:
     - sdk/storage/Azure.Storage.DataMovement/
     - sdk/storage/Azure.Storage.DataMovement.Blobs/
     - sdk/storage/Azure.Storage.DataMovement.Files/
+    - sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/
     - sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/
     - sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/
     - sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/


### PR DESCRIPTION
Adding back in DataMovement to Storage CI.

Changes to storage CI can have affects on the DataMovement package, which results in tests not being rerecorded accordingly.