### PR TITLE
Refactor `PartitionedUploader`

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
@@ -6,10 +6,8 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.Common;
 using Azure.Storage.Shared;
@@ -44,38 +42,6 @@ namespace Azure.Storage
                 ContentChecksum = contentChecksum;
             }
         }
-
-        /// <summary>
-        /// Generic delegate to slice the caller provided content into smaller
-        /// partitions for separate upload.
-        /// </summary>
-        /// <typeparam name="TContent">
-        /// Data structure housing the content to upload.
-        /// </typeparam>
-        /// <param name="content">
-        /// Content to slice.
-        /// </param>
-        /// <param name="contentLength">
-        /// Optional known length of <paramref name="content"/>.
-        /// </param>
-        /// <param name="blockSize">
-        /// Maximum size of the resulting slices.
-        /// </param>
-        /// <param name="async">
-        /// Whether to perform this operation asynchronously.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// Cancellation token for the operation.
-        /// </param>
-        /// <returns>
-        /// Async enumerable of the sliced content.
-        /// </returns>
-        private delegate IAsyncEnumerable<ContentPartition<TContent>> GetContentPartitionsAsync<TContent>(
-            TContent content,
-            long? contentLength,
-            long blockSize,
-            bool async,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Generic delegate to upload and individual content partition.
@@ -361,54 +327,14 @@ namespace Azure.Storage
                 _masterCrcSupplier = () => masterCrc.GetFinalHash();
             }
 
-            // If the caller provided an explicit block size, we'll use it.
-            // Otherwise we'll adjust dynamically based on the size of the
-            // content.
-            long blockSize = _blockSize != null
-                ? _blockSize.Value
-                : length < Constants.LargeUploadThreshold ?
-                    Constants.DefaultBufferSize :
-                    Constants.LargeBufferSize;
-
-            // Otherwise stage individual blocks
-
-            /* We only support parallel upload in an async context to avoid issues in our overall sync story.
-             * We're branching on both async and max worker count, where 3 combinations lead to
-             * UploadInSequenceInternal and 1 combination leads to UploadInParallelAsync. We are guaranteed
-             * to be in an async context when we call UploadInParallelAsync, even though the analyzer can't
-             * detext this, and we properly pass in the async context in the else case when we haven't
-             * explicitly checked.
-             */
-#pragma warning disable AZC0109 // Misuse of 'async' parameter.
-#pragma warning disable AZC0110 // DO NOT use await keyword in possibly synchronous scope.
-            if (async && _maxWorkerCount > 1)
-            {
-                return await UploadInParallelAsync(
-                    content,
-                    length,
-                    blockSize,
-                    args,
-                    progressHandler,
-                    GetContentPartitionsBinaryDataInternal,
-                    StageBinaryDataPartitionInternal,
-                    cancellationToken)
-                    .ConfigureAwait(false);
-            }
-#pragma warning restore AZC0110 // DO NOT use await keyword in possibly synchronous scope.
-#pragma warning restore AZC0109 // Misuse of 'async' parameter.
-            else
-            {
-                return await UploadInSequenceInternal(
-                    content,
-                    length,
-                    blockSize,
-                    args,
-                    progressHandler,
-                    GetContentPartitionsBinaryDataInternal,
-                    StageBinaryDataPartitionInternal,
-                    async: async,
-                    cancellationToken).ConfigureAwait(false);
-            }
+            return await UploadPartitionsInternal(
+                GetContentPartitionsBinaryDataInternal(content, length, GetActualBlockSize(_blockSize, length), async, cancellationToken),
+                args,
+                progressHandler,
+                StageBinaryDataPartitionInternal,
+                async,
+                cancellationToken)
+                .ConfigureAwait(false);
         }
 
         public async Task<Response<TCompleteUploadReturn>> UploadInternal(
@@ -483,61 +409,28 @@ namespace Azure.Storage
                 _masterCrcSupplier = () => masterCrc.GetFinalHash();
             }
 
+            // Streamed partitions only work if we can seek the stream and don't need parallel access to it.
+            GetNextStreamPartition partitionGetter = content.CanSeek && _maxWorkerCount == 1
+                ? (GetNextStreamPartition)GetStreamedPartitionInternal
+                : /*   redundant cast   */GetBufferedPartitionInternal;
+
+            return await UploadPartitionsInternal(
+                GetStreamPartitionsAsync(content, length, GetActualBlockSize(_blockSize, length), partitionGetter, async, cancellationToken),
+                args,
+                progressHandler,
+                StageStreamPartitionInternal,
+                async,
+                cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        private static long GetActualBlockSize(long? blockSize, long? totalLength)
             // If the caller provided an explicit block size, we'll use it.
             // Otherwise we'll adjust dynamically based on the size of the
             // content.
-            long blockSize = _blockSize != null
-                ? _blockSize.Value
-                : length < Constants.LargeUploadThreshold ?
+            => blockSize ?? (totalLength < Constants.LargeUploadThreshold ?
                     Constants.DefaultBufferSize :
-                    Constants.LargeBufferSize;
-
-            // Otherwise stage individual blocks
-
-            /* We only support parallel upload in an async context to avoid issues in our overall sync story.
-             * We're branching on both async and max worker count, where 3 combinations lead to
-             * UploadInSequenceInternal and 1 combination leads to UploadInParallelAsync. We are guaranteed
-             * to be in an async context when we call UploadInParallelAsync, even though the analyzer can't
-             * detext this, and we properly pass in the async context in the else case when we haven't
-             * explicitly checked.
-             */
-#pragma warning disable AZC0109 // Misuse of 'async' parameter.
-#pragma warning disable AZC0110 // DO NOT use await keyword in possibly synchronous scope.
-            if (async && _maxWorkerCount > 1)
-            {
-                return await UploadInParallelAsync(
-                    content,
-                    length,
-                    blockSize,
-                    args,
-                    progressHandler,
-                    // we always buffer stream partitions when uploading in parallel
-                    GetStreamPartitioner(GetBufferedPartitionInternal),
-                    StageStreamPartitionInternal,
-                    cancellationToken)
-                    .ConfigureAwait(false);
-            }
-#pragma warning restore AZC0110 // DO NOT use await keyword in possibly synchronous scope.
-#pragma warning restore AZC0109 // Misuse of 'async' parameter.
-            else
-            {
-                // Streamed partitions only work if we can seek the stream; we need retries on individual uploads.
-                GetNextStreamPartition partitionGetter = content.CanSeek
-                            ? (GetNextStreamPartition)GetStreamedPartitionInternal
-                            : /*   redundant cast   */GetBufferedPartitionInternal;
-
-                return await UploadInSequenceInternal(
-                    content,
-                    length,
-                    blockSize,
-                    args,
-                    progressHandler,
-                    GetStreamPartitioner(partitionGetter),
-                    StageStreamPartitionInternal,
-                    async: async,
-                    cancellationToken).ConfigureAwait(false);
-            }
-        }
+                    Constants.LargeBufferSize);
 
         /// <summary>
         /// Buffers the given stream and optionally checksums the stream contents as they are buffered.
@@ -619,13 +512,51 @@ namespace Azure.Storage
             return (bufferedContent, validationOptions);
         }
 
-        private async Task<Response<TCompleteUploadReturn>> UploadInSequenceInternal<TContent>(
-            TContent content,
-            long? contentLength,
-            long partitionSize,
+        private async Task<Response<TCompleteUploadReturn>> UploadPartitionsInternal<TContent>(
+            IAsyncEnumerable<ContentPartition<TContent>> contentPartitions,
             TServiceSpecificData args,
             IProgress<long> progressHandler,
-            GetContentPartitionsAsync<TContent> partitionContentAsync,
+            StageContentPartitionAsync<TContent> stageContentAsync,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            /* We only support parallel upload in an async context to avoid issues in our overall sync story.
+             * We're branching on both async and max worker count, where 3 combinations lead to
+             * UploadInSequenceInternal and 1 combination leads to UploadInParallelAsync. We are guaranteed
+             * to be in an async context when we call UploadInParallelAsync, even though the analyzer can't
+             * detext this, and we properly pass in the async context in the else case when we haven't
+             * explicitly checked.
+             */
+#pragma warning disable AZC0109 // Misuse of 'async' parameter.
+#pragma warning disable AZC0110 // DO NOT use await keyword in possibly synchronous scope.
+            if (async && _maxWorkerCount > 1)
+            {
+                return await UploadInParallelAsync(
+                    contentPartitions,
+                    args,
+                    progressHandler,
+                    stageContentAsync,
+                    cancellationToken)
+                    .ConfigureAwait(false);
+            }
+#pragma warning restore AZC0110 // DO NOT use await keyword in possibly synchronous scope.
+#pragma warning restore AZC0109 // Misuse of 'async' parameter.
+            else
+            {
+                return await UploadInSequenceInternal(
+                    contentPartitions,
+                    args,
+                    progressHandler,
+                    stageContentAsync,
+                    async: async,
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task<Response<TCompleteUploadReturn>> UploadInSequenceInternal<TContent>(
+            IAsyncEnumerable<ContentPartition<TContent>> contentPartitions,
+            TServiceSpecificData args,
+            IProgress<long> progressHandler,
             StageContentPartitionAsync<TContent> stageContentAsync,
             bool async,
             CancellationToken cancellationToken)
@@ -645,7 +576,7 @@ namespace Azure.Storage
                 }
 
                 // The list tracking blocks IDs we're going to commit
-                List<(long Offset, long Size)> partitions = new List<(long, long)>();
+                List<(long Offset, long Size)> partitions = new();
 
                 Memory<byte> _composedBlockCrc64 = UseMasterCrc
                     ? new Memory<byte>(new byte[Constants.StorageCrc64SizeInBytes])
@@ -653,16 +584,9 @@ namespace Azure.Storage
                 long composedOriginalDataLength = 0;
 
                 // Partition the stream into individual blocks and stage them
-                if (async)
+                async Task StageAsync(ContentPartition<TContent> block, bool async, CancellationToken cancellationToken)
                 {
-                    await foreach (ContentPartition<TContent> block in partitionContentAsync(
-                        content,
-                        contentLength,
-                        partitionSize,
-                        async: true,
-                        cancellationToken).ConfigureAwait(false))
-                    {
-                        await stageContentAsync(
+                    await stageContentAsync(
                             block.Content,
                             block.AbsolutePosition,
                             args,
@@ -672,47 +596,29 @@ namespace Azure.Storage
                                 PrecalculatedChecksum = block.ContentChecksum,
                             },
                             progressHandler,
-                            async: true,
+                            async,
                             cancellationToken).ConfigureAwait(false);
 
-                        partitions.Add((block.AbsolutePosition, block.Length));
-                        if (UseMasterCrc)
-                        {
-                            _composedBlockCrc64 = StorageCrc64Composer.Compose(
-                                (_composedBlockCrc64.ToArray(), composedOriginalDataLength),
-                                (block.ContentChecksum.ToArray(), block.Length));
-                        }
+                    partitions.Add((block.AbsolutePosition, block.Length));
+                    if (UseMasterCrc)
+                    {
+                        _composedBlockCrc64 = StorageCrc64Composer.Compose(
+                            (_composedBlockCrc64.ToArray(), composedOriginalDataLength),
+                            (block.ContentChecksum.ToArray(), block.Length));
+                    }
+                }
+                if (async)
+                {
+                    await foreach (ContentPartition<TContent> block in contentPartitions.ConfigureAwait(false))
+                    {
+                        await StageAsync(block, true, cancellationToken).ConfigureAwait(false);
                     }
                 }
                 else
                 {
-                    foreach (ContentPartition<TContent> block in partitionContentAsync(
-                        content,
-                        contentLength,
-                        partitionSize,
-                        async: false,
-                        cancellationToken).EnsureSyncEnumerable())
+                    foreach (ContentPartition<TContent> block in contentPartitions.EnsureSyncEnumerable())
                     {
-                        stageContentAsync(
-                            block.Content,
-                            block.AbsolutePosition,
-                            args,
-                            new UploadTransferValidationOptions
-                            {
-                                ChecksumAlgorithm = _validationAlgorithm,
-                                PrecalculatedChecksum = block.ContentChecksum
-                            },
-                            progressHandler,
-                            async: false,
-                            cancellationToken).EnsureCompleted();
-
-                        partitions.Add((block.AbsolutePosition, block.Length));
-                        if (UseMasterCrc)
-                        {
-                            _composedBlockCrc64 = StorageCrc64Composer.Compose(
-                                (_composedBlockCrc64.ToArray(), composedOriginalDataLength),
-                                (block.ContentChecksum.ToArray(), block.Length));
-                        }
+                        StageAsync(block, false, cancellationToken).EnsureCompleted();
                     }
                 }
 
@@ -745,12 +651,9 @@ namespace Azure.Storage
         }
 
         private async Task<Response<TCompleteUploadReturn>> UploadInParallelAsync<TContent>(
-            TContent content,
-            long? contentLength,
-            long blockSize,
+            IAsyncEnumerable<ContentPartition<TContent>> contentPartitions,
             TServiceSpecificData args,
             IProgress<long> progressHandler,
-            GetContentPartitionsAsync<TContent> partitionContentAsync,
             StageContentPartitionAsync<TContent> stageContentAsync,
             CancellationToken cancellationToken)
         {
@@ -781,12 +684,7 @@ namespace Azure.Storage
                 long composedOriginalDataLength = 0;
 
                 // Partition the stream into individual blocks
-                await foreach (ContentPartition<TContent> block in partitionContentAsync(
-                    content,
-                    contentLength,
-                    blockSize,
-                    async: true,
-                    cancellationToken).ConfigureAwait(false))
+                await foreach (ContentPartition<TContent> block in contentPartitions.ConfigureAwait(false))
                 {
                     /* We need to do this first! Length is calculated on the fly based on stream buffer
                      * contents; We need to record the partition data first before consuming the stream
@@ -929,9 +827,6 @@ namespace Azure.Storage
         }
 
         #region Content Slicing Impl
-        /// <summary>
-        /// <see cref="GetContentPartitionsAsync{TContent}"/> implementation for <see cref="BinaryData"/>.
-        /// </summary>
         /// <remarks>
         /// Async wrapper over a synchronous operation to satisfy delegate definitions.
         /// </remarks>
@@ -985,18 +880,6 @@ namespace Azure.Storage
                     checksum?.Checksum ?? ReadOnlyMemory<byte>.Empty);
                 position += next.Length;
             }
-        }
-
-        /// <summary>
-        /// Gets the correct implementation of <see cref="GetContentPartitionsAsync{TContent}"/>
-        /// for <see cref="Stream"/> depending on whether the stream is to be sliced in place or
-        /// to be buffered into its new partitions.
-        /// </summary>
-        /// <param name="partitionCreator">Stream partitioning behavior.</param>
-        private static GetContentPartitionsAsync<Stream> GetStreamPartitioner(GetNextStreamPartition partitionCreator)
-        {
-            return (content, contentLength, blockSize, async, cancellationToken) => GetStreamPartitionsAsync(
-                content, contentLength, blockSize, partitionCreator, async, cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
Some changes to the `PartitionedUploader` intended to:
1. Improve readability
2. Prepare for an upcoming optimization on unseekable small streams

Summary of changes:
- The big partitioned upload methods now accept an async enumerable of the partitions to upload, instead of a delegate to create that enumerable plus all the arguments it needs for that delegate. This will simplify the upcoming optimization for unseekable small streams. Ideally this is also easier to reason about when reading the code.
- Factor out block size determination into its own method, reducing code duplication.
- Factor out switching between sequential and parallel upload into its own method, reducing code duplication.
- Factor out some duplicate sync/async staging code into its own async-switching method, reducing code duplication.