### PR TITLE
Update SCM to latest version and change ProjectReference to PackageReference

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -86,7 +86,7 @@
 
     <!-- BCL packages -->
     <PackageReference Update="System.Buffers" Version="4.5.1" />
-    <PackageReference Update="System.ClientModel" Version="1.2.1" />
+    <PackageReference Update="System.ClientModel" Version="1.4.0-beta.1" />
     <PackageReference Update="System.IO.Hashing" Version="6.0.0" />
     <PackageReference Update="System.Memory" Version="4.5.5" />
     <PackageReference Update="System.Memory.Data" Version="6.0.1" />
@@ -383,7 +383,7 @@
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />
-    <PackageReference Update="System.ClientModel" Version="1.2.1" />
+    <PackageReference Update="System.ClientModel" Version="1.4.0-beta.1" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -86,7 +86,7 @@
 
     <!-- BCL packages -->
     <PackageReference Update="System.Buffers" Version="4.5.1" />
-    <PackageReference Update="System.ClientModel" Version="1.4.0-beta.1" />
+    <PackageReference Update="System.ClientModel" Version="1.2.1" />
     <PackageReference Update="System.IO.Hashing" Version="6.0.0" />
     <PackageReference Update="System.Memory" Version="4.5.5" />
     <PackageReference Update="System.Memory.Data" Version="6.0.1" />
@@ -383,7 +383,7 @@
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />
-    <PackageReference Update="System.ClientModel" Version="1.4.0-beta.1" />
+    <PackageReference Update="System.ClientModel" Version="1.2.1" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />

--- a/sdk/ai/Azure.AI.Inference/src/Azure.AI.Inference.csproj
+++ b/sdk/ai/Azure.AI.Inference/src/Azure.AI.Inference.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="System.ClientModel" />
+    <PackageReference Include="System.ClientModel" VersionOverride="1.4.0-beta.1" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/sdk/ai/Azure.AI.Inference/src/Azure.AI.Inference.csproj
+++ b/sdk/ai/Azure.AI.Inference/src/Azure.AI.Inference.csproj
@@ -17,10 +17,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    <PackageReference Include="System.ClientModel" />
     <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\System.ClientModel\src\System.ClientModel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj
+++ b/sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj
@@ -14,12 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    <PackageReference Include="System.ClientModel" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\System.ClientModel\src\System.ClientModel.csproj" />
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj
+++ b/sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="System.ClientModel" />
+    <PackageReference Include="System.ClientModel" VersionOverride="1.4.0-beta.1" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/sdk/cloudmachine/Azure.Projects/src/Azure.Projects.csproj
+++ b/sdk/cloudmachine/Azure.Projects/src/Azure.Projects.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Azure.AI.Inference" />
     <PackageReference Include="Azure.Search.Documents" />
     <PackageReference Include="System.Memory.Data" />
-    <PackageReference Include="System.ClientModel" />
+    <PackageReference Include="System.ClientModel" VersionOverride="1.4.0-beta.1" />
   </ItemGroup>
 
 </Project>

--- a/sdk/cloudmachine/Azure.Projects/src/Azure.Projects.csproj
+++ b/sdk/cloudmachine/Azure.Projects/src/Azure.Projects.csproj
@@ -27,8 +27,4 @@
     <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\System.ClientModel\src\System.ClientModel.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -54,7 +54,7 @@
     <Otherwise>
       <ItemGroup>
         <PackageReference Include="Azure.Core" />
-        <ProjectReference Include="..\..\..\core\System.ClientModel\src\System.ClientModel.csproj" />
+        <PackageReference Include="System.ClientModel" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -54,7 +54,7 @@
     <Otherwise>
       <ItemGroup>
         <PackageReference Include="Azure.Core" />
-        <PackageReference Include="System.ClientModel" />
+        <PackageReference Include="System.ClientModel" VersionOverride="1.4.0-beta.1" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
+++ b/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
@@ -28,11 +28,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    <PackageReference Include="System.ClientModel" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\System.ClientModel\src\System.ClientModel.csproj" />
-  </ItemGroup>
 </Project>

--- a/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
+++ b/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="System.ClientModel" />
+    <PackageReference Include="System.ClientModel" VersionOverride="1.4.0-beta.1" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>


### PR DESCRIPTION
- Updated SCM to the latest available version.  
- Changed all `ProjectReference` entries to `PackageReference` for the referenced packages.  
- Verified compatibility and ensured successful builds after the changes.  