### PR TITLE
[Service Bus] Preserve custom port for AdminClient

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where the custom port associated with a local emulator endpoint was reset by the `ServiceBusAdministrationClient`.
+
 ### Other Changes
 
 ## 7.19.0 (2025-04-08)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/HttpRequestAndResponse.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/HttpRequestAndResponse.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Messaging.ServiceBus.Authorization;
+using Azure.Core;
 using Azure.Core.Pipeline;
-using System.Collections.Generic;
-using System.Globalization;
+using Azure.Messaging.ServiceBus.Authorization;
 
 namespace Azure.Messaging.ServiceBus.Administration
 {
@@ -33,6 +33,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             TokenCredential tokenCredential,
             string fullyQualifiedNamespace,
             ServiceBusAdministrationClientOptions.ServiceVersion version,
+            int port,
             bool useTls)
         {
             _pipeline = pipeline;
@@ -40,7 +41,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             _versionQuery = $"api-version={version.ToVersionString()}";
             _tokenCredential = tokenCredential;
             _fullyQualifiedNamespace = fullyQualifiedNamespace;
-            _port = GetPort(_fullyQualifiedNamespace);
+            _port = GetPort(_fullyQualifiedNamespace, port);
             _scheme = useTls ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
         }
 
@@ -264,6 +265,15 @@ namespace Azure.Messaging.ServiceBus.Administration
             return response;
         }
 
+        internal Uri BuildDefaultUri(string entityPath) =>
+            new UriBuilder(_fullyQualifiedNamespace)
+            {
+                Path = entityPath,
+                Port = _port,
+                Scheme = _scheme,
+                Query = _versionQuery
+            }.Uri;
+
         private async Task<Response> SendHttpRequestAsync(
             Request request,
             CancellationToken cancellationToken)
@@ -281,7 +291,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return response;
         }
 
-        private static int GetPort(string endpoint)
+        private static int GetPort(string endpoint, int port)
         {
             // used for internal testing
             if (endpoint.EndsWith("onebox.windows-int.net", StringComparison.InvariantCultureIgnoreCase))
@@ -289,7 +299,7 @@ namespace Azure.Messaging.ServiceBus.Administration
                 return 4446;
             }
 
-            return -1;
+            return (port > 0) ? port : -1;
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusAdministrationClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusAdministrationClient.cs
@@ -191,9 +191,12 @@ namespace Azure.Messaging.ServiceBus.Administration
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
 
+            var port = -1;
+
             if (Uri.TryCreate(fullyQualifiedNamespace, UriKind.Absolute, out var uri))
             {
                 fullyQualifiedNamespace = uri.Host;
+                port = uri.Port;
             }
 
             Argument.AssertWellFormedServiceBusNamespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
@@ -217,7 +220,7 @@ namespace Azure.Messaging.ServiceBus.Administration
                 credential,
                 _fullyQualifiedNamespace,
                 options.Version,
-                uri.Port,
+                port,
                 true);
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusAdministrationClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusAdministrationClient.cs
@@ -114,6 +114,7 @@ namespace Azure.Messaging.ServiceBus.Administration
                 tokenCredential,
                 _fullyQualifiedNamespace,
                 options.Version,
+                connectionStringProperties.Endpoint.Port,
                 useTls);
         }
 
@@ -216,6 +217,7 @@ namespace Azure.Messaging.ServiceBus.Administration
                 credential,
                 _fullyQualifiedNamespace,
                 options.Version,
+                uri.Port,
                 true);
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to preserve a custom port associated with the local development emulator when creating the admin client.  Previously, this was incorrectly reset to the default.