### PR TITLE
Remove crypto v2 autoflush of inner stream

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -25,7 +25,6 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using static Azure.Storage.Constants.ClientSideEncryption;
 using static Azure.Storage.Test.Shared.ClientSideEncryptionTestExtensions;
-using static Moq.It;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -132,11 +131,11 @@ namespace Azure.Storage.Blobs.Test
         {
             if (IsAsync)
             {
-                keyMock.Verify(k => k.UnwrapKeyAsync(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+                keyMock.Verify(k => k.UnwrapKeyAsync(s_algorithmName, It.IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
             }
             else
             {
-                keyMock.Verify(k => k.UnwrapKey(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()), Times.Once);
+                keyMock.Verify(k => k.UnwrapKey(s_algorithmName, It.IsNotNull<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()), Times.Once);
             }
         }
 
@@ -375,6 +374,15 @@ namespace Azure.Storage.Blobs.Test
 
                 // compare data
                 Assert.AreEqual(expectedEncryptedData, encryptedData);
+
+                var asBlockBlob = InstrumentClient(disposable.Container.GetBlockBlobClient(blobName));
+                BlockList list = (await asBlockBlob.GetBlockListAsync()).Value;
+                if (list.CommittedBlocks.Count() > 1)
+                {
+                    int nonFinalBlockCount = list.CommittedBlocks.Count() - 1;
+                    Assert.That(list.CommittedBlocks.Take(nonFinalBlockCount).Select(bb => bb.Size).ToList(),
+                        Is.EquivalentTo(Enumerable.Repeat(bufferSize, nonFinalBlockCount)));
+                }
             }
         }
 
@@ -1397,9 +1405,9 @@ namespace Azure.Storage.Blobs.Test
             // Assert
             if (IsAsync)
             {
-                mockKey1.Verify(k => k.WrapKeyAsync(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
-                mockKey1.Verify(k => k.UnwrapKeyAsync(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
-                mockKey2.Verify(k => k.WrapKeyAsync(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+                mockKey1.Verify(k => k.WrapKeyAsync(s_algorithmName, It.IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+                mockKey1.Verify(k => k.UnwrapKeyAsync(s_algorithmName, It.IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+                mockKey2.Verify(k => k.WrapKeyAsync(s_algorithmName, It.IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
 
                 var mockKey1_firstInvocation = mockKey1.Invocations.First();
                 var mockKey1_lastInvocation = mockKey1.Invocations.Last();
@@ -1410,9 +1418,9 @@ namespace Azure.Storage.Blobs.Test
             }
             else
             {
-                mockKey1.Verify(k => k.WrapKey(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
-                mockKey1.Verify(k => k.UnwrapKey(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
-                mockKey2.Verify(k => k.WrapKey(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+                mockKey1.Verify(k => k.WrapKey(s_algorithmName, It.IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+                mockKey1.Verify(k => k.UnwrapKey(s_algorithmName, It.IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+                mockKey2.Verify(k => k.WrapKey(s_algorithmName, It.IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
 
                 var mockKey1_firstInvocation = mockKey1.Invocations.First();
                 var mockKey1_lastInvocation = mockKey1.Invocations.Last();

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -7,6 +7,9 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>Azure.Storage.Tests</RootNamespace>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Queues\src\Azure.Storage.Queues.csproj" />
@@ -22,8 +25,10 @@
   </ItemGroup>
   <ItemGroup>
     <!-- To test shared resources that aren't included in Azure.Storage.Common itself. -->
+    <Compile Include="$(AzureStorageSharedSources)AesGcm\**\*.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\AuthenticatedRegionCryptoStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\IAuthenticatedCryptographicTransform.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\GcmAuthenticatedCryptographicTransform.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\Models\TransformMode.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)AggregatingProgressIncrementer.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)BufferExtensions.cs" LinkBase="Shared" />


### PR DESCRIPTION
`AuthenticatedRegionCryptoStream` no longer auto flushes the inner stream its writing to when an authenticated region is finished.

Resolves #39219