### PR TITLE
[Storage][DataMovement] Protocol Validation for NFS over REST

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
@@ -41,6 +41,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
         public bool IsNfs { get { throw null; } set { } }
+        public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net8.0.cs
@@ -41,6 +41,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
         public bool IsNfs { get { throw null; } set { } }
+        public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
@@ -41,6 +41,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
         public bool IsNfs { get { throw null; } set { } }
+        public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_6076f3c64b"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_5ab02c363e"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_0e15ce000a"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_e21af51239"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_e21af51239"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_e8e5b8db0f"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_582d85df8a"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_6076f3c64b"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_e8e5b8db0f"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_582d85df8a"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_7af87df10f"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_0e15ce000a"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/Azure.Storage.DataMovement.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/Azure.Storage.DataMovement.Files.Shares.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)CancellationHelper.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" LinkBase="Shared\Core" />
   </ItemGroup>

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementFileShareEventSource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementFileShareEventSource.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics.Tracing;
+using Azure.Core.Diagnostics;
+
+namespace Azure.Storage.DataMovement.Files.Shares
+{
+    internal class DataMovementFileShareEventSource : AzureEventSource
+    {
+        private const string EventSourceName = "Azure-Storage-DataMovement-Files-Shares";
+
+        private const int ProtocolValidationSkippedEvent = 1;
+
+        private DataMovementFileShareEventSource() : base(EventSourceName) { }
+
+        public static DataMovementFileShareEventSource Singleton { get; } = new DataMovementFileShareEventSource();
+
+        [Event(ProtocolValidationSkippedEvent, Level = EventLevel.Informational, Message = "Transfer [{0}] Protocol Validation skipped for {1}: Resource={2}")]
+        public void ProtocolValidationSkipped(string transferId, string endpoint, string resourceUri)
+        {
+            WriteEvent(ProtocolValidationSkippedEvent, transferId, endpoint, resourceUri);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -684,10 +684,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
             }
         }
 
-        public static async Task<bool> ValidateProtocolAsync(
+        public static async Task ValidateProtocolAsync(
             ShareClient parentShareClient,
             ShareFileStorageResourceOptions options,
+            string transferId,
             string endpoint,
+            string resourceUri,
             CancellationToken cancellationToken)
         {
             if (!options?.SkipProtocolValidation ?? true)
@@ -707,9 +709,11 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 {
                     throw Errors.NoShareLevelPermissions(endpoint);
                 }
-                return true;
             }
-            return false;
+            else
+            {
+                DataMovementFileShareEventSource.Singleton.ProtocolValidationSkipped(transferId, endpoint, resourceUri);
+            }
         }
     }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -707,7 +707,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 }
                 catch (RequestFailedException ex) when (ex.Status == 403)
                 {
-                    throw Errors.NoShareLevelPermissions(endpoint);
+                    throw Errors.ProtocolValidationAuthorizationFailure(ex, endpoint);
                 }
             }
             else

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -684,7 +684,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             }
         }
 
-        public static async Task ValidateProtocolAsync(
+        public static async Task<bool> ValidateProtocolAsync(
             ShareClient parentShareClient,
             ShareFileStorageResourceOptions options,
             string endpoint,
@@ -707,7 +707,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 {
                     throw Errors.NoShareLevelPermissions(endpoint);
                 }
+                return true;
             }
+            return false;
         }
     }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
 using Azure.Storage.Files.Shares.Models;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
+using Azure.Storage.Files.Shares;
 
 namespace Azure.Storage.DataMovement.Files.Shares
 {
@@ -678,6 +681,32 @@ namespace Azure.Storage.DataMovement.Files.Shares
             else
             {
                 throw Storage.Errors.UnexpectedPropertyType(contentPropertyName, DataMovementConstants.StringTypeStr, DataMovementConstants.StringArrayTypeStr);
+            }
+        }
+
+        public static async Task ValidateProtocolAsync(
+            ShareClient parentShareClient,
+            ShareFileStorageResourceOptions options,
+            string endpoint,
+            CancellationToken cancellationToken)
+        {
+            if (!options?.SkipProtocolValidation ?? true)
+            {
+                try
+                {
+                    ShareProperties properties = await parentShareClient.GetPropertiesAsync(cancellationToken).ConfigureAwait(false);
+                    ShareProtocols expectedProtocol = options.IsNfs ? ShareProtocols.Nfs : ShareProtocols.Smb;
+                    ShareProtocols actualProtocol = properties.Protocols ?? ShareProtocols.Smb;
+
+                    if (actualProtocol != expectedProtocol)
+                    {
+                        throw Errors.ProtocolSetMismatch(endpoint, expectedProtocol, actualProtocol);
+                    }
+                }
+                catch (RequestFailedException ex) when (ex.Status == 403)
+                {
+                    throw Errors.NoShareLevelPermissions(endpoint);
+                }
             }
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -177,12 +177,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(
+        protected override async Task ValidateTransferAsync(
+            string transferId,
             StorageResource sourceResource,
             CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
-            bool validateSource = true, validateDest = true;
 
             if (sourceResource is ShareDirectoryStorageResourceContainer sourceShareDirectoryResource)
             {
@@ -193,21 +193,23 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 }
 
                 // Validate the source protocol
-                validateSource = await DataMovementSharesExtensions.ValidateProtocolAsync(
+                await DataMovementSharesExtensions.ValidateProtocolAsync(
                     sourceShareDirectoryResource.ShareDirectoryClient.GetParentShareClient(),
                     sourceShareDirectoryResource.ResourceOptions,
+                    transferId,
                     "source",
+                    sourceResource.Uri.AbsoluteUri,
                     cancellationToken).ConfigureAwait(false);
             }
 
             // Validate the destination protocol
-            validateDest = await DataMovementSharesExtensions.ValidateProtocolAsync(
+            await DataMovementSharesExtensions.ValidateProtocolAsync(
                 ShareDirectoryClient.GetParentShareClient(),
                 ResourceOptions,
+                transferId,
                 "destination",
+                Uri.AbsoluteUri,
                 cancellationToken).ConfigureAwait(false);
-
-            return (ValidateSource: validateSource, ValidateDest: validateDest);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -177,9 +177,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task ValidateTransferAsync(StorageResource sourceResource, CancellationToken cancellationToken = default)
+        protected override async Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(
+            StorageResource sourceResource,
+            CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+            bool validateSource = true, validateDest = true;
 
             if (sourceResource is ShareDirectoryStorageResourceContainer sourceShareDirectoryResource)
             {
@@ -190,7 +193,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 }
 
                 // Validate the source protocol
-                await DataMovementSharesExtensions.ValidateProtocolAsync(
+                validateSource = await DataMovementSharesExtensions.ValidateProtocolAsync(
                     sourceShareDirectoryResource.ShareDirectoryClient.GetParentShareClient(),
                     sourceShareDirectoryResource.ResourceOptions,
                     "source",
@@ -198,11 +201,13 @@ namespace Azure.Storage.DataMovement.Files.Shares
             }
 
             // Validate the destination protocol
-            await DataMovementSharesExtensions.ValidateProtocolAsync(
+            validateDest = await DataMovementSharesExtensions.ValidateProtocolAsync(
                 ShareDirectoryClient.GetParentShareClient(),
                 ResourceOptions,
                 "destination",
                 cancellationToken).ConfigureAwait(false);
+
+            return (ValidateSource: validateSource, ValidateDest: validateDest);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -65,8 +65,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 ShareDirectoryStorageResourceContainer destinationStorageResourceContainer
                     = destinationContainer as ShareDirectoryStorageResourceContainer;
                 ShareFileStorageResourceOptions destinationOptions = destinationStorageResourceContainer.ResourceOptions;
-                // destination must be SMB
-                if ((!destinationOptions?.IsNfs ?? true))
+                // both source and destination must be SMB
+                if ((!ResourceOptions?.IsNfs ?? true) && (!destinationOptions?.IsNfs ?? true))
                 {
                     traits = ShareFileTraits.Attributes;
                     if (destinationOptions?.FilePermissions ?? false)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -181,54 +181,28 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
-            if (sourceResource is ShareDirectoryStorageResourceContainer sourceShareDirectory)
+            if (sourceResource is ShareDirectoryStorageResourceContainer sourceShareDirectoryResource)
             {
-                // Make sure the transfer is supported (NFS -> NFS and SMB -> SMB)
-                if ((ResourceOptions?.IsNfs ?? false) != (sourceShareDirectory.ResourceOptions?.IsNfs ?? false))
+                // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
+                if ((ResourceOptions?.IsNfs ?? false) != (sourceShareDirectoryResource.ResourceOptions?.IsNfs ?? false))
                 {
                     throw Errors.ShareTransferNotSupported();
                 }
 
-                // validate the source protocol
-                if (!sourceShareDirectory.ResourceOptions?.SkipProtocolValidation ?? true)
-                {
-                    try
-                    {
-                        ShareClient sourceParentShare = sourceShareDirectory.ShareDirectoryClient.GetParentShareClient();
-                        ShareProperties sourceProperties = await sourceParentShare.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-                        ShareProtocols setProtocolSource = (sourceShareDirectory.ResourceOptions?.IsNfs ?? false) ? ShareProtocols.Nfs : ShareProtocols.Smb;
-                        ShareProtocols actualProtocolSource = sourceProperties.Protocols ?? ShareProtocols.Smb;
-                        if (actualProtocolSource != setProtocolSource)
-                        {
-                            throw Errors.ProtocolSetMismatch("source", setProtocolSource, actualProtocolSource);
-                        }
-                    }
-                    catch (RequestFailedException ex) when (ex.Status == 403)
-                    {
-                        throw Errors.NoShareLevelPermissions("source");
-                    }
-                }
+                // Validate the source protocol
+                await DataMovementSharesExtensions.ValidateProtocolAsync(
+                    sourceShareDirectoryResource.ShareDirectoryClient.GetParentShareClient(),
+                    sourceShareDirectoryResource.ResourceOptions,
+                    "source",
+                    cancellationToken).ConfigureAwait(false);
             }
 
-            // validate the destination protocol
-            if (!ResourceOptions?.SkipProtocolValidation ?? true)
-            {
-                try
-                {
-                    ShareClient parentShare = ShareDirectoryClient.GetParentShareClient();
-                    ShareProperties properties = await parentShare.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-                    ShareProtocols setProtocol = (ResourceOptions?.IsNfs ?? false) ? ShareProtocols.Nfs : ShareProtocols.Smb;
-                    ShareProtocols actualProtocol = properties.Protocols ?? ShareProtocols.Smb;
-                    if (actualProtocol != setProtocol)
-                    {
-                        throw Errors.ProtocolSetMismatch("destination", setProtocol, actualProtocol);
-                    }
-                }
-                catch (RequestFailedException ex) when (ex.Status == 403)
-                {
-                    throw Errors.NoShareLevelPermissions("destination");
-                }
-            }
+            // Validate the destination protocol
+            await DataMovementSharesExtensions.ValidateProtocolAsync(
+                ShareDirectoryClient.GetParentShareClient(),
+                ResourceOptions,
+                "destination",
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -348,12 +348,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 directoryMetadata: _options?.DirectoryMetadata);
         }
 
-        protected override async Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(
+        protected override async Task ValidateTransferAsync(
+            string transferId,
             StorageResource sourceResource,
             CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
-            bool validateSource = true, validateDest = true;
 
             if (sourceResource is ShareFileStorageResource sourceShareFileResource)
             {
@@ -364,21 +364,23 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 }
 
                 // Validate the source protocol
-                validateSource = await DataMovementSharesExtensions.ValidateProtocolAsync(
+                await DataMovementSharesExtensions.ValidateProtocolAsync(
                     sourceShareFileResource.ShareFileClient.GetParentShareClient(),
                     sourceShareFileResource._options,
+                    transferId,
                     "source",
+                    sourceResource.Uri.AbsoluteUri,
                     cancellationToken).ConfigureAwait(false);
             }
 
             // Validate the destination protocol
-            validateDest = await DataMovementSharesExtensions.ValidateProtocolAsync(
+            await DataMovementSharesExtensions.ValidateProtocolAsync(
                 ShareFileClient.GetParentShareClient(),
                 _options,
+                transferId,
                 "destination",
+                Uri.AbsoluteUri,
                 cancellationToken).ConfigureAwait(false);
-
-            return (ValidateSource: validateSource, ValidateDest: validateDest);
         }
     }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -396,7 +396,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
         public static UnauthorizedAccessException ProtocolValidationAuthorizationFailure(RequestFailedException ex, string endpoint)
             => new UnauthorizedAccessException($"Authorization failure on the {endpoint} when validating the Protocol. " +
-                $"To skip this validation, please enable SkipProtocolValidation. Error details: {ex}");
+                $"To skip this validation, please enable SkipProtocolValidation.", ex);
 
         public static NotSupportedException ShareTransferNotSupported()
             => new NotSupportedException("This Share transfer is not supported. " +

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -394,9 +394,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public static ArgumentException ProtocolSetMismatch(string endpoint, ShareProtocols setProtocol, ShareProtocols actualProtocol)
             => new ArgumentException($"The Protocol set on the {endpoint} '{setProtocol}' does not match the actual Protocol of the share '{actualProtocol}'.");
 
-        public static UnauthorizedAccessException NoShareLevelPermissions(string endpoint)
-            => new UnauthorizedAccessException($"Share-level permissions on the {endpoint} is required to validate the Protocol. " +
-                "Please enable SkipProtocolValidation if you wish to skip the validation.");
+        public static UnauthorizedAccessException ProtocolValidationAuthorizationFailure(RequestFailedException ex, string endpoint)
+            => new UnauthorizedAccessException($"Authorization failure on the {endpoint} when validating the Protocol. " +
+                $"To skip this validation, please enable SkipProtocolValidation. Error details: {ex}");
 
         public static NotSupportedException ShareTransferNotSupported()
             => new NotSupportedException("This Share transfer is not supported. " +

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -348,9 +348,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 directoryMetadata: _options?.DirectoryMetadata);
         }
 
-        protected override async Task ValidateTransferAsync(StorageResource sourceResource, CancellationToken cancellationToken = default)
+        protected override async Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(
+            StorageResource sourceResource,
+            CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+            bool validateSource = true, validateDest = true;
 
             if (sourceResource is ShareFileStorageResource sourceShareFileResource)
             {
@@ -361,7 +364,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 }
 
                 // Validate the source protocol
-                await DataMovementSharesExtensions.ValidateProtocolAsync(
+                validateSource = await DataMovementSharesExtensions.ValidateProtocolAsync(
                     sourceShareFileResource.ShareFileClient.GetParentShareClient(),
                     sourceShareFileResource._options,
                     "source",
@@ -369,11 +372,13 @@ namespace Azure.Storage.DataMovement.Files.Shares
             }
 
             // Validate the destination protocol
-            await DataMovementSharesExtensions.ValidateProtocolAsync(
+            validateDest = await DataMovementSharesExtensions.ValidateProtocolAsync(
                 ShareFileClient.GetParentShareClient(),
                 _options,
                 "destination",
                 cancellationToken).ConfigureAwait(false);
+
+            return (ValidateSource: validateSource, ValidateDest: validateDest);
         }
     }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -276,8 +276,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             if (sourceResource is ShareFileStorageResource)
             {
                 ShareFileStorageResource sourceShareFile = (ShareFileStorageResource)sourceResource;
-                // destination must be SMB and destination FilePermission option must be set.
-                if ((!_options?.IsNfs ?? true) && (_options?.FilePermissions ?? false))
+                // both source and destination must be SMB and destination FilePermission option must be set.
+                if ((!sourceShareFile._options?.IsNfs ?? true) && (!_options?.IsNfs ?? true) && (_options?.FilePermissions ?? false))
                 {
                     string permissionsValue = sourceProperties?.RawProperties?.GetPermission();
                     string destinationPermissionKey = sourceProperties?.RawProperties?.GetDestinationPermissionKey();

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -47,7 +47,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         internal bool _isFileMetadataSet = false;
 
         /// <summary>
-        /// Optional. Specifies whether we should skip validating the protocol of the resource before starting the transfer.
+        /// Optional. Specifies whether protocol validation for the resource should be skipped before starting the transfer.
         /// By default this value is set to false.
         /// Applies to copy, upload, and download transfers.
         /// Note: Protocol validation requires share-level read access.

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -47,6 +47,13 @@ namespace Azure.Storage.DataMovement.Files.Shares
         internal bool _isFileMetadataSet = false;
 
         /// <summary>
+        /// Optional. Specifies whether we should skip validating the protocol of the resource before starting the transfer.
+        /// By default this value is set to false.
+        /// Applies to copy, upload, and download transfers.
+        /// </summary>
+        public bool SkipProtocolValidation { get; set; } = false;
+
+        /// <summary>
         /// Optional. Specifies whether the Share uses NFS or SMB protocol.
         /// By default this value is set to false. If true is selected, the account used must support NFS.
         /// Applies to copy, upload, and download transfers.

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -50,6 +50,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// Optional. Specifies whether we should skip validating the protocol of the resource before starting the transfer.
         /// By default this value is set to false.
         /// Applies to copy, upload, and download transfers.
+        /// Note: Protocol validation requires share-level read access.
         /// </summary>
         public bool SkipProtocolValidation { get; set; } = false;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ClientBuilderExtensions.cs
@@ -60,6 +60,27 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             return await DisposingShare.CreateAsync(share, metadata);
         }
 
+        public static async Task<DisposingShare> GetTestShareSasAsync(
+            this SharesClientBuilder clientBuilder,
+            ShareServiceClient service = default,
+            string shareName = default,
+            IDictionary<string, string> metadata = default,
+            ShareClientOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+            service ??= clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigDefault, options);
+            ShareServiceClient sasService = new ShareServiceClient(service.GenerateAccountSasUri(
+                Sas.AccountSasPermissions.All,
+                clientBuilder.Recording.UtcNow.AddDays(1),
+                Sas.AccountSasResourceTypes.All),
+                clientBuilder.GetOptions());
+            metadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            shareName ??= clientBuilder.GetNewShareName();
+            ShareClient share = clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(sasService.GetShareClient(shareName));
+            return await DisposingShare.CreateAsync(share, metadata);
+        }
+
         public static async Task<DisposingShare> GetTestShareSasNfsAsync(
             this SharesClientBuilder clientBuilder,
             ShareServiceClient service = default,

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -21,7 +21,6 @@ using Metadata = System.Collections.Generic.IDictionary<string, string>;
 using DMShare::Azure.Storage.DataMovement.Files.Shares;
 using Azure.Core.TestFramework;
 using System.Text.RegularExpressions;
-using BaseShares::Azure.Storage.Sas;
 
 namespace Azure.Storage.DataMovement.Files.Shares.Tests
 {

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -537,7 +537,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = false, FilePermissions = false });
+                new ShareFileStorageResourceOptions() { IsNfs = false, });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
@@ -660,6 +660,185 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 destinationContainer: destination.Container,
                 destinationPrefix: destPrefix,
                 propertiesTestType: testType);
+        }
+
+        [RecordedTest]
+        [Combinatorial]
+        public async Task ValidateProtocolAsync_SmbShareDirectoryToSmbShareDirectory_CompareProtocolSetToActual(
+            [Values(true, false)] bool sourceIsNfs,
+            [Values(true, false)] bool destIsNfs)
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
+            await using IDisposingContainer<ShareClient> destination = await GetDestinationDisposingContainerAsync();
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            string sourcePrefix = "sourceFolder";
+            string destPrefix = "destFolder";
+
+            ShareDirectoryCreateOptions directoryCreateOptions = new ShareDirectoryCreateOptions()
+            {
+                Metadata = _defaultMetadata,
+                FilePermission = new ShareFilePermission() { Permission = _defaultPermissions },
+                SmbProperties = new FileSmbProperties()
+                {
+                    FileAttributes = _defaultFileAttributes,
+                    FileCreatedOn = _defaultFileCreatedOn,
+                    FileChangedOn = _defaultFileChangedOn,
+                    FileLastWrittenOn = _defaultFileLastWrittenOn,
+                },
+            };
+            // setup source
+            await CreateDirectoryAsync(source.Container, sourcePrefix, directoryCreateOptions);
+            await CreateDirectoryTreeAsync(source.Container, sourcePrefix, DataMovementTestConstants.KB);
+            // setup destination
+            await CreateDirectoryInDestinationAsync(destination.Container, destPrefix);
+
+            // Create storage resource containers
+            ShareDirectoryClient sourceClient = source.Container.GetDirectoryClient(sourcePrefix);
+            StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
+                sourceClient,
+                new ShareFileStorageResourceOptions() { IsNfs = sourceIsNfs });
+
+            ShareDirectoryClient destClient = destination.Container.GetDirectoryClient(destPrefix);
+            StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
+                destClient,
+                new ShareFileStorageResourceOptions() { IsNfs = destIsNfs });
+
+            // Create Transfer Manager with single threaded operation
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                MaximumConcurrency = 1,
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            // Act and Assert
+            if (!sourceIsNfs && !destIsNfs)
+            {
+                // Start transfer and await for completion.
+                TransferOperation transfer = await transferManager.StartTransferAsync(
+                    sourceResource,
+                    destinationResource,
+                    options).ConfigureAwait(false);
+
+                // Act
+                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+                await TestTransferWithTimeout.WaitForCompletionAsync(
+                    transfer,
+                    testEventsRaised,
+                    cancellationTokenSource.Token);
+
+                // Assert
+                testEventsRaised.AssertUnexpectedFailureCheck();
+                Assert.NotNull(transfer);
+                Assert.IsTrue(transfer.HasCompleted);
+                Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+
+                await VerifyResultsAsync(
+                    sourceContainer: source.Container,
+                    sourcePrefix: sourcePrefix,
+                    destinationContainer: destination.Container,
+                    destinationPrefix: destPrefix,
+                    propertiesTestType: TransferPropertiesTestType.PreserveNoPermissions);
+            }
+            else
+            {
+                var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                    await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
+                string endpoint = destIsNfs ? "destination" : "source";
+                Assert.AreEqual($"The Protocol set on the {endpoint} '{ShareProtocols.Nfs}' does not match the actual Protocol of the share '{ShareProtocols.Smb}'.", ex.Message);
+            }
+        }
+
+        [RecordedTest]
+        [Combinatorial]
+        public async Task ValidateProtocolAsync_NfsShareDirectoryToNfsShareDirectory_CompareProtocolSetToActual(
+            [Values(true, false)] bool sourceIsNfs,
+            [Values(true, false)] bool destIsNfs)
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
+            await using IDisposingContainer<ShareClient> destination = await DestinationClientBuilder.GetTestShareSasNfsAsync();
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            string sourcePrefix = "sourceFolder";
+            string destPrefix = "destFolder";
+
+            ShareDirectoryCreateOptions directoryCreateOptions = new ShareDirectoryCreateOptions()
+            {
+                Metadata = _defaultMetadata,
+                SmbProperties = new FileSmbProperties()
+                {
+                    FileCreatedOn = _defaultFileCreatedOn,
+                    FileLastWrittenOn = _defaultFileLastWrittenOn,
+                },
+                PosixProperties = new FilePosixProperties()
+                {
+                    Owner = "345",
+                    Group = "123",
+                    FileMode = NfsFileMode.ParseOctalFileMode("1777"),
+                }
+            };
+            // setup source
+            await CreateDirectoryAsync(source.Container, sourcePrefix, directoryCreateOptions);
+            await CreateDirectoryTreeNfsAsync(source.Container, sourcePrefix, directoryCreateOptions, DataMovementTestConstants.KB);
+            // setup destination
+            await CreateDirectoryInDestinationAsync(destination.Container, destPrefix);
+
+            // Create storage resource containers
+            StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
+                source.Container.GetDirectoryClient(sourcePrefix),
+                new ShareFileStorageResourceOptions() { IsNfs = sourceIsNfs });
+
+            StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
+                destination.Container.GetDirectoryClient(destPrefix),
+                new ShareFileStorageResourceOptions() { IsNfs = destIsNfs });
+
+            // Create Transfer Manager with single threaded operation
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                MaximumConcurrency = 1,
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            // Act and Assert
+            if (sourceIsNfs && destIsNfs)
+            {
+                // Start transfer and await for completion.
+                TransferOperation transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                options).ConfigureAwait(false);
+
+                // Act
+                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+                await TestTransferWithTimeout.WaitForCompletionAsync(
+                    transfer,
+                    testEventsRaised,
+                    cancellationTokenSource.Token);
+
+                // Assert
+                testEventsRaised.AssertUnexpectedFailureCheck();
+                Assert.NotNull(transfer);
+                Assert.IsTrue(transfer.HasCompleted);
+                Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+
+                await VerifyResultsAsync(
+                    sourceContainer: source.Container,
+                    sourcePrefix: sourcePrefix,
+                    destinationContainer: destination.Container,
+                    destinationPrefix: destPrefix,
+                    propertiesTestType: TransferPropertiesTestType.PreserveNfsNoPermissions);
+            }
+            else
+            {
+                var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                    await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
+                string endpoint = destIsNfs ? "source" : "destination";
+                Assert.AreEqual($"The Protocol set on the {endpoint} '{ShareProtocols.Smb}' does not match the actual Protocol of the share '{ShareProtocols.Nfs}'.", ex.Message);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -663,10 +663,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [Combinatorial]
-        public async Task ValidateProtocolAsync_SmbShareDirectoryToSmbShareDirectory_CompareProtocolSetToActual(
-            [Values(true, false)] bool sourceIsNfs,
-            [Values(true, false)] bool destIsNfs)
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public async Task ValidateProtocolAsync_SmbShareDirectoryToSmbShareDirectory_CompareProtocolSetToActual(bool sourceIsNfs, bool destIsNfs)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -746,16 +745,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
                     await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-                string endpoint = destIsNfs ? "destination" : "source";
-                Assert.AreEqual($"The Protocol set on the {endpoint} '{ShareProtocols.Nfs}' does not match the actual Protocol of the share '{ShareProtocols.Smb}'.", ex.Message);
+                Assert.AreEqual($"The Protocol set on the source '{ShareProtocols.Nfs}' does not match the actual Protocol of the share '{ShareProtocols.Smb}'.", ex.Message);
             }
         }
 
         [RecordedTest]
-        [Combinatorial]
-        public async Task ValidateProtocolAsync_NfsShareDirectoryToNfsShareDirectory_CompareProtocolSetToActual(
-            [Values(true, false)] bool sourceIsNfs,
-            [Values(true, false)] bool destIsNfs)
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public async Task ValidateProtocolAsync_NfsShareDirectoryToNfsShareDirectory_CompareProtocolSetToActual(bool sourceIsNfs, bool destIsNfs)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
@@ -836,8 +833,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
                     await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-                string endpoint = destIsNfs ? "source" : "destination";
-                Assert.AreEqual($"The Protocol set on the {endpoint} '{ShareProtocols.Smb}' does not match the actual Protocol of the share '{ShareProtocols.Nfs}'.", ex.Message);
+                Assert.AreEqual($"The Protocol set on the source '{ShareProtocols.Smb}' does not match the actual Protocol of the share '{ShareProtocols.Nfs}'.", ex.Message);
             }
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -988,7 +988,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 var ex = Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
                     await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-                Console.WriteLine("EXCEPTION: " + ex.Message);
                 StringAssert.Contains("Authorization failure on the source when validating the Protocol. " +
                     "To skip this validation, please enable SkipProtocolValidation. Error details:", ex.Message);
             }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -988,8 +988,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 var ex = Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
                     await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-                Assert.AreEqual("Share-level permissions on the source is required to validate the Protocol. " +
-                    "Please enable SkipProtocolValidation if you wish to skip the validation.", ex.Message);
+                Console.WriteLine("EXCEPTION: " + ex.Message);
+                StringAssert.Contains("Authorization failure on the source when validating the Protocol. " +
+                    "To skip this validation, please enable SkipProtocolValidation. Error details:", ex.Message);
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -988,8 +988,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 var ex = Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
                     await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-                StringAssert.Contains("Authorization failure on the source when validating the Protocol. " +
-                    "To skip this validation, please enable SkipProtocolValidation. Error details:", ex.Message);
+                Assert.AreEqual("Authorization failure on the source when validating the Protocol. " +
+                    "To skip this validation, please enable SkipProtocolValidation.", ex.Message);
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -996,7 +996,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         [RecordedTest]
         [TestCase(true, false)]
         [TestCase(false, true)]
-        public async Task ValidateProtocolAsync_ShareTransferNotSupported(bool sourceIsNfs, bool destIsNfs)
+        public async Task ValidateProtocolAsync_ShareFileToShareFile_ShareTransferNotSupported(bool sourceIsNfs, bool destIsNfs)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -942,14 +942,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareAsync();
             await using IDisposingContainer<ShareClient> destination = await DestinationClientBuilder.GetTestShareAsync();
 
-            // Only File-level access
-            ShareSasBuilder sasBuilder = new ShareSasBuilder
-            {
-                Resource = "f", // "f" for file-level
-                ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
-            };
-            sasBuilder.SetPermissions(ShareFileSasPermissions.All);
-
             // Create Source with no share-level permissions
             ShareFileClient sourceClient = await CreateFileClientWithoutShareLevelPermissionsAsync(
                 container: source.Container,

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -778,10 +778,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [Combinatorial]
-        public async Task ValidateProtocolAsync_SmbShareFileToSmbShareFile_CompareProtocolSetToActual(
-            [Values(true, false)] bool sourceIsNfs,
-            [Values(true, false)] bool destIsNfs)
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public async Task ValidateProtocolAsync_SmbShareFileToSmbShareFile_CompareProtocolSetToActual(bool sourceIsNfs, bool destIsNfs)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -833,16 +832,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
                     await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-                string endpoint = destIsNfs ? "destination" : "source";
-                Assert.AreEqual($"The Protocol set on the {endpoint} '{ShareProtocols.Nfs}' does not match the actual Protocol of the share '{ShareProtocols.Smb}'.", ex.Message);
+                Assert.AreEqual($"The Protocol set on the source '{ShareProtocols.Nfs}' does not match the actual Protocol of the share '{ShareProtocols.Smb}'.", ex.Message);
             }
         }
 
         [RecordedTest]
-        [Combinatorial]
-        public async Task ValidateProtocolAsync_NfsShareFileToNfsShareFile_CompareProtocolSetToActual(
-            [Values(true, false)] bool sourceIsNfs,
-            [Values(true, false)] bool destIsNfs)
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public async Task ValidateProtocolAsync_NfsShareFileToNfsShareFile_CompareProtocolSetToActual(bool sourceIsNfs, bool destIsNfs)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
@@ -894,8 +891,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
                     await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-                string endpoint = destIsNfs ? "source" : "destination";
-                Assert.AreEqual($"The Protocol set on the {endpoint} '{ShareProtocols.Smb}' does not match the actual Protocol of the share '{ShareProtocols.Nfs}'.", ex.Message);
+                Assert.AreEqual($"The Protocol set on the source '{ShareProtocols.Smb}' does not match the actual Protocol of the share '{ShareProtocols.Nfs}'.", ex.Message);
             }
         }
 
@@ -964,7 +960,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 var ex = Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
                     await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-                Assert.AreEqual("Share-level permissions on the destination is required to validate the Protocol. " +
+                Assert.AreEqual("Share-level permissions on the source is required to validate the Protocol. " +
                     "Please enable SkipProtocolValidation if you wish to skip the validation.", ex.Message);
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(string transferId, Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -24,6 +24,8 @@ namespace Azure.Storage.DataMovement
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetDestinationCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(string transferId, Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
@@ -24,6 +24,8 @@ namespace Azure.Storage.DataMovement
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetDestinationCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(string transferId, Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -24,6 +24,8 @@ namespace Azure.Storage.DataMovement
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetDestinationCheckpointDetails();
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract Azure.Storage.DataMovement.StorageResourceCheckpointDetails GetSourceCheckpointDetails();
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected internal virtual System.Threading.Tasks.Task ValidateTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class StorageResourceCheckpointDetails

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataMovementEventSource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataMovementEventSource.cs
@@ -72,7 +72,7 @@ namespace Azure.Storage.DataMovement
             WriteEvent(EnumerationCompleteEvent, transferId, jobPartCount);
         }
 
-        [Event(ResumeTransferEvent, Level = EventLevel.Informational, Message = "Resume transfer [{0]} Transfer queued: {1} -> {2}")]
+        [Event(ResumeTransferEvent, Level = EventLevel.Informational, Message = "Resume transfer [{0}] Transfer queued: {1} -> {2}")]
         public void ResumeTransfer(string transferId, string source, string destination)
         {
             WriteEvent(ResumeTransferEvent, transferId, source, destination);

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataMovementEventSource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataMovementEventSource.cs
@@ -16,7 +16,6 @@ namespace Azure.Storage.DataMovement
         private const int EnumerationCompleteEvent = 4;
         private const int ResumeTransferEvent = 5;
         private const int ResumeEnumerationCompleteEvent = 6;
-        private const int TransferValidationSkippedEvent = 7;
 
         private DataMovementEventSource() : base(EventSourceName) { }
 
@@ -92,12 +91,6 @@ namespace Azure.Storage.DataMovement
         public void ResumeEnumerationComplete(string transferId, int jobPartCount)
         {
             WriteEvent(ResumeEnumerationCompleteEvent, transferId, jobPartCount);
-        }
-
-        [Event(TransferValidationSkippedEvent, Level = EventLevel.Informational, Message = "Transfer [{0}] Validation skipped for {1}: Resource={2}")]
-        public void TransferValidationSkipped(string transferId, string endpoint, string resourceUri)
-        {
-            WriteEvent(TransferValidationSkippedEvent, transferId, endpoint, resourceUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataMovementEventSource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataMovementEventSource.cs
@@ -16,6 +16,7 @@ namespace Azure.Storage.DataMovement
         private const int EnumerationCompleteEvent = 4;
         private const int ResumeTransferEvent = 5;
         private const int ResumeEnumerationCompleteEvent = 6;
+        private const int TransferValidationSkippedEvent = 7;
 
         private DataMovementEventSource() : base(EventSourceName) { }
 
@@ -91,6 +92,12 @@ namespace Azure.Storage.DataMovement
         public void ResumeEnumerationComplete(string transferId, int jobPartCount)
         {
             WriteEvent(ResumeEnumerationCompleteEvent, transferId, jobPartCount);
+        }
+
+        [Event(TransferValidationSkippedEvent, Level = EventLevel.Informational, Message = "Transfer [{0}] Validation skipped for {1}: Resource={2}")]
+        public void TransferValidationSkipped(string transferId, string endpoint, string resourceUri)
+        {
+            WriteEvent(TransferValidationSkippedEvent, transferId, endpoint, resourceUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
@@ -115,8 +115,5 @@ namespace Azure.Storage
 
         public static InvalidOperationException SingleItemContainerNoGetProperties()
             => new InvalidOperationException("SingleItemStorageResourceContainer does not support GetPropertiesAsync");
-
-        public static NotSupportedException ShareTransferNotSupported()
-            => new NotSupportedException("This Share transfer is not supported. Currently only NFS -> NFS and SMB -> SMB Share transfers are supported");
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
@@ -115,5 +115,8 @@ namespace Azure.Storage
 
         public static InvalidOperationException SingleItemContainerNoGetProperties()
             => new InvalidOperationException("SingleItemStorageResourceContainer does not support GetPropertiesAsync");
+
+        public static NotSupportedException ShareTransferNotSupported()
+            => new NotSupportedException("This Share transfer is not supported. Currently only NFS -> NFS and SMB -> SMB Share transfers are supported");
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
@@ -53,11 +53,10 @@ namespace Azure.Storage.DataMovement
         protected internal abstract StorageResourceCheckpointDetails GetDestinationCheckpointDetails();
 
         /// <summary>
-        /// Ensures the transfer is valid. Intended to be called on destination resources.
+        /// Ensures the transfer is valid. Intended to be called on destination resource with the source resource passed-in.
         /// </summary>
-        /// <returns>A (bool ValidateSource, bool ValidateDest) indicating whether the source and destination were validated or skipped.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected internal virtual Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(StorageResource sourceResource, CancellationToken cancellationToken = default)
+        protected internal virtual Task ValidateTransferAsync(string transferId, StorageResource sourceResource, CancellationToken cancellationToken = default)
             => Task.FromResult((ValidateSource: true, ValidateDest: true));
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
@@ -57,6 +57,6 @@ namespace Azure.Storage.DataMovement
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected internal virtual Task ValidateTransferAsync(string transferId, StorageResource sourceResource, CancellationToken cancellationToken = default)
-            => Task.FromResult((ValidateSource: true, ValidateDest: true));
+            => Task.CompletedTask;
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
@@ -55,8 +55,9 @@ namespace Azure.Storage.DataMovement
         /// <summary>
         /// Ensures the transfer is valid. Intended to be called on destination resources.
         /// </summary>
+        /// <returns>A (bool ValidateSource, bool ValidateDest) indicating whether the source and destination were validated or skipped.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected internal virtual Task ValidateTransferAsync(StorageResource sourceResource, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
+        protected internal virtual Task<(bool ValidateSource, bool ValidateDest)> ValidateTransferAsync(StorageResource sourceResource, CancellationToken cancellationToken = default)
+            => Task.FromResult((ValidateSource: true, ValidateDest: true));
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
@@ -53,10 +53,8 @@ namespace Azure.Storage.DataMovement
         protected internal abstract StorageResourceCheckpointDetails GetDestinationCheckpointDetails();
 
         /// <summary>
-        /// Validates whether the proper protocol has been set for the resource.
-        /// Applies only to File Shares.
+        /// Ensures the transfer is valid. Intended to be called on destination resources.
         /// </summary>
-        /// <returns>Whether the protocol of the resource is NFS. Returns null if the resource is not File Share.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected internal virtual Task ValidateTransferAsync(StorageResource sourceResource, CancellationToken cancellationToken = default)
             => Task.CompletedTask;

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
@@ -58,7 +58,7 @@ namespace Azure.Storage.DataMovement
         /// </summary>
         /// <returns>Whether the protocol of the resource is NFS. Returns null if the resource is not File Share.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected internal virtual Task<bool?> ValidateProtocolAsync(bool isDestination, CancellationToken cancellationToken = default)
-            => Task.FromResult<bool?>(null);
+        protected internal virtual Task ValidateTransferAsync(StorageResource sourceResource, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResource.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Azure.Storage.DataMovement
 {
@@ -49,5 +51,14 @@ namespace Azure.Storage.DataMovement
         /// <returns>A <see cref="StorageResourceCheckpointDetails"/> containing the checkpoint information for this resource.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected internal abstract StorageResourceCheckpointDetails GetDestinationCheckpointDetails();
+
+        /// <summary>
+        /// Validates whether the proper protocol has been set for the resource.
+        /// Applies only to File Shares.
+        /// </summary>
+        /// <returns>Whether the protocol of the resource is NFS. Returns null if the resource is not File Share.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal virtual Task<bool?> ValidateProtocolAsync(bool isDestination, CancellationToken cancellationToken = default)
+            => Task.FromResult<bool?>(null);
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -375,17 +375,8 @@ namespace Azure.Storage.DataMovement
             Argument.AssertNotNull(sourceResource, nameof(sourceResource));
             Argument.AssertNotNull(destinationResource, nameof(destinationResource));
 
-            (bool validateSource, bool validateDest) = await destinationResource.ValidateTransferAsync(sourceResource, cancellationToken).ConfigureAwait(false);
-
             string transferId = _generateTransferId();
-            if (!validateSource)
-            {
-                DataMovementEventSource.Singleton.TransferValidationSkipped(transferId, "source", sourceResource.Uri.AbsoluteUri);
-            }
-            if (!validateDest)
-            {
-                DataMovementEventSource.Singleton.TransferValidationSkipped(transferId, "destination", destinationResource.Uri.AbsoluteUri);
-            }
+            await destinationResource.ValidateTransferAsync(transferId, sourceResource, cancellationToken).ConfigureAwait(false);
 
             transferOptions ??= new TransferOptions();
             try

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -375,11 +375,19 @@ namespace Azure.Storage.DataMovement
             Argument.AssertNotNull(sourceResource, nameof(sourceResource));
             Argument.AssertNotNull(destinationResource, nameof(destinationResource));
 
-            await destinationResource.ValidateTransferAsync(sourceResource, cancellationToken).ConfigureAwait(false);
-
-            transferOptions ??= new TransferOptions();
+            (bool validateSource, bool validateDest) = await destinationResource.ValidateTransferAsync(sourceResource, cancellationToken).ConfigureAwait(false);
 
             string transferId = _generateTransferId();
+            if (!validateSource)
+            {
+                DataMovementEventSource.Singleton.TransferValidationSkipped(transferId, "source", sourceResource.Uri.AbsoluteUri);
+            }
+            if (!validateDest)
+            {
+                DataMovementEventSource.Singleton.TransferValidationSkipped(transferId, "destination", destinationResource.Uri.AbsoluteUri);
+            }
+
+            transferOptions ??= new TransferOptions();
             try
             {
                 await _checkpointer.AddNewJobAsync(

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -375,14 +375,7 @@ namespace Azure.Storage.DataMovement
             Argument.AssertNotNull(sourceResource, nameof(sourceResource));
             Argument.AssertNotNull(destinationResource, nameof(destinationResource));
 
-            // Perform protocol validation check on the destination and source
-            bool? destIsNfs = await destinationResource.ValidateProtocolAsync(true, cancellationToken).ConfigureAwait(false);
-            bool? sourceIsNfs = await sourceResource.ValidateProtocolAsync(false, cancellationToken).ConfigureAwait(false);
-            // NFS -> SMB and SMB -> NFS transfers are not supported
-            if (destIsNfs != null && sourceIsNfs != null && destIsNfs != sourceIsNfs)
-            {
-                throw Errors.ShareTransferNotSupported();
-            }
+            await destinationResource.ValidateTransferAsync(sourceResource, cancellationToken).ConfigureAwait(false);
 
             transferOptions ??= new TransferOptions();
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -375,6 +375,15 @@ namespace Azure.Storage.DataMovement
             Argument.AssertNotNull(sourceResource, nameof(sourceResource));
             Argument.AssertNotNull(destinationResource, nameof(destinationResource));
 
+            // Perform protocol validation check on the destination and source
+            bool? destIsNfs = await destinationResource.ValidateProtocolAsync(true, cancellationToken).ConfigureAwait(false);
+            bool? sourceIsNfs = await sourceResource.ValidateProtocolAsync(false, cancellationToken).ConfigureAwait(false);
+            // NFS -> SMB and SMB -> NFS transfers are not supported
+            if (destIsNfs != null && sourceIsNfs != null && destIsNfs != sourceIsNfs)
+            {
+                throw Errors.ShareTransferNotSupported();
+            }
+
             transferOptions ??= new TransferOptions();
 
             string transferId = _generateTransferId();

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
@@ -84,7 +84,7 @@ namespace Azure.Storage.DataMovement.Tests
 
         private void AssertBaseSource(Mock<StorageResourceItem> source)
         {
-            source.Verify(b => b.Uri, Times.Exactly(13));
+            source.Verify(b => b.Uri, Times.Exactly(12));
             source.Verify(b => b.ProviderId, Times.Once());
             source.Verify(b => b.ResourceId, Times.Exactly(2));
             source.Verify(b => b.IsContainer, Times.Once());
@@ -114,12 +114,12 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             AssertBaseSource(sourceMock);
-            destMock.Verify(b => b.Uri, Times.Exactly(7));
+            destMock.Verify(b => b.Uri, Times.Exactly(6));
             destMock.Verify(b => b.ProviderId, Times.Once());
             destMock.Verify(b => b.ResourceId, Times.Once());
             destMock.Verify(b => b.MaxSupportedSingleTransferSize, Times.Once());
             destMock.Verify(b => b.MaxSupportedChunkSize, Times.Once());
-            destMock.Verify(b => b.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
+            destMock.Verify(b => b.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
             destMock.Verify(b => b.GetDestinationCheckpointDetails(), Times.Once());
             destMock.Verify(b => b.SetPermissionsAsync(
                 sourceMock.Object,
@@ -159,12 +159,12 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             AssertBaseSource(sourceMock);
-            destMock.Verify(b => b.Uri, Times.Exactly(7));
+            destMock.Verify(b => b.Uri, Times.Exactly(6));
             destMock.Verify(b => b.ProviderId, Times.Once());
             destMock.Verify(b => b.ResourceId, Times.Once());
             destMock.Verify(b => b.MaxSupportedSingleTransferSize, Times.Once());
             destMock.Verify(b => b.MaxSupportedChunkSize, Times.Once());
-            destMock.Verify(b => b.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
+            destMock.Verify(b => b.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
             destMock.Verify(b => b.GetDestinationCheckpointDetails(), Times.Once());
             destMock.Verify(b => b.SetPermissionsAsync(
                 sourceMock.Object,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
@@ -84,7 +84,7 @@ namespace Azure.Storage.DataMovement.Tests
 
         private void AssertBaseSource(Mock<StorageResourceItem> source)
         {
-            source.Verify(b => b.Uri, Times.Exactly(12));
+            source.Verify(b => b.Uri, Times.Exactly(13));
             source.Verify(b => b.ProviderId, Times.Once());
             source.Verify(b => b.ResourceId, Times.Exactly(2));
             source.Verify(b => b.IsContainer, Times.Once());

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
@@ -114,7 +114,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             AssertBaseSource(sourceMock);
-            destMock.Verify(b => b.Uri, Times.Exactly(6));
+            destMock.Verify(b => b.Uri, Times.Exactly(7));
             destMock.Verify(b => b.ProviderId, Times.Once());
             destMock.Verify(b => b.ResourceId, Times.Once());
             destMock.Verify(b => b.MaxSupportedSingleTransferSize, Times.Once());
@@ -159,7 +159,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             AssertBaseSource(sourceMock);
-            destMock.Verify(b => b.Uri, Times.Exactly(6));
+            destMock.Verify(b => b.Uri, Times.Exactly(7));
             destMock.Verify(b => b.ProviderId, Times.Once());
             destMock.Verify(b => b.ResourceId, Times.Once());
             destMock.Verify(b => b.MaxSupportedSingleTransferSize, Times.Once());

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
@@ -119,6 +119,7 @@ namespace Azure.Storage.DataMovement.Tests
             destMock.Verify(b => b.ResourceId, Times.Once());
             destMock.Verify(b => b.MaxSupportedSingleTransferSize, Times.Once());
             destMock.Verify(b => b.MaxSupportedChunkSize, Times.Once());
+            destMock.Verify(b => b.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
             destMock.Verify(b => b.GetDestinationCheckpointDetails(), Times.Once());
             destMock.Verify(b => b.SetPermissionsAsync(
                 sourceMock.Object,
@@ -163,6 +164,7 @@ namespace Azure.Storage.DataMovement.Tests
             destMock.Verify(b => b.ResourceId, Times.Once());
             destMock.Verify(b => b.MaxSupportedSingleTransferSize, Times.Once());
             destMock.Verify(b => b.MaxSupportedChunkSize, Times.Once());
+            destMock.Verify(b => b.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
             destMock.Verify(b => b.GetDestinationCheckpointDetails(), Times.Once());
             destMock.Verify(b => b.SetPermissionsAsync(
                 sourceMock.Object,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -655,7 +655,7 @@ internal static partial class MockExtensions
             });
 
         items.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.FromResult((ValidateSource: true, ValidateDest: true)));
+            .Returns(Task.CompletedTask);
 
         items.Source.Setup(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
             .Returns<long, long?, CancellationToken>((position, length, cancellationToken) =>
@@ -728,7 +728,7 @@ internal static partial class MockExtensions
         containers.Destination.SetupGet(r => r.Uri).Returns(dstUri);
 
         containers.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.FromResult((ValidateSource: true, ValidateDest: true)));
+            .Returns(Task.CompletedTask);
 
         containers.Source.Setup(r => r.GetStorageResourcesAsync(It.IsAny<StorageResourceContainer>(), It.IsAny<CancellationToken>()))
             .Returns(SubResourcesAsAsyncEnumerable);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -654,7 +654,7 @@ internal static partial class MockExtensions
                 });
             });
 
-        items.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
+        items.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult((ValidateSource: true, ValidateDest: true)));
 
         items.Source.Setup(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
@@ -727,7 +727,7 @@ internal static partial class MockExtensions
         containers.Source.SetupGet(r => r.Uri).Returns(srcUri);
         containers.Destination.SetupGet(r => r.Uri).Returns(dstUri);
 
-        containers.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
+        containers.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult((ValidateSource: true, ValidateDest: true)));
 
         containers.Source.Setup(r => r.GetStorageResourcesAsync(It.IsAny<StorageResourceContainer>(), It.IsAny<CancellationToken>()))
@@ -768,7 +768,7 @@ internal static partial class MockExtensions
     public static void VerifyDestinationResourceOnQueue(this Mock<StorageResourceItem> dstResource)
     {
         dstResource.VerifyGet(r => r.Uri);
-        dstResource.Verify(b => b.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
+        dstResource.Verify(b => b.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
     }
 
     public static void VerifySourceResourceOnQueue(this Mock<StorageResourceContainer> srcResource)
@@ -779,7 +779,7 @@ internal static partial class MockExtensions
     public static void VerifyDestinationResourceOnQueue(this Mock<StorageResourceContainer> dstResource)
     {
         dstResource.VerifyGet(r => r.Uri);
-        dstResource.Verify(b => b.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
+        dstResource.Verify(b => b.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
     }
 
     public static void VerifySourceResourceOnJobProcess(this Mock<StorageResourceItem> srcResource)

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -768,6 +768,7 @@ internal static partial class MockExtensions
     public static void VerifyDestinationResourceOnQueue(this Mock<StorageResourceItem> dstResource)
     {
         dstResource.VerifyGet(r => r.Uri);
+        dstResource.Verify(b => b.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
     }
 
     public static void VerifySourceResourceOnQueue(this Mock<StorageResourceContainer> srcResource)
@@ -778,6 +779,7 @@ internal static partial class MockExtensions
     public static void VerifyDestinationResourceOnQueue(this Mock<StorageResourceContainer> dstResource)
     {
         dstResource.VerifyGet(r => r.Uri);
+        dstResource.Verify(b => b.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()), Times.Once());
     }
 
     public static void VerifySourceResourceOnJobProcess(this Mock<StorageResourceItem> srcResource)

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -655,7 +655,7 @@ internal static partial class MockExtensions
             });
 
         items.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .Returns(Task.FromResult((ValidateSource: true, ValidateDest: true)));
 
         items.Source.Setup(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
             .Returns<long, long?, CancellationToken>((position, length, cancellationToken) =>
@@ -728,7 +728,7 @@ internal static partial class MockExtensions
         containers.Destination.SetupGet(r => r.Uri).Returns(dstUri);
 
         containers.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .Returns(Task.FromResult((ValidateSource: true, ValidateDest: true)));
 
         containers.Source.Setup(r => r.GetStorageResourcesAsync(It.IsAny<StorageResourceContainer>(), It.IsAny<CancellationToken>()))
             .Returns(SubResourcesAsAsyncEnumerable);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -15,6 +15,7 @@ using Azure.Storage.DataMovement.Tests.Shared;
 using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
+using NUnit.Framework.Interfaces;
 
 namespace Azure.Storage.DataMovement.Tests;
 
@@ -653,6 +654,9 @@ internal static partial class MockExtensions
                 });
             });
 
+        items.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
         items.Source.Setup(r => r.ReadStreamAsync(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
             .Returns<long, long?, CancellationToken>((position, length, cancellationToken) =>
             {
@@ -722,6 +726,9 @@ internal static partial class MockExtensions
 
         containers.Source.SetupGet(r => r.Uri).Returns(srcUri);
         containers.Destination.SetupGet(r => r.Uri).Returns(dstUri);
+
+        containers.Destination.Setup(r => r.ValidateTransferAsync(It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         containers.Source.Setup(r => r.GetStorageResourcesAsync(It.IsAny<StorageResourceContainer>(), It.IsAny<CancellationToken>()))
             .Returns(SubResourcesAsAsyncEnumerable);


### PR DESCRIPTION
This PR introduces validation of the Protocol set by the customer for the Source and Destination file share resource.

If the protocol set by the customer does not match the actual protocol, then the transfer will fail. If there are insufficient share-level permissions (can't validate), then the transfer will fail. The customer can opt-out of the validation by setting SkipProtocolValidation = true. The transfer will also fail for unsupported transfers, such as NFS -> SMB and SMB -> NFS.