### PR TITLE
Add ProtectKeysWithAzureKeyVault overload that accepts ServiceProvider for keyIdentifier

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/api/Azure.Extensions.AspNetCore.DataProtection.Keys.net8.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/api/Azure.Extensions.AspNetCore.DataProtection.Keys.net8.0.cs
@@ -2,6 +2,7 @@ namespace Microsoft.AspNetCore.DataProtection
 {
     public static partial class AzureDataProtectionKeyVaultKeyBuilderExtensions
     {
+        public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder ProtectKeysWithAzureKeyVault(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, System.Func<System.IServiceProvider, string> keyIdentifierFactory, System.Func<System.IServiceProvider, Azure.Core.TokenCredential> tokenCredentialFactory) { throw null; }
         public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder ProtectKeysWithAzureKeyVault(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, string keyIdentifier, Azure.Core.Cryptography.IKeyEncryptionKeyResolver keyResolver) { throw null; }
         public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder ProtectKeysWithAzureKeyVault(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, string keyIdentifier, System.Func<System.IServiceProvider, Azure.Core.Cryptography.IKeyEncryptionKeyResolver> keyResolverFactory) { throw null; }
         public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder ProtectKeysWithAzureKeyVault(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, string keyIdentifier, System.Func<System.IServiceProvider, Azure.Core.TokenCredential> tokenCredentialFactory) { throw null; }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/api/Azure.Extensions.AspNetCore.DataProtection.Keys.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/api/Azure.Extensions.AspNetCore.DataProtection.Keys.netstandard2.0.cs
@@ -2,6 +2,7 @@ namespace Microsoft.AspNetCore.DataProtection
 {
     public static partial class AzureDataProtectionKeyVaultKeyBuilderExtensions
     {
+        public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder ProtectKeysWithAzureKeyVault(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, System.Func<System.IServiceProvider, string> keyIdentifierFactory, System.Func<System.IServiceProvider, Azure.Core.TokenCredential> tokenCredentialFactory) { throw null; }
         public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder ProtectKeysWithAzureKeyVault(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, string keyIdentifier, Azure.Core.Cryptography.IKeyEncryptionKeyResolver keyResolver) { throw null; }
         public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder ProtectKeysWithAzureKeyVault(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, string keyIdentifier, System.Func<System.IServiceProvider, Azure.Core.Cryptography.IKeyEncryptionKeyResolver> keyResolverFactory) { throw null; }
         public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder ProtectKeysWithAzureKeyVault(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, string keyIdentifier, System.Func<System.IServiceProvider, Azure.Core.TokenCredential> tokenCredentialFactory) { throw null; }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/AzureDataProtectionKeyVaultKeyBuilderExtensions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/AzureDataProtectionKeyVaultKeyBuilderExtensions.cs
@@ -97,23 +97,7 @@ namespace Microsoft.AspNetCore.DataProtection
             Argument.AssertNotNull(tokenCredentialFactory, nameof(tokenCredentialFactory));
             Argument.AssertNotNullOrEmpty(keyIdentifier, nameof(keyIdentifier));
 
-            builder.Services.AddSingleton<IActivator, DecryptorTypeForwardingActivator>();
-
-            builder.Services.AddSingleton<IKeyEncryptionKeyResolver>(sp =>
-            {
-                var tokenCredential = tokenCredentialFactory(sp);
-                return new KeyResolver(tokenCredential);
-            });
-
-            builder.Services.AddSingleton(sp =>
-            {
-                var keyResolver = sp.GetRequiredService<IKeyEncryptionKeyResolver>();
-                return new AzureKeyVaultXmlEncryptor(keyResolver, keyIdentifier);
-            });
-
-            builder.Services.AddSingleton<IConfigureOptions<KeyManagementOptions>, ConfigureKeyManagementKeyVaultEncryptorClientOptions>();
-
-            return builder;
+            return builder.ProtectKeysWithAzureKeyVault(_ => keyIdentifier, tokenCredentialFactory);
         }
 
         /// <summary>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/tests/AzureDataProtectionBuilderExtensionsTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/tests/AzureDataProtectionBuilderExtensionsTests.cs
@@ -49,5 +49,22 @@ namespace Azure.Extensions.AspNetCore.DataProtection.Keys.Tests
             var options = services.GetRequiredService<IOptions<KeyManagementOptions>>();
             Assert.IsInstanceOf<AzureKeyVaultXmlEncryptor>(options.Value.XmlEncryptor);
         }
+
+        [Test]
+        public void ProtectKeysWithAzureKeyVault_WithServiceProviderAndUriFuncs_UsesAzureKeyVaultXmlEncryptor()
+        {
+            // Arrange
+            var client = new KeyClient(new Uri("http://www.example.com/dummyKey"), new MockCredential());
+            var serviceCollection = new ServiceCollection();
+            var builder = serviceCollection.AddDataProtection();
+
+            // Act
+            builder.ProtectKeysWithAzureKeyVault(sp => "http://www.example.com/dummyKey", sp => new DefaultAzureCredential());
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var options = services.GetRequiredService<IOptions<KeyManagementOptions>>();
+            Assert.IsInstanceOf<AzureKeyVaultXmlEncryptor>(options.Value.XmlEncryptor);
+        }
     }
 }

--- a/sdk/extensions/Microsoft.Extensions.Azure/api/Microsoft.Extensions.Azure.net8.0.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/api/Microsoft.Extensions.Azure.net8.0.cs
@@ -3,7 +3,6 @@ namespace Microsoft.Extensions.Azure
     public static partial class AzureClientBuilderExtensions
     {
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Binding strongly typed objects to configuration values requires generating dynamic code at runtime, for example instantiating generic types. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Binding strongly typed objects to configuration values is not supported with trimming. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
         public static Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> ConfigureOptions<TClient, TOptions>(this Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> builder, Microsoft.Extensions.Configuration.IConfiguration configuration) where TOptions : class { throw null; }
         public static Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> ConfigureOptions<TClient, TOptions>(this Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> builder, System.Action<TOptions, System.IServiceProvider> configureOptions) where TOptions : class { throw null; }
         public static Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> ConfigureOptions<TClient, TOptions>(this Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> builder, System.Action<TOptions> configureOptions) where TOptions : class { throw null; }
@@ -21,11 +20,9 @@ namespace Microsoft.Extensions.Azure
         public Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(System.Func<TOptions, TClient> factory) where TOptions : class { throw null; }
         Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> Azure.Core.Extensions.IAzureClientFactoryBuilder.RegisterClientFactory<TClient, TOptions>(System.Func<TOptions, TClient> clientFactory) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Binding strongly typed objects to configuration values requires generating dynamic code at runtime, for example instantiating generic types. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Binding strongly typed objects to configuration values is not supported with trimming. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
         Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> Azure.Core.Extensions.IAzureClientFactoryBuilderWithConfiguration<Microsoft.Extensions.Configuration.IConfiguration>.RegisterClientFactory<TClient, TOptions>(Microsoft.Extensions.Configuration.IConfiguration configuration) { throw null; }
         Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> Azure.Core.Extensions.IAzureClientFactoryBuilderWithCredential.RegisterClientFactory<TClient, TOptions>(System.Func<TOptions, Azure.Core.TokenCredential, TClient> clientFactory, bool requiresCredential) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Binding strongly typed objects to configuration values requires generating dynamic code at runtime, for example instantiating generic types. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Binding strongly typed objects to configuration values is not supported with trimming. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
         public Microsoft.Extensions.Azure.AzureClientFactoryBuilder ConfigureDefaults(Microsoft.Extensions.Configuration.IConfiguration configuration) { throw null; }
         public Microsoft.Extensions.Azure.AzureClientFactoryBuilder ConfigureDefaults(System.Action<Azure.Core.ClientOptions, System.IServiceProvider> configureOptions) { throw null; }
         public Microsoft.Extensions.Azure.AzureClientFactoryBuilder ConfigureDefaults(System.Action<Azure.Core.ClientOptions> configureOptions) { throw null; }
@@ -42,10 +39,8 @@ namespace Microsoft.Extensions.Azure
     public abstract partial class AzureComponentFactory
     {
         protected AzureComponentFactory() { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Binding strongly typed objects to configuration values is not supported with trimming. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
         public abstract object CreateClient([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type clientType, Microsoft.Extensions.Configuration.IConfiguration configuration, Azure.Core.TokenCredential credential, object clientOptions);
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Binding strongly typed objects to configuration values requires generating dynamic code at runtime, for example instantiating generic types. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Binding strongly typed objects to configuration values is not supported with trimming. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
         public abstract object CreateClientOptions([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type optionsType, object serviceVersion, Microsoft.Extensions.Configuration.IConfiguration configuration);
         public abstract Azure.Core.TokenCredential CreateTokenCredential(Microsoft.Extensions.Configuration.IConfiguration configuration);
     }


### PR DESCRIPTION
Fixes #37903.

Adds an additional overload for `IDataProtectionBuilder.ProtectKeysWithAzureKeyVault` that allows for retrieving the key identifier from the `IServiceProvider`.

This is necessary for cases where the key identifier should be retrieved via the `IOptions<T>` pattern.