### PR TITLE
Pass `ExcludePaths` to `save-package-properties.yml`

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -45,6 +45,9 @@ parameters:
   - name: LimitForPullRequest
     type: boolean
     default: false
+  - name: ExcludePaths
+    type: object
+    default: []
 
 jobs:
   - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
@@ -77,6 +80,7 @@ jobs:
               ServiceDirectory: ${{ parameters.ServiceDirectory }}
               PublishingArtifactName: BuildPackagesArtifact
               ForceDirect: true
+              ExcludePaths: ${{ parameters.ExcludePaths }}
 
   - ${{ else }}:
     - job: Build
@@ -186,6 +190,7 @@ jobs:
               parameters:
                 ServiceDirectory: ${{ parameters.ServiceDirectory }}
                 PublishingArtifactName: TestPackagesArtifact
+                ExcludePaths: ${{ parameters.ExcludePaths }}
 
         AdditionalParameters:
           SDKType: ${{ parameters.SDKType }}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -54,6 +54,9 @@ parameters:
   - name: oneESTemplateTag
     type: string
     default: true
+  - name: ExcludePaths
+    type: object
+    default: []
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml

--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -6,6 +6,9 @@ parameters:
   - name: ForceDirect
     type: boolean
     default: false
+  - name: ExcludePaths
+    type: object
+    default: []
 
 steps:
   - script: |
@@ -18,6 +21,7 @@ steps:
     parameters:
       ServiceDirectory: ${{parameters.ServiceDirectory}}
       PackageInfoDirectory: $(Build.ArtifactStagingDirectory)/PackageInfoPublishing
+      ExcludePaths: ${{ parameters.ExcludePaths }}
 
   # when we publish the packageinfo as an artifact, it actually cleans up the original files. Since we need them during matrix generation steps
   # that will execute directly after the pregeneration steps here, we output them to a publishing directory, copy from there into the target PackageInfoDirectory,

--- a/sdk/pullrequest.yml
+++ b/sdk/pullrequest.yml
@@ -24,3 +24,5 @@ extends:
     ServiceDirectory: ${{ parameters.Service }}
     CheckAOTCompat: true
     BuildSnippets: true
+    ExcludePaths:
+      - eng/packages/http-client-csharp/


### PR DESCRIPTION
We aren't identifying the eng/packages/http-client-csharp as packages that need to be tested right _now_, but if any configuration changes we _might_. I'd rather address this now via a mechanism that we have built in.