### PR TITLE
[EventGrid] Generate switch expressions instead of dictionary lookups

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/src/EventGridSourceGenerator.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/src/EventGridSourceGenerator.cs
@@ -109,28 +109,21 @@ namespace Azure.Messaging.EventGrid
     {{
         public static object AsSystemEventData(string eventType, JsonElement data)
         {{
-            if (s_systemEventDeserializers.TryGetValue(eventType, out Func<JsonElement,{(_isSystemEventsLibrary ? " ModelReaderWriterOptions," : string.Empty)} object> systemDeserializationFunction))
+            return eventType switch
             {{
-                return systemDeserializationFunction(data{(_isSystemEventsLibrary ? ", null" : string.Empty)});
-            }}
-            else
-            {{
-                return null;
-            }}
-        }}
-
-        internal static readonly IReadOnlyDictionary<string, Func<JsonElement,{(_isSystemEventsLibrary ? " ModelReaderWriterOptions," : string.Empty)} object>> s_systemEventDeserializers = new Dictionary<string, Func<JsonElement,{(_isSystemEventsLibrary ? " ModelReaderWriterOptions," : string.Empty)} object>>(StringComparer.OrdinalIgnoreCase)
-        {{
 ");
             foreach (SystemEventNode sysEvent in _visitor.SystemEvents)
             {
                 // Add each an entry for each system event to the dictionary containing a mapping from constant name to deserialization method.
                 sourceBuilder.AppendLine(
-                    $"{Indent}{Indent}{Indent}{{ SystemEventNames.{sysEvent.EventConstantName}, {sysEvent.EventName}.{sysEvent.DeserializeMethod} }},");
+                    $"{Indent}{Indent}{Indent}{Indent}SystemEventNames.{sysEvent.EventConstantName} => {sysEvent.EventName}.{sysEvent.DeserializeMethod}(data{(_isSystemEventsLibrary ? ", null": string.Empty)}),");
             }
-            sourceBuilder.Append($@"{Indent}{Indent}}};
-{Indent}}}
-}}");
+            sourceBuilder.AppendLine($"{Indent}{Indent}{Indent}{Indent}_ => null");
+            sourceBuilder.AppendLine($"{Indent}{Indent}{Indent}}};");
+            sourceBuilder.AppendLine($"{Indent}{Indent}}}");
+            sourceBuilder.AppendLine($"{Indent}}}");
+            sourceBuilder.AppendLine("}");
+
             return sourceBuilder.ToString();
         }
     }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/src/EventGridSourceGenerator.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/src/EventGridSourceGenerator.cs
@@ -109,14 +109,15 @@ namespace Azure.Messaging.EventGrid
     {{
         public static object AsSystemEventData(string eventType, JsonElement data)
         {{
-            return eventType switch
+            var eventTypeSpan = eventType.AsSpan();
+            return eventTypeSpan switch
             {{
 ");
             foreach (SystemEventNode sysEvent in _visitor.SystemEvents)
             {
                 // Add each an entry for each system event to the dictionary containing a mapping from constant name to deserialization method.
                 sourceBuilder.AppendLine(
-                    $"{Indent}{Indent}{Indent}{Indent}SystemEventNames.{sysEvent.EventConstantName} => {sysEvent.EventName}.{sysEvent.DeserializeMethod}(data{(_isSystemEventsLibrary ? ", null": string.Empty)}),");
+                    $"{Indent}{Indent}{Indent}{Indent}_ when eventTypeSpan.Equals(SystemEventNames.{sysEvent.EventConstantName}.AsSpan(), StringComparison.OrdinalIgnoreCase) => {sysEvent.EventName}.{sysEvent.DeserializeMethod}(data{(_isSystemEventsLibrary ? ", null": string.Empty)}),");
             }
             sourceBuilder.AppendLine($"{Indent}{Indent}{Indent}{Indent}_ => null");
             sourceBuilder.AppendLine($"{Indent}{Indent}{Indent}}};");

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/src/EventGridSourceGenerator.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator/src/EventGridSourceGenerator.cs
@@ -110,17 +110,16 @@ namespace Azure.Messaging.EventGrid
         public static object AsSystemEventData(string eventType, JsonElement data)
         {{
             var eventTypeSpan = eventType.AsSpan();
-            return eventTypeSpan switch
-            {{
 ");
             foreach (SystemEventNode sysEvent in _visitor.SystemEvents)
             {
                 // Add each an entry for each system event to the dictionary containing a mapping from constant name to deserialization method.
                 sourceBuilder.AppendLine(
-                    $"{Indent}{Indent}{Indent}{Indent}_ when eventTypeSpan.Equals(SystemEventNames.{sysEvent.EventConstantName}.AsSpan(), StringComparison.OrdinalIgnoreCase) => {sysEvent.EventName}.{sysEvent.DeserializeMethod}(data{(_isSystemEventsLibrary ? ", null": string.Empty)}),");
+                    $"{Indent}{Indent}{Indent}if (eventTypeSpan.Equals(SystemEventNames.{sysEvent.EventConstantName}.AsSpan(), StringComparison.OrdinalIgnoreCase))");
+                sourceBuilder.AppendLine(
+                    $"{Indent}{Indent}{Indent}{Indent}return {sysEvent.EventName}.{sysEvent.DeserializeMethod}(data{(_isSystemEventsLibrary ? ", null" : string.Empty)});");
             }
-            sourceBuilder.AppendLine($"{Indent}{Indent}{Indent}{Indent}_ => null");
-            sourceBuilder.AppendLine($"{Indent}{Indent}{Indent}}};");
+            sourceBuilder.AppendLine($"{Indent}{Indent}{Indent}return null;");
             sourceBuilder.AppendLine($"{Indent}{Indent}}}");
             sourceBuilder.AppendLine($"{Indent}}}");
             sourceBuilder.AppendLine("}");

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SystemEventTests.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SystemEventTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using Azure.Messaging.EventGrid.SystemEvents;
 using NUnit.Framework;
 
@@ -39,10 +40,9 @@ namespace Azure.Messaging.EventGrid.Tests
                 }
 
                 ValidateName(systemEvent.Name);
-                Assert.IsTrue(
-                    SystemEventExtensions.s_systemEventDeserializers.Values.Any(
-                        f => f.Method.ReturnType == systemEvent), systemEvent.Name);
+                Assert.IsNotNull(SystemEventExtensions.AsSystemEventData(systemEvent.Name, JsonDocument.Parse("{}").RootElement));
             }
+            Assert.IsNull(SystemEventExtensions.AsSystemEventData("DoesNotExist", JsonDocument.Parse("{}").RootElement));
         }
 
         [Test]


### PR DESCRIPTION
This PR refactors the `SystemEventExtensions.AsSystemEventData` method by replacing the [existing dictionary-based lookup](https://github.com/Azure/azure-sdk-for-net/pull/49088) with a switch expression. This change directly maps event type strings to their corresponding deserialization methods.

While the performance gains are relatively small and mostly noticeable in microbenchmarks or hot-path scenarios, this change streamlines the code and enables the runtime to produce more efficient IL. The overall design remains functionally equivalent, ensuring a smooth transition without breaking existing functionality.

### Assumptions

- Performance Improvements: The if statements reduce overhead by eliminating the need for dictionary lookups and indirect delegate calls. This leads to fewer IL-level indirections and leverages direct branch optimizations, which are advantageous in frequently executed code paths.
- Optimized IL Code: The if statements compiles into more predictable branching logic. This allows the JIT compiler to apply inlining and other optimizations more effectively, further enhancing runtime performance.
- Code Clarity and Maintainability: Directly associating event types with their deserialization logic in an if statement improves readability. The intent of the code becomes clearer, making it easier to maintain and less error-prone compared to managing a separate dictionary.

### Before

```csharp
    internal class SystemEventExtensions
    {
        public static object AsSystemEventData(string eventType, JsonElement data)
        {
            if (s_systemEventDeserializers.TryGetValue(eventType, out Func<JsonElement, object> systemDeserializationFunction))
            {
                return systemDeserializationFunction(data);
            }
            else
            {
                return null;
            }
        }

        internal static readonly IReadOnlyDictionary<string, Func<JsonElement, object>> s_systemEventDeserializers = new Dictionary<string, Func<JsonElement, object>>(StringComparer.OrdinalIgnoreCase)
        {
            { SystemEventNames.AcsRecordingFileStatusUpdated, AcsRecordingFileStatusUpdatedEventData.DeserializeAcsRecordingFileStatusUpdatedEventData },
            { SystemEventNames.AcsRouterJobClassificationFailed, AcsRouterJobClassificationFailedEventData.DeserializeAcsRouterJobClassificationFailedEventData },
            ...
        }
```

### After

```csharp
    internal class SystemEventExtensions
    {
        public static object AsSystemEventData(string eventType, JsonElement data)
        {
            var eventTypeSpan = eventType.AsSpan();
            if (eventTypeSpan.Equals(SystemEventNames.AcsRecordingFileStatusUpdated.AsSpan(), StringComparison.OrdinalIgnoreCase))
                return AcsRecordingFileStatusUpdatedEventData.DeserializeAcsRecordingFileStatusUpdatedEventData(data);
            if (eventTypeSpan.Equals(SystemEventNames.AcsRouterJobClassificationFailed.AsSpan(), StringComparison.OrdinalIgnoreCase))
                ...
            return null;
        }
    }       
```

