### PR TITLE
Remove variable blocksize

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PartitionedUploaderTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Storage.Blobs.Test
 
             Assert.AreEqual(1, sink.Staged.Count);
             Assert.AreEqual(s_response, info);
-            Assert.AreEqual(2, testPool.TotalRents); // while conceptually there is one rental, the second rental occurs upon checking for stream end on a Read() call
+            Assert.AreEqual(1, testPool.TotalRents);
             Assert.AreEqual(0, testPool.CurrentCount);
             AssertStaged(sink, content);
         }
@@ -107,14 +107,14 @@ namespace Azure.Storage.Blobs.Test
             clientMock.SetupGet(c => c.ClientConfiguration).CallBase();
             SetupInternalStaging(clientMock, sink);
 
-            var uploader = new PartitionedUploader<BlobUploadOptions, BlobContentInfo>(BlockBlobClient.GetPartitionedUploaderBehaviors(clientMock.Object), new StorageTransferOptions() { MaximumTransferLength = 20}, s_validationEmpty, arrayPool: testPool);
+            var uploader = new PartitionedUploader<BlobUploadOptions, BlobContentInfo>(BlockBlobClient.GetPartitionedUploaderBehaviors(clientMock.Object), new StorageTransferOptions() { MaximumTransferLength = 10}, s_validationEmpty, arrayPool: testPool);
             Response<BlobContentInfo> info = await InvokeUploadAsync(uploader, content);
 
             Assert.AreEqual(2, sink.Staged.Count);
             Assert.AreEqual(s_response, info);
             AssertStaged(sink, content);
 
-            Assert.AreEqual(3, testPool.TotalRents);
+            Assert.AreEqual(2, testPool.TotalRents);
             Assert.AreEqual(0, testPool.CurrentCount);
         }
 
@@ -137,7 +137,7 @@ namespace Azure.Storage.Blobs.Test
 
             Assert.AreEqual(1, sink.Staged.Count);
             Assert.AreEqual(s_response, info);
-            Assert.AreEqual(2, testPool.TotalRents); // while conceptually there is one rental, the second rental occurs upon checking for stream end on a Read() call
+            Assert.AreEqual(1, testPool.TotalRents);
             Assert.AreEqual(0, testPool.CurrentCount);
             AssertStaged(sink, content);
         }
@@ -161,7 +161,7 @@ namespace Azure.Storage.Blobs.Test
 
             Assert.AreEqual(s_response, info);
             Assert.AreEqual(0, testPool.CurrentCount);
-            Assert.AreEqual(41, testPool.TotalRents);
+            Assert.AreEqual(20, testPool.TotalRents);
             AssertStaged(sink, content);
 
             foreach (byte[] bytes in sink.Staged.Values.Select(val => val.Data))
@@ -186,14 +186,14 @@ namespace Azure.Storage.Blobs.Test
             clientMock.SetupGet(c => c.ClientConfiguration).CallBase();
             SetupInternalStaging(clientMock, sink);
 
-            var uploader = new PartitionedUploader<BlobUploadOptions, BlobContentInfo>(BlockBlobClient.GetPartitionedUploaderBehaviors(clientMock.Object), new StorageTransferOptions() { MaximumTransferLength = 20}, s_validationEmpty, arrayPool: testPool);
+            var uploader = new PartitionedUploader<BlobUploadOptions, BlobContentInfo>(BlockBlobClient.GetPartitionedUploaderBehaviors(clientMock.Object), new StorageTransferOptions() { MaximumTransferLength = 10}, s_validationEmpty, arrayPool: testPool);
             Response<BlobContentInfo> info = await InvokeUploadAsync(uploader, content);
 
             Assert.AreEqual(2, sink.Staged.Count);
             // First two should be merged
             CollectionAssert.AreEqual(new byte[] {0, 0, 0, 0, 0, 1, 1, 1, 1, 1 }, sink.Staged[sink.Blocks.First()].Data);
             Assert.AreEqual(s_response, info);
-            Assert.AreEqual(3, testPool.TotalRents);
+            Assert.AreEqual(2, testPool.TotalRents);
             Assert.AreEqual(0, testPool.CurrentCount);
             AssertStaged(sink, content);
         }
@@ -212,7 +212,7 @@ namespace Azure.Storage.Blobs.Test
             clientMock.SetupGet(c => c.ClientConfiguration).CallBase();
             SetupInternalStaging(clientMock, sink);
 
-            var uploader = new PartitionedUploader<BlobUploadOptions, BlobContentInfo>(BlockBlobClient.GetPartitionedUploaderBehaviors(clientMock.Object), new StorageTransferOptions() { MaximumTransferLength = 20 }, s_validationEmpty);
+            var uploader = new PartitionedUploader<BlobUploadOptions, BlobContentInfo>(BlockBlobClient.GetPartitionedUploaderBehaviors(clientMock.Object), new StorageTransferOptions() { MaximumTransferLength = 10 }, s_validationEmpty);
             Response<BlobContentInfo> info = await InvokeUploadAsync(uploader, content);
 
             Assert.AreEqual(2, sink.Staged.Count);

--- a/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
@@ -379,7 +379,7 @@ namespace Azure.Storage
                     }
                     else
                     {
-                        (bufferedContent, oneshotValidationOptions) = await BufferAndChecksumStreamInternal(
+                        (bufferedContent, oneshotValidationOptions) = await BufferAndOptionalChecksumStreamInternal(
                             content, length.Value, oneshotValidationOptions, async, cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -462,7 +462,7 @@ namespace Azure.Storage
         /// </list>
         /// </returns>
         private async Task<(Stream Stream, UploadTransferValidationOptions ValidationOptions)>
-            BufferAndChecksumStreamInternal(
+            BufferAndOptionalChecksumStreamInternal(
                 Stream source,
                 long? count,
                 UploadTransferValidationOptions validationOptions,
@@ -980,7 +980,7 @@ namespace Azure.Storage
         {
             // also calculate checksum here for the partition checksum
             (Stream slicedStream, UploadTransferValidationOptions validationOptions)
-                = await BufferAndChecksumStreamInternal(
+                = await BufferAndOptionalChecksumStreamInternal(
                     stream,
                     maxCount,
                     new UploadTransferValidationOptions { ChecksumAlgorithm = _validationAlgorithm },

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageWriteStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageWriteStream.cs
@@ -93,7 +93,7 @@ namespace Azure.Storage.Shared
             {
                 _buffer = new PooledMemoryStream(
                     arrayPool: _bufferPool,
-                    maxArraySize: (int)Math.Min(Constants.MB, bufferSize));
+                    bufferSize: (int)Math.Min(Constants.MB, bufferSize));
                 _accumulatedDisposables.Add(_buffer);
             }
             _bufferChecksumer = ContentHasher.GetHasherFromAlgorithmId(_checksumAlgorithm);

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StreamExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StreamExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +14,8 @@ namespace Azure.Storage
     /// </summary>
     internal static partial class StreamExtensions
     {
+        private const int DefaultCopyBufferSize = 81920; // default from .NET documentation
+
         public static async Task<int> ReadInternal(
             this Stream stream,
             byte[] buffer,
@@ -56,7 +60,7 @@ namespace Azure.Storage
             => CopyToInternal(
                 src,
                 dest,
-                bufferSize: 81920, // default from .NET documentation
+                DefaultCopyBufferSize,
                 async,
                 cancellationToken);
 
@@ -94,6 +98,44 @@ namespace Azure.Storage
             {
                 src.CopyTo(dest, bufferSize);
             }
+        }
+
+        public static async Task<long> CopyToExactInternal(
+            this Stream src,
+            Stream dst,
+            long count,
+            bool async,
+            CancellationToken cancellationToken)
+            => await CopyToExactInternal(
+                src,
+                dst,
+                count,
+                DefaultCopyBufferSize,
+                async,
+                cancellationToken)
+                .ConfigureAwait(false);
+
+        public static async Task<long> CopyToExactInternal(
+            this Stream src,
+            Stream dst,
+            long count,
+            int copyBufferSize,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            using IDisposable _ = ArrayPool<byte>.Shared.RentDisposable(copyBufferSize, out byte[] copyBuffer);
+            long totalCopied = 0;
+            while (totalCopied < count)
+            {
+                int read = await src.ReadInternal(copyBuffer, 0, (int)Math.Min(count - totalCopied, copyBuffer.Length), async, cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+                await dst.WriteInternal(copyBuffer, 0, read, async, cancellationToken).ConfigureAwait(false);
+                totalCopied += read;
+            }
+            return totalCopied;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
@@ -44,11 +44,13 @@ namespace Azure.Storage.Tests
         [TestCase(Constants.KB, 256)] // buffer split size smaller than data
         [TestCase(Constants.KB, 2 * Constants.KB)] // buffer split size larger than data.
         [TestCase(Constants.KB + 11, 256)] // content doesn't line up with buffers (extremely unlikely any array pool implementation will add exactly 11 bytes more than requested across 4 buffers)
-        public async Task ReadStream(int dataSize, int bufferPartitionSize)
+        public void ReadStream(int dataSize, int bufferPartitionSize)
         {
             PredictableStream originalStream = new PredictableStream();
-            PooledMemoryStream arrayPoolStream = await PooledMemoryStream.BufferStreamPartitionInternal(originalStream, dataSize, dataSize, _pool, bufferPartitionSize, true, default);
+            PooledMemoryStream arrayPoolStream = new(_pool, bufferPartitionSize);
+            originalStream.CopyToExactInternal(arrayPoolStream, dataSize, async: false, cancellationToken: default).EnsureCompleted();
             originalStream.Position = 0;
+            arrayPoolStream.Position = 0;
 
             byte[] originalStreamData = new byte[dataSize];
             byte[] poolStreamData = new byte[dataSize];
@@ -67,7 +69,8 @@ namespace Azure.Storage.Tests
             const long dataSize = (long)int.MaxValue + Constants.MB;
             const int bufferPartitionSize = 512 * Constants.MB;
             PredictableStream originalStream = new PredictableStream();
-            PooledMemoryStream arrayPoolStream = PooledMemoryStream.BufferStreamPartitionInternal(originalStream, dataSize, dataSize, _pool, bufferPartitionSize, false, default).EnsureCompleted();
+            PooledMemoryStream arrayPoolStream = new(_pool, bufferPartitionSize);
+            originalStream.CopyToExactInternal(arrayPoolStream, dataSize, async: false, cancellationToken: default).EnsureCompleted();
             originalStream.Position = 0;
 
             // assert it holds the correct amount of data. other tests assert data validity and it's so expensive to do that here.

--- a/sdk/storage/Azure.Storage.Common/tests/StorageWriteStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageWriteStreamTests.cs
@@ -36,7 +36,8 @@ namespace Azure.Storage.Tests
             Mock<PooledMemoryStream> mockBuffer = new(
                 MockBehavior.Loose,
                 ArrayPool<byte>.Shared,
-                Constants.MB)
+                Constants.MB,
+                default(int?))
             {
                 CallBase = true,
             };
@@ -94,7 +95,8 @@ namespace Azure.Storage.Tests
             Mock<PooledMemoryStream> mockBuffer = new(
                 MockBehavior.Loose,
                 ArrayPool<byte>.Shared,
-                Constants.MB)
+                Constants.MB,
+                default(int?))
             {
                 CallBase = true,
             };
@@ -149,7 +151,8 @@ namespace Azure.Storage.Tests
             Mock<PooledMemoryStream> mockBuffer = new(
                 MockBehavior.Loose,
                 ArrayPool<byte>.Shared,
-                Constants.MB)
+                Constants.MB,
+                default(int?))
             {
                 CallBase = true,
             };
@@ -198,7 +201,8 @@ namespace Azure.Storage.Tests
             Mock<PooledMemoryStream> mockBuffer = new(
                 MockBehavior.Loose,
                 ArrayPool<byte>.Shared,
-                Constants.MB)
+                Constants.MB,
+                default(int?))
             {
                 CallBase = true,
             };

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -31,6 +31,7 @@
     <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" LinkBase="Shared\Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(AzureStorageSharedSources)BufferExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ContentRange.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Constants.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)Errors.cs" LinkBase="Shared\Storage" />

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakePartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakePartitionedUploaderTests.cs
@@ -78,7 +78,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             Assert.AreEqual(1, sink.Appended.Count);
             Assert.AreEqual(s_response, info);
-            Assert.AreEqual(2, testPool.TotalRents); // while conceptually there is one rental, the second rental occurs upon checking for stream end on a Read() call
+            Assert.AreEqual(1, testPool.TotalRents);
             Assert.AreEqual(0, testPool.CurrentCount);
             AssertAppended(sink, content);
         }
@@ -123,7 +123,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             var uploader = new PartitionedUploader<DataLakeFileUploadOptions, PathInfo>(
                 DataLakeFileClient.GetPartitionedUploaderBehaviors(clientMock.Object),
-                new StorageTransferOptions() { MaximumTransferLength = 20 },
+                new StorageTransferOptions() { MaximumTransferLength = 10 },
                 transferValidation: s_validationNone,
                 arrayPool: testPool);
             Response<PathInfo> info = await InvokeUploadAsync(uploader, content);
@@ -132,7 +132,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual(s_response, info);
             AssertAppended(sink, content);
 
-            Assert.AreEqual(3, testPool.TotalRents);
+            Assert.AreEqual(2, testPool.TotalRents);
             Assert.AreEqual(0, testPool.CurrentCount);
         }
 
@@ -160,7 +160,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             Assert.AreEqual(1, sink.Appended.Count);
             Assert.AreEqual(s_response, info);
-            Assert.AreEqual(2, testPool.TotalRents); // while conceptually there is one rental, the second rental occurs upon checking for stream end on a Read() call
+            Assert.AreEqual(1, testPool.TotalRents);
             Assert.AreEqual(0, testPool.CurrentCount);
             AssertAppended(sink, content);
         }
@@ -189,7 +189,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             Assert.AreEqual(s_response, info);
             Assert.AreEqual(0, testPool.CurrentCount);
-            Assert.AreEqual(41, testPool.TotalRents);
+            Assert.AreEqual(20, testPool.TotalRents);
             AssertAppended(sink, content);
 
             foreach ((byte[] bytes, _) in sink.Appended.Values)
@@ -216,7 +216,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             var uploader = new PartitionedUploader<DataLakeFileUploadOptions, PathInfo>(
                 DataLakeFileClient.GetPartitionedUploaderBehaviors(clientMock.Object),
-                new StorageTransferOptions() { MaximumTransferLength = 20 },
+                new StorageTransferOptions() { MaximumTransferLength = 10 },
                 transferValidation: s_validationNone,
                 arrayPool: testPool);
             Response<PathInfo> info = await InvokeUploadAsync(uploader, content);
@@ -225,7 +225,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // First two should be merged
             CollectionAssert.AreEqual(new byte[] { 0, 0, 0, 0, 0, 1, 1, 1, 1, 1 }, sink.Appended[0].Data);
             Assert.AreEqual(s_response, info);
-            Assert.AreEqual(3, testPool.TotalRents);
+            Assert.AreEqual(2, testPool.TotalRents);
             Assert.AreEqual(0, testPool.CurrentCount);
             AssertAppended(sink, content);
         }


### PR DESCRIPTION
Removes behavior from PartitionedUploader where if a block is at least half-filled with data, it will be uploaded as is without waiting for another stream read.

This is a behavior which produces inconsistent results and adds maintenance overhead. It has been removed.