### PR TITLE
Update commitId to get rid of config violation

### DIFF
--- a/sdk/ai/Azure.AI.Inference/tsp-location.yaml
+++ b/sdk/ai/Azure.AI.Inference/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/ai/ModelClient
 repo: Azure/azure-rest-api-specs
-commit: 317bc61a428bdbc6113f375f7c22b8575eff041f
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8

--- a/sdk/ai/Azure.AI.Inference/tsp-location.yaml
+++ b/sdk/ai/Azure.AI.Inference/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/ai/ModelClient
 repo: Azure/azure-rest-api-specs
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: 9524584541371b1fc89720e9325332f52f850e70

--- a/sdk/communication/Azure.Communication.ProgrammableConnectivity/tsp-location.yaml
+++ b/sdk/communication/Azure.Communication.ProgrammableConnectivity/tsp-location.yaml
@@ -1,4 +1,4 @@
-commit: 462574dbd02088c209bb1da3eef0d93f699e8de2
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
 repo: Azure/azure-rest-api-specs
 directory: specification/programmableconnectivity/Azure.ProgrammableConnectivity
 

--- a/sdk/communication/Azure.Communication.ProgrammableConnectivity/tsp-location.yaml
+++ b/sdk/communication/Azure.Communication.ProgrammableConnectivity/tsp-location.yaml
@@ -1,4 +1,3 @@
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: 35e1c956eb49d6307efc6b79b0c37cb287d4d2e7
 repo: Azure/azure-rest-api-specs
 directory: specification/programmableconnectivity/Azure.ProgrammableConnectivity
-

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tsp-location.yaml
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tsp-location.yaml
@@ -1,3 +1,3 @@
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: 72a8e363d667f0681fc3c63f3b6422d1063a2f19
 repo: Azure/azure-rest-api-specs
 directory: specification/confidentialledger/Microsoft.CodeTransparency

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tsp-location.yaml
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tsp-location.yaml
@@ -1,5 +1,3 @@
-commit: bdb83beae5c03e21a9778c5ba746f1f762831efb
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
 repo: Azure/azure-rest-api-specs
 directory: specification/confidentialledger/Microsoft.CodeTransparency
-additionalDirectories: []
-

--- a/sdk/databasewatcher/Azure.ResourceManager.DatabaseWatcher/tsp-location.yaml
+++ b/sdk/databasewatcher/Azure.ResourceManager.DatabaseWatcher/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/databasewatcher/DatabaseWatcher.Management
-commit: 0e8e3ecd19f7e804b70c6ec2ff5bc406666bff6f
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
 repo: Azure/azure-rest-api-specs

--- a/sdk/face/Azure.AI.Vision.Face/tsp-location.yaml
+++ b/sdk/face/Azure.AI.Vision.Face/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/ai/Face
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: 6aa6d3d429c1155be6e3cce7d7a4929ce602bf01
 repo: Azure/azure-rest-api-specs
 

--- a/sdk/face/Azure.AI.Vision.Face/tsp-location.yaml
+++ b/sdk/face/Azure.AI.Vision.Face/tsp-location.yaml
@@ -1,5 +1,4 @@
 directory: specification/ai/Face
-commit: 06c18ef1f7fa1fd30744f6d681b7281c18396bdf
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
 repo: Azure/azure-rest-api-specs
-additionalDirectories: []
 

--- a/sdk/purview/Azure.Analytics.Purview.DataMap/tsp-location.yaml
+++ b/sdk/purview/Azure.Analytics.Purview.DataMap/tsp-location.yaml
@@ -1,4 +1,3 @@
 repo: Azure/azure-rest-api-specs
-commit: 6f5c5d483c9bd284d57862244163d7ff09a83491
-additionalDirectories: []
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
 directory: specification/purview/Azure.Analytics.Purview.DataMap

--- a/sdk/purview/Azure.Analytics.Purview.DataMap/tsp-location.yaml
+++ b/sdk/purview/Azure.Analytics.Purview.DataMap/tsp-location.yaml
@@ -1,3 +1,3 @@
 repo: Azure/azure-rest-api-specs
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: d60d09058d070aba1bbaa5becab33fac08810c5c
 directory: specification/purview/Azure.Analytics.Purview.DataMap

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tsp-location.yaml
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tsp-location.yaml
@@ -1,3 +1,3 @@
 repo: Azure/azure-rest-api-specs
 directory: specification/schemaregistry/SchemaRegistry
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: b9bf4a18d355f3857f43bb6f4ad4fe06f467da37

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tsp-location.yaml
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tsp-location.yaml
@@ -1,4 +1,3 @@
 repo: Azure/azure-rest-api-specs
 directory: specification/schemaregistry/SchemaRegistry
-additionalDirectories: []
-commit: 462574dbd02088c209bb1da3eef0d93f699e8de2
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8

--- a/sdk/translation/Azure.AI.Translation.Document/tsp-location.yaml
+++ b/sdk/translation/Azure.AI.Translation.Document/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/translation/Azure.AI.DocumentTranslation
-commit: a605f581cff367622d933b0c9a0eaffd106b1a7a
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
 repo: Azure/azure-rest-api-specs

--- a/sdk/translation/Azure.AI.Translation.Document/tsp-location.yaml
+++ b/sdk/translation/Azure.AI.Translation.Document/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/translation/Azure.AI.DocumentTranslation
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: 1e7df61f78a4d334a21ad79a38414b163b0f1aaa
 repo: Azure/azure-rest-api-specs

--- a/sdk/translation/Azure.AI.Translation.Text/tsp-location.yaml
+++ b/sdk/translation/Azure.AI.Translation.Text/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/translation/Azure.AI.TextTranslation
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: 2aad49a1fcf08aedde3d281f893ddc744d5224cf
 repo: Azure/azure-rest-api-specs

--- a/sdk/translation/Azure.AI.Translation.Text/tsp-location.yaml
+++ b/sdk/translation/Azure.AI.Translation.Text/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/translation/Azure.AI.TextTranslation
-commit: eeb8d28f3dcc630e8eb99e10e0bfb371b4b22509
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
While bump tsp version, we found below error during regen.
```
azure-sdk/sdk/schemaregistry/Azure.Data.SchemaRegistry/TempTypeSpecFiles/SchemaRegistry/tspconfig.yaml:5:5 - error invalid-schema: Schema violation: must NOT have additional properties (/parameters/dependencies)
    additionalProperty: additionalDirectories
```
update the commit id to solve this.
