### PR TITLE
[Core] Wiring up rehydration token logic in data-plane

### DIFF
--- a/sdk/communication/Azure.Communication.Email/src/EmailSendOperation.cs
+++ b/sdk/communication/Azure.Communication.Email/src/EmailSendOperation.cs
@@ -184,6 +184,10 @@ namespace Azure.Communication.Email
             return OperationState<EmailSendResult>.Pending(rawResponse);
         }
 
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<EmailSendResult>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
+
         private static IDictionary<string, string> CreateAdditionalInformation(ErrorDetail error)
         {
             if (string.IsNullOrEmpty(error.ToString()))

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CreateEntryOperation.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CreateEntryOperation.cs
@@ -125,5 +125,9 @@ namespace Azure.Security.CodeTransparency
                 }
              }
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
@@ -79,6 +79,10 @@ namespace Azure.Security.ConfidentialLedger
             return OperationState.Pending(statusResponse);
         }
 
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
+
         /// <summary>
         /// The transactionId of the posted ledger entry.
         /// </summary>

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -58,17 +58,21 @@ namespace Azure.Core
                 apiVersionStr = !skipApiVersionOverride && TryGetApiVersion(startRequestUri, out ReadOnlySpan<char> apiVersion) ? apiVersion.ToString() : null;
             }
             var headerSource = GetHeaderSource(requestMethod, startRequestUri, response, apiVersionStr, out string nextRequestUri, out bool isNextRequestPolling);
-            if (headerSource == HeaderSource.None && IsFinalState(response, headerSource, out var failureState, out _))
-            {
-                return new CompletedOperation(failureState ?? GetOperationStateFromFinalResponse(requestMethod, response), requestMethod, startRequestUri);
-            }
 
             string? lastKnownLocation;
             if (!response.Headers.TryGetValue("Location", out lastKnownLocation))
             {
                 lastKnownLocation = null;
             }
-            return new NextLinkOperationImplementation(pipeline, requestMethod, startRequestUri, nextRequestUri, headerSource, lastKnownLocation, finalStateVia, apiVersionStr, isNextRequestPolling : isNextRequestPolling);
+
+            NextLinkOperationImplementation operation = new(pipeline, requestMethod, startRequestUri, nextRequestUri, headerSource, lastKnownLocation, finalStateVia, apiVersionStr, isNextRequestPolling: isNextRequestPolling);
+
+            if (headerSource == HeaderSource.None && IsFinalState(response, headerSource, out var failureState, out _))
+            {
+                return new CompletedOperation(failureState ?? GetOperationStateFromFinalResponse(requestMethod, response), operation);
+            }
+
+            return operation;
         }
 
         public static IOperation<T> Create<T>(
@@ -190,7 +194,7 @@ namespace Azure.Core
             }
         }
 
-        public RehydrationToken? GetRehydrationToken()
+        public RehydrationToken GetRehydrationToken()
             => GetRehydrationToken(RequestMethod, _startRequestUri, _nextRequestUri, _headerSource.ToString(), _lastKnownLocation, _finalStateVia.ToString(), OperationId);
 
         public static RehydrationToken GetRehydrationToken(
@@ -647,21 +651,17 @@ namespace Azure.Core
         {
             private readonly OperationState _operationState;
 
-            private readonly RequestMethod _requestMethod;
+            private readonly NextLinkOperationImplementation _operation;
 
-            private readonly Uri _startRequestUri;
-
-            public CompletedOperation(OperationState operationState, RequestMethod requestMethod, Uri startRequestUri)
+            public CompletedOperation(OperationState operationState, NextLinkOperationImplementation operation)
             {
                 _operationState = operationState;
-                _requestMethod = requestMethod;
-                _startRequestUri = startRequestUri;
+                _operation = operation;
             }
 
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(_operationState);
 
-            public RehydrationToken? GetRehydrationToken() =>
-                NextLinkOperationImplementation.GetRehydrationToken(_requestMethod, _startRequestUri, _startRequestUri.AbsoluteUri, "None", null, OperationFinalStateVia.OriginalUri.ToString());
+            public RehydrationToken GetRehydrationToken() => _operation.GetRehydrationToken();
         }
 
         private sealed class OperationToOperationOfT<T> : IOperation<T>
@@ -695,7 +695,7 @@ namespace Azure.Core
                 return OperationState<T>.Pending(state.RawResponse);
             }
 
-            public RehydrationToken? GetRehydrationToken() => _operation.GetRehydrationToken();
+            public RehydrationToken GetRehydrationToken() => _operation.GetRehydrationToken();
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -190,7 +190,7 @@ namespace Azure.Core
             }
         }
 
-        public RehydrationToken GetRehydrationToken()
+        public RehydrationToken? GetRehydrationToken()
             => GetRehydrationToken(RequestMethod, _startRequestUri, _nextRequestUri, _headerSource.ToString(), _lastKnownLocation, _finalStateVia.ToString(), OperationId);
 
         public static RehydrationToken GetRehydrationToken(
@@ -653,6 +653,8 @@ namespace Azure.Core
             }
 
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(_operationState);
+
+            public RehydrationToken? GetRehydrationToken() => null;
         }
 
         private sealed class OperationToOperationOfT<T> : IOperation<T>
@@ -685,6 +687,8 @@ namespace Azure.Core
 
                 return OperationState<T>.Pending(state.RawResponse);
             }
+
+            public RehydrationToken? GetRehydrationToken() => _operation.GetRehydrationToken();
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -190,7 +190,7 @@ namespace Azure.Core
             }
         }
 
-        public RehydrationToken GetRehydrationToken()
+        public RehydrationToken? GetRehydrationToken()
             => GetRehydrationToken(RequestMethod, _startRequestUri, _nextRequestUri, _headerSource.ToString(), _lastKnownLocation, _finalStateVia.ToString(), OperationId);
 
         public static RehydrationToken GetRehydrationToken(
@@ -660,7 +660,7 @@ namespace Azure.Core
 
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(_operationState);
 
-            public RehydrationToken GetRehydrationToken() =>
+            public RehydrationToken? GetRehydrationToken() =>
                 NextLinkOperationImplementation.GetRehydrationToken(_requestMethod, _startRequestUri, _startRequestUri.AbsoluteUri, "None", null, OperationFinalStateVia.OriginalUri.ToString());
         }
 

--- a/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
@@ -119,6 +119,8 @@ namespace Azure.Core
                 _operation = operation;
             }
 
+            public RehydrationToken? GetRehydrationToken() => _operation.GetRehydrationToken();
+
             public async ValueTask<OperationState<VoidValue>> UpdateStateAsync(bool async, CancellationToken cancellationToken)
             {
                 var state = await _operation.UpdateStateAsync(async, cancellationToken).ConfigureAwait(false);
@@ -172,6 +174,11 @@ namespace Azure.Core
         /// </list>
         /// </returns>
         ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get a token that can be used to rehydrate the operation.
+        /// </summary>
+        RehydrationToken? GetRehydrationToken();
     }
 
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
@@ -178,7 +178,7 @@ namespace Azure.Core
         /// <summary>
         /// Get a token that can be used to rehydrate the operation.
         /// </summary>
-        RehydrationToken? GetRehydrationToken();
+        RehydrationToken GetRehydrationToken();
     }
 
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
@@ -178,7 +178,7 @@ namespace Azure.Core
         /// <summary>
         /// Get a token that can be used to rehydrate the operation.
         /// </summary>
-        RehydrationToken GetRehydrationToken();
+        RehydrationToken? GetRehydrationToken();
     }
 
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternal.cs
@@ -119,7 +119,7 @@ namespace Azure.Core
                 _operation = operation;
             }
 
-            public RehydrationToken? GetRehydrationToken() => _operation.GetRehydrationToken();
+            public RehydrationToken GetRehydrationToken() => _operation.GetRehydrationToken();
 
             public async ValueTask<OperationState<VoidValue>> UpdateStateAsync(bool async, CancellationToken cancellationToken)
             {
@@ -178,7 +178,7 @@ namespace Azure.Core
         /// <summary>
         /// Get a token that can be used to rehydrate the operation.
         /// </summary>
-        RehydrationToken? GetRehydrationToken();
+        RehydrationToken GetRehydrationToken();
     }
 
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/OperationInternalBase.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternalBase.cs
@@ -185,12 +185,6 @@ namespace Azure.Core
         public Response WaitForCompletionResponse(TimeSpan pollingInterval, CancellationToken cancellationToken)
             => WaitForCompletionResponseAsync(async: false, pollingInterval, _waitForCompletionResponseScopeName, cancellationToken).EnsureCompleted();
 
-        /// <summary>
-        /// Get a token that can be used to rehydrate the operation.
-        /// </summary>
-        public RehydrationToken GetRehydrationToken(RequestMethod requestMethod, Uri startRequestUri, OperationFinalStateVia finalStateVia)
-            => NextLinkOperationImplementation.GetRehydrationToken(requestMethod, startRequestUri, RawResponse, finalStateVia);
-
         protected async ValueTask<Response> WaitForCompletionResponseAsync(bool async, TimeSpan? pollingInterval, string scopeName, CancellationToken cancellationToken)
         {
             // If _responseLock has the value, lockOrValue will contain that value, and no lock is acquired.

--- a/sdk/core/Azure.Core/src/Shared/OperationInternalBase.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternalBase.cs
@@ -185,6 +185,12 @@ namespace Azure.Core
         public Response WaitForCompletionResponse(TimeSpan pollingInterval, CancellationToken cancellationToken)
             => WaitForCompletionResponseAsync(async: false, pollingInterval, _waitForCompletionResponseScopeName, cancellationToken).EnsureCompleted();
 
+        /// <summary>
+        /// Get a token that can be used to rehydrate the operation.
+        /// </summary>
+        public RehydrationToken GetRehydrationToken(RequestMethod requestMethod, Uri startRequestUri, OperationFinalStateVia finalStateVia)
+            => NextLinkOperationImplementation.GetRehydrationToken(requestMethod, startRequestUri, RawResponse, finalStateVia);
+
         protected async ValueTask<Response> WaitForCompletionResponseAsync(bool async, TimeSpan? pollingInterval, string scopeName, CancellationToken cancellationToken)
         {
             // If _responseLock has the value, lockOrValue will contain that value, and no lock is acquired.

--- a/sdk/core/Azure.Core/src/Shared/OperationInternalOfT.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternalOfT.cs
@@ -290,7 +290,8 @@ namespace Azure.Core
                 => throw new NotSupportedException("The operation has already completed");
 
             // Unreachable path. _operation.GetRehydrationToken() is never invoked.
-            public RehydrationToken? GetRehydrationToken() => null;
+            public RehydrationToken? GetRehydrationToken()
+                => throw new NotSupportedException($"Getting the rehydration token of a {nameof(FinalOperation)} is not supported");
         }
     }
 

--- a/sdk/core/Azure.Core/src/Shared/OperationInternalOfT.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternalOfT.cs
@@ -288,6 +288,9 @@ namespace Azure.Core
         {
             public ValueTask<OperationState<T>> UpdateStateAsync(bool async, CancellationToken cancellationToken)
                 => throw new NotSupportedException("The operation has already completed");
+
+            // Unreachable path. _operation.GetRehydrationToken() is never invoked.
+            public RehydrationToken? GetRehydrationToken() => null;
         }
     }
 
@@ -328,6 +331,11 @@ namespace Azure.Core
         /// </list>
         /// </returns>
         ValueTask<OperationState<T>> UpdateStateAsync(bool async, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get a token that can be used to rehydrate the operation.
+        /// </summary>
+        RehydrationToken? GetRehydrationToken();
     }
 
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/OperationInternalOfT.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationInternalOfT.cs
@@ -290,7 +290,7 @@ namespace Azure.Core
                 => throw new NotSupportedException("The operation has already completed");
 
             // Unreachable path. _operation.GetRehydrationToken() is never invoked.
-            public RehydrationToken? GetRehydrationToken()
+            public RehydrationToken GetRehydrationToken()
                 => throw new NotSupportedException($"Getting the rehydration token of a {nameof(FinalOperation)} is not supported");
         }
     }
@@ -336,7 +336,7 @@ namespace Azure.Core
         /// <summary>
         /// Get a token that can be used to rehydrate the operation.
         /// </summary>
-        RehydrationToken? GetRehydrationToken();
+        RehydrationToken GetRehydrationToken();
     }
 
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/ProtocolOperation.cs
+++ b/sdk/core/Azure.Core/src/Shared/ProtocolOperation.cs
@@ -31,6 +31,17 @@ namespace Azure.Core
 #pragma warning restore CA1822
 
         /// <inheritdoc />
+        public override RehydrationToken? GetRehydrationToken()
+        {
+            if (_nextLinkOperation is NextLinkOperationImplementation nextLinkOperation)
+            {
+               return nextLinkOperation?.GetRehydrationToken();
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
         public override T Value => _operation.Value;
 
         /// <inheritdoc />

--- a/sdk/core/Azure.Core/src/Shared/ProtocolOperation.cs
+++ b/sdk/core/Azure.Core/src/Shared/ProtocolOperation.cs
@@ -31,7 +31,9 @@ namespace Azure.Core
 #pragma warning restore CA1822
 
         /// <inheritdoc />
-        public override RehydrationToken? GetRehydrationToken() => _nextLinkOperation.GetRehydrationToken();
+        public override RehydrationToken? GetRehydrationToken() => ((IOperation<T>)this).GetRehydrationToken();
+
+        RehydrationToken IOperation<T>.GetRehydrationToken() => _nextLinkOperation.GetRehydrationToken();
 
         /// <inheritdoc />
         public override T Value => _operation.Value;

--- a/sdk/core/Azure.Core/src/Shared/ProtocolOperation.cs
+++ b/sdk/core/Azure.Core/src/Shared/ProtocolOperation.cs
@@ -31,15 +31,7 @@ namespace Azure.Core
 #pragma warning restore CA1822
 
         /// <inheritdoc />
-        public override RehydrationToken? GetRehydrationToken()
-        {
-            if (_nextLinkOperation is NextLinkOperationImplementation nextLinkOperation)
-            {
-               return nextLinkOperation?.GetRehydrationToken();
-            }
-
-            return null;
-        }
+        public override RehydrationToken? GetRehydrationToken() => _nextLinkOperation.GetRehydrationToken();
 
         /// <inheritdoc />
         public override T Value => _operation.Value;

--- a/sdk/core/Azure.Core/src/Shared/ProtocolOperationHelpers.cs
+++ b/sdk/core/Azure.Core/src/Shared/ProtocolOperationHelpers.cs
@@ -76,6 +76,7 @@ namespace Azure.Core
             public override TTo Value => GetOrCreateValue();
             public override bool HasValue => _operation.HasValue;
             public override bool HasCompleted => _operation.HasCompleted;
+            public override RehydrationToken? GetRehydrationToken() => _operation.GetRehydrationToken();
             public override Response GetRawResponse() => _operation.GetRawResponse();
 
             public override Response UpdateStatus(CancellationToken cancellationToken = default)

--- a/sdk/core/Azure.Core/tests/OperationInternalOfTTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationInternalOfTTests.cs
@@ -519,7 +519,8 @@ namespace Azure.Core.Tests
 
             public ValueTask<OperationState<int>> UpdateStateAsync(bool async, CancellationToken cancellationToken) => _updateStateAsyncHandler(async, cancellationToken);
 
-            public RehydrationToken GetRehydrationToken() => default;
+            public RehydrationToken GetRehydrationToken() =>
+                throw new NotImplementedException();
         }
 
         private class CallCountStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationInternalOfTTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationInternalOfTTests.cs
@@ -519,7 +519,7 @@ namespace Azure.Core.Tests
 
             public ValueTask<OperationState<int>> UpdateStateAsync(bool async, CancellationToken cancellationToken) => _updateStateAsyncHandler(async, cancellationToken);
 
-            public RehydrationToken? GetRehydrationToken() => null;
+            public RehydrationToken GetRehydrationToken() => default;
         }
 
         private class CallCountStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationInternalOfTTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationInternalOfTTests.cs
@@ -518,6 +518,8 @@ namespace Azure.Core.Tests
             }
 
             public ValueTask<OperationState<int>> UpdateStateAsync(bool async, CancellationToken cancellationToken) => _updateStateAsyncHandler(async, cancellationToken);
+
+            public RehydrationToken? GetRehydrationToken() => null;
         }
 
         private class CallCountStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationInternalTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationInternalTests.cs
@@ -439,7 +439,8 @@ namespace Azure.Core.Tests
 
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => _updateStateAsyncHandler(async, cancellationToken);
 
-            public RehydrationToken GetRehydrationToken() => default;
+            public RehydrationToken GetRehydrationToken() =>
+                throw new NotImplementedException();
         }
 
         private class CallCountStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationInternalTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationInternalTests.cs
@@ -439,7 +439,7 @@ namespace Azure.Core.Tests
 
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => _updateStateAsyncHandler(async, cancellationToken);
 
-            public RehydrationToken GetRehydrationToken() => default;
+            public RehydrationToken? GetRehydrationToken() => null;
         }
 
         private class CallCountStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationInternalTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationInternalTests.cs
@@ -438,6 +438,8 @@ namespace Azure.Core.Tests
             }
 
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => _updateStateAsyncHandler(async, cancellationToken);
+
+            public RehydrationToken? GetRehydrationToken() => null;
         }
 
         private class CallCountStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationInternalTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationInternalTests.cs
@@ -439,7 +439,7 @@ namespace Azure.Core.Tests
 
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => _updateStateAsyncHandler(async, cancellationToken);
 
-            public RehydrationToken? GetRehydrationToken() => null;
+            public RehydrationToken GetRehydrationToken() => default;
         }
 
         private class CallCountStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationPollerTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationPollerTests.cs
@@ -58,7 +58,8 @@ namespace Azure.Core.Tests.DelayStrategies
         {
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(OperationState.Pending(new MockResponse(200)));
 
-            public RehydrationToken GetRehydrationToken() => default;
+            public RehydrationToken GetRehydrationToken() =>
+                throw new NotImplementedException();
         }
 
         private class TestDelayStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationPollerTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationPollerTests.cs
@@ -58,7 +58,7 @@ namespace Azure.Core.Tests.DelayStrategies
         {
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(OperationState.Pending(new MockResponse(200)));
 
-            public RehydrationToken? GetRehydrationToken() => null;
+            public RehydrationToken GetRehydrationToken() => default;
         }
 
         private class TestDelayStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationPollerTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationPollerTests.cs
@@ -57,6 +57,8 @@ namespace Azure.Core.Tests.DelayStrategies
         private class EndlessOperation : IOperation
         {
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(OperationState.Pending(new MockResponse(200)));
+
+            public RehydrationToken? GetRehydrationToken() => default;
         }
 
         private class TestDelayStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationPollerTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationPollerTests.cs
@@ -58,7 +58,7 @@ namespace Azure.Core.Tests.DelayStrategies
         {
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(OperationState.Pending(new MockResponse(200)));
 
-            public RehydrationToken? GetRehydrationToken() => default;
+            public RehydrationToken GetRehydrationToken() => default;
         }
 
         private class TestDelayStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/OperationPollerTests.cs
+++ b/sdk/core/Azure.Core/tests/OperationPollerTests.cs
@@ -58,7 +58,7 @@ namespace Azure.Core.Tests.DelayStrategies
         {
             public ValueTask<OperationState> UpdateStateAsync(bool async, CancellationToken cancellationToken) => new(OperationState.Pending(new MockResponse(200)));
 
-            public RehydrationToken GetRehydrationToken() => default;
+            public RehydrationToken? GetRehydrationToken() => null;
         }
 
         private class TestDelayStrategy : DelayStrategy

--- a/sdk/core/Azure.Core/tests/ProtocolOperationTests.cs
+++ b/sdk/core/Azure.Core/tests/ProtocolOperationTests.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class ProtocolOperationTests
+    {
+        [Test]
+        public void GetRehydrationToken()
+        {
+            const string OperationId = "oper-ati-oni-d00";
+            const string RequestUri = "https://www.example.com/request";
+            const string LocationUri = $"https://www.example.com/{OperationId}";
+
+            using var request = new MockRequest() { Method = RequestMethod.Post };
+            using var response = new MockResponse(200);
+            var transport = new MockTransport();
+            var pipeline = new HttpPipeline(transport);
+
+            request.Uri.Reset(new Uri(RequestUri));
+            response.AddHeader("Location", LocationUri);
+
+            var operation = new ProtocolOperation<MockJsonModel>(null, pipeline, request, response, OperationFinalStateVia.Location, null, null);
+            var token = operation.GetRehydrationToken();
+
+            Assert.True(token.HasValue);
+            Assert.AreEqual(OperationId, token.Value.Id);
+            Assert.AreEqual(NextLinkOperationImplementation.RehydrationTokenVersion, token.Value.Version);
+            Assert.AreEqual("Location", token.Value.HeaderSource);
+            Assert.AreEqual(LocationUri, token.Value.NextRequestUri);
+            Assert.AreEqual(RequestUri, token.Value.InitialUri);
+            Assert.AreEqual(RequestMethod.Post, token.Value.RequestMethod);
+            Assert.AreEqual(LocationUri, token.Value.LastKnownLocation);
+            Assert.AreEqual("Location", token.Value.FinalStateVia);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task RehydrationOperationCanPoll(bool isAsync)
+        {
+            const string RequestUri = "https://www.example.com/request";
+            const string LocationUri = "https://www.example.com/oper-ati-oni-d00";
+
+            using var request = new MockRequest() { Method = RequestMethod.Post };
+            using var response = new MockResponse(200);
+            var transport = new MockTransport(response);
+            var pipeline = new HttpPipeline(transport);
+
+            request.Uri.Reset(new Uri(RequestUri));
+            response.AddHeader("Location", LocationUri);
+
+            var operation = new ProtocolOperation<MockJsonModel>(null, pipeline, request, response, OperationFinalStateVia.Location, null, null);
+            var token = operation.GetRehydrationToken();
+            _ = isAsync
+                ? await Operation.RehydrateAsync(pipeline, token.Value)
+                : Operation.Rehydrate(pipeline, token.Value);
+            var rehydrationUpdateRequest = transport.SingleRequest;
+
+            Assert.AreEqual(LocationUri, rehydrationUpdateRequest.Uri.ToString());
+            Assert.AreEqual(RequestMethod.Get, rehydrationUpdateRequest.Method);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task RehydrationOperationOfTCanPoll(bool isAsync)
+        {
+            const string RequestUri = "https://www.example.com/request";
+            const string LocationUri = "https://www.example.com/oper-ati-oni-d00";
+
+            using var request = new MockRequest() { Method = RequestMethod.Post };
+            using var response = new MockResponse(200);
+            var transport = new MockTransport(response);
+            var pipeline = new HttpPipeline(transport);
+            using var responseContentStream = new MemoryStream(Encoding.UTF8.GetBytes("""
+                {
+                    "IntValue": 1,
+                    "StringValue": "one"
+                }
+                """));
+
+            request.Uri.Reset(new Uri(RequestUri));
+            response.AddHeader("Location", LocationUri);
+            response.ContentStream = responseContentStream;
+
+            var operation = new ProtocolOperation<MockJsonModel>(null, pipeline, request, response, OperationFinalStateVia.Location, null, null);
+            var token = operation.GetRehydrationToken();
+            var rehydrationOperation = isAsync
+                ? await Operation.RehydrateAsync<MockJsonModel>(pipeline, token.Value)
+                : Operation.Rehydrate<MockJsonModel>(pipeline, token.Value);
+            var rehydrationUpdateRequest = transport.SingleRequest;
+
+            Assert.AreEqual(LocationUri, rehydrationUpdateRequest.Uri.ToString());
+            Assert.AreEqual(RequestMethod.Get, rehydrationUpdateRequest.Method);
+
+            Assert.True(rehydrationOperation.HasValue);
+            Assert.AreEqual(rehydrationOperation.Value.IntValue, 1);
+            Assert.AreEqual(rehydrationOperation.Value.StringValue, "one");
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/ProtocolOperationTests.cs
+++ b/sdk/core/Azure.Core/tests/ProtocolOperationTests.cs
@@ -65,7 +65,7 @@ namespace Azure.Core.Tests
             Assert.AreEqual(RequestUri, token.Value.InitialUri);
             Assert.AreEqual(RequestMethod.Post, token.Value.RequestMethod);
             Assert.Null(token.Value.LastKnownLocation);
-            Assert.AreEqual("OriginalUri", token.Value.FinalStateVia);
+            Assert.AreEqual("Location", token.Value.FinalStateVia);
         }
 
         [Test]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOperation.cs
@@ -206,6 +206,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AnalyzeResult>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AnalyzeResult>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOperation.cs
@@ -204,5 +204,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             return OperationState<AnalyzeResult>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AnalyzeResult>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildDocumentClassifierOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildDocumentClassifierOperation.cs
@@ -195,6 +195,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<DocumentClassifierDetails>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<DocumentClassifierDetails>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildDocumentClassifierOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildDocumentClassifierOperation.cs
@@ -193,5 +193,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             return OperationState<DocumentClassifierDetails>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<DocumentClassifierDetails>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildDocumentModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildDocumentModelOperation.cs
@@ -193,5 +193,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             return OperationState<DocumentModelDetails>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildDocumentModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildDocumentModelOperation.cs
@@ -195,6 +195,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClassifyDocumentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClassifyDocumentOperation.cs
@@ -194,6 +194,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AnalyzeResult>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AnalyzeResult>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClassifyDocumentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClassifyDocumentOperation.cs
@@ -192,5 +192,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             return OperationState<AnalyzeResult>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AnalyzeResult>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ComposeDocumentModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ComposeDocumentModelOperation.cs
@@ -193,5 +193,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             return OperationState<DocumentModelDetails>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ComposeDocumentModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ComposeDocumentModelOperation.cs
@@ -195,6 +195,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyDocumentModelToOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyDocumentModelToOperation.cs
@@ -200,6 +200,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyDocumentModelToOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyDocumentModelToOperation.cs
@@ -198,5 +198,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             return OperationState<DocumentModelDetails>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<DocumentModelDetails>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeBusinessCardsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeBusinessCardsOperation.cs
@@ -171,5 +171,8 @@ namespace Azure.AI.FormRecognizer.Models
 
             return OperationState<RecognizedFormCollection>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeBusinessCardsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeBusinessCardsOperation.cs
@@ -173,6 +173,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeContentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeContentOperation.cs
@@ -173,6 +173,9 @@ namespace Azure.AI.FormRecognizer.Models
             return OperationState<FormPageCollection>.Pending(rawResponse);
         }
 
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<FormPageCollection>.GetRehydrationToken() => default;
+
         private static FormPageCollection ConvertValue(IReadOnlyList<PageResult> pageResults, IReadOnlyList<ReadResult> readResults)
         {
             Debug.Assert(pageResults.Count == readResults.Count);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeContentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeContentOperation.cs
@@ -174,7 +174,8 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<FormPageCollection>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<FormPageCollection>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
 
         private static FormPageCollection ConvertValue(IReadOnlyList<PageResult> pageResults, IReadOnlyList<ReadResult> readResults)
         {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeCustomFormsOperation.cs
@@ -206,6 +206,9 @@ namespace Azure.AI.FormRecognizer.Models
             return OperationState<RecognizedFormCollection>.Pending(rawResponse);
         }
 
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
+
         private static RecognizedFormCollection ConvertToRecognizedForms(V2AnalyzeResult analyzeResult, string modelId)
         {
             return analyzeResult.DocumentResults?.Count == 0 ?

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeCustomFormsOperation.cs
@@ -207,7 +207,8 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
 
         private static RecognizedFormCollection ConvertToRecognizedForms(V2AnalyzeResult analyzeResult, string modelId)
         {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeIdentityDocumentsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeIdentityDocumentsOperation.cs
@@ -172,6 +172,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeIdentityDocumentsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeIdentityDocumentsOperation.cs
@@ -170,5 +170,8 @@ namespace Azure.AI.FormRecognizer.Models
 
             return OperationState<RecognizedFormCollection>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeInvoicesOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeInvoicesOperation.cs
@@ -171,5 +171,8 @@ namespace Azure.AI.FormRecognizer.Models
 
             return OperationState<RecognizedFormCollection>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeInvoicesOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeInvoicesOperation.cs
@@ -173,6 +173,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeReceiptsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeReceiptsOperation.cs
@@ -172,6 +172,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeReceiptsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeReceiptsOperation.cs
@@ -170,5 +170,8 @@ namespace Azure.AI.FormRecognizer.Models
 
             return OperationState<RecognizedFormCollection>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<RecognizedFormCollection>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/CopyModelOperation.cs
@@ -206,7 +206,8 @@ namespace Azure.AI.FormRecognizer.Training
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<CustomFormModelInfo>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<CustomFormModelInfo>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
 
         private static CustomFormModelInfo ConvertValue(CopyOperationResult result, string modelId, CustomFormModelStatus status)
         {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/CopyModelOperation.cs
@@ -205,6 +205,9 @@ namespace Azure.AI.FormRecognizer.Training
             return OperationState<CustomFormModelInfo>.Pending(rawResponse);
         }
 
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<CustomFormModelInfo>.GetRehydrationToken() => default;
+
         private static CustomFormModelInfo ConvertValue(CopyOperationResult result, string modelId, CustomFormModelStatus status)
         {
             return new CustomFormModelInfo(

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/CreateCustomFormModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/CreateCustomFormModelOperation.cs
@@ -177,6 +177,7 @@ namespace Azure.AI.FormRecognizer.Training
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<CustomFormModel>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<CustomFormModel>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/CreateCustomFormModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/CreateCustomFormModelOperation.cs
@@ -175,5 +175,8 @@ namespace Azure.AI.FormRecognizer.Training
 
             return OperationState<CustomFormModel>.Pending(rawResponse);
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<CustomFormModel>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/DeleteCertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/DeleteCertificateOperation.cs
@@ -114,5 +114,9 @@ namespace Azure.Security.KeyVault.Certificates
                     return OperationState.Failure(response, new RequestFailedException(response));
             }
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException("Rehydration token not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/DeleteCertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/DeleteCertificateOperation.cs
@@ -116,6 +116,7 @@ namespace Azure.Security.KeyVault.Certificates
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() => default;
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/DeleteCertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/DeleteCertificateOperation.cs
@@ -116,7 +116,6 @@ namespace Azure.Security.KeyVault.Certificates
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() =>
-            throw new NotSupportedException("Rehydration token not supported.");
+        RehydrationToken IOperation.GetRehydrationToken() => default;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/RecoverDeletedCertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/RecoverDeletedCertificateOperation.cs
@@ -106,7 +106,6 @@ namespace Azure.Security.KeyVault.Certificates
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() =>
-            throw new NotSupportedException("Rehydration token not supported.");
+        RehydrationToken IOperation.GetRehydrationToken() => default;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/RecoverDeletedCertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/RecoverDeletedCertificateOperation.cs
@@ -104,5 +104,9 @@ namespace Azure.Security.KeyVault.Certificates
                     return OperationState.Failure(response, new RequestFailedException(response));
             }
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException("Rehydration token not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/RecoverDeletedCertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/RecoverDeletedCertificateOperation.cs
@@ -106,6 +106,7 @@ namespace Azure.Security.KeyVault.Certificates
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() => default;
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
@@ -114,5 +114,9 @@ namespace Azure.Security.KeyVault.Keys
                     return OperationState.Failure(response, new RequestFailedException(response));
             }
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException("Rehydration token not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
@@ -116,6 +116,7 @@ namespace Azure.Security.KeyVault.Keys
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() => default;
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
@@ -116,7 +116,6 @@ namespace Azure.Security.KeyVault.Keys
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() =>
-            throw new NotSupportedException("Rehydration token not supported.");
+        RehydrationToken IOperation.GetRehydrationToken() => default;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RecoverDeletedKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RecoverDeletedKeyOperation.cs
@@ -104,5 +104,9 @@ namespace Azure.Security.KeyVault.Keys
                     return OperationState.Failure(response, new RequestFailedException(response));
             }
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException("Rehydration token not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RecoverDeletedKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RecoverDeletedKeyOperation.cs
@@ -106,6 +106,7 @@ namespace Azure.Security.KeyVault.Keys
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() => default;
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RecoverDeletedKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RecoverDeletedKeyOperation.cs
@@ -106,7 +106,6 @@ namespace Azure.Security.KeyVault.Keys
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() =>
-            throw new NotSupportedException("Rehydration token not supported.");
+        RehydrationToken IOperation.GetRehydrationToken() => default;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
@@ -110,5 +110,9 @@ namespace Azure.Security.KeyVault.Secrets
                     return OperationState.Failure(response, new RequestFailedException(response));
             }
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException("Rehydration token not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
@@ -112,6 +112,7 @@ namespace Azure.Security.KeyVault.Secrets
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() => default;
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
@@ -112,7 +112,6 @@ namespace Azure.Security.KeyVault.Secrets
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() =>
-            throw new NotSupportedException("Rehydration token not supported.");
+        RehydrationToken IOperation.GetRehydrationToken() => default;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/RecoverDeletedSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/RecoverDeletedSecretOperation.cs
@@ -100,5 +100,9 @@ namespace Azure.Security.KeyVault.Secrets
                     return OperationState.Failure(response, new RequestFailedException(response));
             }
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException("Rehydration token not supported.");
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/RecoverDeletedSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/RecoverDeletedSecretOperation.cs
@@ -102,7 +102,6 @@ namespace Azure.Security.KeyVault.Secrets
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() =>
-            throw new NotSupportedException("Rehydration token not supported.");
+        RehydrationToken IOperation.GetRehydrationToken() => default;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/RecoverDeletedSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/RecoverDeletedSecretOperation.cs
@@ -102,6 +102,7 @@ namespace Azure.Security.KeyVault.Secrets
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation.GetRehydrationToken() => default;
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/TestFramework/MockOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/TestFramework/MockOperation.cs
@@ -119,6 +119,9 @@ namespace Azure.Core.TestFramework
             return new ValueTask<OperationState>(OnUpdateState(cancellationToken));
         }
 
+        RehydrationToken IOperation.GetRehydrationToken() =>
+            throw new NotImplementedException();
+
         public MockOperationInternal MockOperationInternal { get; }
 
         public Func<CancellationToken, OperationState> OnUpdateState { get; set; }

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/TestFramework/MockOperationOfT.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/TestFramework/MockOperationOfT.cs
@@ -129,6 +129,9 @@ namespace Azure.Core.Tests
             return new ValueTask<OperationState<T>>(OnUpdateState(cancellationToken));
         }
 
+        RehydrationToken IOperation<T>.GetRehydrationToken() =>
+            throw new NotImplementedException();
+
         internal MockOperationInternal<T> MockOperationInternal { get; }
 
         internal Func<CancellationToken, OperationState<T>> OnUpdateState { get; set; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractiveSummarizeOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractiveSummarizeOperation.cs
@@ -294,5 +294,8 @@ namespace Azure.AI.TextAnalytics
 
             return OperationState<AsyncPageable<AbstractiveSummarizeResultCollection>>.Failure(rawResponse, new RequestFailedException(rawResponse));
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AsyncPageable<AbstractiveSummarizeResultCollection>>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractiveSummarizeOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractiveSummarizeOperation.cs
@@ -296,6 +296,7 @@ namespace Azure.AI.TextAnalytics
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AsyncPageable<AbstractiveSummarizeResultCollection>>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AsyncPageable<AbstractiveSummarizeResultCollection>>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
@@ -321,6 +321,9 @@ namespace Azure.AI.TextAnalytics
             return OperationState<AsyncPageable<AnalyzeActionsResult>>.Failure(rawResponse, new RequestFailedException(rawResponse));
         }
 
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AsyncPageable<AnalyzeActionsResult>>.GetRehydrationToken() => default;
+
         private AsyncPageable<AnalyzeActionsResult> CreateOperationValueAsync(CancellationToken cancellationToken = default)
         {
             async Task<Page<AnalyzeActionsResult>> NextPageFunc(string nextLink, int? pageSizeHint)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
@@ -322,7 +322,8 @@ namespace Azure.AI.TextAnalytics
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AsyncPageable<AnalyzeActionsResult>>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AsyncPageable<AnalyzeActionsResult>>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
 
         private AsyncPageable<AnalyzeActionsResult> CreateOperationValueAsync(CancellationToken cancellationToken = default)
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
@@ -296,6 +296,7 @@ namespace Azure.AI.TextAnalytics
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AsyncPageable<AnalyzeHealthcareEntitiesResultCollection>>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AsyncPageable<AnalyzeHealthcareEntitiesResultCollection>>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
@@ -294,5 +294,8 @@ namespace Azure.AI.TextAnalytics
 
             return OperationState<AsyncPageable<AnalyzeHealthcareEntitiesResultCollection>>.Failure(rawResponse, new RequestFailedException(rawResponse));
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AsyncPageable<AnalyzeHealthcareEntitiesResultCollection>>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ClassifyDocumentOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ClassifyDocumentOperation.cs
@@ -294,5 +294,8 @@ namespace Azure.AI.TextAnalytics
 
             return OperationState<AsyncPageable<ClassifyDocumentResultCollection>>.Failure(rawResponse, new RequestFailedException(rawResponse));
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AsyncPageable<ClassifyDocumentResultCollection>>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ClassifyDocumentOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ClassifyDocumentOperation.cs
@@ -296,6 +296,7 @@ namespace Azure.AI.TextAnalytics
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AsyncPageable<ClassifyDocumentResultCollection>>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AsyncPageable<ClassifyDocumentResultCollection>>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractiveSummarizeOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractiveSummarizeOperation.cs
@@ -296,6 +296,7 @@ namespace Azure.AI.TextAnalytics
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AsyncPageable<ExtractiveSummarizeResultCollection>>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AsyncPageable<ExtractiveSummarizeResultCollection>>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractiveSummarizeOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractiveSummarizeOperation.cs
@@ -294,5 +294,8 @@ namespace Azure.AI.TextAnalytics
 
             return OperationState<AsyncPageable<ExtractiveSummarizeResultCollection>>.Failure(rawResponse, new RequestFailedException(rawResponse));
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AsyncPageable<ExtractiveSummarizeResultCollection>>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeCustomEntitiesOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeCustomEntitiesOperation.cs
@@ -296,6 +296,7 @@ namespace Azure.AI.TextAnalytics
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AsyncPageable<RecognizeCustomEntitiesResultCollection>>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AsyncPageable<RecognizeCustomEntitiesResultCollection>>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeCustomEntitiesOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeCustomEntitiesOperation.cs
@@ -294,5 +294,8 @@ namespace Azure.AI.TextAnalytics
 
             return OperationState<AsyncPageable<RecognizeCustomEntitiesResultCollection>>.Failure(rawResponse, new RequestFailedException(rawResponse));
         }
+
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AsyncPageable<RecognizeCustomEntitiesResultCollection>>.GetRehydrationToken() => default;
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
@@ -240,6 +240,9 @@ namespace Azure.AI.Translation.Document
             return OperationState<AsyncPageable<DocumentStatusResult>>.Pending(rawResponse);
         }
 
+        // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
+        RehydrationToken IOperation<AsyncPageable<DocumentStatusResult>>.GetRehydrationToken() => default;
+
         private AsyncPageable<DocumentStatusResult> CreateOperationValueAsync(CancellationToken cancellationToken = default)
         {
             return GetDocumentStatusesAsync(cancellationToken: cancellationToken);

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
@@ -241,7 +241,8 @@ namespace Azure.AI.Translation.Document
         }
 
         // This method is never invoked since we don't override Operation<T>.GetRehydrationToken.
-        RehydrationToken IOperation<AsyncPageable<DocumentStatusResult>>.GetRehydrationToken() => default;
+        RehydrationToken IOperation<AsyncPageable<DocumentStatusResult>>.GetRehydrationToken() =>
+            throw new NotSupportedException($"{nameof(GetRehydrationToken)} is not supported.");
 
         private AsyncPageable<DocumentStatusResult> CreateOperationValueAsync(CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Currently DPG libraries do not support rehydrating long-running operations. This means that, after a long-running operation has been started, users must hold their `Operation<T>` reference until its completion in order to access its final result. This can be a problem as some operations could take hours or even days to complete.

Our TypeSpec code generator already supports the creation of rehydration tokens to retrieve the status of long-running operations, but the logic to do so had not been wired into our `Operation` API yet.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/48594.