### PR TITLE
[Search] Add unit tests to validate the GetIndexStatsSummary API

### DIFF
--- a/sdk/search/Azure.Search.Documents/assets.json
+++ b/sdk/search/Azure.Search.Documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/search/Azure.Search.Documents",
-  "Tag": "net/search/Azure.Search.Documents_7aedfaf14a"
+  "Tag": "net/search/Azure.Search.Documents_d95b07f81b"
 }

--- a/sdk/search/Azure.Search.Documents/tests/SearchIndexClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchIndexClientTests.cs
@@ -132,6 +132,35 @@ namespace Azure.Search.Documents.Tests
         }
 
         [Test]
+        [ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2025_03_01_Preview)]
+        public async Task GetIndexStatsSummary()
+        {
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+
+            SearchIndexClient client = resources.GetIndexClient();
+            Response<ListIndexStatsSummary> response = await client.GetIndexStatsSummaryAsync();
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.IsNotNull(response.Value);
+            Assert.IsNotNull(response.Value.IndexesStatistics);
+            Assert.AreEqual(1, response.Value.IndexesStatistics.Count);
+            Assert.AreEqual(resources.IndexName, response.Value.IndexesStatistics[0].Name);
+        }
+
+        [Test]
+        [ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2025_03_01_Preview)]
+        public async Task GetIndexStatsSummaryWithNoIndexes()
+        {
+            await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);
+
+            SearchIndexClient client = resources.GetIndexClient();
+            Response<ListIndexStatsSummary> response = await client.GetIndexStatsSummaryAsync();
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.IsNotNull(response.Value);
+            Assert.IsNotNull(response.Value.IndexesStatistics);
+            Assert.AreEqual(0, response.Value.IndexesStatistics.Count);
+        }
+
+        [Test]
         [SyncOnly]
         public void CreateIndexParameterValidation()
         {


### PR DESCRIPTION
Adding unit tests to this new API now that the deployment is completed on the service side.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/48721.