### PR TITLE
[CODEOWNERS] Remove retired label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -450,9 +450,6 @@
 # ServiceLabel: %Data Lake
 # ServiceOwners:                                                   @sumantmehtams
 
-# ServiceLabel: %Data Lake Storage Gen1
-# ServiceOwners:                                                   @sumantmehtams @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft @nickliu-msft
-
 # ServiceLabel: %Data Lake Storage Gen2
 # ServiceOwners:                                                   @sumantmehtams @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft @nickliu-msft
 


### PR DESCRIPTION
# Sumnmary

The focus of these changes is to remove a the `Data Lake Storage Gen1` label that is associated with a retired service no longer under support.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4632360&view=results) _(Microsoft internal)_
