### PR TITLE
Fix Fully Disabled Snippets

### DIFF
--- a/eng/scripts/Build-Snippets.ps1
+++ b/eng/scripts/Build-Snippets.ps1
@@ -18,11 +18,12 @@ Set-StrictMode -Version 4
 $TargetProjects = $ProjectNames -split ","
 $RepoRoot = Resolve-Path (Join-Path "$PSScriptRoot" ".." "..")
 
-$snippetEnabledProjects = Get-ChildItem -Recurse "$PackageInfoFolder" *.json `
+$snippetEnabledProjects = (Get-ChildItem -Recurse "$PackageInfoFolder" *.json `
 | Foreach-Object { Get-Content -Raw -Path $_.FullName | ConvertFrom-Json } `
 | Where-Object { $_.ArtifactName -in $TargetProjects -and $_.CIParameters.BuildSnippets -eq $true }
+| ForEach-Object { $_.ArtifactName }) -join ","
 
-$scopedFile = Write-PkgInfoToDependencyGroupFile -OutputPath "$RepoRoot" -PackageInfoFolder $PackageInfoFolder -ProjectNames $TargetProjects
+$scopedFile = Write-PkgInfoToDependencyGroupFile -OutputPath "$RepoRoot" -PackageInfoFolder $PackageInfoFolder -ProjectNames $snippetEnabledProjects
 
 Write-Host "Writing project list to $scopedFile"
 Write-Host (Get-Content -Raw -Path $scopedFile)

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -121,7 +121,7 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
     if ($ciProps) {
       # CheckAOTCompat is opt _in_, so we should default to false if not specified
       $shouldAot = GetValueSafelyFrom-Yaml $ciProps.ParsedYml @("extends", "parameters", "CheckAOTCompat")
-      if ($shouldAot) {
+      if ($null -ne $shouldAot) {
         $parsedBool = $null
         if ([bool]::TryParse($shouldAot, [ref]$parsedBool)) {
           $pkgProp.CIParameters["CheckAOTCompat"] = $parsedBool


### PR DESCRIPTION
`Write-PkgInfoToDependencyGroupFile` rightfully throws if there are no packages provided. 