### PR TITLE
[Tables] Fixing batch error docs

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -1543,8 +1543,10 @@ namespace Azure.Data.Tables
         /// <returns><see cref="Response{T}"/> containing a <see cref="IReadOnlyList{T}"/> of <see cref="Response"/>.
         /// Each sub-response in the collection corresponds to the <see cref="TableTransactionAction"/> provided to the <paramref name="transactionActions"/> parameter at the same index position.
         /// Each response can be inspected for details for its corresponding table operation, such as the <see cref="Response.Headers"/> property containing the <see cref="ResponseHeaders.ETag"/></returns>
-        /// <exception cref="RequestFailedException"/> if the batch transaction fails./>
-        /// <exception cref="InvalidOperationException"/> if the batch has been previously submitted.
+        /// <exception cref="RequestFailedException"> Thrown when the batch transaction operation fails.</exception>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="transactionActions"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if <paramref name="transactionActions"/> contains no items.</exception>
+        /// <exception cref="InvalidOperationException"> Thrown if the batch has been previously submitted.</exception>
         public virtual async Task<Response<IReadOnlyList<Response>>> SubmitTransactionAsync(
             IEnumerable<TableTransactionAction> transactionActions,
             CancellationToken cancellationToken = default) =>
@@ -1560,8 +1562,10 @@ namespace Azure.Data.Tables
         /// <returns><see cref="Response{T}"/> containing a <see cref="IReadOnlyList{T}"/> of <see cref="Response"/>.
         /// Each sub-response in the collection corresponds to the <see cref="TableTransactionAction"/> provided to the <paramref name="transactionActions"/> parameter at the same index position.
         /// Each response can be inspected for details for its corresponding table operation, such as the <see cref="Response.Headers"/> property containing the <see cref="ResponseHeaders.ETag"/></returns>
-        /// <exception cref="RequestFailedException"/> if the batch transaction fails./>
-        /// <exception cref="InvalidOperationException"/> if the batch has been previously submitted.
+        /// <exception cref="RequestFailedException"> Thrown when the batch transaction operation fails.</exception>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="transactionActions"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when <paramref name="transactionActions"/> contains no items.</exception>
+        /// <exception cref="InvalidOperationException"> Thrown if the batch has been previously submitted.</exception>
         public virtual Response<IReadOnlyList<Response>> SubmitTransaction(
             IEnumerable<TableTransactionAction> transactionActions,
             CancellationToken cancellationToken = default) =>


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a formatting error with the batch operations and add the error scenario for an empty batch passed to the method.

## References and resources

- [[BUG] TableClient SubmitTransactionAsync throws InvalidOperationExteption on empty arguments (#48746)](https://github.com/Azure/azure-sdk-for-net/issues/48746)