### PR TITLE
[Search] Fixing incorrect use of ReadOnlyMemory in documentation

### DIFF
--- a/sdk/search/Azure.Search.Documents/src/Indexes/VectorSearchFieldAttribute.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/VectorSearchFieldAttribute.cs
@@ -7,7 +7,7 @@ using Azure.Search.Documents.Indexes.Models;
 namespace Azure.Search.Documents.Indexes
 {
     /// <summary>
-    /// Attributes a ReadOnlyMemory&lt;float&gt; vector field, allowing its use with the VectorSearch indexes.
+    /// Attributes a Collection(<see cref="SearchFieldDataType.Single"/>) vector field, allowing its use with the VectorSearch indexes.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class VectorSearchFieldAttribute : Attribute, ISearchFieldAttribute


### PR DESCRIPTION
Related to: https://github.com/Azure/azure-sdk-for-net/issues/48164

Docstrings in class `VectorSearchFieldAttribute` incorrectly mention a "ReadOnlyMemory<float> vector field", which lead customers to believe the attribute can be used with `ReadOnlyMemory<T>` types.

This should be corrected to "Collection(SearchFieldDataType.Single) vector field".