### PR TITLE
[Event Hubs] Secondary package offset fixes

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -117,7 +117,7 @@
     <PackageReference Update="Azure.Core.Expressions.DataFactory" Version="1.0.0" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.8.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.12.0" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.12.1" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.21.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.19.0" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.4.0" />
@@ -301,7 +301,7 @@
     <PackageReference Update="Azure.Core" Version="1.44.1" />
     <PackageReference Update="Azure.Identity" Version="1.13.1" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.17.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.11.6" />
+    <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.12.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.19.0" />
     <PackageReference Update="Azure.ResourceManager" Version="1.13.0" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.7.0-beta.1" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.13.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.12.1 (2025-04-09)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed a bug which caused the placeholder value used to represent missing offsets in v5.11.3 - v5.11.6 to not be properly detected and incorrectly used as a valid offset when reading from a partition.
 
 ## 5.12.0 (2025-04-08)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.13.0-beta.1</Version>
+    <Version>5.12.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually. -->
     <ApiCompatVersion>5.12.0</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 6.6.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 6.5.1 (2025-04-09)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed a bug which caused the placeholder value used to represent missing offsets in v5.11.3 - v5.11.6 to not be properly detected and incorrectly used as a valid offset when reading from a partition.
 
 ## 6.5.0 (2025-04-08)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>6.6.0-beta.1</Version>
+    <Version>6.5.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>6.5.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);CS1591;SA1636</NoWarn>


### PR DESCRIPTION
# Summary 

The focus of these changes is to fix a bug which caused the placeholder value used to represent missing offsets in v5.11.3 - v5.11.6 to not be properly detected and incorrectly used as a valid offset when reading from a partition.
