### PR TITLE
Fix `VerifyGeneratedCode` timeouts

### DIFF
--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -98,7 +98,7 @@ try {
 
         Write-Host "Re-generating clients"
         Invoke-Block {
-            & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory $diagnosticArguments
+            & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory $diagnosticArguments /p:ProjectListOverrideFile=""
         }
     }
 


### PR DESCRIPTION
Proved out in [this sample PR](https://github.com/Azure/azure-sdk-for-net/pull/49423)

A follow-up PR for utilizing the ProjectListOverrideFile is coming.