### PR TITLE
Always pack in `release` mode

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -97,7 +97,7 @@ steps:
           /p:SDKType=${{ parameters.SDKType }} `
           /p:IncludeTests=false `
           /p:PublicSign=false $(VersioningProperties) `
-          /p:Configuration=$(BuildConfiguration) `
+          /p:Configuration=Release `
           /p:CommitSHA=$(Build.SourceVersion) `
           /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) `
           /p:ServiceDirectory=* `
@@ -116,7 +116,7 @@ steps:
         /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
         /p:IncludeTests=false
         /p:PublicSign=false $(VersioningProperties)
-        /p:Configuration=$(BuildConfiguration)
+        /p:Configuration=Release
         /p:CommitSHA=$(Build.SourceVersion)
         /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory)
         $(DiagnosticArguments)

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -89,8 +89,11 @@ steps:
     parameters:
       LogFilePath: $(Build.ArtifactStagingDirectory)/pack.binlog
 
-  # only use the project list override file if the service directory is not auto
+  # Due to discovering differing pack errors during debug vs release builds, we simply always opt into the more advanced
+  # release pack. This ensures that the public ci is packing the same way as what we will eventually release, and we won't be
+  # surprised by new errors that pop up only in internal when public CI was clean.
   - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+    # only use the project list override file if the service directory is not auto
     - pwsh: |
         dotnet pack eng/service.proj -warnaserror `
           /p:ValidateRunApiCompat=true `

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -137,7 +137,7 @@ steps:
       arguments: >
         -RepoRoot $(Build.SourcesDirectory)
         -PackageInfoDirectory $(Build.ArtifactStagingDirectory)/PackageInfo
-        -BuildConfiguration $(BuildConfiguration)
+        -BuildConfiguration Release
       pwsh: true
       workingDirectory: $(Pipeline.Workspace)
     displayName: Update package properties with namespaces

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -4,10 +4,7 @@ variables:
   AdditionalTestArguments: ''
   skipComponentGovernanceDetection: true
   nugetMultiFeedWarnLevel: 'none'
-  ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-    BuildConfiguration: 'Debug'
-  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    BuildConfiguration: 'Release'
+  BuildConfiguration: 'Release'
   DocFxVersion: 'v2.56.1'
   CollectCoverage: false
   NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages/

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -4,7 +4,10 @@ variables:
   AdditionalTestArguments: ''
   skipComponentGovernanceDetection: true
   nugetMultiFeedWarnLevel: 'none'
-  BuildConfiguration: 'Release'
+  ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+    BuildConfiguration: 'Debug'
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    BuildConfiguration: 'Release'
   DocFxVersion: 'v2.56.1'
   CollectCoverage: false
   NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages/


### PR DESCRIPTION
We should immediately see failures in `core` due to `System.ClientModel` exploding with `cref` errors.