### PR TITLE
[AzureMonitor] fix AOT warnings (part 4)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -767,6 +767,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
             return null;
         }
 
+        [UnconditionalSuppressMessage("AOT", "IL2075", Justification = "The DocumentIngress class and its derived classes have DynamicallyAccessedMembers attribute applied to preserve public properties.")]
         private Expression ProduceComparatorExpressionForAnyFieldCondition(ParameterExpression documentExpression)
         {
             // this.predicate is either Predicate.Contains or Predicate.DoesNotContain at this point
@@ -786,7 +787,17 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     if (string.Equals(propertyInfo.Name, CustomDimensionsPropertyName, StringComparison.Ordinal))
                     {
                         // ScanList(document.<CustomDimensionsPropertyName>, <this.comparand>)
-                        MemberExpression customDimensionsProperty = Expression.Property(documentExpression, CustomDimensionsPropertyName);
+                        PropertyInfo customDimensionsPropertyInfo = documentExpression.Type.GetProperty(
+                            CustomDimensionsPropertyName, BindingFlags.Instance | BindingFlags.Public);
+
+                        if (customDimensionsPropertyInfo == null)
+                        {
+                            continue; // Skip if property doesn't exist
+                        }
+
+                        MemberExpression customDimensionsProperty = Expression.Property(documentExpression, customDimensionsPropertyInfo);
+                        //MemberExpression customDimensionsProperty = Expression.Property(documentExpression, CustomDimensionsPropertyName);
+
                         propertyComparatorExpression = Expression.Call(
                             null,
                             ListKeyValuePairStringScanMethodInfo,
@@ -801,7 +812,17 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     else if (string.Equals(propertyInfo.Name, CustomMetricsPropertyName, StringComparison.Ordinal))
                     {
                         // ScanDictionary(document.<CustomMetricsPropertyName>, <this.comparand>)
-                        MemberExpression customMetricsProperty = Expression.Property(documentExpression, CustomMetricsPropertyName);
+                        PropertyInfo customMetricsPropertyInfo = documentExpression.Type.GetProperty(
+                            CustomMetricsPropertyName, BindingFlags.Instance | BindingFlags.Public);
+
+                        if (customMetricsPropertyInfo == null)
+                        {
+                            continue; // Skip if property doesn't exist
+                        }
+
+                        MemberExpression customMetricsProperty = Expression.Property(documentExpression, customMetricsPropertyInfo);
+                        //MemberExpression customMetricsProperty = Expression.Property(documentExpression, CustomMetricsPropertyName);
+
                         propertyComparatorExpression = Expression.Call(
                             null,
                             DictionaryStringDoubleScanMethodInfo,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -796,7 +796,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                         }
 
                         MemberExpression customDimensionsProperty = Expression.Property(documentExpression, customDimensionsPropertyInfo);
-                        //MemberExpression customDimensionsProperty = Expression.Property(documentExpression, CustomDimensionsPropertyName);
 
                         propertyComparatorExpression = Expression.Call(
                             null,
@@ -821,7 +820,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                         }
 
                         MemberExpression customMetricsProperty = Expression.Property(documentExpression, customMetricsPropertyInfo);
-                        //MemberExpression customMetricsProperty = Expression.Property(documentExpression, CustomMetricsPropertyName);
 
                         propertyComparatorExpression = Expression.Call(
                             null,


### PR DESCRIPTION
working towards https://github.com/Azure/azure-sdk-for-net/pull/49600

This PR fixes 2 out of 6 warnings.
These warnings are the same as https://github.com/Azure/azure-sdk-for-net/pull/49665

Issues Addressed:


## IL2026 Warnings (Expression.Property with string parameter)
We refactored the following methods in `Filter.cs` to avoid using `Expression.Property(Expression, String)` which has `RequiresUnreferencedCodeAttribute`:
•	`ProduceComparatorExpressionForAnyFieldCondition()`

The original implementation used string-based property access, which is problematic during trimming because the compiler cannot statically analyze which properties might be referenced. The refactored code now:
•	Gets `PropertyInfo` objects directly using `Type.GetProperty()` with binding flags

## IL2075 Warnings (Type information lost in reflection)
These warnings occurred because reflection-based property access via Type.GetProperty() requires that the type being accessed has its public properties preserved during trimming. We implemented a multi-layered solution:
1.	**Base Class Annotation**: Added `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]` to the `DocumentIngress` class, ensuring all derived classes preserve public properties during trimming.
2.	**Type Constraints**: Added `where TTelemetry : DocumentIngress` constraints to generic type parameters and methods throughout the codebase, guaranteeing that only types derived from the annotated base class are used.
3.	**Suppressed Remaining Warnings**: Applied `[UnconditionalSuppressMessage("AOT", "IL2075")]` to methods that use reflection on types that we're confident have their properties preserved due to the above changes:
•	`ProduceComparatorExpressionForAnyFieldCondition()`

The suppression is justified because:
•	The `DocumentIngress` class is annotated with `DynamicallyAccessedMembers` which guarantees that properties are preserved during trimming
•	All uses of `TTelemetry` are constrained to `DocumentIngress`
