### PR TITLE
Adding test for continue update cluster to NetworkCloudClusterTests  

### DIFF
--- a/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/assets.json
+++ b/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/networkcloud/Azure.ResourceManager.NetworkCloud",
-  "Tag": "net/networkcloud/Azure.ResourceManager.NetworkCloud_a38b05eb14"
+  "Tag": "net/networkcloud/Azure.ResourceManager.NetworkCloud_9079956b9a"
 }

--- a/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/assets.json
+++ b/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/networkcloud/Azure.ResourceManager.NetworkCloud",
-  "Tag": "net/networkcloud/Azure.ResourceManager.NetworkCloud_5878d0f594"
+  "Tag": "net/networkcloud/Azure.ResourceManager.NetworkCloud_1e65ea4aab"
 }

--- a/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/assets.json
+++ b/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/networkcloud/Azure.ResourceManager.NetworkCloud",
-  "Tag": "net/networkcloud/Azure.ResourceManager.NetworkCloud_b263140953"
+  "Tag": "net/networkcloud/Azure.ResourceManager.NetworkCloud_5878d0f594"
 }

--- a/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/assets.json
+++ b/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/networkcloud/Azure.ResourceManager.NetworkCloud",
-  "Tag": "net/networkcloud/Azure.ResourceManager.NetworkCloud_1e65ea4aab"
+  "Tag": "net/networkcloud/Azure.ResourceManager.NetworkCloud_a38b05eb14"
 }

--- a/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/tests/NetworkCloudManagementTestBase.cs
+++ b/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/tests/NetworkCloudManagementTestBase.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.NetworkCloud.Tests
         : base(isAsync, mode)
         {
             BodyKeySanitizers.Add(new BodyKeySanitizer("properties.vmImageRepositoryCredentials.password") { Value = "fake-password123" });
-            BodyKeySanitizers.Add(new BodyKeySanitizer("properties.commandOutputSettings.containerUrl") { Value = "https://sanitized.blob.core.windows.net/container" });
+            BodyKeySanitizers.Add(new BodyKeySanitizer("..containerUri") { Value = "https://sanitized.blob.core.windows.net/container" });
             BodyKeySanitizers.Add(new BodyKeySanitizer("..vaultUri") { Value = "https://sanitized.vault.azure.net" });
 
             SanitizersToRemove.Add("AZSDK3402");

--- a/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/tests/NetworkCloudManagementTestBase.cs
+++ b/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/tests/NetworkCloudManagementTestBase.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.NetworkCloud.Tests
         : base(isAsync, mode)
         {
             BodyKeySanitizers.Add(new BodyKeySanitizer("properties.vmImageRepositoryCredentials.password") { Value = "fake-password123" });
-            BodyKeySanitizers.Add(new BodyKeySanitizer("..containerUri") { Value = "https://sanitized.blob.core.windows.net/container" });
+            BodyKeySanitizers.Add(new BodyKeySanitizer("..containerUrl") { Value = "https://sanitized.blob.core.windows.net/container" });
             BodyKeySanitizers.Add(new BodyKeySanitizer("..vaultUri") { Value = "https://sanitized.vault.azure.net" });
 
             SanitizersToRemove.Add("AZSDK3402");
@@ -31,6 +31,7 @@ namespace Azure.ResourceManager.NetworkCloud.Tests
             : base(isAsync)
         {
             BodyKeySanitizers.Add(new BodyKeySanitizer("properties.vmImageRepositoryCredentials.password") { Value = "fake-password123" });
+            BodyKeySanitizers.Add(new BodyKeySanitizer("..containerUrl") { Value = "https://sanitized.blob.core.windows.net/container" });
             BodyKeySanitizers.Add(new BodyKeySanitizer("..vaultUri") { Value = "https://sanitized.vault.azure.net" });
 
             SanitizersToRemove.Add("AZSDK3402");

--- a/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/tests/NetworkCloudManagementTestBase.cs
+++ b/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/tests/NetworkCloudManagementTestBase.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.NetworkCloud.Tests
         : base(isAsync, mode)
         {
             BodyKeySanitizers.Add(new BodyKeySanitizer("properties.vmImageRepositoryCredentials.password") { Value = "fake-password123" });
-            BodyKeySanitizers.Add(new BodyKeySanitizer("..containerUrl") { Value = "https://sanitized.blob.core.windows.net/container" });
+            BodyKeySanitizers.Add(new BodyKeySanitizer("properties.commandOutputSettings.containerUrl") { Value = "https://sanitized.blob.core.windows.net/container" });
             BodyKeySanitizers.Add(new BodyKeySanitizer("..vaultUri") { Value = "https://sanitized.vault.azure.net" });
 
             SanitizersToRemove.Add("AZSDK3402");

--- a/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/tests/Scenario/NetworkCloudClustersTests.cs
+++ b/sdk/networkcloud/Azure.ResourceManager.NetworkCloud/tests/Scenario/NetworkCloudClustersTests.cs
@@ -198,10 +198,22 @@ namespace Azure.ResourceManager.NetworkCloud.Tests.ScenarioTests
             catch (Exception ex)
             {
                 // special case: if the cluster was never deployed, version update (CUVA) is not allowed
-                // once the API bug is resolved this can be used. Until then, will compare 2 strings instead
-                // StringAssert.Contains($"cluster conditions do not pass validation for cluster {clusterName}: ClusterDeployedCondition is not True", ex.Message);
-                StringAssert.Contains("cluster conditions do not pass validation for cluster", ex.Message);
-                StringAssert.Contains("ClusterDeployedCondition is not True", ex.Message);
+                StringAssert.Contains($"cluster conditions do not pass validation for cluster {clusterName}: ClusterDeployedCondition is not True", ex.Message);
+            }
+
+             // Continue Cluster Update Version
+            try
+            {
+                ClusterContinueUpdateVersionContent continueUpdateContent = new ClusterContinueUpdateVersionContent
+                {
+                    MachineGroupTargetingMode = ClusterContinueUpdateVersionMachineGroupTargetingMode.AlphaByRack
+                };
+                var updatedClusterResult = await clusterResource.ContinueUpdateVersionAsync(WaitUntil.Completed, continueUpdateContent);
+            }
+            catch (Exception ex)
+            {
+                // special case: if the cluster was never deployed, version update (CUVA) is not allowed
+                StringAssert.Contains($"cluster {clusterName} does not have suitable conditions to continue to update", ex.Message);
             }
 
             // Delete


### PR DESCRIPTION
# Contributing to the Azure SDK

- Added an additional test case for the continue update cluster test command
- Updated tests to match error messages which include the name of the cluster
