### PR TITLE
Filter MCP tool calls based on embeddings vectors

### DIFF
--- a/sdk/cloudmachine/Azure.Projects.AI/api/Azure.Projects.AI.net8.0.cs
+++ b/sdk/cloudmachine/Azure.Projects.AI/api/Azure.Projects.AI.net8.0.cs
@@ -82,8 +82,9 @@ namespace Azure.Projects.AI
     }
     public partial class ChatTools
     {
-        public ChatTools() { }
+        public ChatTools(OpenAI.Embeddings.EmbeddingClient? embeddingClient = null) { }
         public ChatTools(params System.Type[] tools) { }
+        public bool CanFilterTools { get { throw null; } }
         public System.Collections.Generic.IList<OpenAI.Chat.ChatTool> Definitions { get { throw null; } }
         public void Add(System.Reflection.MethodInfo function) { }
         public void Add(System.Type functions) { }
@@ -95,6 +96,13 @@ namespace Azure.Projects.AI
         public System.Threading.Tasks.Task<Azure.Projects.AI.ToolCallResult> CallAllWithErrors(System.Collections.Generic.IEnumerable<OpenAI.Chat.ChatToolCall> toolCalls) { throw null; }
         public static implicit operator OpenAI.Chat.ChatCompletionOptions (Azure.Projects.AI.ChatTools tools) { throw null; }
         public OpenAI.Chat.ChatCompletionOptions ToOptions() { throw null; }
+        public OpenAI.Chat.ChatCompletionOptions ToOptions(string prompt, Azure.Projects.AI.ChatTools.ToolFindOptions? options = null) { throw null; }
+        public partial class ToolFindOptions
+        {
+            public ToolFindOptions() { }
+            public int MaxEntries { get { throw null; } set { } }
+            public float Threshold { get { throw null; } set { } }
+        }
     }
     public abstract partial class EmbeddingsStore
     {

--- a/sdk/cloudmachine/Azure.Projects.AI/api/Azure.Projects.AI.netstandard2.0.cs
+++ b/sdk/cloudmachine/Azure.Projects.AI/api/Azure.Projects.AI.netstandard2.0.cs
@@ -82,8 +82,9 @@ namespace Azure.Projects.AI
     }
     public partial class ChatTools
     {
-        public ChatTools() { }
+        public ChatTools(OpenAI.Embeddings.EmbeddingClient? embeddingClient = null) { }
         public ChatTools(params System.Type[] tools) { }
+        public bool CanFilterTools { get { throw null; } }
         public System.Collections.Generic.IList<OpenAI.Chat.ChatTool> Definitions { get { throw null; } }
         public void Add(System.Reflection.MethodInfo function) { }
         public void Add(System.Type functions) { }
@@ -95,6 +96,13 @@ namespace Azure.Projects.AI
         public System.Threading.Tasks.Task<Azure.Projects.AI.ToolCallResult> CallAllWithErrors(System.Collections.Generic.IEnumerable<OpenAI.Chat.ChatToolCall> toolCalls) { throw null; }
         public static implicit operator OpenAI.Chat.ChatCompletionOptions (Azure.Projects.AI.ChatTools tools) { throw null; }
         public OpenAI.Chat.ChatCompletionOptions ToOptions() { throw null; }
+        public OpenAI.Chat.ChatCompletionOptions ToOptions(string prompt, Azure.Projects.AI.ChatTools.ToolFindOptions? options = null) { throw null; }
+        public partial class ToolFindOptions
+        {
+            public ToolFindOptions() { }
+            public int MaxEntries { get { throw null; } set { } }
+            public float Threshold { get { throw null; } set { } }
+        }
     }
     public abstract partial class EmbeddingsStore
     {

--- a/sdk/cloudmachine/Azure.Projects.AI/src/Agents/ChatRunner.cs
+++ b/sdk/cloudmachine/Azure.Projects.AI/src/Agents/ChatRunner.cs
@@ -23,7 +23,7 @@ namespace Azure.Projects.AI
         /// <summary>
         /// Tools to call.
         /// </summary>
-        public ChatTools Tools { get; protected set; } = new();
+        public ChatTools Tools { get; protected set; }
 
         private readonly ChatClient _chat;
 
@@ -34,6 +34,7 @@ namespace Azure.Projects.AI
         public ChatRunner(ChatClient chat)
         {
             _chat = chat;
+            Tools = new ChatTools();
         }
 
         /// <summary>
@@ -44,6 +45,7 @@ namespace Azure.Projects.AI
         public ChatRunner(ChatClient chat, EmbeddingClient? embeddings)
         {
             _chat = chat;
+            Tools = new ChatTools(embeddings);
             if (embeddings != null)
             {
                 VectorDb = new MemoryEmbeddingsStore(embeddings);
@@ -106,7 +108,7 @@ namespace Azure.Projects.AI
         {
             if (Tools != null)
             {
-                ChatCompletion completion = _chat.CompleteChat(conversation, Tools.ToOptions());
+                ChatCompletion completion = _chat.CompleteChat(conversation, Tools.ToOptions(prompt));
                 return completion;
             }
             else

--- a/sdk/cloudmachine/Azure.Projects.AI/src/Agents/ChatTools.cs
+++ b/sdk/cloudmachine/Azure.Projects.AI/src/Agents/ChatTools.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
@@ -23,6 +24,7 @@ public class ChatTools
     private readonly Dictionary<string, Func<string, BinaryData, Task<BinaryData>>> _mcpMethods = [];
     private readonly List<ChatTool> _definitions = [];
     private readonly EmbeddingClient? _client;
+    private readonly List<VectorbaseEntry> _entries = [];
 
     private List<McpClient> _mcpClients = [];
     private Dictionary<string, McpClient> _mcpClientsByEndpoint = [];
@@ -63,7 +65,7 @@ public class ChatTools
         _mcpClientsByEndpoint[serverEndpoint.AbsoluteUri] = client;
         await client.StartAsync().ConfigureAwait(false);
         BinaryData tools = await client.ListToolsAsync().ConfigureAwait(false);
-        Add(tools, client);
+        await Add(tools, client).ConfigureAwait(false);
         _mcpClients.Add(client);
     }
 
@@ -71,6 +73,11 @@ public class ChatTools
     /// Gets the tool definitions.
     /// </summary>
     public IList<ChatTool> Definitions => _definitions;
+
+    /// <summary>
+    /// Determines if the tools can be filtered using the EmbeddingsClient.
+    /// </summary>
+    public bool CanFilterTools => _client != null;
 
     /// <summary>
     /// Implicitly converts a <see cref="ChatTools"/> to <see cref="ChatCompletionOptions"/>.
@@ -93,7 +100,7 @@ public class ChatTools
     /// <param name="client">The McpClient.</param>
     /// <exception cref="ArgumentNullException">Thrown when toolDefinitions is null</exception>
     /// <exception cref="JsonException">Thrown when JSON parsing fails</exception>
-    internal void Add(BinaryData toolDefinitions, McpClient client)
+    internal async Task Add(BinaryData toolDefinitions, McpClient client)
     {
         using var document = JsonDocument.Parse(toolDefinitions);
         if (!document.RootElement.TryGetProperty("tools", out JsonElement toolsElement))
@@ -104,6 +111,8 @@ public class ChatTools
         var tools = toolsElement.EnumerateArray();
         // the replacement is to deal with OpenAI's tool name regex validation.
         var serverKey = client.ServerEndpoint.Host + client.ServerEndpoint.Port.ToString();
+
+        List<ChatTool> ToolsToVectorize = new();
 
         foreach (var tool in tools)
         {
@@ -122,9 +131,12 @@ public class ChatTools
                 BinaryData.FromString(inputSchema));
 
             _definitions.Add(chatTool);
+            ToolsToVectorize.Add(chatTool);
 
             _mcpMethods[name] = client.CallToolAsync;
         }
+
+        await AddToolsToVectorBaseAsync(ToolsToVectorize).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -210,12 +222,12 @@ public class ChatTools
     {
         if (_mcpMethods.TryGetValue(call.FunctionName, out Func<string, BinaryData, Task<BinaryData>>? method))
         {
-            #if !NETSTANDARD2_0
-                        var actualFunctionName = call.FunctionName.Split(_mcpToolSeparator, 2)[1];
-            #else
+#if !NETSTANDARD2_0
+            var actualFunctionName = call.FunctionName.Split(_mcpToolSeparator, 2)[1];
+#else
                         var index = call.FunctionName.IndexOf(_mcpToolSeparator);
                         var actualFunctionName = call.FunctionName.Substring(index + _mcpToolSeparator.Length);
-            #endif
+#endif
             var result = await method(actualFunctionName, call.FunctionArguments).ConfigureAwait(false);
             return result.ToString();
         }
@@ -285,6 +297,36 @@ public class ChatTools
             options.Tools.Add(tool);
         }
         return options;
+    }
+
+    /// <summary>
+    /// Converts the <see cref="ChatTools"/> to a <see cref="ChatCompletionOptions"/> using the current prompt to filter the related tools via embeddings.
+    /// </summary>
+    /// <param name="prompt">The prompt to use for filtering the related tools.</param>
+    /// <param name="options">Optional options to refine how the related tools are found.</param>
+    /// <returns></returns>
+    public ChatCompletionOptions ToOptions(string prompt, ToolFindOptions? options = null)
+    {
+        if (!CanFilterTools)
+        {
+            return ToOptions();
+        }
+
+        ChatCompletionOptions completionOptions = new();
+        var related = Find(prompt, options ?? new ToolFindOptions { MaxEntries = 5 });
+        foreach (VectorbaseEntry entry in related)
+        {
+            ChatTool tool = ParseToolDefinition(entry.Data);
+            completionOptions.Tools.Add(tool);
+        }
+        // TODO: Add this to logging when we have a logger.
+        // Uncomment the following lines to see the related tools found.
+        // Console.WriteLine($"Found {related.Count()} related tools for prompt '{prompt}'.");
+        // foreach (ChatTool tool in completionOptions.Tools)
+        // {
+        //     Console.WriteLine($"\tTool: {tool.FunctionName}");
+        // }
+        return completionOptions;
     }
 
     private static string MethodInfoToDescription(MethodInfo function)
@@ -375,5 +417,113 @@ public class ChatTools
         writer.Flush();
         stream.Position = 0;
         return BinaryData.FromStream(stream);
+    }
+
+    private static BinaryData SerializeChatTool(ChatTool tool)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+
+        writer.WriteStartObject();
+
+        writer.WriteString("name", tool.FunctionName);
+        writer.WriteString("description", tool.FunctionDescription);
+
+        // Write the inputSchema by parsing the existing BinaryData
+        writer.WritePropertyName("inputSchema");
+        using (var inputSchemaDoc = JsonDocument.Parse(tool.FunctionParameters))
+        {
+            inputSchemaDoc.RootElement.WriteTo(writer);
+        }
+
+        writer.WriteEndObject();
+        writer.Flush();
+        stream.Position = 0;
+
+        return BinaryData.FromStream(stream);
+    }
+
+    private ChatTool ParseToolDefinition(BinaryData toolDefinition)
+    {
+        using var document = JsonDocument.Parse(toolDefinition);
+        var root = document.RootElement;
+
+        var name = root.GetProperty("name").GetString()!;
+        var description = root.GetProperty("description").GetString()!;
+        var inputSchema = BinaryData.FromString(root.GetProperty("inputSchema").GetRawText());
+
+        return ChatTool.CreateFunctionTool(
+            name,
+            description,
+            inputSchema);
+    }
+
+    private async Task AddToolsToVectorBaseAsync(List<ChatTool> tools)
+    {
+        if (!CanFilterTools)
+            return;
+
+        OpenAIEmbeddingCollection embeddings = await _client!.GenerateEmbeddingsAsync(tools.Select(t => t.FunctionDescription)).ConfigureAwait(false);
+
+        Console.WriteLine($"Adding {embeddings.Count} tools to vectorbase.");
+
+        foreach (OpenAIEmbedding embedding in embeddings)
+        {
+            ReadOnlyMemory<float> vector = embedding.ToFloats();
+            ChatTool item = tools[embedding.Index];
+            BinaryData toolDefinition = SerializeChatTool(item);
+            _entries.Add(new VectorbaseEntry(vector, toolDefinition));
+        }
+    }
+
+    internal IEnumerable<VectorbaseEntry> Find(string prompt, ToolFindOptions options)
+    {
+        ReadOnlyMemory<float> vector = GetEmbedding(prompt);
+        lock (_entries)
+        {
+            var distances = new List<(float Distance, int Index)>(_entries.Count);
+            for (int index = 0; index < _entries.Count; index++)
+            {
+                VectorbaseEntry entry = _entries[index];
+                ReadOnlyMemory<float> dbVector = entry.Vector;
+                float distance = 1.0f - EmbeddingsStore.CosineSimilarity(dbVector.Span, vector.Span);
+                distances.Add((distance, index));
+            }
+            distances.Sort(((float D1, int I1) v1, (float D2, int I2) v2) => v1.D1.CompareTo(v2.D2));
+
+            List<VectorbaseEntry> results = new(options.MaxEntries);
+            int top = Math.Min(options.MaxEntries, distances.Count);
+            for (int i = 0; i < top; i++)
+            {
+                float distance = distances[i].Distance;
+                if (distance > options.Threshold)
+                    break;
+                int index = distances[i].Index;
+                results.Add(_entries[index]);
+            }
+            return results;
+        }
+    }
+
+    private ReadOnlyMemory<float> GetEmbedding(string fact)
+    {
+        OpenAIEmbedding embedding = _client!.GenerateEmbedding(fact);
+        return embedding.ToFloats();
+    }
+
+    /// <summary>
+    /// The options for finding entries in the vectorbase.
+    /// </summary>
+    public class ToolFindOptions
+    {
+        /// <summary>
+        /// The maximum number of entries to return.
+        /// </summary>
+        public int MaxEntries { get; set; } = 3;
+
+        /// <summary>
+        /// The threshold for the cosine similarity.
+        /// </summary>
+        public float Threshold { get; set; } = 0.29f;
     }
 }

--- a/sdk/cloudmachine/Azure.Projects.AI/src/Agents/ChatTools.cs
+++ b/sdk/cloudmachine/Azure.Projects.AI/src/Agents/ChatTools.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using OpenAI.Chat;
+using OpenAI.Embeddings;
 
 namespace Azure.Projects.AI;
 
@@ -21,6 +22,7 @@ public class ChatTools
     private readonly Dictionary<string, MethodInfo> _methods = [];
     private readonly Dictionary<string, Func<string, BinaryData, Task<BinaryData>>> _mcpMethods = [];
     private readonly List<ChatTool> _definitions = [];
+    private readonly EmbeddingClient? _client;
 
     private List<McpClient> _mcpClients = [];
     private Dictionary<string, McpClient> _mcpClientsByEndpoint = [];
@@ -29,8 +31,9 @@ public class ChatTools
     /// <summary>
     /// Initializes a new instance of the <see cref="ChatTools"/> class.
     /// </summary>
-    public ChatTools()
+    public ChatTools(EmbeddingClient? embeddingClient = null)
     {
+        _client = embeddingClient;
     }
 
     /// <summary>

--- a/sdk/cloudmachine/Azure.Projects/samples/ConsoleAgent/.gitignore
+++ b/sdk/cloudmachine/Azure.Projects/samples/ConsoleAgent/.gitignore
@@ -1,3 +1,4 @@
 appsettings.json
 azure.yaml
 infra/
+.azure

--- a/sdk/cloudmachine/Azure.Projects/samples/ConsoleAgent/Program.cs
+++ b/sdk/cloudmachine/Azure.Projects/samples/ConsoleAgent/Program.cs
@@ -23,9 +23,6 @@ runner.Tools.AddLocalTools(typeof(Tools));
 
 ChatThread conversation = new();
 
-
-await runner.Tools.AddMcpServerAsync(new Uri("http://localhost:5000/sse")).ConfigureAwait(false);
-
 while (true)
 {
     Console.Write("> ");

--- a/sdk/cloudmachine/Azure.Projects/samples/ConsoleAgent/Program.cs
+++ b/sdk/cloudmachine/Azure.Projects/samples/ConsoleAgent/Program.cs
@@ -23,13 +23,18 @@ runner.Tools.AddLocalTools(typeof(Tools));
 
 ChatThread conversation = new();
 
+
+await runner.Tools.AddMcpServerAsync(new Uri("http://localhost:5000/sse")).ConfigureAwait(false);
+
 while (true)
 {
     Console.Write("> ");
     string prompt = Console.ReadLine();
 
-    if (string.IsNullOrEmpty(prompt)) continue;
-    if (string.Equals(prompt, "bye", StringComparison.OrdinalIgnoreCase)) break;
+    if (string.IsNullOrEmpty(prompt))
+        continue;
+    if (string.Equals(prompt, "bye", StringComparison.OrdinalIgnoreCase))
+        break;
     if (prompt.StartsWith("fact:", StringComparison.OrdinalIgnoreCase))
     {
         string fact = prompt[5..].Trim();
@@ -38,7 +43,7 @@ while (true)
     }
     if (prompt.StartsWith("mcp:", StringComparison.OrdinalIgnoreCase))
     {
-        string mcp = prompt[7..].Trim();
+        string mcp = prompt[4..].Trim();
         Console.WriteLine($"adding MCP server {mcp}");
         await runner.Tools.AddMcpServerAsync(new Uri(mcp)).ConfigureAwait(false);
         continue;


### PR DESCRIPTION
With debug logging, a prompt that would invoke tools looks like this now:

```
> can you list the resource groups on the sub?
Found 5 related tools for prompt 'can you list the resource groups on the sub?'.
        Tool: localhost5000_._azmcp-group-list
        Tool: localhost5000_._azmcp-subscription-list
        Tool: localhost5000_._azmcp-monitor-workspace-list
        Tool: localhost5000_._azmcp-storage-account-list
        Tool: localhost5000_._azmcp-storage-table-list
Calling tool azmcp-subscription-list...
```