### PR TITLE
Remove refs to Microsoft.Identity.Client

### DIFF
--- a/sdk/communication/Azure.Communication.Identity/tests/Azure.Communication.Identity.Tests.csproj
+++ b/sdk/communication/Azure.Communication.Identity/tests/Azure.Communication.Identity.Tests.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.Identity.Client" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/Azure.Developer.DevCenter.Tests.csproj
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/Azure.Developer.DevCenter.Tests.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="Microsoft.Identity.Client" />
   </ItemGroup>
   
 </Project>

--- a/sdk/hdinsightcontainers/Azure.ResourceManager.HDInsight.Containers/tests/Azure.ResourceManager.HDInsight.Containers.Tests.csproj
+++ b/sdk/hdinsightcontainers/Azure.ResourceManager.HDInsight.Containers/tests/Azure.ResourceManager.HDInsight.Containers.Tests.csproj
@@ -8,7 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.ResourceManager.ManagedServiceIdentities" />
-    <PackageReference Include="Microsoft.Identity.Client" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />


### PR DESCRIPTION
I'm seeing some errors pop up in the core pipeline, for example here https://github.com/Azure/azure-sdk-for-net/pull/49573/checks?check_run_id=41026638019

I think the easiest way to fix would just be to remove the reference from the test project. These test projects get this reference transitively from either their main project or from Azure.Core.TestFramework.