### PR TITLE
[Smoke Tests] Fixing up failures from new packages

### DIFF
--- a/common/SmokeTests/SmokeTest/Program.cs
+++ b/common/SmokeTests/SmokeTest/Program.cs
@@ -205,7 +205,7 @@ void ProcessType(Type type)
             catch (PlatformNotSupportedException)
             {
                 // Expected; this is a known scenario where the type is not impactful to the
-                // Azure SDK experience and cane be safely ignored.
+                // Azure SDK experience and can be safely ignored.
             }
         }
     }
@@ -292,6 +292,7 @@ bool ShouldIgnoreInvocationException(TargetInvocationException targetInvocationE
     TypeLoadException => true,
     TypeInitializationException => true,
     ThreadStateException => true,
+    MissingMethodException => true,
 
     // Occurs when the assembly is locked; this is most likely a framework assembly.
     IOException ioEx when (ioEx.Message.ToLower().Contains("being used by another process.")) => true,

--- a/common/SmokeTests/SmokeTest/Program.cs
+++ b/common/SmokeTests/SmokeTest/Program.cs
@@ -202,6 +202,11 @@ void ProcessType(Type type)
                 // Expected; this is a known scenario where the type is not impactful to the
                 // Azure SDK experience and cane be safely ignored.
             }
+            catch (PlatformNotSupportedException)
+            {
+                // Expected; this is a known scenario where the type is not impactful to the
+                // Azure SDK experience and cane be safely ignored.
+            }
         }
     }
     catch (Exception ex)

--- a/common/SmokeTests/SmokeTest/Program.cs
+++ b/common/SmokeTests/SmokeTest/Program.cs
@@ -191,6 +191,12 @@ void ProcessType(Type type)
                 // Expected; this is a known scenario where the type is not impactful to the
                 // Azure SDK experience and cane be safely ignored.
             }
+            catch (NotSupportedException ex) when (ShouldIgnoreNotSupportedException(ex))
+            {
+                // Expected; this is a known scenario where the type is not able to be created
+                // via reflection using the Activator.  These are not types related to the SDK
+                // and are not impactful to the Azure SDK experience.
+            }
             catch (COMException)
             {
                 // Expected; this is a known scenario where the type is not impactful to the
@@ -293,6 +299,15 @@ bool ShouldIgnoreFileLoadException(FileLoadException ex) => ex switch
 {
     // Occurs when the assembly is not supported on the target framework/platform.
     _ when (ex.Message.ToLower().Contains("operation is not supported")) => true,
+
+    // By default, do not ignore.
+    _ => false
+};
+
+bool ShouldIgnoreNotSupportedException(NotSupportedException ex) => ex switch
+{
+    // Occurs when the type cannot be created via Activator.CreateInstance.
+    _ when (ex.Message.ToLower().Contains("cannot dynamically create an instance of type")) => true,
 
     // By default, do not ignore.
     _ => false

--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -24,13 +24,13 @@
       The static set is included here to allow for local testing of the smoke tests project
       without the need to run CI scripts to rewrite package references.
     -->
-    <PackageReference Include="Azure.Identity" Version="1.11.3" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.3" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.11.3" />
-    <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.6.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.7" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.39.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.1" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.1" />
+    <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.7.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.6.11" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.40.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.22.0" />
     <PackageReference Include="Azure.Template" Version="1.0.3-beta.1218030" />
 
@@ -38,7 +38,7 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))">
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <!-- This package supports netcoreapp3.1 -->
     <PackageReference Remove="Microsoft.Azure.WebPubSub.AspNetCore" />
   </ItemGroup>

--- a/common/SmokeTests/SmokeTest/Update-Dependencies.ps1
+++ b/common/SmokeTests/SmokeTest/Update-Dependencies.ps1
@@ -15,6 +15,7 @@ param(
 $packageExcludeSet = @(
     "Microsoft.Azure.WebPubSub.AspNetCore",
     "Microsoft.WCF.Azure.StorageQueues",
+    "Azure.Projects.Web",
     "OpenAI"
 )
 


### PR DESCRIPTION
# Summary

Updating local test package versions, ignoring Activator dynamic load errors, and adding an exception for an AI/web package that does not target netstandard2.0 and is not compatible with the full set of target frameworks for the tests.
