### PR TITLE
Providing scopes as optional parameter

### DIFF
--- a/sdk/communication/Azure.Communication.Common/README.md
+++ b/sdk/communication/Azure.Communication.Common/README.md
@@ -118,17 +118,15 @@ var entraTokenCredential = new InteractiveBrowserCredential(options);
 
 var entraTokenCredentialOptions = new EntraCommunicationTokenCredentialOptions(
     resourceEndpoint: "https://<your-resource>.communication.azure.com",
-    entraTokenCredential: entraTokenCredential)
-    {
-      Scopes = new[] { "https://communication.azure.com/clients/VoIP" }
-    };
+    entraTokenCredential: entraTokenCredential,
+    "https://communication.azure.com/clients/VoIP");
 
 var credential = new CommunicationTokenCredential(entraTokenCredentialOptions);
 
 ```
 
 The same approach can be used for authorizing an Entra user with a Teams license to use Teams Phone Extensibility features through your Azure Communication Services resource.
-This requires providing the `https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls` scope
+This requires providing the `https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls` scope. Only one of those scopes can be used at a time.
 ```C# 
 var options = new InteractiveBrowserCredentialOptions
     {
@@ -140,11 +138,8 @@ var entraTokenCredential = new InteractiveBrowserCredential(options);
 
 var entraTokenCredentialOptions = new EntraCommunicationTokenCredentialOptions(
     resourceEndpoint: "https://<your-resource>.communication.azure.com",
-    entraTokenCredential: entraTokenCredential)
-    )
-    {
-      Scopes = new[] { "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls" }
-    };
+    entraTokenCredential: entraTokenCredential,
+    "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls");
 
 var credential = new CommunicationTokenCredential(entraTokenCredentialOptions);
 

--- a/sdk/communication/Azure.Communication.Common/src/EntraCommunicationTokenCredentialOptions.cs
+++ b/sdk/communication/Azure.Communication.Common/src/EntraCommunicationTokenCredentialOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using Azure.Core;
 
 namespace Azure.Communication
@@ -25,23 +26,27 @@ namespace Azure.Communication
         /// <summary>
         /// The scopes required for the Entra user token. These scopes determine the permissions granted to the token. For example, ["https://communication.azure.com/clients/VoIP"].
         /// </summary>
-        public string[] Scopes { get; set; }
+        public string[] Scopes { get; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="EntraCommunicationTokenCredentialOptions"/>.
         /// </summary>
         /// <param name="resourceEndpoint">The URI of the Azure Communication Services resource.For example, https://myResource.communication.azure.com.</param>
         /// <param name="entraTokenCredential">The credential capable of fetching an Entra user token.</param>
+        /// <param name="scopes">One or more scopes required for the Entra user token. Optional, "https://communication.azure.com/clients/VoIP" is be used if not provided.</param>"
         public EntraCommunicationTokenCredentialOptions(
             string resourceEndpoint,
-            TokenCredential entraTokenCredential)
+            TokenCredential entraTokenCredential,
+            params string[] scopes)
         {
             Argument.AssertNotNullOrEmpty(resourceEndpoint, nameof(resourceEndpoint));
             Argument.AssertNotNull(entraTokenCredential, nameof(entraTokenCredential));
 
             this.ResourceEndpoint = resourceEndpoint;
             this.TokenCredential = entraTokenCredential;
-            this.Scopes = DefaultScopes;
+
+            var validScopes = scopes?.Where(s => !string.IsNullOrEmpty(s)).ToArray() ?? Array.Empty<string>();
+            this.Scopes = validScopes.Length > 0 ? validScopes : DefaultScopes;
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/EntraCommunicationTokenCredentialOptionsTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/EntraCommunicationTokenCredentialOptionsTest.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Communication.Identity
+{
+    [TestFixture]
+    public class EntraCommunicationTokenCredentialOptionsTest
+    {
+        private Mock<TokenCredential> _mockTokenCredential = null!;
+        private const string communicationClientsPrefix = "https://communication.azure.com/clients/";
+        private const string communicationClientsScope = communicationClientsPrefix + "VoIP";
+        private const string defaultScope = communicationClientsPrefix + ".default";
+        private const string teamsExtensionScope = "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls";
+        private string _resourceEndpoint = "https://myResource.communication.azure.com";
+
+        private static readonly object[] validScopes =
+        {
+            new object[] { new string[] { communicationClientsScope }},
+            new object[] { new string[] { teamsExtensionScope } }
+        };
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockTokenCredential = new Mock<TokenCredential>();
+        }
+
+        [Test, TestCaseSource(nameof(validScopes))]
+        public void EntraCommunicationTokenCredentialOptionsTest_Init_ThrowsErrorWithNulls(string[] scopes)
+        {
+            Assert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
+                null,
+                _mockTokenCredential.Object,
+                scopes));
+
+            Assert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
+                "",
+                _mockTokenCredential.Object,
+                scopes));
+
+            Assert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                null,
+                scopes));
+        }
+
+        [Test]
+        public void EntraCommunicationTokenCredentialOptionsTest_InitWithoutScopes_InitsWithDefaultScope()
+        {
+            var credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(defaultScope, credential.Scopes[0]);
+
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                null);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(defaultScope, credential.Scopes[0]);
+
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                null, null);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(defaultScope, credential.Scopes[0]);
+
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                Array.Empty<string>());
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(defaultScope, credential.Scopes[0]);
+        }
+
+        [Test]
+        public void EntraCommunicationTokenCredentialOptionsTest_InitByParameters()
+        {
+            var credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                communicationClientsScope);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(communicationClientsScope, credential.Scopes[0]);
+
+            var scope = new string[] { communicationClientsScope, teamsExtensionScope };
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                scope[0], scope[1]);
+            Assert.AreEqual(scope.Length, credential.Scopes.Length);
+            Assert.AreEqual(scope, credential.Scopes);
+
+            scope = new string[] { communicationClientsScope, teamsExtensionScope, communicationClientsPrefix + "Chat" };
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                scope[0], scope[1], scope[2]);
+            Assert.AreEqual(scope.Length, credential.Scopes.Length);
+            Assert.AreEqual(scope, credential.Scopes);
+        }
+
+        [Test]
+        public void EntraCommunicationTokenCredentialOptionsTest_InitByArray()
+        {
+            var scope = new string[] { communicationClientsScope };
+            var credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                scope);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(communicationClientsScope, credential.Scopes[0]);
+
+            scope = new string[] { communicationClientsScope, teamsExtensionScope };
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                scope);
+            Assert.AreEqual(scope.Length, credential.Scopes.Length);
+            Assert.AreEqual(scope, credential.Scopes);
+
+            scope = new string[] { communicationClientsScope, teamsExtensionScope, communicationClientsPrefix + "Chat" };
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                scope);
+            Assert.AreEqual(scope.Length, credential.Scopes.Length);
+            Assert.AreEqual(scope, credential.Scopes);
+        }
+
+        [Test]
+        public void EntraCommunicationTokenCredentialOptionsTest_NullInScopes_Skipped()
+        {
+            var credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                communicationClientsScope, null);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(communicationClientsScope, credential.Scopes[0]);
+
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                null, communicationClientsScope, null);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(communicationClientsScope, credential.Scopes[0]);
+
+            var scope = new string[] { communicationClientsScope, teamsExtensionScope };
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                scope[0], null, scope[1]);
+            Assert.AreEqual(scope.Length, credential.Scopes.Length);
+            Assert.AreEqual(scope, credential.Scopes);
+        }
+
+        [Test]
+        public void EntraCommunicationTokenCredentialOptionsTest_EmptyStringInScopes_Skipped()
+        {
+            var credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                communicationClientsScope, String.Empty);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(communicationClientsScope, credential.Scopes[0]);
+
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                String.Empty, communicationClientsScope, null);
+            Assert.AreEqual(1, credential.Scopes.Length);
+            Assert.AreEqual(communicationClientsScope, credential.Scopes[0]);
+
+            var scope = new string[] { communicationClientsScope, teamsExtensionScope };
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                scope[0], String.Empty, null, String.Empty, scope[1]);
+            Assert.AreEqual(scope.Length, credential.Scopes.Length);
+            Assert.AreEqual(scope, credential.Scopes);
+
+            var scopeWithEmpty = new string[] { String.Empty, communicationClientsScope, String.Empty, teamsExtensionScope, String.Empty, String.Empty, communicationClientsPrefix + "Chat" };
+            var expectedScope = new string[] { communicationClientsScope, teamsExtensionScope, communicationClientsPrefix + "Chat" };
+            credential = new EntraCommunicationTokenCredentialOptions(
+                _resourceEndpoint,
+                _mockTokenCredential.Object,
+                scopeWithEmpty);
+            Assert.AreEqual(expectedScope.Length, credential.Scopes.Length);
+            Assert.AreEqual(expectedScope, credential.Scopes);
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
@@ -41,8 +41,6 @@ namespace Azure.Communication.Identity
             new object[] { new string[] { communicationClientsScope, teamsExtensionScope } },
             new object[] { new string[] { teamsExtensionScope, communicationClientsScope } },
             new object[] { new string[] { "invalidScope" } },
-            new object[] { new string[] { "" } },
-            new object[] { new string[] { } }
         };
 
         [SetUp]
@@ -53,41 +51,6 @@ namespace Azure.Communication.Identity
             _mockTokenCredential
               .Setup(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
               .ReturnsAsync(new AccessToken(SampleToken, expiryTime));
-        }
-
-        [Test, TestCaseSource(nameof(validScopes))]
-        public void EntraTokenCredential_Init_ThrowsErrorWithNulls(string[] scopes)
-        {
-            Assert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
-                null,
-                _mockTokenCredential.Object)
-            {
-                Scopes = scopes
-            });
-
-            Assert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
-                "",
-                _mockTokenCredential.Object)
-            {
-                Scopes = scopes
-            });
-
-            Assert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
-                _resourceEndpoint,
-                null)
-            {
-                Scopes = scopes
-            });
-        }
-
-        [Test]
-        public void EntraTokenCredential_InitWithoutScopes_InitsWithDefaultScope()
-        {
-            var credential = new EntraCommunicationTokenCredentialOptions(
-                _resourceEndpoint,
-                _mockTokenCredential.Object);
-            var scopes = new[] { "https://communication.azure.com/clients/.default" };
-            Assert.AreEqual(credential.Scopes, scopes);
         }
 
         [Test, TestCaseSource(nameof(validScopes))]
@@ -274,10 +237,7 @@ namespace Azure.Communication.Identity
 
         private EntraCommunicationTokenCredentialOptions CreateEntraTokenCredentialOptions(string[] scopes)
         {
-            return new EntraCommunicationTokenCredentialOptions(_resourceEndpoint, _mockTokenCredential.Object)
-            {
-                Scopes = scopes
-            };
+            return new EntraCommunicationTokenCredentialOptions(_resourceEndpoint, _mockTokenCredential.Object, scopes);
         }
 
         private MockResponse CreateMockResponse(int statusCode, string body)


### PR DESCRIPTION
Optional Scopes property of EntraCommunicationTokenCredentialOptions.cs is immutable now and needs to be provided as (one or more) parameter. If not provided, default is used as before.
