### PR TITLE
SIP X-* Header Support for Beta3 IncomingCall & Transfer

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.net8.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.net8.0.cs
@@ -717,8 +717,13 @@ namespace Azure.Communication.CallAutomation
         public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> VoipHeaders { get { throw null; } }
         public void AddSipUui(string value) { }
-        public void AddSipX(string key, string value) { }
+        public void AddSipX(string key, string value, Azure.Communication.CallAutomation.CustomCallingContext.SipHeaderPrefix prefix = Azure.Communication.CallAutomation.CustomCallingContext.SipHeaderPrefix.XMSCustom) { }
         public void AddVoip(string key, string value) { }
+        public enum SipHeaderPrefix
+        {
+            XMSCustom = 0,
+            X = 1,
+        }
     }
     public partial class DialogCompleted : Azure.Communication.CallAutomation.CallAutomationEventBase
     {

--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -716,8 +716,13 @@ namespace Azure.Communication.CallAutomation
         public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> VoipHeaders { get { throw null; } }
         public void AddSipUui(string value) { }
-        public void AddSipX(string key, string value) { }
+        public void AddSipX(string key, string value, Azure.Communication.CallAutomation.CustomCallingContext.SipHeaderPrefix prefix = Azure.Communication.CallAutomation.CustomCallingContext.SipHeaderPrefix.XMSCustom) { }
         public void AddVoip(string key, string value) { }
+        public enum SipHeaderPrefix
+        {
+            XMSCustom = 0,
+            X = 1,
+        }
     }
     public partial class DialogCompleted : Azure.Communication.CallAutomation.CallAutomationEventBase
     {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomCallingContext.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomCallingContext.cs
@@ -40,17 +40,25 @@ namespace Azure.Communication.CallAutomation
         }
 
         /// <summary>
-        /// Add a custom calling context sip X header. The provided key is appended to such as 'X-MS-Custom-{key}'
+        /// Add a custom calling context sip X header (X-* or X-MS-Custom-*).
         /// </summary>
         /// <param name="key">custom calling context sip X header's key.</param>
         /// <param name="value">custom calling context sip X header's value.</param>
-        public void AddSipX(string key, string value)
+        /// <param name="prefix">prefix to be used for SIP X headers.</param>
+        public void AddSipX(string key, string value, SipHeaderPrefix prefix = SipHeaderPrefix.XMSCustom)
         {
             if (SipHeaders == null)
             {
                 throw new InvalidOperationException("Cannot add sip X header, SipHeaders is null.");
             }
-            SipHeaders.Add("X-MS-Custom-" + key, value);
+            if (prefix == SipHeaderPrefix.XMSCustom)
+            {
+                SipHeaders.Add("X-MS-Custom-" + key, value);
+            }
+            else
+            {
+                SipHeaders.Add("X-" + key, value);
+            }
         }
 
         /// <summary>
@@ -65,6 +73,22 @@ namespace Azure.Communication.CallAutomation
                 throw new InvalidOperationException("Cannot add voip header, VoipHeaders is null.");
             }
             VoipHeaders.Add(key, value);
+        }
+
+        /// <summary>
+        /// Enum representing the prefix to be used for SIP X headers.
+        /// </summary>
+        public enum SipHeaderPrefix
+        {
+            /// <summary>
+            /// Use the legacy "X-MS-Custom-" prefix.
+            /// </summary>
+            XMSCustom = 0,
+
+            /// <summary>
+            /// Use the generic "X-" prefix.
+            /// </summary>
+            X = 1
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionTests.cs
@@ -133,6 +133,24 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             verifyOperationContext(response);
         }
 
+        [TestCaseSource(nameof(TestData_TransferCallToParticipant_PhoneNumberIdentifier))]
+        public async Task TransferCallToParticipantAsync_simpleMethod_PhoneNumberIdentifier_202Accepted(CallInvite callInvite)
+        {
+            var callConnection = CreateMockCallConnection(202, OperationContextPayload);
+            var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
+            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            verifyOperationContext(response);
+        }
+
+        [TestCaseSource(nameof(TestData_TransferCallToParticipant_PhoneNumberIdentifier_MS))]
+        public async Task TransferCallToParticipantAsync_simpleMethod_PhoneNumberIdentifier_MSAsTarget_202Accepted(CallInvite callInvite)
+        {
+            var callConnection = CreateMockCallConnection(202, OperationContextPayload);
+            var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
+            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            verifyOperationContext(response);
+        }
+
         [TestCaseSource(nameof(TestData_TransferCallToParticipant))]
         public async Task TransferCallToParticipantAsync_202Accepted(CallInvite callInvite)
         {
@@ -519,6 +537,31 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 new object?[]
                 {
                     new CommunicationUserIdentifier("userId")
+                },
+            };
+        }
+
+        private static IEnumerable<object?[]> TestData_TransferCallToParticipant_PhoneNumberIdentifier_MS()
+        {
+            var callInvite = new CallInvite(new PhoneNumberIdentifier(PhoneNumber), new PhoneNumberIdentifier("+17654321"));
+            callInvite.CustomCallingContext.AddSipX("key1", "value1", CustomCallingContext.SipHeaderPrefix.XMSCustom);
+            return new[]
+            {
+                new object?[]
+                {
+                    callInvite
+                },
+            };
+        }
+        private static IEnumerable<object?[]> TestData_TransferCallToParticipant_PhoneNumberIdentifier()
+        {
+            var callInvite = new CallInvite(new PhoneNumberIdentifier(PhoneNumber), new PhoneNumberIdentifier("+17654321"));
+            callInvite.CustomCallingContext.AddSipX("key1", "value1", CustomCallingContext.SipHeaderPrefix.X);
+            return new[]
+            {
+                new object?[]
+                {
+                    callInvite
                 },
             };
         }


### PR DESCRIPTION
Added Sip X-* Header support for CustomCallingContext as per design doc + unit tests for both X-* header and X-MS-Custom header. All unit tests for call transfers and incoming call event pass successfully.

Correlation ID -> 3a481dc5-171a-4d16-aa03-e0f4ca77415a
https://ngc.skype.net/call/3a481dc5-171a-4d16-aa03-e0f4ca77415a/
