### PR TITLE
[AppConfig] chore: rename ConfigurationAudience

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net8.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net8.0.cs
@@ -1,22 +1,22 @@
 namespace Azure.Data.AppConfiguration
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct ConfigurationAudience : System.IEquatable<Azure.Data.AppConfiguration.ConfigurationAudience>
+    public readonly partial struct AppConfigurationAudience : System.IEquatable<Azure.Data.AppConfiguration.AppConfigurationAudience>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public ConfigurationAudience(string value) { throw null; }
-        public static Azure.Data.AppConfiguration.ConfigurationAudience AzureChina { get { throw null; } }
-        public static Azure.Data.AppConfiguration.ConfigurationAudience AzureGovernment { get { throw null; } }
-        public static Azure.Data.AppConfiguration.ConfigurationAudience AzurePublicCloud { get { throw null; } }
-        public bool Equals(Azure.Data.AppConfiguration.ConfigurationAudience other) { throw null; }
+        public AppConfigurationAudience(string value) { throw null; }
+        public static Azure.Data.AppConfiguration.AppConfigurationAudience AzureChina { get { throw null; } }
+        public static Azure.Data.AppConfiguration.AppConfigurationAudience AzureGovernment { get { throw null; } }
+        public static Azure.Data.AppConfiguration.AppConfigurationAudience AzurePublicCloud { get { throw null; } }
+        public bool Equals(Azure.Data.AppConfiguration.AppConfigurationAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Data.AppConfiguration.ConfigurationAudience left, Azure.Data.AppConfiguration.ConfigurationAudience right) { throw null; }
-        public static implicit operator Azure.Data.AppConfiguration.ConfigurationAudience (string value) { throw null; }
-        public static bool operator !=(Azure.Data.AppConfiguration.ConfigurationAudience left, Azure.Data.AppConfiguration.ConfigurationAudience right) { throw null; }
+        public static bool operator ==(Azure.Data.AppConfiguration.AppConfigurationAudience left, Azure.Data.AppConfiguration.AppConfigurationAudience right) { throw null; }
+        public static implicit operator Azure.Data.AppConfiguration.AppConfigurationAudience (string value) { throw null; }
+        public static bool operator !=(Azure.Data.AppConfiguration.AppConfigurationAudience left, Azure.Data.AppConfiguration.AppConfigurationAudience right) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class ConfigurationClient
@@ -93,7 +93,7 @@ namespace Azure.Data.AppConfiguration
     public partial class ConfigurationClientOptions : Azure.Core.ClientOptions
     {
         public ConfigurationClientOptions(Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion version = Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion.V2023_11_01) { }
-        public Azure.Data.AppConfiguration.ConfigurationAudience? Audience { get { throw null; } set { } }
+        public Azure.Data.AppConfiguration.AppConfigurationAudience? Audience { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V1_0 = 0,

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -1,22 +1,22 @@
 namespace Azure.Data.AppConfiguration
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct ConfigurationAudience : System.IEquatable<Azure.Data.AppConfiguration.ConfigurationAudience>
+    public readonly partial struct AppConfigurationAudience : System.IEquatable<Azure.Data.AppConfiguration.AppConfigurationAudience>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public ConfigurationAudience(string value) { throw null; }
-        public static Azure.Data.AppConfiguration.ConfigurationAudience AzureChina { get { throw null; } }
-        public static Azure.Data.AppConfiguration.ConfigurationAudience AzureGovernment { get { throw null; } }
-        public static Azure.Data.AppConfiguration.ConfigurationAudience AzurePublicCloud { get { throw null; } }
-        public bool Equals(Azure.Data.AppConfiguration.ConfigurationAudience other) { throw null; }
+        public AppConfigurationAudience(string value) { throw null; }
+        public static Azure.Data.AppConfiguration.AppConfigurationAudience AzureChina { get { throw null; } }
+        public static Azure.Data.AppConfiguration.AppConfigurationAudience AzureGovernment { get { throw null; } }
+        public static Azure.Data.AppConfiguration.AppConfigurationAudience AzurePublicCloud { get { throw null; } }
+        public bool Equals(Azure.Data.AppConfiguration.AppConfigurationAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Data.AppConfiguration.ConfigurationAudience left, Azure.Data.AppConfiguration.ConfigurationAudience right) { throw null; }
-        public static implicit operator Azure.Data.AppConfiguration.ConfigurationAudience (string value) { throw null; }
-        public static bool operator !=(Azure.Data.AppConfiguration.ConfigurationAudience left, Azure.Data.AppConfiguration.ConfigurationAudience right) { throw null; }
+        public static bool operator ==(Azure.Data.AppConfiguration.AppConfigurationAudience left, Azure.Data.AppConfiguration.AppConfigurationAudience right) { throw null; }
+        public static implicit operator Azure.Data.AppConfiguration.AppConfigurationAudience (string value) { throw null; }
+        public static bool operator !=(Azure.Data.AppConfiguration.AppConfigurationAudience left, Azure.Data.AppConfiguration.AppConfigurationAudience right) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class ConfigurationClient
@@ -93,7 +93,7 @@ namespace Azure.Data.AppConfiguration
     public partial class ConfigurationClientOptions : Azure.Core.ClientOptions
     {
         public ConfigurationClientOptions(Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion version = Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion.V2023_11_01) { }
-        public Azure.Data.AppConfiguration.ConfigurationAudience? Audience { get { throw null; } set { } }
+        public Azure.Data.AppConfiguration.AppConfigurationAudience? Audience { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V1_0 = 0,

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AppConfigurationAudience.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AppConfigurationAudience.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 namespace Azure.Data.AppConfiguration
 {
     /// <summary> Cloud audiences available for AppConfiguration. </summary>
-    public readonly struct ConfigurationAudience : IEquatable<ConfigurationAudience>
+    public readonly struct AppConfigurationAudience : IEquatable<AppConfigurationAudience>
     {
         private readonly string _value;
         private const string AzureChinaValue = "https://appconfig.azure.cn";
@@ -15,39 +15,39 @@ namespace Azure.Data.AppConfiguration
         private const string AzurePublicCloudValue = "https://appconfig.azure.com";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigurationAudience"/> object.
+        /// Initializes a new instance of the <see cref="AppConfigurationAudience"/> object.
         /// </summary>
         /// <param name="value">The Microsoft Entra audience to use when forming authorization scopes.
         /// For the App Configuration service, this value corresponds to a URL that identifies the Azure cloud where the resource is located.</param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         /// <remarks>Please use one of the constant members over creating a custom value unless you have special needs for doing so.</remarks>
-        public ConfigurationAudience(string value)
+        public AppConfigurationAudience(string value)
         {
             Argument.AssertNotNullOrEmpty(value, nameof(value));
             _value = value;
         }
 
         /// <summary> Azure China. </summary>
-        public static ConfigurationAudience AzureChina { get; } = new ConfigurationAudience(AzureChinaValue);
+        public static AppConfigurationAudience AzureChina { get; } = new AppConfigurationAudience(AzureChinaValue);
 
         /// <summary> Azure Government. </summary>
-        public static ConfigurationAudience AzureGovernment { get; } = new ConfigurationAudience(AzureGovernmentValue);
+        public static AppConfigurationAudience AzureGovernment { get; } = new AppConfigurationAudience(AzureGovernmentValue);
 
         /// <summary> Azure Public Cloud. </summary>
-        public static ConfigurationAudience AzurePublicCloud { get; } = new ConfigurationAudience(AzurePublicCloudValue);
+        public static AppConfigurationAudience AzurePublicCloud { get; } = new AppConfigurationAudience(AzurePublicCloudValue);
 
-        /// <summary> Determines if two <see cref="ConfigurationAudience"/> values are the same. </summary>
-        public static bool operator ==(ConfigurationAudience left, ConfigurationAudience right) => left.Equals(right);
-        /// <summary> Determines if two <see cref="ConfigurationAudience"/> values are not the same. </summary>
-        public static bool operator !=(ConfigurationAudience left, ConfigurationAudience right) => !left.Equals(right);
-        /// <summary> Converts a string to a <see cref="ConfigurationAudience"/>. </summary>
-        public static implicit operator ConfigurationAudience(string value) => new ConfigurationAudience(value);
+        /// <summary> Determines if two <see cref="AppConfigurationAudience"/> values are the same. </summary>
+        public static bool operator ==(AppConfigurationAudience left, AppConfigurationAudience right) => left.Equals(right);
+        /// <summary> Determines if two <see cref="AppConfigurationAudience"/> values are not the same. </summary>
+        public static bool operator !=(AppConfigurationAudience left, AppConfigurationAudience right) => !left.Equals(right);
+        /// <summary> Converts a string to a <see cref="AppConfigurationAudience"/>. </summary>
+        public static implicit operator AppConfigurationAudience(string value) => new AppConfigurationAudience(value);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object obj) => obj is ConfigurationAudience other && Equals(other);
+        public override bool Equals(object obj) => obj is AppConfigurationAudience other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(ConfigurationAudience other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
+        public bool Equals(AppConfigurationAudience other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientOptions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientOptions.cs
@@ -43,8 +43,7 @@ namespace Azure.Data.AppConfiguration
         /// <summary>
         /// Gets or sets the Audience to use for authentication with Microsoft Entra. The audience is not considered when using a shared key.
         /// </summary>
-        /// <value>If <c>null</c>, <see cref="ConfigurationAudience.AzurePublicCloud" /> will be assumed.</value>
-        public ConfigurationAudience? Audience { get; set; }
+        public AppConfigurationAudience? Audience { get; set; }
 
         internal string Version { get; }
 
@@ -77,10 +76,10 @@ namespace Azure.Data.AppConfiguration
                 return host switch
                 {
                     _ when host.EndsWith(AzConfigUsGovCloudHostName, StringComparison.InvariantCultureIgnoreCase) || host.EndsWith(AppConfigUsGovCloudHostName, StringComparison.InvariantCultureIgnoreCase)
-                        => $"{ConfigurationAudience.AzureGovernment}/.default",
+                        => $"{AppConfigurationAudience.AzureGovernment}/.default",
                     _ when host.EndsWith(AzConfigChinaCloudHostName, StringComparison.InvariantCultureIgnoreCase) || host.EndsWith(AppConfigChinaCloudHostName, StringComparison.InvariantCultureIgnoreCase)
-                        => $"{ConfigurationAudience.AzureChina}/.default",
-                    _ => $"{ConfigurationAudience.AzurePublicCloud}/.default"
+                        => $"{AppConfigurationAudience.AzureChina}/.default",
+                    _ => $"{AppConfigurationAudience.AzurePublicCloud}/.default"
                 };
             }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/AppConfigurationTestEnvironment.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/AppConfigurationTestEnvironment.cs
@@ -13,23 +13,23 @@ namespace Azure.Data.AppConfiguration
         public string Endpoint => GetRecordedVariable("APPCONFIGURATION_ENDPOINT_STRING");
         public string SecretId => GetRecordedVariable("KEYVAULT_SECRET_URL");
 
-        public ConfigurationAudience GetAudience()
+        public AppConfigurationAudience GetAudience()
         {
             Uri authorityHost = new(AuthorityHostUrl);
 
             if (authorityHost == AzureAuthorityHosts.AzurePublicCloud)
             {
-                return ConfigurationAudience.AzurePublicCloud;
+                return AppConfigurationAudience.AzurePublicCloud;
             }
 
             if (authorityHost == AzureAuthorityHosts.AzureChina)
             {
-                return ConfigurationAudience.AzureChina;
+                return AppConfigurationAudience.AzureChina;
             }
 
             if (authorityHost == AzureAuthorityHosts.AzureGovernment)
             {
-                return ConfigurationAudience.AzureGovernment;
+                return AppConfigurationAudience.AzureGovernment;
             }
 
             throw new NotSupportedException($"Cloud for authority host {authorityHost} is not supported.");

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationClientOptionsTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationClientOptionsTests.cs
@@ -13,7 +13,7 @@ namespace Azure.Data.AppConfiguration.Tests
         // when it is provided via the options.
         [TestCaseSource(nameof(GetDefaultScopeWithSuppliedValueTestCases))]
         public void TestGetDefaultScope_WithSuppliedValue(
-            ConfigurationAudience? configurationAudience,
+            AppConfigurationAudience? configurationAudience,
             string url,
             string expectedScope)
         {
@@ -38,16 +38,16 @@ namespace Azure.Data.AppConfiguration.Tests
         {
             get
             {
-                yield return new TestCaseData(ConfigurationAudience.AzurePublicCloud, "https://locaLhost.azconfiG.com", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData(ConfigurationAudience.AzurePublicCloud, "https://locaLhost.azconfiG.com/", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData(ConfigurationAudience.AzureChina, "https://other.AZconfig.cn", $"{ConfigurationAudience.AzureChina}/.default");
-                yield return new TestCaseData(ConfigurationAudience.AzureChina, "https://other.AZconfig.cn/", $"{ConfigurationAudience.AzureChina}/.default");
-                yield return new TestCaseData(ConfigurationAudience.AzureGovernment, "https://gov-localhost-2353453.azconfig.us", $"{ConfigurationAudience.AzureGovernment}/.default");
-                yield return new TestCaseData(ConfigurationAudience.AzureGovernment, "https://gov-localhost-2353453.azconfig.us/", $"{ConfigurationAudience.AzureGovernment}/.default");
-                yield return new TestCaseData(null, "https://localhost.azconfig.com", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData(null, "https://localhost.azconfig.com/", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData(new ConfigurationAudience("my.custom.audience"), "http://other.my.custom.audience", "my.custom.audience/.default");
-                yield return new TestCaseData(new ConfigurationAudience("my.custom.audience"), "http://other.my.custom.audience/", "my.custom.audience/.default");
+                yield return new TestCaseData(AppConfigurationAudience.AzurePublicCloud, "https://locaLhost.azconfiG.com", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData(AppConfigurationAudience.AzurePublicCloud, "https://locaLhost.azconfiG.com/", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData(AppConfigurationAudience.AzureChina, "https://other.AZconfig.cn", $"{AppConfigurationAudience.AzureChina}/.default");
+                yield return new TestCaseData(AppConfigurationAudience.AzureChina, "https://other.AZconfig.cn/", $"{AppConfigurationAudience.AzureChina}/.default");
+                yield return new TestCaseData(AppConfigurationAudience.AzureGovernment, "https://gov-localhost-2353453.azconfig.us", $"{AppConfigurationAudience.AzureGovernment}/.default");
+                yield return new TestCaseData(AppConfigurationAudience.AzureGovernment, "https://gov-localhost-2353453.azconfig.us/", $"{AppConfigurationAudience.AzureGovernment}/.default");
+                yield return new TestCaseData(null, "https://localhost.azconfig.com", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData(null, "https://localhost.azconfig.com/", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData(new AppConfigurationAudience("my.custom.audience"), "http://other.my.custom.audience", "my.custom.audience/.default");
+                yield return new TestCaseData(new AppConfigurationAudience("my.custom.audience"), "http://other.my.custom.audience/", "my.custom.audience/.default");
             }
         }
 
@@ -56,27 +56,27 @@ namespace Azure.Data.AppConfiguration.Tests
             get
             {
                 // public cloud
-                yield return new TestCaseData("http://locaLhost.azconfiG.io", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData("https://locaLhost.azconfiG.io/", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData("https://locaLhost.azconfiG.io//", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData("https://contoso.azconfig.io", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData("https://contoso.appconfig.azure.com", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData("https://contoso.appconfig.azure.com/", $"{ConfigurationAudience.AzurePublicCloud}/.default");
-                yield return new TestCaseData("http://other.my.custom.audience", $"{ConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData("http://locaLhost.azconfiG.io", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData("https://locaLhost.azconfiG.io/", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData("https://locaLhost.azconfiG.io//", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData("https://contoso.azconfig.io", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData("https://contoso.appconfig.azure.com", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData("https://contoso.appconfig.azure.com/", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
+                yield return new TestCaseData("http://other.my.custom.audience", $"{AppConfigurationAudience.AzurePublicCloud}/.default");
                 // china cloud
-                yield return new TestCaseData("http://other-23232.AZconfig.azure.cn", $"{ConfigurationAudience.AzureChina}/.default");
-                yield return new TestCaseData("https://contoso.azconfig.azure.cn", $"{ConfigurationAudience.AzureChina}/.default");
-                yield return new TestCaseData("https://other.APPconfig.azure.cn", $"{ConfigurationAudience.AzureChina}/.default");
-                yield return new TestCaseData("https://contoso.appconfig.azure.cn", $"{ConfigurationAudience.AzureChina}/.default");
-                yield return new TestCaseData("https://contoso.appconfig.azure.cn/", $"{ConfigurationAudience.AzureChina}/.default");
-                yield return new TestCaseData("https://contoso.appconfig.azure.cn//", $"{ConfigurationAudience.AzureChina}/.default");
+                yield return new TestCaseData("http://other-23232.AZconfig.azure.cn", $"{AppConfigurationAudience.AzureChina}/.default");
+                yield return new TestCaseData("https://contoso.azconfig.azure.cn", $"{AppConfigurationAudience.AzureChina}/.default");
+                yield return new TestCaseData("https://other.APPconfig.azure.cn", $"{AppConfigurationAudience.AzureChina}/.default");
+                yield return new TestCaseData("https://contoso.appconfig.azure.cn", $"{AppConfigurationAudience.AzureChina}/.default");
+                yield return new TestCaseData("https://contoso.appconfig.azure.cn/", $"{AppConfigurationAudience.AzureChina}/.default");
+                yield return new TestCaseData("https://contoso.appconfig.azure.cn//", $"{AppConfigurationAudience.AzureChina}/.default");
                 // us gov cloud
-                yield return new TestCaseData("http://other-23232.AZconfig.azure.us", $"{ConfigurationAudience.AzureGovernment}/.default");
-                yield return new TestCaseData("https://contoso.azconfig.azure.us", $"{ConfigurationAudience.AzureGovernment}/.default");
-                yield return new TestCaseData("https://other.APPconfig.azure.us", $"{ConfigurationAudience.AzureGovernment}/.default");
-                yield return new TestCaseData("https://contoso.appconfig.azure.us", $"{ConfigurationAudience.AzureGovernment}/.default");
-                yield return new TestCaseData("https://contoso.appconfig.azure.us/", $"{ConfigurationAudience.AzureGovernment}/.default");
-                yield return new TestCaseData("https://contoso.appconfig.azure.us//", $"{ConfigurationAudience.AzureGovernment}/.default");
+                yield return new TestCaseData("http://other-23232.AZconfig.azure.us", $"{AppConfigurationAudience.AzureGovernment}/.default");
+                yield return new TestCaseData("https://contoso.azconfig.azure.us", $"{AppConfigurationAudience.AzureGovernment}/.default");
+                yield return new TestCaseData("https://other.APPconfig.azure.us", $"{AppConfigurationAudience.AzureGovernment}/.default");
+                yield return new TestCaseData("https://contoso.appconfig.azure.us", $"{AppConfigurationAudience.AzureGovernment}/.default");
+                yield return new TestCaseData("https://contoso.appconfig.azure.us/", $"{AppConfigurationAudience.AzureGovernment}/.default");
+                yield return new TestCaseData("https://contoso.appconfig.azure.us//", $"{AppConfigurationAudience.AzureGovernment}/.default");
             }
         }
     }


### PR DESCRIPTION
This PR simply renames the `ConfigurationAudience` extensible enum to `AppConfigurationAudience` based on architect feedback.
