### PR TITLE
Update deps project to .NET 9

### DIFF
--- a/eng/scripts/dependencies/azure-sdk.deps.csproj
+++ b/eng/scripts/dependencies/azure-sdk.deps.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableDefaultItems>false</EnableDefaultItems>
     <!--


### PR DESCRIPTION
I noticed the `net - aggregate-reports` failing https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4788455&view=logs&j=d41e9505-d81b-5b3c-5b50-be71bc9b0ccb&t=6bed6805-9e83-5bb6-8279-e54cc1dfbcba

This should get us past this point at least.