### PR TITLE
Fix regen for healthdataservices

### DIFF
--- a/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices/tsp-location.yaml
+++ b/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/healthdataaiservices/HealthDataAIServices.Management
-commit: 462574dbd02088c209bb1da3eef0d93f699e8de2
+commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
We were not able to get all the failing regen during the TypeSpec version bump, this is 1 left needing fix.