### PR TITLE
Ensure eng/ triggers `Azure.Core`

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -46,6 +46,7 @@ extends:
       safeName: AzureCore
       triggeringPaths:
       - /sdk/resourcemanager/
+      - /eng/
     - name: Azure.Core.Experimental
       safeName: AzureCoreExperimental
     - name: Azure.Core.Expressions.DataFactory

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -46,7 +46,12 @@ extends:
       safeName: AzureCore
       triggeringPaths:
       - /sdk/resourcemanager/
-      - /eng/
+      - /eng/Versioning.targets
+      - /eng/Packages.Data.props
+      - /eng/Directory.Build.Common.props
+      - /eng/Directory.Build.Common.targets
+      - /eng/service.proj
+
     - name: Azure.Core.Experimental
       safeName: AzureCoreExperimental
     - name: Azure.Core.Expressions.DataFactory


### PR DESCRIPTION
Following up on a question from @jsquire . I just needed to [fix a bug](https://github.com/Azure/azure-sdk-tools/pull/10400) before this change would do anything.