### PR TITLE
[AzureMonitor] fix AOT warnings (part 3) 

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/Models/DocumentIngress.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/Models/DocumentIngress.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
     /// <summary> Additional properties used to calculate metrics. </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
     internal partial class DocumentIngress
     {
         public bool Extension_IsSuccess { get; set; }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
@@ -118,16 +118,17 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
         public string ETag => info.ETag;
 
-        private static void AddMetric<DocumentIngress>(
+        private static void AddMetric<TTelemetry>(
           DerivedMetricInfo metricInfo,
-          List<DerivedMetric<DocumentIngress>> metrics,
+          List<DerivedMetric<TTelemetry>> metrics,
           out CollectionConfigurationError[] errors)
+          where TTelemetry : DocumentIngress
         {
             errors = Array.Empty<CollectionConfigurationError>();
 
             try
             {
-                metrics.Add(new DerivedMetric<DocumentIngress>(metricInfo, out errors));
+                metrics.Add(new DerivedMetric<TTelemetry>(metricInfo, out errors));
             }
             catch (System.Exception e)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
@@ -16,7 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
     /// which defines which field to use as a value, and an aggregation which dictates the algorithm of arriving at
     /// a single reportable value within a second.
     /// </summary>
-    internal class DerivedMetric<TTelemetry>
+    internal class DerivedMetric<TTelemetry> where TTelemetry : DocumentIngress
     {
         private const string ProjectionCount = "Count()";
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DocumentStream.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DocumentStream.cs
@@ -92,6 +92,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
             List<FilterConjunctionGroup<TTelemetry>> filterGroups,
             TTelemetry document,
             out CollectionConfigurationError[] errors)
+            where TTelemetry : DocumentIngress
         {
             var errorList = new List<CollectionConfigurationError>();
             bool leastOneConjunctionGroupPassed = false;
@@ -121,6 +122,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
         }
 
         private static bool CheckFiltersGeneric<TTelemetry>(TTelemetry document, FilterConjunctionGroup<TTelemetry> filterGroup, List<CollectionConfigurationError> errorList)
+            where TTelemetry : DocumentIngress
         {
             bool filterPassed = false;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
@@ -11,7 +11,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
     /// <summary>
     /// Defines an AND group of filters.
     /// </summary>
-    internal class FilterConjunctionGroup<TTelemetry>
+    internal class FilterConjunctionGroup<TTelemetry> where TTelemetry : DocumentIngress
     {
         private readonly FilterConjunctionGroupInfo info;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/LiveMetricsClientManager.MetricsCollection.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/LiveMetricsClientManager.MetricsCollection.cs
@@ -225,6 +225,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             TTelemetry telemetry,
             out CollectionConfigurationError[] filteringErrors,
             ref string projectionError)
+            where TTelemetry : DocumentIngress
         {
             filteringErrors = Array.Empty<CollectionConfigurationError>();
 


### PR DESCRIPTION
working towards https://github.com/Azure/azure-sdk-for-net/pull/49600

This PR fixes 3 out of 9 warnings.

Issues Addressed:


## IL2026 Warnings (Expression.Property with string parameter)
We refactored the following methods in `Filter.cs` to avoid using `Expression.Property(Expression, String)` which has `RequiresUnreferencedCodeAttribute`:
•	`ProduceFieldExpression()`
•	`CreateListAccessExpression()`
•	`CreateDictionaryAccessExpression()`

The original implementation used string-based property access, which is problematic during trimming because the compiler cannot statically analyze which properties might be referenced. The refactored code now:
•	Uses `Expression.Property(Expression, PropertyInfo)` which is AOT-compatible
•	Gets `PropertyInfo` objects directly using `Type.GetProperty()` with binding flags
•	Uses `Expression.Aggregate()` for property chain navigation, ensuring proper static analysis

## IL2075 Warnings (Type information lost in reflection)
These warnings occurred because reflection-based property access via Type.GetProperty() requires that the type being accessed has its public properties preserved during trimming. We implemented a multi-layered solution:
1.	**Base Class Annotation**: Added `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]` to the `DocumentIngress` class, ensuring all derived classes preserve public properties during trimming.
2.	**Type Constraints**: Added `where TTelemetry : DocumentIngress` constraints to generic type parameters and methods throughout the codebase, guaranteeing that only types derived from the annotated base class are used.
3.	**Suppressed Remaining Warnings**: Applied `[UnconditionalSuppressMessage("AOT", "IL2075")]` to methods that use reflection on types that we're confident have their properties preserved due to the above changes:
•	`ProduceFieldExpression()`
•	`CreateListAccessExpression()`
•	`CreateDictionaryAccessExpression()`

The suppression is justified because:
•	The `DocumentIngress` class is annotated with `DynamicallyAccessedMembers` which guarantees that properties are preserved during trimming
•	All uses of `TTelemetry` are constrained to `DocumentIngress`


## Testing
The changes have been validated by:
- Building with AOT compatibility warnings enabled
- Verifying that the original functionality continues to work as expected
