### PR TITLE
Stop publishing test framework to dev feed

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);net47</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" />

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -66,9 +66,6 @@ extends:
       safeName: AzureCoreAmqp
     - name: System.ClientModel
       safeName: SystemClientModel
-    - name: Azure.Core.TestFramework
-      safeName: AzureCoreTestFramework
-      skipReleaseStage: true
     CheckAOTCompat: true
     AOTTestInputs:
     - ArtifactName: Azure.Core


### PR DESCRIPTION
It didn't end up getting used by Azure.MCP so we don't need to publish it to the dev feed anymore. It had been causing errors/warnings in the Core release pipeline.