### PR TITLE
Fix Issue with parameterless artifacts

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -151,6 +151,13 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
         $pkgProp.CIParameters["BuildSnippets"] = $true
       }
     }
+    # if the package isn't associated with a CI.yml, we still want to set the defaults values for these parameters
+    # so that when we are checking the package set for which need to "Build Snippets" or "Check AOT" we won't crash due to the property being null
+    else {
+      $pkgProp.CIParameters["CheckAOTCompat"] = $false
+      $pkgProp.CIParameters["AOTTestInputs"] = @()
+      $pkgProp.CIParameters["BuildSnippets"] = $true
+    }
 
     $allPackageProps += $pkgProp
   }


### PR DESCRIPTION
This turned up in @m-redding 's PR check [over here](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4706842&view=logs&jobId=3d7563ef-542b-53e3-b128-b2254dfd77e3&j=3d7563ef-542b-53e3-b128-b2254dfd77e3&t=a8fac941-abe2-568c-a163-aad503a88f28).

This was occurring because `Azure.OpenAI.Assistant` wasn't added to a `ci.yml`, so it _wasn't_ getting populated with the necessary `CIParameters`. Due to that, we were crashing while filtering the packages for which ones "should AOT check."

It could be fixed by properly adding `Azure.OpenAI.Assistant` to the artifact list in the openai `ci.yml`, but it turned up a real issue that this pr resolves!