### PR TITLE
Build servicebus snippets

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample16_CrossReceiverMessageSettlement.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample16_CrossReceiverMessageSettlement.md
@@ -13,7 +13,7 @@ First we can get the raw AMQP message bytes and lock token as shown below:
 actually part of the AMQP message so it needs to stored separately from the AMQP bytes.*
 
 ```C# Snippet:ServiceBusWriteReceivedMessage
-DefaultAzureCredential credential = new();
+var credential = new DefaultAzureCredential();
 ServiceBusClient client1 = new(fullyQualifiedNamespace, credential);
 ServiceBusSender sender = client1.CreateSender(queueName);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample17_BatchDelete.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample17_BatchDelete.md
@@ -11,7 +11,7 @@ Because multiple service requests may be made, it is possible to experience part
 It is also important to be aware that if there is a receiver reading the entity when `PurgeAllMessgesAsync` is called, any locked messages will not be deleted.
 
 ```C# Snippet:ServiceBusPurgeMessages
-string fullQualifiedNamespace = "<fully_qualified_namespace>";
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";
 await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
 await using ServiceBusReceiver receiver = client.CreateReceiver(queueName);
@@ -25,7 +25,7 @@ int numberOfMessagesDeleted = await receiver.PurgeMessagesAsync();
 For scenarios where you would like to delete all messages enqueued before a given date, `PurgeMessagesAsync` accepts an optional parameter to specify the cut-off point.
 
 ```C# Snippet:ServiceBusPurgeMessagesByDate
-string fullQualifiedNamespace = "<fully_qualified_namespace>";
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";;
 await using ServiceBusClient client = new(fullQualifiedNamespace, new DefaultAzureCredential());
 await using ServiceBusReceiver receiver = client.CreateReceiver(queueName);
@@ -42,7 +42,7 @@ When you wish to only delete some number of messages from the entity, rather tha
 Note that the service may delete fewer messages than were requested, but will never delete more. It is also important to be aware that if there is a receiver reading the entity when `DeleteMessages` is called, any locked messages will not be deleted.
 
 ```C# Snippet:ServiceBusDeleteMessages
-string fullQualifiedNamespace = "<fully_qualified_namespace>";
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";
 await using ServiceBusClient client = new(fullQualifiedNamespace, new DefaultAzureCredential());
 await using ServiceBusReceiver receiver = client.CreateReceiver(queueName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample17_BatchDelete.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample17_BatchDelete.md
@@ -27,7 +27,7 @@ For scenarios where you would like to delete all messages enqueued before a give
 ```C# Snippet:ServiceBusPurgeMessagesByDate
 string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";;
-await using ServiceBusClient client = new(fullQualifiedNamespace, new DefaultAzureCredential());
+await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
 await using ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 // Delete all messages in the queue that were enqueued more than a year ago.
@@ -44,7 +44,7 @@ Note that the service may delete fewer messages than were requested, but will ne
 ```C# Snippet:ServiceBusDeleteMessages
 string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";
-await using ServiceBusClient client = new(fullQualifiedNamespace, new DefaultAzureCredential());
+await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
 await using ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 // Delete the oldest 50 messages in the queue.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_SendReceive.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_SendReceive.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample02_MessageSettlement.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample02_MessageSettlement.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using System.Transactions;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample07_CrudOperations.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample07_CrudOperations.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus.Administration;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample09_Extensibility.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample09_Extensibility.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 using Plugins;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample10_ClaimCheck.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample10_ClaimCheck.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using NUnit.Framework;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample11_CloudEvents.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample11_CloudEvents.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample12_ManagingRules.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample12_ManagingRules.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Azure.Messaging.ServiceBus.Administration;
 using NUnit.Framework;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample13_AdvancedConfiguration.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample13_AdvancedConfiguration.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample14_AMQPMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample14_AMQPMessage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.Amqp;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample16_CrossReceiverMessageSettlement.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample16_CrossReceiverMessageSettlement.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Core.Amqp;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples
@@ -17,11 +18,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             {
                 string fullyQualifiedNamespace = TestEnvironment.FullyQualifiedNamespace;
                 string queueName = scope.QueueName;
-                var credential = TestEnvironment.Credential;
 
                 #region Snippet:ServiceBusWriteReceivedMessage
 #if SNIPPET
-                DefaultAzureCredential credential = new();
+                var credential = new DefaultAzureCredential();
+#else
+                var credential = TestEnvironment.Credential;
 #endif
                 ServiceBusClient client1 = new(fullyQualifiedNamespace, credential);
                 ServiceBusSender sender = client1.CreateSender(queueName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample17_BatchDelete.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample17_BatchDelete.cs
@@ -45,11 +45,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 #if SNIPPET
                 string fullyQualifiedNamespace = "<fully_qualified_namespace>";
                 string queueName = "<queue_name>";;
-                await using ServiceBusClient client = new(fullQualifiedNamespace, new DefaultAzureCredential());
+                await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
 #else
-                string fullQualifiedNamespace = TestEnvironment.FullyQualifiedNamespace;
+                string fullyQualifiedNamespace = TestEnvironment.FullyQualifiedNamespace;
                 string queueName = scope.QueueName;
-                await using ServiceBusClient client = new(fullQualifiedNamespace, TestEnvironment.Credential);
+                await using ServiceBusClient client = new(fullyQualifiedNamespace, TestEnvironment.Credential);
 #endif
                 await using ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
@@ -72,11 +72,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 #if SNIPPET
                 string fullyQualifiedNamespace = "<fully_qualified_namespace>";
                 string queueName = "<queue_name>";
-                await using ServiceBusClient client = new(fullQualifiedNamespace, new DefaultAzureCredential());
+                await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
 #else
-                string fullQualifiedNamespace = TestEnvironment.FullyQualifiedNamespace;
+                string fullyQualifiedNamespace = TestEnvironment.FullyQualifiedNamespace;
                 string queueName = scope.QueueName;
-                await using ServiceBusClient client = new(fullQualifiedNamespace, TestEnvironment.Credential);
+                await using ServiceBusClient client = new(fullyQualifiedNamespace, TestEnvironment.Credential);
 #endif
                 await using ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample17_BatchDelete.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample17_BatchDelete.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples
@@ -16,7 +17,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             {
                 #region Snippet:ServiceBusPurgeMessages
 #if SNIPPET
-                string fullQualifiedNamespace = "<fully_qualified_namespace>";
+                string fullyQualifiedNamespace = "<fully_qualified_namespace>";
                 string queueName = "<queue_name>";
                 await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
 #else
@@ -42,7 +43,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             {
                 #region Snippet:ServiceBusPurgeMessagesByDate
 #if SNIPPET
-                string fullQualifiedNamespace = "<fully_qualified_namespace>";
+                string fullyQualifiedNamespace = "<fully_qualified_namespace>";
                 string queueName = "<queue_name>";;
                 await using ServiceBusClient client = new(fullQualifiedNamespace, new DefaultAzureCredential());
 #else
@@ -69,7 +70,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             {
                 #region Snippet:ServiceBusDeleteMessages
 #if SNIPPET
-                string fullQualifiedNamespace = "<fully_qualified_namespace>";
+                string fullyQualifiedNamespace = "<fully_qualified_namespace>";
                 string queueName = "<queue_name>";
                 await using ServiceBusClient client = new(fullQualifiedNamespace, new DefaultAzureCredential());
 #else

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -30,7 +30,6 @@ extends:
   parameters:
     SDKType: client
     ServiceDirectory: servicebus
-    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.Messaging.ServiceBus

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -30,7 +30,7 @@ extends:
   parameters:
     SDKType: client
     ServiceDirectory: servicebus
-    BuildSnippets: false
+    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.Messaging.ServiceBus


### PR DESCRIPTION
ServiceBus was explicitly opted out of the default behavior of building snippets. Don't have the history on this but removing this after I ran into a typo in one of the snippets I fixed as part of SFI snippet upgrades.
