### PR TITLE
[Extensions] March 2025 Release Prep

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/CHANGELOG.md
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.5.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 3.4.4 (2025-03-14)
 
 ### Other Changes
+
+- Updating .NET runtime dependencies to the 6.x line, the Azure extensions to 1.8.0, and the latest dependencies for the Functions host.
 
 ## 3.4.3 (2024-11-19)
 

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>This extension adds bindings for EventGrid</Description>
-    <Version>3.5.0-beta.1</Version>
+    <Version>3.4.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>3.4.3</ApiCompatVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 6.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 6.4.0-beta.1 (2025-03-14)
 
 ### Bugs Fixed
 
 - Fixed a misspelling of "PartitionId" in the trigger input data passed to the function executor.  This caused function logs and metrics reported by AppInsights and the portal to reflect the wrong label.  To ensure that applications that rely on the misspelling are not impacted, a new member with the correct spelling was added.
 
 ### Other Changes
+
+- Updating .NET runtime dependencies to the 6.x line, the Azure extensions to 1.8.0, and the latest dependencies for the Functions host.
 
 ## 6.3.5 (2024-08-01)
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added support for [AzurePipelinesCredential](https://learn.microsoft.com/dotnet/api/azure.identity.azurepipelinescredential?view=azure-dotnet) in the client factory by specifying configuration item `credential` as "azurepipelinescredential" and providing each credential parameter as a named configuration item.
+- Added support for [AzurePipelinesCredential](https://learn.microsoft.com/dotnet/api/azure.identity.azurepipelinescredential?view=azure-dotnet) in the client factory by specifying configuration item `credential` as "azurepipelines" and providing each credential parameter as a named configuration item.
 
 ### Bugs Fixed
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Release History
 
-## 1.11.0-beta.1 (Unreleased)
+## 1.11.0 (2025-03-15)
 
 ### Features Added
 
 - Added support for [AzurePipelinesCredential](https://learn.microsoft.com/dotnet/api/azure.identity.azurepipelinescredential?view=azure-dotnet) in the client factory by specifying configuration item `credential` as "azurepipelinescredential" and providing each credential parameter as a named configuration item.
-
-### Breaking Changes
 
 ### Bugs Fixed
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 - Fixed an issue when creating clients from configuration using the ASP.NET Core integration testing library, `Microsoft.AspNetCore.Mvc.Testing`.  Due to a difference in how an section value is represented, logic was interpreting a setting with a child object as an empty connection string value.  The child object is now properly parsed and applied for client construction.  ([#48368](https://github.com/Azure/azure-sdk-for-net/issues/48368))
 
-### Other Changes
-
 ## 1.10.0 (2025-02-11)
 
 ### Other Changes

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -179,11 +179,11 @@ namespace Microsoft.Extensions.Azure
                 throw new ArgumentException("For workload identity, 'tenantId', 'clientId', and 'tokenFilePath' must be specified via environment variables or the configuration.");
             }
 
-            if (string.Equals(credentialType, "azurepipelinescredential", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(credentialType, "azurepipelines", StringComparison.OrdinalIgnoreCase))
             {
                 if (string.IsNullOrWhiteSpace(tenantId) ||
                     string.IsNullOrWhiteSpace(clientId) ||
-                    string.IsNullOrEmpty(serviceConnectionId) ||
+                    string.IsNullOrWhiteSpace(serviceConnectionId) ||
                     string.IsNullOrWhiteSpace(systemAccessToken))
                 {
                     throw new ArgumentException("For Azure Pipelines, 'tenantId', 'clientId', 'serviceConnectionId', and 'systemAccessToken' must be specified via the configuration.");

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Azure Client SDK integration with Microsoft.Extensions libraries</Description>
     <AssemblyTitle>Azure Client SDK integration Microsoft.Extensions</AssemblyTitle>
-    <Version>1.11.0-</Version>
+    <Version>1.11.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.10.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline AspNetCore Extensions</PackageTags>

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Azure Client SDK integration with Microsoft.Extensions libraries</Description>
     <AssemblyTitle>Azure Client SDK integration Microsoft.Extensions</AssemblyTitle>
-    <Version>1.11.0-beta.1</Version>
+    <Version>1.11.0-</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.10.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline AspNetCore Extensions</PackageTags>

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -283,7 +283,7 @@ namespace Azure.Core.Extensions.Tests
         public void CreatesAzurePipelinesCredential()
         {
             IConfiguration configuration = GetConfiguration(
-                new KeyValuePair<string, string>("credential", "azurepipelinescredential"),
+                new KeyValuePair<string, string>("credential", "azurepipelines"),
                 new KeyValuePair<string, string>("clientId", "ConfigurationClientId"),
                 new KeyValuePair<string, string>("tenantId", "ConfigurationTenantId"),
                 new KeyValuePair<string, string>("serviceConnectionId", "SomeServiceConnectionId"),
@@ -316,7 +316,7 @@ namespace Azure.Core.Extensions.Tests
         public void CreatesAzurePipelinesCredential_AdditionalTenants(string additionalTenants)
         {
             IConfiguration configuration = GetConfiguration(
-                new KeyValuePair<string, string>("credential", "azurepipelinescredential"),
+                new KeyValuePair<string, string>("credential", "azurepipelines"),
                 new KeyValuePair<string, string>("clientId", "ConfigurationClientId"),
                 new KeyValuePair<string, string>("tenantId", "ConfigurationTenantId"),
                 new KeyValuePair<string, string>("serviceConnectionId", "SomeServiceConnectionId"),
@@ -352,7 +352,7 @@ namespace Azure.Core.Extensions.Tests
         public void CreatesAzurePipelinesCredential_InvalidConfig(string clientId, string tenantId, string serviceConnectionId, string systemAccessToken)
         {
             IConfiguration configuration = GetConfiguration(
-                new KeyValuePair<string, string>("credential", "azurepipelinescredential"),
+                new KeyValuePair<string, string>("credential", "azurepipelines"),
                 new KeyValuePair<string, string>("clientId", clientId),
                 new KeyValuePair<string, string>("tenantId", tenantId),
                 new KeyValuePair<string, string>("serviceConnectionId", serviceConnectionId),

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -1,15 +1,12 @@
 # Release History
 
-## 5.17.0-beta.1 (Unreleased)
+## 5.16.5 (2025-03-14)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-GetProcessorCount for webjobs service bus extension does not override processor count for flex consumption. (#45970)
+Updated GetProcessorCount to not override the processor count for flex consumption. (#45970)
 
 ### Other Changes
+
+- Updating .NET runtime dependencies to the 6.x line, the Azure extensions to 1.8.0, and the latest dependencies for the Functions host.
 
 ## 5.16.4 (2024-08-08)
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK ServiceBus Extension</Description>
-    <Version>5.17.0-beta.1</Version>
+    <Version>5.16.5</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <!--Since we are adding a new target for net6.0, we need to temporarily condition on netstandard-->
     <ApiCompatVersion>5.16.4</ApiCompatVersion>

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/CHANGELOG.md
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3/3 (2025-03-14)
 
 ### Other Changes
+
+- Updating .NET runtime dependencies to the 6.x line, the Azure extensions to 1.8.0, and the latest dependencies for the Functions host.
 
 ## 1.3.2 (2024-06-13)
 

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/CHANGELOG.md
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3/3 (2025-03-14)
+## 1.3.3 (2025-03-14)
 
 ### Other Changes
 

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/Microsoft.Azure.WebJobs.Extensions.Tables.csproj
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/Microsoft.Azure.WebJobs.Extensions.Tables.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>1.4.0-beta.1</Version>
+        <Version>1.3.3</Version>
         <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
         <ApiCompatVersion>1.3.2</ApiCompatVersion>
         <Description>This package extends the Microsoft.Azure.WebJobs library with Table triggers using Azure Table service.</Description>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare for the March 2025 release of a set of extensions packages. Included are Event Grid, Event Hubs, Service Bus, and Tables.  Also included is the `Microsoft.Extensions.Azure`
package containing minor fixes and configuration support for the Azure Pipelines credential.

## References and related

- [[EngSys] Release inactive packages with 6.x dependencies (#48083)](https://github.com/Azure/azure-sdk-for-net/issues/48083)