### PR TITLE
fix: use correct model ns for encode/numeric

### DIFF
--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Encode/Numeric/EncodeNumericTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Encode/Numeric/EncodeNumericTests.cs
@@ -3,7 +3,7 @@
 
 using System.Threading.Tasks;
 using Encode.Numeric;
-using Encode.Numeric.Models;
+using Encode.Numeric._Property;
 using NUnit.Framework;
 
 namespace TestProjects.Spector.Tests.Http.Encode.Numeric


### PR DESCRIPTION
This PR fixes a [build failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4786982&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3) related to the encode/numeric spector test case.
