### PR TITLE
Add reference to Microsoft.Bcl.AsyncInterfaces back

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -100,7 +100,6 @@
 
   <!-- Remove packages built into the .NET 6+ runtime -->
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <PackageReference Remove="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Remove="System.Buffers" />
     <PackageReference Remove="System.Diagnostics.DiagnosticSource" />
     <PackageReference Remove="System.Net.Http" />


### PR DESCRIPTION
Currently investigating an issue with this package being removed.

cc: @m-nash 