### PR TITLE
remove generator-specific SCM dep

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -207,7 +207,6 @@
 
   <ItemGroup Condition="'$(IsGeneratorLibrary)' == 'true'">
     <PackageReference Update="Microsoft.TypeSpec.Generator.ClientModel" Version="1.0.0-alpha.20250317.2" />
-    <PackageReference Update="System.ClientModel" Version="1.3.0" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
This is no longer needed as the repo-wide version has been updated.