### PR TITLE
Ensure that `Azure.Core` is built/analyzed even if only indirectly changed

### DIFF
--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -38,6 +38,18 @@ steps:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)/PackageInfoPublishing'
 
   - pwsh: |
+      # if Azure.Core is in the list of packages we want to always keep it around for validation regardless of whether or not it is a direct package
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/PackageInfo" -Filter "Azure.Core.json" -Recurse |
+        ForEach-Object {
+          $json = Get-Content $_.FullName | ConvertFrom-Json
+
+          if ($json.IncludedForValidation -eq $true) {
+            Write-Host "Azure.Core is indirectly included, setting it to direct so that we build and analyze it."
+            $json.IncludedForValidation = $false
+            $json | ConvertTo-Json -Depth 100 | Set-Content $_.FullName
+          }
+        }
+
       $packageInfos = Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/PackageInfo" -Filter "*.json" -Recurse `
         | ForEach-Object { Get-Content $_.FullName | ConvertFrom-Json }
 
@@ -65,4 +77,3 @@ steps:
         }
     displayName: Only target direct packages for build and test
     condition: and(succeededOrFailed(), eq(${{ parameters.ForceDirect }}, true))
-


### PR DESCRIPTION
The reason we don't build and analyze _all_ indirectly changed packages is because any change in `Azure.Core` will immediately invoke `build`/`analyze` for _all_ dependent packages on it. This will have a pretty nasty effect on stability and timing for any `net - pullrequest` that change `Azure.Core` or `Azure.ResourceManager`.

We don't have to hardcode `Azure.Core` here. An alternative is to utilize "include even if indirect" logic for any package that is indirectly included and has additional `triggeringPaths` aside from the default. We'll get the same effect without hardcoding any packages directly.

This PR is in response to your question about #49259 @m-redding 
