### PR TITLE
[OperationalInsights] Fix for issue #48747

### DIFF
--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/CHANGELOG.md
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Release History
 
-## 1.3.0-beta.2 (Unreleased)
+## 1.3.0-beta.2 (2025-03-18)
 
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Fix issue #48747, add custom serialization and deserialization methods for `KeyVaultUri` in `OperationalInsightsKeyVaultProperties`
 
 ### Other Changes
 

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/CHANGELOG.md
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/CHANGELOG.md
@@ -2,15 +2,9 @@
 
 ## 1.3.0-beta.2 (2025-03-18)
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fix issue #48747, add custom serialization and deserialization methods for `KeyVaultUri` in `OperationalInsightsKeyVaultProperties`
-
-### Other Changes
 
 ## 1.3.0-beta.1 (2024-10-15)
 

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/assets.json
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/operationalinsights/Azure.ResourceManager.OperationalInsights",
-  "Tag": "net/operationalinsights/Azure.ResourceManager.OperationalInsights_d5fdec293c"
+  "Tag": "net/operationalinsights/Azure.ResourceManager.OperationalInsights_96f96be3ff"
 }

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Custom/OperationalInsightsKeyVaultProperties.Serialization.cs
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Custom/OperationalInsightsKeyVaultProperties.Serialization.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.ResourceManager.OperationalInsights.Models
+{
+    // This is a fix for issue 48747.
+    [CodeGenSerialization(nameof(KeyVaultUri), SerializationValueHook = nameof(WriteKeyVaultUri), DeserializationValueHook = nameof(DeserializeKeyVaultUri))]
+    public partial class OperationalInsightsKeyVaultProperties
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void WriteKeyVaultUri(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            if (KeyVaultUri.IsAbsoluteUri)
+                writer.WriteStringValue(KeyVaultUri.AbsoluteUri);
+            else
+                writer.WriteStringValue(KeyVaultUri.OriginalString);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DeserializeKeyVaultUri(JsonProperty property, ref Uri keyVaultUri)
+        {
+            if (property.Value.ValueKind != JsonValueKind.Null)
+            {
+                keyVaultUri = String.IsNullOrEmpty(property.Value.GetString()) ? new Uri("", UriKind.Relative) : new Uri(property.Value.GetString());
+            }
+        }
+    }
+}

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Generated/Models/OperationalInsightsKeyVaultProperties.Serialization.cs
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Generated/Models/OperationalInsightsKeyVaultProperties.Serialization.cs
@@ -38,7 +38,7 @@ namespace Azure.ResourceManager.OperationalInsights.Models
             if (Optional.IsDefined(KeyVaultUri))
             {
                 writer.WritePropertyName("keyVaultUri"u8);
-                writer.WriteStringValue(KeyVaultUri.AbsoluteUri);
+                WriteKeyVaultUri(writer, options);
             }
             if (Optional.IsDefined(KeyName))
             {
@@ -102,11 +102,7 @@ namespace Azure.ResourceManager.OperationalInsights.Models
             {
                 if (property.NameEquals("keyVaultUri"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
-                    keyVaultUri = new Uri(property.Value.GetString());
+                    DeserializeKeyVaultUri(property, ref keyVaultUri);
                     continue;
                 }
                 if (property.NameEquals("keyName"u8))

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/tests/Scenario/OperationalInsightsClusterTests.cs
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/tests/Scenario/OperationalInsightsClusterTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.ResourceManager.Models;
+using Azure.ResourceManager.OperationalInsights.Models;
+using Azure.ResourceManager.Resources;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.OperationalInsights.Tests.Scenario
+{
+    public class OperationalInsightsClusterTests : OperationalInsightsManagementTestBase
+    {
+        private ResourceGroupResource _resourceGroup;
+
+        public OperationalInsightsClusterTests(bool isAsync) : base(isAsync, RecordedTestMode.Record)
+        {
+        }
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _resourceGroup = await CreateResourceGroup();
+        }
+
+        [RecordedTest]
+        public async Task RemovingKeyVaultPropertiesTest()
+        {
+            string clusterName = "sdkcluser";
+            var clusterData = new OperationalInsightsClusterData(_resourceGroup.Data.Location)
+            {
+                Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.SystemAssigned),
+                Sku = new OperationalInsightsClusterSku()
+                {
+                    Name = OperationalInsightsClusterSkuName.CapacityReservation,
+                    Capacity = OperationalInsightsClusterCapacity.TenHundred,
+                },
+                KeyVaultProperties = new OperationalInsightsKeyVaultProperties()
+                {
+                    KeyVaultUri = new Uri("", UriKind.Relative),
+                    KeyName = "",
+                    KeyVersion = "",
+                }
+            };
+            var cluster = (await _resourceGroup.GetOperationalInsightsClusters().CreateOrUpdateAsync(WaitUntil.Completed, clusterName, clusterData)).Value;
+            Assert.IsTrue(cluster.Data.KeyVaultProperties.KeyVaultUri.ToString().Equals(""));
+        }
+    }
+}

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/tests/Scenario/OperationalInsightsClusterTests.cs
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/tests/Scenario/OperationalInsightsClusterTests.cs
@@ -15,7 +15,7 @@ namespace Azure.ResourceManager.OperationalInsights.Tests.Scenario
     {
         private ResourceGroupResource _resourceGroup;
 
-        public OperationalInsightsClusterTests(bool isAsync) : base(isAsync, RecordedTestMode.Record)
+        public OperationalInsightsClusterTests(bool isAsync) : base(isAsync)//, RecordedTestMode.Record)
         {
         }
 


### PR DESCRIPTION
This is a fix for issue #48747 
Add custom serialization and deserialization methods for `KeyVaultUri` in `OperationalInsightsKeyVaultProperties`

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
