### PR TITLE
Update token exchange API routes to be called, prevent update of scop…

### DIFF
--- a/sdk/communication/Azure.Communication.Common/src/EntraTokenCredential.cs
+++ b/sdk/communication/Azure.Communication.Common/src/EntraTokenCredential.cs
@@ -18,11 +18,11 @@ namespace Azure.Communication
     internal sealed class EntraTokenCredential : ICommunicationTokenCredential
     {
         private const string TeamsExtensionScopePrefix = "https://auth.msft.communication.azure.com/";
-        private const string ComunicationClientsScopePrefix = "https://communication.azure.com/clients/";
+        private const string CommunicationClientsScopePrefix = "https://communication.azure.com/clients/";
         private const string TeamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken";
         private const string TeamsExtensionApiVersion = "2025-03-02-preview";
-        private const string ComunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
-        private const string ComunicationClientsApiVersion = "2025-03-02-preview";
+        private const string CommunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
+        private const string CommunicationClientsApiVersion = "2025-03-02-preview";
 
         private HttpPipeline _pipeline;
         private string _resourceEndpoint;
@@ -136,19 +136,19 @@ namespace Azure.Communication
         {
             if (_scopes == null || !_scopes.Any())
             {
-                throw new ArgumentException($"Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {ComunicationClientsScopePrefix}.", nameof(_scopes));
+                throw new ArgumentException($"Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {CommunicationClientsScopePrefix}.", nameof(_scopes));
             }
             else if (_scopes.All(item => item.StartsWith(TeamsExtensionScopePrefix)))
             {
                 return (TeamsExtensionEndpoint, TeamsExtensionApiVersion);
             }
-            else if (_scopes.All(item => item.StartsWith(ComunicationClientsScopePrefix)))
+            else if (_scopes.All(item => item.StartsWith(CommunicationClientsScopePrefix)))
             {
-                return (ComunicationClientsEndpoint, ComunicationClientsApiVersion);
+                return (CommunicationClientsEndpoint, CommunicationClientsApiVersion);
             }
             else
             {
-                throw new ArgumentException($"Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {ComunicationClientsScopePrefix}.", nameof(_scopes));
+                throw new ArgumentException($"Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {CommunicationClientsScopePrefix}.", nameof(_scopes));
             }
         }
 

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
@@ -25,7 +25,7 @@ namespace Azure.Communication.Identity
         protected string TokenResponse = string.Format(TokenResponseTemplate, SampleToken, SampleTokenExpiry);
 
         private Mock<TokenCredential> _mockTokenCredential = null!;
-        private const string comunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
+        private const string communicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
         private const string communicationClientsPrefix = "https://communication.azure.com/clients/";
         private const string communicationClientsScope = communicationClientsPrefix + "VoIP";
         private const string teamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken";
@@ -124,13 +124,13 @@ namespace Azure.Communication.Identity
             }
             else
             {
-                Assert.AreEqual(comunicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
+                Assert.AreEqual(communicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
             }
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
-        public async Task EntraTokenCredential_InitWithoutScopes_ReturnsComunicationClientsToken()
+        public async Task EntraTokenCredential_InitWithoutScopes_ReturnsCommunicationClientsToken()
         {
             // Arrange
             var expiryTime = DateTimeOffset.Parse(SampleTokenExpiry, null, System.Globalization.DateTimeStyles.RoundtripKind);
@@ -144,7 +144,7 @@ namespace Azure.Communication.Identity
             // Assert
             Assert.AreEqual(SampleToken, token.Token);
             Assert.AreEqual(token.ExpiresOn, expiryTime);
-            Assert.AreEqual(comunicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
+            Assert.AreEqual(communicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
@@ -26,8 +26,9 @@ namespace Azure.Communication.Identity
 
         private Mock<TokenCredential> _mockTokenCredential = null!;
         private const string comunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
-        private const string communicationClientsScope = "https://communication.azure.com/clients/VoIP";
-        private const string teamsExtensionEndpoint = "/access/teamsPhone/:exchangeAccessToken";
+        private const string communicationClientsPrefix = "https://communication.azure.com/clients/";
+        private const string communicationClientsScope = communicationClientsPrefix + "VoIP";
+        private const string teamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken";
         private const string teamsExtensionScope = "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls";
         private string _resourceEndpoint = "https://myResource.communication.azure.com";
 
@@ -152,18 +153,20 @@ namespace Azure.Communication.Identity
         {
             // Arrange
             var expiryTime = DateTimeOffset.Parse(SampleTokenExpiry, null, System.Globalization.DateTimeStyles.RoundtripKind);
-            var newToken = "newToken";
             var refreshOn = DateTimeOffset.Now;
+            _mockTokenCredential.Reset();
             _mockTokenCredential
                 .SetupSequence(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new AccessToken("Entra token for call from constructor", refreshOn))
                 .ReturnsAsync(new AccessToken("Entra token for the first getToken call token", expiryTime));
 
-            var options = CreateEntraTokenCredentialOptions(scopes);
+            var newToken = "newToken";
             var latestTokenResponse = string.Format(TokenResponseTemplate, newToken, SampleTokenExpiry);
             var mockTransport = CreateMockTransport(new[] { CreateMockResponse(200, TokenResponse), CreateMockResponse(200, latestTokenResponse) });
-            var entraTokenCredential = new EntraTokenCredential(options, mockTransport);
+            var options = CreateEntraTokenCredentialOptions(scopes);
+
             // Act
+            var entraTokenCredential = new EntraTokenCredential(options, mockTransport);
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert for cached tokens are updated
@@ -270,6 +273,38 @@ namespace Azure.Communication.Identity
             // Act & Assert
             var ex = Assert.ThrowsAsync<ArgumentException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
             StringAssert.Contains("Scopes validation failed. Ensure all scopes start with either", ex?.Message);
+        }
+
+        [Test]
+        public async Task EntraTokenCredential_GetToken_NoIssueIfScopesChanged()
+        {
+            var scopes = new string[] { communicationClientsScope, communicationClientsPrefix + "Chat" };
+
+            // Arrange
+            _mockTokenCredential.Reset();
+            var expiryTime = DateTimeOffset.Parse(SampleTokenExpiry, null, System.Globalization.DateTimeStyles.RoundtripKind);
+            var refreshOn = DateTimeOffset.Now;
+            _mockTokenCredential
+                .SetupSequence(tc => tc.GetTokenAsync(It.Is<TokenRequestContext>(c => c.Scopes.SequenceEqual(scopes)), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AccessToken("Entra token for call from constructor", refreshOn))
+                .ReturnsAsync(new AccessToken("Entra token for the first getToken call token", expiryTime));
+
+            var newToken = "newToken";
+            var latestTokenResponse = string.Format(TokenResponseTemplate, newToken, SampleTokenExpiry);
+            var mockTransport = CreateMockTransport(new[] { CreateMockResponse(200, TokenResponse), CreateMockResponse(200, latestTokenResponse) });
+
+            var options = CreateEntraTokenCredentialOptions((string[])scopes.Clone());
+
+            // Act
+            var entraTokenCredential = new EntraTokenCredential(options, mockTransport);
+
+            // Change scopes
+            options.Scopes[1] = teamsExtensionScope;
+            var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
+
+            // Assert for cached tokens are updated
+            Assert.AreEqual(newToken, token.Token);
+            _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         private EntraCommunicationTokenCredentialOptions CreateEntraTokenCredentialOptions(string[] scopes)


### PR DESCRIPTION
…es through options

Update route and api version in  token exchange API called by credential routes to be consistent by REST API review.

Make sure that update of scopes in EntraCommunicationTokenCredential won't affect already constructed EntraTokenCredential.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
