### PR TITLE
Add presence REST API to web pubsub service client

### DIFF
--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Features Added
 - Added support for SocketIO when generating ClientAccessURI
+- Added method `serviceClient.ListConnectionsInGroup` and `serviceClient.ListConnectionsInGroupAsync`.`
 
 ## 1.4.0 (2024-07-31)
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
+## 1.6.0 (2025-05-07)
 
 ### Features Added
 - Added method `serviceClient.ListConnectionsInGroup` and `serviceClient.ListConnectionsInGroupAsync`.`

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
@@ -3,18 +3,12 @@
 ## 1.6.0-beta.1 (Unreleased)
 
 ### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added method `serviceClient.ListConnectionsInGroup` and `serviceClient.ListConnectionsInGroupAsync`.`
 
 ## 1.5.0 (2025-02-27)
 
 ### Features Added
 - Added support for SocketIO when generating ClientAccessURI
-- Added method `serviceClient.ListConnectionsInGroup` and `serviceClient.ListConnectionsInGroupAsync`.`
 
 ## 1.4.0 (2024-07-31)
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/README.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/README.md
@@ -161,6 +161,23 @@ var client = new WebPubSubServiceClient(connectionString, "some_hub");
 client.RemoveConnectionFromAllGroups("some_connection");
 ```
 
+#### List connections in group
+Synchronous version:
+```C# Snippet:WebPubSubListConnectionsInGroup
+foreach (WebPubSubGroupMember member in client.ListConnectionsInGroup("groupName"))
+{
+    Console.WriteLine($"ConnectionId: {member.ConnectionId}, UserId: {member.UserId}");
+}
+```
+
+Asynchronous version:
+```C# Snippet:WebPubSubListConnectionsInGroupAsync
+await foreach (WebPubSubGroupMember member in client.ListConnectionsInGroupAsync("groupName"))
+{
+    Console.WriteLine($"ConnectionId: {member.ConnectionId}, UserId: {member.UserId}");
+}
+```
+
 ## Troubleshooting
 
 ### Setting up console logging

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.net8.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.net8.0.cs
@@ -14,7 +14,7 @@ namespace Azure.Messaging.WebPubSub
     public partial class WebPubSubGroupMember
     {
         public WebPubSubGroupMember(string connectionId) { }
-        public string ConnectionId { get { throw null; } set { } }
+        public string ConnectionId { get { throw null; } }
         public string? UserId { get { throw null; } set { } }
     }
     public enum WebPubSubPermission

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.net8.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.net8.0.cs
@@ -11,6 +11,12 @@ namespace Azure.Messaging.WebPubSub
         Mqtt = 1,
         SocketIO = 2,
     }
+    public partial class WebPubSubGroupMember
+    {
+        public WebPubSubGroupMember(string connectionId) { }
+        public string ConnectionId { get { throw null; } set { } }
+        public string? UserId { get { throw null; } set { } }
+    }
     public enum WebPubSubPermission
     {
         SendToGroup = 1,
@@ -70,6 +76,8 @@ namespace Azure.Messaging.WebPubSub
         public virtual System.Threading.Tasks.Task<Azure.Response> GrantPermissionAsync(Azure.Messaging.WebPubSub.WebPubSubPermission permission, string connectionId, string targetName = null, Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response<bool> GroupExists(string group, Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<bool>> GroupExistsAsync(string group, Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Pageable<Azure.Messaging.WebPubSub.WebPubSubGroupMember> ListConnectionsInGroup(string group, int? maxpagesize = default(int?), int? maxCount = default(int?), string continuationToken = null) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.Messaging.WebPubSub.WebPubSubGroupMember> ListConnectionsInGroupAsync(string group, int? maxpagesize = default(int?), int? maxCount = default(int?), string continuationToken = null) { throw null; }
         public virtual Azure.Response RemoveConnectionFromAllGroups(string connectionId, Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> RemoveConnectionFromAllGroupsAsync(string connectionId, Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response RemoveConnectionFromGroup(string group, string connectionId, Azure.RequestContext context = null) { throw null; }
@@ -109,12 +117,13 @@ namespace Azure.Messaging.WebPubSub
     }
     public partial class WebPubSubServiceClientOptions : Azure.Core.ClientOptions
     {
-        public WebPubSubServiceClientOptions(Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion version = Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion.V2024_01_01) { }
+        public WebPubSubServiceClientOptions(Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion version = Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion.V2024_12_01) { }
         public System.Uri ReverseProxyEndpoint { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V2021_10_01 = 1,
             V2024_01_01 = 2,
+            V2024_12_01 = 3,
         }
     }
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.netstandard2.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.netstandard2.0.cs
@@ -14,7 +14,7 @@ namespace Azure.Messaging.WebPubSub
     public partial class WebPubSubGroupMember
     {
         public WebPubSubGroupMember(string connectionId) { }
-        public string ConnectionId { get { throw null; } set { } }
+        public string ConnectionId { get { throw null; } }
         public string? UserId { get { throw null; } set { } }
     }
     public enum WebPubSubPermission

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.netstandard2.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.netstandard2.0.cs
@@ -11,6 +11,12 @@ namespace Azure.Messaging.WebPubSub
         Mqtt = 1,
         SocketIO = 2,
     }
+    public partial class WebPubSubGroupMember
+    {
+        public WebPubSubGroupMember(string connectionId) { }
+        public string ConnectionId { get { throw null; } set { } }
+        public string? UserId { get { throw null; } set { } }
+    }
     public enum WebPubSubPermission
     {
         SendToGroup = 1,
@@ -70,6 +76,8 @@ namespace Azure.Messaging.WebPubSub
         public virtual System.Threading.Tasks.Task<Azure.Response> GrantPermissionAsync(Azure.Messaging.WebPubSub.WebPubSubPermission permission, string connectionId, string targetName = null, Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response<bool> GroupExists(string group, Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<bool>> GroupExistsAsync(string group, Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Pageable<Azure.Messaging.WebPubSub.WebPubSubGroupMember> ListConnectionsInGroup(string group, int? maxpagesize = default(int?), int? maxCount = default(int?), string continuationToken = null) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.Messaging.WebPubSub.WebPubSubGroupMember> ListConnectionsInGroupAsync(string group, int? maxpagesize = default(int?), int? maxCount = default(int?), string continuationToken = null) { throw null; }
         public virtual Azure.Response RemoveConnectionFromAllGroups(string connectionId, Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> RemoveConnectionFromAllGroupsAsync(string connectionId, Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response RemoveConnectionFromGroup(string group, string connectionId, Azure.RequestContext context = null) { throw null; }
@@ -109,12 +117,13 @@ namespace Azure.Messaging.WebPubSub
     }
     public partial class WebPubSubServiceClientOptions : Azure.Core.ClientOptions
     {
-        public WebPubSubServiceClientOptions(Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion version = Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion.V2024_01_01) { }
+        public WebPubSubServiceClientOptions(Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion version = Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion.V2024_12_01) { }
         public System.Uri ReverseProxyEndpoint { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V2021_10_01 = 1,
             V2024_01_01 = 2,
+            V2024_12_01 = 3,
         }
     }
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/assets.json
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/webpubsub/Azure.Messaging.WebPubSub",
-  "Tag": "net/webpubsub/Azure.Messaging.WebPubSub_7d6164a51f"
+  "Tag": "net/webpubsub/Azure.Messaging.WebPubSub_61ea04e0f7"
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Azure.Messaging.WebPubSub.csproj
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Azure.Messaging.WebPubSub.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Azure SDK client library for the WebPubSub service</Description>
     <AssemblyTitle>Azure SDK for WebPubSub</AssemblyTitle>
-    <Version>1.6.0-beta.1</Version>
+    <Version>1.6.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.0</ApiCompatVersion>
     <PackageTags>Azure, WebPubSub, SignalR</PackageTags>

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Generated/WebPubSubServiceClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Generated/WebPubSubServiceClient.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Autorest.CSharp.Core;
 using Azure.Core;
 using Azure.Core.Pipeline;
 
@@ -1539,6 +1540,62 @@ namespace Azure.Messaging.WebPubSub
             }
         }
 
+        /// <summary>
+        /// [Protocol Method] List connections in a group.
+        /// <list type="bullet">
+        /// <item>
+        /// <description>
+        /// This <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/ProtocolMethods.md">protocol method</see> allows explicit creation of the request and processing of the response for advanced scenarios.
+        /// </description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="group"> Target group name, whose length should be greater than 0 and less than 1025. </param>
+        /// <param name="maxpagesize"> The maximum number of connections to include in a single response. It should be between 1 and 200. </param>
+        /// <param name="maxCount"> The maximum number of connections to return. If the value is not set, then all the connections in a group are returned. </param>
+        /// <param name="continuationToken"> A token that allows the client to retrieve the next page of results. This parameter is provided by the service in the response of a previous request when there are additional results to be fetched. Clients should include the continuationToken in the next request to receive the subsequent page of data. If this parameter is omitted, the server will return the first page of results. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="group"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The <see cref="AsyncPageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
+        internal virtual AsyncPageable<BinaryData> GetConnectionsInGroupsAsync(string group, int? maxpagesize = null, int? maxCount = null, string continuationToken = null, RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(group, nameof(group));
+
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConnectionsInGroupsRequest(group, pageSizeHint, maxCount, continuationToken, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConnectionsInGroupsNextPageRequest(nextLink, group, pageSizeHint, maxCount, continuationToken, context);
+            return GeneratorPageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "WebPubSubServiceClient.GetConnectionsInGroups", "value", "nextLink", maxpagesize, context);
+        }
+
+        /// <summary>
+        /// [Protocol Method] List connections in a group.
+        /// <list type="bullet">
+        /// <item>
+        /// <description>
+        /// This <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/ProtocolMethods.md">protocol method</see> allows explicit creation of the request and processing of the response for advanced scenarios.
+        /// </description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="group"> Target group name, whose length should be greater than 0 and less than 1025. </param>
+        /// <param name="maxpagesize"> The maximum number of connections to include in a single response. It should be between 1 and 200. </param>
+        /// <param name="maxCount"> The maximum number of connections to return. If the value is not set, then all the connections in a group are returned. </param>
+        /// <param name="continuationToken"> A token that allows the client to retrieve the next page of results. This parameter is provided by the service in the response of a previous request when there are additional results to be fetched. Clients should include the continuationToken in the next request to receive the subsequent page of data. If this parameter is omitted, the server will return the first page of results. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="group"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The <see cref="Pageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
+        internal virtual Pageable<BinaryData> GetConnectionsInGroups(string group, int? maxpagesize = null, int? maxCount = null, string continuationToken = null, RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(group, nameof(group));
+
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConnectionsInGroupsRequest(group, pageSizeHint, maxCount, continuationToken, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConnectionsInGroupsNextPageRequest(nextLink, group, pageSizeHint, maxCount, continuationToken, context);
+            return GeneratorPageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "WebPubSubServiceClient.GetConnectionsInGroups", "value", "nextLink", maxpagesize, context);
+        }
+
         internal HttpMessage CreateAddConnectionsToGroupsRequest(RequestContent content, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
@@ -1824,6 +1881,36 @@ namespace Azure.Messaging.WebPubSub
             return message;
         }
 
+        internal HttpMessage CreateGetConnectionsInGroupsRequest(string group, int? maxpagesize, int? maxCount, string continuationToken, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
+            var request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendPath("/api/hubs/", false);
+            uri.AppendPath(_hub, true);
+            uri.AppendPath("/groups/", false);
+            uri.AppendPath(group, true);
+            uri.AppendPath("/connections", false);
+            if (maxpagesize != null)
+            {
+                uri.AppendQuery("maxpagesize", maxpagesize.Value, true);
+            }
+            if (maxCount != null)
+            {
+                uri.AppendQuery("top", maxCount.Value, true);
+            }
+            if (continuationToken != null)
+            {
+                uri.AppendQuery("continuationToken", continuationToken, true);
+            }
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            return message;
+        }
+
         internal HttpMessage CreateRemoveConnectionFromGroupRequest(string group, string connectionId, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier204);
@@ -2050,6 +2137,19 @@ namespace Azure.Messaging.WebPubSub
             uri.AppendPath("/groups/", false);
             uri.AppendPath(group, true);
             uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            return message;
+        }
+
+        internal HttpMessage CreateGetConnectionsInGroupsNextPageRequest(string nextLink, string group, int? maxpagesize, int? maxCount, string continuationToken, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
+            var request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Models/WebPubSubGroupMember.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Models/WebPubSubGroupMember.cs
@@ -19,7 +19,7 @@ public class WebPubSubGroupMember(string connectionId)
     /// <summary>
     /// The connection id.
     /// </summary>
-    public string ConnectionId { get; set; } = connectionId;
+    public string ConnectionId { get; } = connectionId;
     /// <summary>
     /// The user id.
     /// </summary>

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Models/WebPubSubGroupMember.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Models/WebPubSubGroupMember.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace Azure.Messaging.WebPubSub;
+
+#nullable enable
+
+/// <summary>
+/// Represents a connection in a group.
+/// </summary>
+/// <remarks>
+/// Creates a new instance of <see cref="WebPubSubGroupMember"/> with the specified connection id.
+/// </remarks>
+/// <param name="connectionId"></param>
+public class WebPubSubGroupMember(string connectionId)
+{
+    /// <summary>
+    /// The connection id.
+    /// </summary>
+    public string ConnectionId { get; set; } = connectionId;
+    /// <summary>
+    /// The user id.
+    /// </summary>
+    public string? UserId { get; set; }
+
+    internal static WebPubSubGroupMember ParseFromJson(JsonElement root)
+    {
+        var connectionId = root.GetProperty("connectionId").GetString() ??
+            throw new JsonException("Required property 'connectionId' was null or not present");
+        var userId = root.TryGetProperty("userId", out JsonElement userIdElement) ? userIdElement.GetString() : null;
+        return new WebPubSubGroupMember(connectionId)
+        {
+            UserId = userId
+        };
+    }
+}

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClientOptions.ServiceVersion.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClientOptions.ServiceVersion.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+
 using Azure.Core;
 
 [assembly: CodeGenSuppressType("WebPubSubServiceClientOptions")]
@@ -30,13 +31,17 @@ namespace Azure.Messaging.WebPubSub
             /// The 2024_01_01_stable version of the Azure WebPubSub service.
             /// </summary>
             V2024_01_01 = 2,
+            /// <summary>
+            /// The 2024_12_01_stable version of the Azure WebPubSub service.
+            /// </summary>
+            V2024_12_01 = 3,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
         /// <summary>
         /// The Latest <see cref="ServiceVersion"/> supported by this client library.
         /// </summary>
-        private const ServiceVersion LatestVersion = ServiceVersion.V2024_01_01;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2024_12_01;
 
         /// <summary>
         /// Gets the version of the service API used when making requests.
@@ -85,6 +90,7 @@ namespace Azure.Messaging.WebPubSub
             {
                 WebPubSubServiceClientOptions.ServiceVersion.V2021_10_01 => "2021-10-01",
                 WebPubSubServiceClientOptions.ServiceVersion.V2024_01_01 => "2024-01-01",
+                WebPubSubServiceClientOptions.ServiceVersion.V2024_12_01 => "2024-12-01",
                 _ => throw CreateInvalidVersionException(version)
             };
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClient_extensions.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClient_extensions.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
+using Autorest.CSharp.Core;
+
 using Azure.Core;
 using Azure.Core.Pipeline;
 
@@ -616,6 +619,46 @@ namespace Azure.Messaging.WebPubSub
             Argument.AssertNotNull(groups, nameof(groups));
 
             return await RemoveConnectionsFromGroupsAsync(RequestContent.Create(new { filter = filter, groups = groups }), context).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// List all the connections in a group.
+        /// </summary>
+        /// <param name="group"> Target group name, whose length should be greater than 0 and less than 1025. </param>
+        /// <param name="maxpagesize"> The maximum number of connections to include in a single response. It should be between 1 and 200. </param>
+        /// <param name="maxCount"> The maximum number of connections to return. If the value is not set, then all the connections in a group are returned. </param>
+        /// <param name="continuationToken"> A token that allows the client to retrieve the next page of results. This parameter is provided by the service in the response of a previous request when there are additional results to be fetched. Clients should include the continuationToken in the next request to receive the subsequent page of data. If this parameter is omitted, the server will return the first page of results. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="group"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The <see cref="Pageable{GroupMember}"/> from the service. </returns>
+        public virtual Pageable<WebPubSubGroupMember> ListConnectionsInGroup(string group, int? maxpagesize = null, int? maxCount = null, string continuationToken = null)
+        {
+            Argument.AssertNotNullOrEmpty(group, nameof(group));
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConnectionsInGroupsRequest(group, pageSizeHint, maxCount, continuationToken, null);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConnectionsInGroupsNextPageRequest(nextLink, group, pageSizeHint, maxCount, continuationToken, null);
+
+            return GeneratorPageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, WebPubSubGroupMember.ParseFromJson, ClientDiagnostics, _pipeline, "WebPubSubServiceClient.ListConnectionsInGroup", "value", "nextLink", maxpagesize, null);
+        }
+
+        /// <summary>
+        /// List all the connections in a group.
+        /// </summary>
+        /// <param name="group"> Target group name, whose length should be greater than 0 and less than 1025. </param>
+        /// <param name="maxpagesize"> The maximum number of connections to include in a single response. It should be between 1 and 200. </param>
+        /// <param name="maxCount"> The maximum number of connections to return. If the value is not set, then all the connections in a group are returned. </param>
+        /// <param name="continuationToken"> A token that allows the client to retrieve the next page of results. This parameter is provided by the service in the response of a previous request when there are additional results to be fetched. Clients should include the continuationToken in the next request to receive the subsequent page of data. If this parameter is omitted, the server will return the first page of results. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="group"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The <see cref="AsyncPageable{GroupMember}"/> from the service. </returns>
+        public virtual AsyncPageable<WebPubSubGroupMember> ListConnectionsInGroupAsync(string group, int? maxpagesize = null, int? maxCount = null, string continuationToken = null)
+        {
+            Argument.AssertNotNullOrEmpty(group, nameof(group));
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConnectionsInGroupsRequest(group, pageSizeHint, maxCount, continuationToken, null);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConnectionsInGroupsNextPageRequest(nextLink, group, pageSizeHint, maxCount, continuationToken, null);
+
+            return GeneratorPageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, WebPubSubGroupMember.ParseFromJson, ClientDiagnostics, _pipeline, "WebPubSubServiceClient.ListConnectionsInGroup", "value", "nextLink", maxpagesize, null);
         }
     }
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/autorest.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/autorest.md
@@ -9,7 +9,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 title: WebPubSubServiceClient
 input-file:
-- https://github.com/Azure/azure-rest-api-specs/blob/356aa5174e8eec6ed904bf5ff104595aec8c0411/specification/webpubsub/data-plane/WebPubSub/stable/2024-01-01/webpubsub.json
+- https://github.com/Azure/azure-rest-api-specs/blob/a67a8c166cdbcb357ac3e56cbc1c1e285b52706a/specification/webpubsub/data-plane/WebPubSub/stable/2024-12-01/webpubsub.json
 
 credential-types: AzureKeyCredential
 credential-header-name: Ocp-Apim-Subscription-Key
@@ -344,4 +344,18 @@ directive:
 - from: swagger-document
   where: $.paths["/api/hubs/{hub}/connections/{connectionId}/groups"].delete.parameters["0"]
   transform: $["x-ms-parameter-location"] = "client"
+```
+
+### ListConnectionsInGroup
+``` yaml
+directive:
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/groups/{group}/connections"].get.operationId
+  transform: return "WebPubSubService_ListConnectionsInGroup";
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/groups/{group}/connections"].get.parameters["0"]
+  transform: $["x-ms-parameter-location"] = "client"
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/groups/{group}/connections"].get
+  transform: $["x-accessibility"] = "internal"
 ```

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/Samples/WebPubSubSamples.HelloWorld.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/Samples/WebPubSubSamples.HelloWorld.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Web.UI;
+using System.Threading.Tasks;
 
 using Azure.Core;
 using Azure.Core.TestFramework;
@@ -135,6 +135,32 @@ namespace Azure.Template.Tests.Samples
             }
 
             client.RemoveUserFromGroup("some_group", "some_user");
+            #endregion
+        }
+
+        public async Task ListConnectionsInGroupAsync()
+        {
+            var connectionString = TestEnvironment.ConnectionString;
+            var client = new WebPubSubServiceClient(connectionString, "some_hub");
+
+            #region Snippet:WebPubSubListConnectionsInGroupAsync
+            await foreach (WebPubSubGroupMember member in client.ListConnectionsInGroupAsync("groupName"))
+            {
+                Console.WriteLine($"ConnectionId: {member.ConnectionId}, UserId: {member.UserId}");
+            }
+            #endregion
+        }
+
+        public void ListConnectionsInGroup()
+        {
+            var connectionString = TestEnvironment.ConnectionString;
+            var client = new WebPubSubServiceClient(connectionString, "some_hub");
+
+            #region Snippet:WebPubSubListConnectionsInGroup
+            foreach (WebPubSubGroupMember member in client.ListConnectionsInGroup("groupName"))
+            {
+                Console.WriteLine($"ConnectionId: {member.ConnectionId}, UserId: {member.UserId}");
+            }
             #endregion
         }
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
@@ -56,7 +56,7 @@ namespace Azure.Rest.WebPubSub.Tests
 
             var clients = new ClientWebSocket[totalConnectionCount];
             // Client WebSocket connections cannot be recorded, so disable them in playback mode.
-            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            if (TestEnvironment.Mode != RecordedTestMode.Playback)
             {
                 for (int i = 0; i < totalConnectionCount; i++)
                 {
@@ -103,7 +103,7 @@ namespace Azure.Rest.WebPubSub.Tests
 
             var clients = new ClientWebSocket[totalCount];
             // Client WebSocket connections cannot be recorded, so disable them in playback mode.
-            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            if (TestEnvironment.Mode != RecordedTestMode.Playback)
             {
                 for (int i = 0; i < totalCount; i++)
                 {

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
@@ -80,7 +80,7 @@ namespace Azure.Rest.WebPubSub.Tests
             Assert.AreEqual(expectedPageCount, actualPageCount);
             Assert.AreEqual(expectedTotalCount, actualConnectionCount);
 
-            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            if (TestEnvironment.Mode != RecordedTestMode.Playback)
             {
                 foreach (ClientWebSocket client in clients)
                 {
@@ -127,7 +127,7 @@ namespace Azure.Rest.WebPubSub.Tests
             List<WebPubSubGroupMember> remainingConnectionsAfterFirstPage = await serviceClient.ListConnectionsInGroupAsync(groupName, continuationToken: firstContinuationToken).ToEnumerableAsync();
             Assert.AreEqual(totalCount - firstPageSize, remainingConnectionsAfterFirstPage.Count);
 
-            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            if (TestEnvironment.Mode != RecordedTestMode.Playback)
             {
                 foreach (ClientWebSocket client in clients)
                 {

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.WebSockets;
-using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -42,6 +39,102 @@ namespace Azure.Rest.WebPubSub.Tests
             var binaryContent = BinaryData.FromString("Hello");
             response = await serviceClient.SendToAllAsync(RequestContent.Create(binaryContent), ContentType.ApplicationOctetStream);
             Assert.AreEqual(202, response.Status);
+        }
+
+        [TestCase(6, 6, null, 6, 1)]
+        [TestCase(6, 3, null, 3, 1)]
+        [TestCase(6, null, 2, 6, 3)]
+        [TestCase(6, 5, 2, 5, 3)]
+        public async Task ServiceClientCanListConnectionsInGroup(int totalConnectionCount, int? maxCountToList, int? maxPageSize, int expectedTotalCount, int expectedPageCount)
+        {
+            WebPubSubServiceClientOptions serviceClientOptions = InstrumentClientOptions(new WebPubSubServiceClientOptions());
+            var serviceClient = new WebPubSubServiceClient(TestEnvironment.ConnectionString, nameof(ServiceClientCanListConnectionsInGroup).ToLower(), serviceClientOptions);
+
+            // Connect a few websocket connections to a group
+            var groupName = "group1";
+            Uri clientAccessUri = serviceClient.GetClientAccessUri(groups: [groupName]);
+
+            var clients = new ClientWebSocket[totalConnectionCount];
+            // Client WebSocket connections cannot be recorded, so disable them in playback mode.
+            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            {
+                for (int i = 0; i < totalConnectionCount; i++)
+                {
+                    var client = new ClientWebSocket();
+                    await client.ConnectAsync(clientAccessUri, CancellationToken.None);
+                    clients[i] = client;
+                }
+            }
+
+            // List connections in the group
+            var actualPageCount = 0;
+            var actualConnectionCount = 0;
+
+            await foreach (Page<WebPubSubGroupMember> page in serviceClient.ListConnectionsInGroupAsync(groupName, maxPageSize, maxCountToList).AsPages())
+            {
+                //actualPageCount++;
+                actualConnectionCount += page.Values.Count;
+                actualPageCount++;
+            }
+
+            Assert.AreEqual(expectedPageCount, actualPageCount);
+            Assert.AreEqual(expectedTotalCount, actualConnectionCount);
+
+            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            {
+                foreach (ClientWebSocket client in clients)
+                {
+                    await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                    client.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public async Task ServiceClientCanListConnectionsInGroupWithContinuationToken()
+        {
+            WebPubSubServiceClientOptions options = InstrumentClientOptions(new WebPubSubServiceClientOptions());
+            var serviceClient = new WebPubSubServiceClient(TestEnvironment.ConnectionString, nameof(ServiceClientCanListConnectionsInGroupWithContinuationToken).ToLower(), options);
+
+            // Connect a few websocket connections to a group
+            var groupName = nameof(ServiceClientCanListConnectionsInGroupWithContinuationToken).ToLower();
+            var totalCount = 2;
+            Uri clientAccessUri = serviceClient.GetClientAccessUri(groups: [groupName]);
+
+            var clients = new ClientWebSocket[totalCount];
+            // Client WebSocket connections cannot be recorded, so disable them in playback mode.
+            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            {
+                for (int i = 0; i < totalCount; i++)
+                {
+                    var client = new ClientWebSocket();
+                    await client.ConnectAsync(clientAccessUri, CancellationToken.None);
+                    clients[i] = client;
+                }
+            }
+
+            // List connections in the group
+            var firstContinuationToken = "";
+            var firstPageSize = 0;
+
+            await foreach (var page in serviceClient.ListConnectionsInGroupAsync(groupName, maxpagesize: 1).AsPages())
+            {
+                firstContinuationToken = page.ContinuationToken;
+                firstPageSize = page.Values.Count;
+                break;
+            }
+
+            List<WebPubSubGroupMember> remainingConnectionsAfterFirstPage = await serviceClient.ListConnectionsInGroupAsync(groupName, continuationToken: firstContinuationToken).ToEnumerableAsync();
+            Assert.AreEqual(totalCount - firstPageSize, remainingConnectionsAfterFirstPage.Count);
+
+            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            {
+                foreach (ClientWebSocket client in clients)
+                {
+                    await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                    client.Dispose();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### PR Classification
New feature implementation for the WebPubSubServiceClient.

#### PR Summary
This pull request adds new methods for listing connections in a group and introduces a new class to represent group members. It also updates the service version enumeration and modifies the documentation to reflect these changes.
- **WebPubSubServiceClient.cs**: Added `ListConnectionsInGroup` and `ListConnectionsInGroupAsync` methods.
- **WebPubSubGroupMember.cs**: Introduced `WebPubSubGroupMember` class for representing connections in a group with JSON parsing capabilities.
- **WebPubSubServiceClientOptions.ServiceVersion.cs**: Updated service version enumeration to include `V2024_12_01` and modified the latest version constant.
- **autorest.md**: Updated to reflect new API operations and their transformations in the Swagger documentation.

### Remarks
Why not add `RequestContext` to the new methods?
If so, the methods will be recognized as "protocol method" and get error "Protocol methods should take a RequestContext parameter called `context` and not use a model type in a parameter or return type".
