### PR TITLE
[Search] Fixing Sample01: removing new[]

### DIFF
--- a/sdk/search/Azure.Search.Documents/samples/Sample02_Service.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample02_Service.md
@@ -100,7 +100,7 @@ SearchIndex index = new SearchIndex(indexName)
                 new SearchableField("StreetAddress"),
                 new SearchableField("City") { IsFilterable = true, IsSortable = true, IsFacetable = true },
                 new SearchableField("StateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                new SearchableField("Country") { SynonymMapNames = new[] { synonymMapName }, IsFilterable = true, IsSortable = true, IsFacetable = true },
+                new SearchableField("Country") { SynonymMapNames = { synonymMapName }, IsFilterable = true, IsSortable = true, IsFacetable = true },
                 new SearchableField("PostalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
             }
         }

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
@@ -242,7 +242,7 @@ namespace Azure.Search.Documents.Tests.Samples
                                 new SearchableField("StreetAddress"),
                                 new SearchableField("City") { IsFilterable = true, IsSortable = true, IsFacetable = true },
                                 new SearchableField("StateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                                new SearchableField("Country") { SynonymMapNames = new[] { synonymMapName }, IsFilterable = true, IsSortable = true, IsFacetable = true },
+                                new SearchableField("Country") { SynonymMapNames = { synonymMapName }, IsFilterable = true, IsSortable = true, IsFacetable = true },
                                 new SearchableField("PostalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
                             }
                         }


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-net/issues/49102.

Removing the accidental invocation of the SynonymMapNames' setter in our sample as it's an `internal` member of `SearchableField`.