### PR TITLE
Use windows 2022 datacenter image for storage live tests

### DIFF
--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -476,7 +476,7 @@
                 "imageReference": {
                   "publisher": "MicrosoftWindowsServer",
                   "offer": "WindowsServer",
-                  "sku": "2019-Datacenter",
+                  "sku": "2022-Datacenter",
                   "version": "latest"
                 },
                 "osDisk": {


### PR DESCRIPTION
This should remove TLS version violations.