### PR TITLE
Always add default property

### DIFF
--- a/sdk/core/System.ClientModel/gen/ModelReaderWriterContextGenerator.Emitter.cs
+++ b/sdk/core/System.ClientModel/gen/ModelReaderWriterContextGenerator.Emitter.cs
@@ -83,36 +83,33 @@ internal sealed partial class ModelReaderWriterContextGenerator
                 builder.AppendLine();
             }
 
-            if (contextGenerationSpec.TypeBuilders.Count > 0)
+            builder.AppendLine(indent, $"private static {contextName} _{contextName.ToCamelCase()};");
+            builder.AppendLine(indent, "/// <summary> Gets the default instance </summary>");
+            builder.AppendLine(indent, $"public static {contextName} Default => _{contextName.ToCamelCase()} ??= new();");
+            builder.AppendLine();
+
+            builder.AppendLine(indent, $"private {contextName}()");
+            builder.AppendLine(indent, "{");
+            indent++;
+            foreach (var modelInfo in contextGenerationSpec.TypeBuilders)
             {
-                builder.AppendLine(indent, $"private static {contextName} _{contextName.ToCamelCase()};");
-                builder.AppendLine(indent, "/// <summary> Gets the default instance </summary>");
-                builder.AppendLine(indent, $"public static {contextName} Default => _{contextName.ToCamelCase()} ??= new();");
-                builder.AppendLine();
-
-                builder.AppendLine(indent, $"private {contextName}()");
-                builder.AppendLine(indent, "{");
-                indent++;
-                foreach (var modelInfo in contextGenerationSpec.TypeBuilders)
+                builder.Append(indent, $"_typeBuilderFactories.Add(typeof({modelInfo.Type.FullyQualifiedName}), () => ");
+                if (ShouldGenerateAsLocal(contextGenerationSpec, modelInfo))
                 {
-                    builder.Append(indent, $"_typeBuilderFactories.Add(typeof({modelInfo.Type.FullyQualifiedName}), () => ");
-                    if (ShouldGenerateAsLocal(contextGenerationSpec, modelInfo))
-                    {
-                        builder.AppendLine($" new global::{modelInfo.Type.GetInnerItemType().Namespace}.{modelInfo.Type.TypeCaseName}Builder());");
-                    }
-                    else
-                    {
-                        builder.AppendLine($" s_referenceContexts[typeof({modelInfo.ContextType.FullyQualifiedName})].GetTypeBuilder(typeof({modelInfo.Type.FullyQualifiedName})));");
-                    }
+                    builder.AppendLine($" new global::{modelInfo.Type.GetInnerItemType().Namespace}.{modelInfo.Type.TypeCaseName}Builder());");
                 }
-                builder.AppendLine();
-
-                builder.AppendLine(indent, "AddAdditionalFactories(_typeBuilderFactories);");
-
-                indent--;
-                builder.AppendLine(indent, "}");
-                builder.AppendLine();
+                else
+                {
+                    builder.AppendLine($" s_referenceContexts[typeof({modelInfo.ContextType.FullyQualifiedName})].GetTypeBuilder(typeof({modelInfo.Type.FullyQualifiedName})));");
+                }
             }
+            builder.AppendLine();
+
+            builder.AppendLine(indent, "AddAdditionalFactories(_typeBuilderFactories);");
+
+            indent--;
+            builder.AppendLine(indent, "}");
+            builder.AppendLine();
 
             builder.AppendLine(indent, "/// <inheritdoc/>");
             builder.Append(indent, "protected override bool TryGetTypeBuilderCore(");

--- a/sdk/core/System.ClientModel/tests/gen.unit/CompilationHelper.cs
+++ b/sdk/core/System.ClientModel/tests/gen.unit/CompilationHelper.cs
@@ -95,6 +95,9 @@ namespace System.ClientModel.SourceGeneration.Tests.Unit
         }
 
         public static GeneratorResult RunSourceGenerator(Compilation compilation, bool disableDiagnosticValidation = false)
+            => RunSourceGenerator(compilation, out _, disableDiagnosticValidation);
+
+        public static GeneratorResult RunSourceGenerator(Compilation compilation, out Compilation newCompilation, bool disableDiagnosticValidation = false)
         {
             ModelReaderWriterContextGenerationSpec? generatedSpecs = null;
             var generator = new ModelReaderWriterContextGenerator
@@ -103,7 +106,7 @@ namespace System.ClientModel.SourceGeneration.Tests.Unit
             };
 
             CSharpGeneratorDriver driver = CreateJsonSourceGeneratorDriver(compilation, generator);
-            driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outCompilation, out ImmutableArray<Diagnostic> diagnostics);
+            driver.RunGeneratorsAndUpdateCompilation(compilation, out newCompilation, out ImmutableArray<Diagnostic> diagnostics);
 
             return new()
             {


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/48292.

In the event you have no builders we still need the Default property added.