### PR TITLE
[AzureMonitor] fix AOT warnings (part 1)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
@@ -201,7 +201,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                             MethodInfo? parseMethod = typeof(TimeSpan).GetMethod("Parse", new[] { typeof(string) });
                             fieldExpression = Expression.Call(parseMethod!, fieldExpression);
                         }
-                        fieldExpression = Expression.Property(fieldExpression, "TotalMilliseconds");
+
+                        var totalMillisecondsProperty = typeof(TimeSpan).GetProperty("TotalMilliseconds");
+                        fieldExpression = Expression.Property(fieldExpression, totalMillisecondsProperty!);
                     }
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
@@ -202,8 +202,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                             fieldExpression = Expression.Call(parseMethod!, fieldExpression);
                         }
 
-                        var totalMillisecondsProperty = typeof(TimeSpan).GetProperty("TotalMilliseconds");
-                        fieldExpression = Expression.Property(fieldExpression, totalMillisecondsProperty!);
+                        var totalMillisecondsProperty = typeof(TimeSpan).GetProperty(nameof(TimeSpan.TotalMilliseconds))!;
+                        fieldExpression = Expression.Property(fieldExpression, totalMillisecondsProperty);
                     }
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -447,6 +447,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
                             Type enumUnderlyingType = fieldType.GetTypeInfo().GetEnumUnderlyingType();
 
+                            // This block matches the case statements just above.
                             static Type GetNullableType(Type inputType) => inputType switch
                             {
                                 _ when inputType == typeof(sbyte) => typeof(sbyte?),

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -458,28 +458,28 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                                 case Predicate.LessThan:
                                     // (int)fieldValue < (int)enumValue
                                     // (int?)fieldValue < (int?)enumValue
-                                    Type underlyingType = isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(enumUnderlyingType) : enumUnderlyingType;
+                                    Type underlyingType = isFieldTypeNullable ? GetNullableType(enumUnderlyingType) : enumUnderlyingType;
                                     return Expression.LessThan(
                                         Expression.Convert(fieldExpression, underlyingType),
                                         Expression.Convert(Expression.Constant(enumValue, fieldType), underlyingType));
                                 case Predicate.GreaterThan:
                                     // (int)fieldValue > (int)enumValue
                                     // (int?)fieldValue > (int?)enumValue
-                                    underlyingType = isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(enumUnderlyingType) : enumUnderlyingType;
+                                    underlyingType = isFieldTypeNullable ? GetNullableType(enumUnderlyingType) : enumUnderlyingType;
                                     return Expression.GreaterThan(
                                         Expression.Convert(fieldExpression, underlyingType),
                                         Expression.Convert(Expression.Constant(enumValue, fieldType), underlyingType));
                                 case Predicate.LessThanOrEqual:
                                     // (int)fieldValue <= (int)enumValue
                                     // (int?)fieldValue <= (int?)enumValue
-                                    underlyingType = isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(enumUnderlyingType) : enumUnderlyingType;
+                                    underlyingType = isFieldTypeNullable ? GetNullableType(enumUnderlyingType) : enumUnderlyingType;
                                     return Expression.LessThanOrEqual(
                                         Expression.Convert(fieldExpression, underlyingType),
                                         Expression.Convert(Expression.Constant(enumValue, fieldType), underlyingType));
                                 case Predicate.GreaterThanOrEqual:
                                     // (int)fieldValue >= (int)enumValue
                                     // (int?)fieldValue >= (int?)enumValue
-                                    underlyingType = isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(enumUnderlyingType) : enumUnderlyingType;
+                                    underlyingType = isFieldTypeNullable ? GetNullableType(enumUnderlyingType) : enumUnderlyingType;
                                     return Expression.GreaterThanOrEqual(
                                         Expression.Convert(fieldExpression, underlyingType),
                                         Expression.Convert(Expression.Constant(enumValue, fieldType), underlyingType));
@@ -513,32 +513,32 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                                     ThrowOnInvalidFilter(fieldType, !comparandDouble.HasValue);
                                     return Expression.Equal(
                                         fieldConvertedExpression,
-                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(double?) : typeof(double)));
                                 case Predicate.NotEqual:
                                     ThrowOnInvalidFilter(fieldType, !comparandDouble.HasValue);
                                     return Expression.NotEqual(
                                         fieldConvertedExpression,
-                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(double?) : typeof(double)));
                                 case Predicate.LessThan:
                                     ThrowOnInvalidFilter(fieldType, !comparandDouble.HasValue);
                                     return Expression.LessThan(
                                         fieldConvertedExpression,
-                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(double?) : typeof(double)));
                                 case Predicate.GreaterThan:
                                     ThrowOnInvalidFilter(fieldType, !comparandDouble.HasValue);
                                     return Expression.GreaterThan(
                                         fieldConvertedExpression,
-                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(double?) : typeof(double)));
                                 case Predicate.LessThanOrEqual:
                                     ThrowOnInvalidFilter(fieldType, !comparandDouble.HasValue);
                                     return Expression.LessThanOrEqual(
                                         fieldConvertedExpression,
-                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(double?) : typeof(double)));
                                 case Predicate.GreaterThanOrEqual:
                                     ThrowOnInvalidFilter(fieldType, !comparandDouble.HasValue);
                                     return Expression.GreaterThanOrEqual(
                                         fieldConvertedExpression,
-                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(Nullable<>).MakeGenericType(typeof(double)) : typeof(double)));
+                                        Expression.Constant(comparandDouble.Value, isFieldTypeNullable ? typeof(double?) : typeof(double)));
                                 case Predicate.Contains:
                                     // fieldValue.ToString(CultureInfo.InvariantCulture).IndexOf(this.comparand, StringComparison.OrdinalIgnoreCase) != -1
                                     Expression toStringCall = isFieldTypeNullable
@@ -672,6 +672,31 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
             }
 
             return null;
+        }
+
+        // Helper method to determine the nullable type without using MakeGenericType
+        private static Type GetNullableType(Type type)
+        {
+            // Most common numeric types - handle these specifically instead of using MakeGenericType
+            if (type == typeof(byte)) return typeof(byte?);
+            if (type == typeof(sbyte)) return typeof(sbyte?);
+            if (type == typeof(short)) return typeof(short?);
+            if (type == typeof(ushort)) return typeof(ushort?);
+            if (type == typeof(int)) return typeof(int?);
+            if (type == typeof(uint)) return typeof(uint?);
+            if (type == typeof(long)) return typeof(long?);
+            if (type == typeof(ulong)) return typeof(ulong?);
+            if (type == typeof(float)) return typeof(float?);
+            if (type == typeof(double)) return typeof(double?);
+            if (type == typeof(decimal)) return typeof(decimal?);
+            if (type == typeof(bool)) return typeof(bool?);
+            if (type == typeof(char)) return typeof(char?);
+            if (type == typeof(TimeSpan)) return typeof(TimeSpan?);
+            if (type == typeof(DateTime)) return typeof(DateTime?);
+            if (type == typeof(DateTimeOffset)) return typeof(DateTimeOffset?);
+            if (type == typeof(Guid)) return typeof(Guid?);
+
+            throw new ArgumentException($"Cannot create a nullable type for {type.FullName}.");
         }
 
         private Expression ProduceComparatorExpressionForAnyFieldCondition(ParameterExpression documentExpression)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -447,6 +447,21 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
                             Type enumUnderlyingType = fieldType.GetTypeInfo().GetEnumUnderlyingType();
 
+                            static Type GetNullableType(Type inputType) => inputType switch
+                            {
+                                _ when inputType == typeof(sbyte) => typeof(sbyte?),
+                                _ when inputType == typeof(short) => typeof(short?),
+                                _ when inputType == typeof(int) => typeof(int?),
+                                _ when inputType == typeof(long) => typeof(long?),
+                                _ when inputType == typeof(byte) => typeof(byte?),
+                                _ when inputType == typeof(ushort) => typeof(ushort?),
+                                _ when inputType == typeof(uint) => typeof(uint?),
+                                _ when inputType == typeof(ulong) => typeof(ulong?),
+                                _ when inputType == typeof(float) => typeof(float?),
+                                _ when inputType == typeof(double) => typeof(double?),
+                                _ => throw new ArgumentException($"Cannot create a nullable type for {inputType.FullName}."),
+                            };
+
                             switch (predicate)
                             {
                                 case Predicate.Equal:
@@ -672,31 +687,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
             }
 
             return null;
-        }
-
-        // Helper method to determine the nullable type without using MakeGenericType
-        private static Type GetNullableType(Type type)
-        {
-            // Most common numeric types - handle these specifically instead of using MakeGenericType
-            if (type == typeof(byte)) return typeof(byte?);
-            if (type == typeof(sbyte)) return typeof(sbyte?);
-            if (type == typeof(short)) return typeof(short?);
-            if (type == typeof(ushort)) return typeof(ushort?);
-            if (type == typeof(int)) return typeof(int?);
-            if (type == typeof(uint)) return typeof(uint?);
-            if (type == typeof(long)) return typeof(long?);
-            if (type == typeof(ulong)) return typeof(ulong?);
-            if (type == typeof(float)) return typeof(float?);
-            if (type == typeof(double)) return typeof(double?);
-            if (type == typeof(decimal)) return typeof(decimal?);
-            if (type == typeof(bool)) return typeof(bool?);
-            if (type == typeof(char)) return typeof(char?);
-            if (type == typeof(TimeSpan)) return typeof(TimeSpan?);
-            if (type == typeof(DateTime)) return typeof(DateTime?);
-            if (type == typeof(DateTimeOffset)) return typeof(DateTimeOffset?);
-            if (type == typeof(Guid)) return typeof(Guid?);
-
-            throw new ArgumentException($"Cannot create a nullable type for {type.FullName}.");
         }
 
         private Expression ProduceComparatorExpressionForAnyFieldCondition(ParameterExpression documentExpression)


### PR DESCRIPTION
working towards #49600

This PR fixes 11 out of 22 warnings.
I confirmed that each of these areas are covered with unit tests and that these changes don't break existing functionality.

- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\DerivedMetric.cs(204): Trim analysis warning IL2026: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.DerivedMetric`1.CreateProjection(): Using member 'System.Linq.Expressions.Expression.Property(Expression,String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Creating Expressions requires unreferenced code because the members being referenced by the Expression may be trimmed.  

- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(461): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(468): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(475): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(482): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  



- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(514): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(519): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(524): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(529): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(534): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.  
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.LiveMetrics\src\Internals\Filtering\Filter.cs(539): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering.Filter`1.ProduceComparatorExpressionForSingleFieldCondition(Expression,Type,Boolean): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime. 