### PR TITLE
Add case to support proxying a different type

### DIFF
--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
@@ -123,6 +123,11 @@ public static class ModelReaderWriter
         {
             return WritePersistable(iModel, options);
         }
+        else if (model is IPersistableModel<object> objModel)
+        {
+            //used for the class proxy case since the proxy does not need to implement reading and writing for itself
+            return WritePersistable(objModel, options);
+        }
         else
         {
             var enumerable = model as IEnumerable ?? context.GetTypeBuilder(model!.GetType()).ToEnumerable(model);

--- a/sdk/core/System.ClientModel/tests/ModelReaderWriterTests/Models/BaseModelTests.cs
+++ b/sdk/core/System.ClientModel/tests/ModelReaderWriterTests/Models/BaseModelTests.cs
@@ -3,7 +3,11 @@
 
 using NUnit.Framework;
 using System.Linq;
+#if SOURCE_GENERATOR
+using System.ClientModel.SourceGeneration.Tests;
+#else
 using System.ClientModel.Tests.Client.ModelReaderWriterTests.Models;
+#endif
 using System.ClientModel.Primitives;
 
 namespace System.ClientModel.Tests.ModelReaderWriterTests.Models
@@ -20,7 +24,11 @@ namespace System.ClientModel.Tests.ModelReaderWriterTests.Models
 
         protected override string WirePayload => "{\"kind\":\"X\",\"name\":\"xmodel\",\"xProperty\":100,\"extra\":\"stuff\"}";
 
-        protected override ModelReaderWriterContext Context => new TestClientModelReaderWriterContext();
+#if SOURCE_GENERATOR
+        protected override ModelReaderWriterContext Context => BasicContext.Default;
+#else
+        protected override ModelReaderWriterContext Context => TestClientModelReaderWriterContext.Default;
+#endif
 
         protected override void CompareModels(BaseModel model, BaseModel model2, string format)
         {

--- a/sdk/core/System.ClientModel/tests/ModelReaderWriterTests/Models/UnknownBaseModelTests.cs
+++ b/sdk/core/System.ClientModel/tests/ModelReaderWriterTests/Models/UnknownBaseModelTests.cs
@@ -3,7 +3,11 @@
 
 using NUnit.Framework;
 using System.Linq;
+#if SOURCE_GENERATOR
+using System.ClientModel.SourceGeneration.Tests;
+#else
 using System.ClientModel.Tests.Client.ModelReaderWriterTests.Models;
+#endif
 using System.ClientModel.Primitives;
 
 namespace System.ClientModel.Tests.ModelReaderWriterTests.Models
@@ -20,7 +24,11 @@ namespace System.ClientModel.Tests.ModelReaderWriterTests.Models
 
         protected override string WirePayload => "{\"kind\":\"Z\",\"name\":\"zmodel\",\"zProperty\":1.5,\"extra\":\"stuff\"}";
 
+#if SOURCE_GENERATOR
+        protected override ModelReaderWriterContext Context => BasicContext.Default;
+#else
         protected override ModelReaderWriterContext Context => new TestClientModelReaderWriterContext();
+#endif
 
         protected override void CompareModels(BaseModel model, BaseModel model2, string format)
         {

--- a/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/Models/DiscriminatorSet/ModelX.cs
+++ b/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/Models/DiscriminatorSet/ModelX.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using ClientModel.Tests.ClientShared;
 using System.ClientModel.Primitives;
+#if !SOURCE_GENERATOR
+using System.ClientModel.Tests.ModelReaderWriterTests;
+#endif
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using ClientModel.Tests.ClientShared;
 
 #if SOURCE_GENERATOR
 namespace System.ClientModel.SourceGeneration.Tests
@@ -206,9 +209,19 @@ namespace System.ClientModel.Tests.Client.ModelReaderWriterTests.Models
 
         BinaryData IPersistableModel<ModelX>.Write(ModelReaderWriterOptions options)
         {
-            ModelReaderWriterHelper.ValidateFormat(this, options.Format);
+            var format = options.Format == "W" ? ((IPersistableModel<ModelX>)this).GetFormatFromOptions(options) : options.Format;
 
-            return ModelReaderWriter.Write(this, options);
+            switch (format)
+            {
+                case "J":
+#if SOURCE_GENERATOR
+                    return ModelReaderWriter.Write(this, options, BasicContext.Default);
+#else
+                    return ModelReaderWriter.Write(this, options, TestClientModelReaderWriterContext.Default);
+#endif
+                default:
+                    throw new FormatException($"The model {nameof(ModelX)} does not support writing '{options.Format}' format.");
+            }
         }
 
         string IPersistableModel<ModelX>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";

--- a/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/Models/DiscriminatorSet/UnknownBaseModel.cs
+++ b/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/Models/DiscriminatorSet/UnknownBaseModel.cs
@@ -70,9 +70,19 @@ namespace System.ClientModel.Tests.Client.ModelReaderWriterTests.Models
 
         BinaryData IPersistableModel<BaseModel>.Write(ModelReaderWriterOptions options)
         {
-            ModelReaderWriterHelper.ValidateFormat(this, options.Format);
+            var format = options.Format == "W" ? ((IPersistableModel<BaseModel>)this).GetFormatFromOptions(options) : options.Format;
 
-            return ModelReaderWriter.Write(this, options);
+            switch (format)
+            {
+                case "J":
+# if SOURCE_GENERATOR
+                    return ModelReaderWriter.Write(this, options, BasicContext.Default);
+#else
+                    return ModelReaderWriter.Write(this, options);
+#endif
+                default:
+                    throw new FormatException($"The model {nameof(BaseModel)} does not support writing '{options.Format}' format.");
+            }
         }
     }
 }

--- a/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/TestClientModelReaderWriterContext.cs
+++ b/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/TestClientModelReaderWriterContext.cs
@@ -5,12 +5,14 @@ using System.ClientModel.Primitives;
 using System.ClientModel.Tests.Client.ModelReaderWriterTests.Models;
 using System.ClientModel.Tests.Client.Models.ResourceManager.Compute;
 using System.ClientModel.Tests.Client.Models.ResourceManager.Resources;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.ClientModel.Tests.ModelReaderWriterTests
 {
     public class TestClientModelReaderWriterContext : ModelReaderWriterContext
     {
+        private static TestClientModelReaderWriterContext? _default;
+        public static TestClientModelReaderWriterContext Default => _default ??= new TestClientModelReaderWriterContext();
+
         private AvailabilitySetData_Builder? _availabilitySetData_Builder;
         private BaseModel_Builder? _baseModel_Builder;
         private ModelAsStruct_Builder? _modelAsStruct_Builder;

--- a/sdk/core/System.ClientModel/tests/gen/System.ClientModel.SourceGeneration.Tests.csproj
+++ b/sdk/core/System.ClientModel/tests/gen/System.ClientModel.SourceGeneration.Tests.csproj
@@ -37,6 +37,8 @@
     <Compile Include="..\ModelReaderWriterTests\Models\AvailabilitySetDataTests.cs" LinkBase="SharedTests" />
     <Compile Include="..\ModelReaderWriterTests\Models\BaseModels\ListTests.cs" LinkBase="SharedTests\BaseModels" />
     <Compile Include="..\ModelReaderWriterTests\Models\BaseModels\ModelInstances.cs" LinkBase="SharedTests\BaseModels" />
+    <Compile Include="..\ModelReaderWriterTests\Models\BaseModelTests.cs" LinkBase="SharedTests\BaseModels" />
+    <Compile Include="..\ModelReaderWriterTests\Models\UnknownBaseModelTests.cs" LinkBase="SharedTests\BaseModels" />
     <Compile Include="..\ModelReaderWriterTests\Models\ModelJsonTests.cs" LinkBase="SharedTests" />
     <Compile Include="..\ModelReaderWriterTests\MrwModelTests.cs" LinkBase="SharedTests" />
     <Compile Include="..\ModelReaderWriterTests\MrwCollectionTests.cs" LinkBase="SharedTests" />


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/48292.

Fixes a case where an MRW proxy doesn't read or write itself but instead reads and writes a different type.
