### PR TITLE
[AzureMonitorExporter] Prevent multiple Azure Monitor Exporter registrations on the same IServiceCollection

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterExtensions.cs
@@ -82,6 +82,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     exporterOptions.Credential ??= credential;
                 }
 
+                sp.EnsureNoUseAzureMonitorExporterRegistrations();
+
                 builder.AddProcessor(new CompositeProcessor<Activity>(new BaseProcessor<Activity>[]
                 {
                     new StandardMetricsExtractionProcessor(new AzureMonitorMetricExporter(exporterOptions)),
@@ -142,6 +144,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     // Options should take precedence.
                     exporterOptions.Credential ??= credential;
                 }
+
+                sp.EnsureNoUseAzureMonitorExporterRegistrations();
 
                 return new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions))
                 { TemporalityPreference = MetricReaderTemporalityPreference.Delta };
@@ -238,6 +242,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     // Options should take precedence.
                     exporterOptions.Credential ??= credential;
                 }
+
+                sp.EnsureNoUseAzureMonitorExporterRegistrations();
 
                 // TODO: Do we need provide an option to alter BatchExportLogRecordProcessorOptions?
                 return new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(exporterOptions));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ExporterRegistrationHostedService.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ExporterRegistrationHostedService.cs
@@ -53,6 +53,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             var tracerProvider = serviceProvider!.GetService<TracerProvider>();
             if (tracerProvider != null)
             {
+                // Ensure that the AzureMonitorTraceExporter is registered only once
+                serviceProvider!.EnsureSingleUseAzureMonitorExporterRegistration();
+
                 // Add a processor manually to the TracerProvider created by the SDK
                 var exporterOptions = serviceProvider!.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().Get(Options.DefaultName);
 
@@ -73,6 +76,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             var loggerProvider = serviceProvider!.GetService<LoggerProvider>();
             if (loggerProvider != null)
             {
+                // Ensure that the AzureMonitorLogExporter is registered only once
+                serviceProvider!.EnsureSingleUseAzureMonitorExporterRegistration();
+
                 // Add a processor manually to the LoggerProvider created by the SDK
                 var exporterOptions = serviceProvider!.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().Get(Options.DefaultName);
                 var exporter = new AzureMonitorLogExporter(exporterOptions);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/OpenTelemetryBuilderExtensions.cs
@@ -80,6 +80,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             builder.Services.ConfigureOpenTelemetryMeterProvider((serviceProvider, meterProviderBuilder) =>
             {
+                // Ensure that the AzureMonitorMetricExporter is registered only once
+                serviceProvider!.EnsureSingleUseAzureMonitorExporterRegistration();
+
                 var exporterOptions = serviceProvider!.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().Get(Options.DefaultName);
                 meterProviderBuilder.AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions))
                     { TemporalityPreference = MetricReaderTemporalityPreference.Delta });

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/OpenTelemetryBuilderServiceProviderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/OpenTelemetryBuilderServiceProviderExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    internal static class OpenTelemetryBuilderServiceProviderExtensions
+    {
+        public static void EnsureSingleUseAzureMonitorExporterRegistration(this IServiceProvider serviceProvider)
+        {
+            var registrations = serviceProvider.GetServices<UseAzureMonitorExporterRegistration>();
+            if (registrations.Count() > 1)
+            {
+                throw new NotSupportedException("Multiple calls to UseAzureMonitorExporter on the same IServiceCollection are not supported.");
+            }
+        }
+
+        public static void EnsureNoUseAzureMonitorExporterRegistrations(this IServiceProvider serviceProvider)
+        {
+            var registrations = serviceProvider.GetServices<UseAzureMonitorExporterRegistration>();
+            if (registrations.Any())
+            {
+                throw new NotSupportedException("Signal-specific AddAzureMonitorExporter / UseAzureMonitor methods and the cross-cutting UseAzureMonitorExporter method being invoked on the same IServiceCollection is not supported.");
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/UseAzureMonitorExporterRegistration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/UseAzureMonitorExporterRegistration.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter;
+
+// Note: This class is added to the IServiceCollection when UseAzureMonitorExporter is
+// called. Its purpose is to detect registrations so that subsequent calls and
+// calls to signal-specific UseAzureMonitorExporter can throw.
+internal sealed class UseAzureMonitorExporterRegistration
+{
+    public static readonly UseAzureMonitorExporterRegistration Instance = new();
+
+    private UseAzureMonitorExporterRegistration()
+    {
+        // Note: Some dependency injection containers (ex: Unity, Grace) will
+        // automatically create services if they have a public constructor even
+        // if the service was never registered into the IServiceCollection. The
+        // behavior of UseAzureMonitorExporterRegistration requires that it should only
+        // exist if registered. This private constructor is intended to prevent
+        // automatic instantiation.
+    }
+}


### PR DESCRIPTION
# Contributing to the Azure SDK

**Scenario 1:** Calling UseAzureMonitorExporter more than once throws an error.

```
builder.Services.AddOpenTelemetry().UseAzureMonitorExporter();
builder.Services.AddOpenTelemetry().UseAzureMonitorExporter();
```

**Error:** 
```
System.NotSupportedException: Multiple calls to UseAzureMonitorExporter on the same IServiceCollection are not supported.
         at Azure.Monitor.OpenTelemetry.Exporter.OpenTelemetryBuilderServiceProviderExtensions.EnsureSingleUseAzureMonitorExporterRegistration(IServiceProvider serviceProvider) in C:\repo\azure-sdk-for-net\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\src\OpenTelemetryBuilderServiceProviderExtensions.cs:line 17
```

**Scenario 2:** Combining .UseAzureMonitorExporter() with signal-specific methods like .AddAzureMonitorTraceExporter() throws.

```
builder.Services.AddOpenTelemetry().UseAzureMonitorExporter();
builder.Services.AddOpenTelemetry().WithTracing(tracing => tracing.AddAzureMonitorTraceExporter());
```

**Error:** 
```
Unhandled exception. System.NotSupportedException: Signal-specific AddAzureMonitorExporter / UseAzureMonitor methods and the cross-cutting UseAzureMonitorExporter method being invoked on the same IServiceCollection is not supported.
   at Azure.Monitor.OpenTelemetry.Exporter.OpenTelemetryBuilderServiceProviderExtensions.EnsureNoUseAzureMonitorExporterRegistrations(IServiceProvider serviceProvider) in C:\repo\azure-sdk-for-net\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\src\OpenTelemetryBuilderServiceProviderExtensions.cs:line 26
```

**Scenario 3:** Using .UseAzureMonitorExporter() alongside .UseAzureMonitor() throws.

```
builder.Services.AddOpenTelemetry().UseAzureMonitorExporter();
builder.Services.AddOpenTelemetry().UseAzureMonitor();
```

**Error:** 
```
Unhandled exception. System.NotSupportedException: Signal-specific AddAzureMonitorExporter / UseAzureMonitor methods and the cross-cutting UseAzureMonitorExporter method being invoked on the same IServiceCollection is not supported.
   at Azure.Monitor.OpenTelemetry.Exporter.OpenTelemetryBuilderServiceProviderExtensions.EnsureNoUseAzureMonitorExporterRegistrations(IServiceProvider serviceProvider) in C:\repo\azure-sdk-for-net\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\src\OpenTelemetryBuilderServiceProviderExtensions.cs:line 26
```

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
