### PR TITLE
Reduce Overall Size of PR Build/Analyze Batches

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -62,7 +62,7 @@ jobs:
           - "!SessionRecords"
         EnablePRGeneration: true
         PRMatrixSetting: ProjectNames
-        PRJobBatchSize: 20
+        PRJobBatchSize: 10
         AdditionalParameters:
           Artifacts: ${{ parameters.Artifacts }}
           TestPipeline: ${{ parameters.TestPipeline }}


### PR DESCRIPTION
This should have zero impact on runtime for `net - pullrequest`, but timeouts on `VerifyGeneratedCode` sections should be ameliorated.