### PR TITLE
Backport MessagePack fix to v1.14.0

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -188,8 +188,7 @@
     <PackageReference Update="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0" />
     <PackageReference Update="Google.Protobuf" Version="3.24.3" />
     <PackageReference Update="Grpc.Tools" Version="2.51.0" PrivateAssets="all" />
-    <PackageReference Update="MessagePack" Version="1.9.11" />
-    <PackageReference Update="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="1.1.5" />
+    <PackageReference Update="MessagePack" Version="2.5.192" />
     <PackageReference Update="Microsoft.Azure.SignalR" Version="1.25.2" />
     <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.25.2" />
     <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.25.2" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.14.1 (Unreleased)
+
+### Other Changes
+* Update `MessagePack` to 2.5.192
+
 ## 1.14.0 (2024-05-24)
 
 ### Other Changes

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -1,11 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
-    <Version>1.14.0</Version>
-    <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.13.0</ApiCompatVersion>
+    <Version>1.14.1</Version>
     <SignAssembly>true</SignAssembly>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
     <NoWarn>$(NoWarn);CS1591;AZC0107;</NoWarn>
@@ -13,15 +11,17 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="6.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsTargetingNetStandard)' == 'true' or '$(IsTargetingNetFx)' == 'true'">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />  
   </ItemGroup>
 </Project>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsTargetingNetStandard)' == 'true' or '$(IsTargetingNetFx)' == 'true'">
+  <ItemGroup Condition="$(![MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />  
   </ItemGroup>
 </Project>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -11,8 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" />
+    <!--To resolve the version conflict of Microsoft.Bcl.AsyncInterfaces under .net 6 and above frameworks,
+    version override is added. Tracked by issue: https://github.com/Azure/azure-sdk-for-net/issues/49840 -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride ="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="6.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.SignalR" />
@@ -21,7 +23,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(![MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />  
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0')) == false">  
+   <PackageReference Include="Microsoft.AspNetCore.Http.Connections" />  
   </ItemGroup>
 </Project>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/BinaryMessageFormatter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/BinaryMessageFormatter.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+
+namespace Microsoft.AspNetCore.Internal;
+
+/// <summary>
+/// Copied from https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
+/// </summary>
+internal static class BinaryMessageFormatter
+{
+    public static void WriteLengthPrefix(long length, IBufferWriter<byte> output)
+    {
+        Span<byte> lenBuffer = stackalloc byte[5];
+
+        var lenNumBytes = WriteLengthPrefix(length, lenBuffer);
+
+        output.Write(lenBuffer.Slice(0, lenNumBytes));
+    }
+
+    public static int WriteLengthPrefix(long length, Span<byte> output)
+    {
+        // This code writes length prefix of the message as a VarInt. Read the comment in
+        // the BinaryMessageParser.TryParseMessage for details.
+        var lenNumBytes = 0;
+        do
+        {
+            ref var current = ref output[lenNumBytes];
+            current = (byte)(length & 0x7f);
+            length >>= 7;
+            if (length > 0)
+            {
+                current |= 0x80;
+            }
+            lenNumBytes++;
+        }
+        while (length > 0);
+
+        return lenNumBytes;
+    }
+
+    public static int LengthPrefixLength(long length)
+    {
+        var lenNumBytes = 0;
+        do
+        {
+            length >>= 7;
+            lenNumBytes++;
+        }
+        while (length > 0);
+
+        return lenNumBytes;
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/DefaultMessagePackHubProtocolWorker.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/DefaultMessagePackHubProtocolWorker.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+
+using MessagePack;
+
+namespace Microsoft.AspNetCore.SignalR.Protocol;
+
+#nullable enable
+
+/// <summary>
+/// Copied from https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
+/// </summary>
+internal sealed class DefaultMessagePackHubProtocolWorker : MessagePackHubProtocolWorker
+{
+    private readonly MessagePackSerializerOptions _messagePackSerializerOptions;
+
+    public DefaultMessagePackHubProtocolWorker(MessagePackSerializerOptions messagePackSerializerOptions)
+    {
+        _messagePackSerializerOptions = messagePackSerializerOptions;
+    }
+
+    protected override object? DeserializeObject(ref MessagePackReader reader, Type type, string field)
+    {
+        try
+        {
+            return MessagePackSerializer.Deserialize(type, ref reader, _messagePackSerializerOptions);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Deserializing object of the `{type.Name}` type for '{field}' failed.", ex);
+        }
+    }
+
+    protected override void Serialize(ref MessagePackWriter writer, Type type, object value)
+    {
+        MessagePackSerializer.Serialize(type, ref writer, value, _messagePackSerializerOptions);
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MemoryBufferWriter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MemoryBufferWriter.cs
@@ -1,0 +1,402 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Internal;
+
+/// <summary>
+/// Copied from https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
+/// </summary>
+internal sealed class MemoryBufferWriter : Stream, IBufferWriter<byte>
+{
+    [ThreadStatic]
+    private static MemoryBufferWriter _cachedInstance;
+
+#if DEBUG
+    private bool _inUse;
+#endif
+
+    private readonly int _minimumSegmentSize;
+    private int _bytesWritten;
+
+    private List<CompletedBuffer> _completedSegments;
+    private byte[] _currentSegment;
+    private int _position;
+
+    public MemoryBufferWriter(int minimumSegmentSize = 4096)
+    {
+        _minimumSegmentSize = minimumSegmentSize;
+    }
+
+    public override long Length => _bytesWritten;
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public static MemoryBufferWriter Get()
+    {
+        var writer = _cachedInstance;
+        if (writer == null)
+        {
+            writer = new MemoryBufferWriter();
+        }
+        else
+        {
+            // Taken off the thread static
+            _cachedInstance = null;
+        }
+#if DEBUG
+        if (writer._inUse)
+        {
+            throw new InvalidOperationException("The reader wasn't returned!");
+        }
+
+        writer._inUse = true;
+#endif
+
+        return writer;
+    }
+
+    public static void Return(MemoryBufferWriter writer)
+    {
+        _cachedInstance = writer;
+#if DEBUG
+        writer._inUse = false;
+#endif
+        writer.Reset();
+    }
+
+    public void Reset()
+    {
+        if (_completedSegments != null)
+        {
+            for (var i = 0; i < _completedSegments.Count; i++)
+            {
+                _completedSegments[i].Return();
+            }
+
+            _completedSegments.Clear();
+        }
+
+        if (_currentSegment != null)
+        {
+            ArrayPool<byte>.Shared.Return(_currentSegment);
+            _currentSegment = null;
+        }
+
+        _bytesWritten = 0;
+        _position = 0;
+    }
+
+    public void Advance(int count)
+    {
+        _bytesWritten += count;
+        _position += count;
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+
+        return _currentSegment.AsMemory(_position, _currentSegment.Length - _position);
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+
+        return _currentSegment.AsSpan(_position, _currentSegment.Length - _position);
+    }
+
+    public void CopyTo(IBufferWriter<byte> destination)
+    {
+        if (_completedSegments != null)
+        {
+            // Copy completed segments
+            var count = _completedSegments.Count;
+            for (var i = 0; i < count; i++)
+            {
+                destination.Write(_completedSegments[i].Span);
+            }
+        }
+
+        destination.Write(_currentSegment.AsSpan(0, _position));
+    }
+
+    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+    {
+        if (_completedSegments == null && _currentSegment is not null)
+        {
+            // There is only one segment so write without awaiting.
+            return destination.WriteAsync(_currentSegment, 0, _position, cancellationToken);
+        }
+
+        return CopyToSlowAsync(destination, cancellationToken);
+    }
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        // This does the Right Thing. It only subtracts _position from the current segment length if it's non-null.
+        // If _currentSegment is null, it returns 0.
+        var remainingSize = _currentSegment?.Length - _position ?? 0;
+
+        // If the sizeHint is 0, any capacity will do
+        // Otherwise, the buffer must have enough space for the entire size hint, or we need to add a segment.
+        if ((sizeHint == 0 && remainingSize > 0) || (sizeHint > 0 && remainingSize >= sizeHint))
+        {
+            // We have capacity in the current segment
+#pragma warning disable CS8774 // Member must have a non-null value when exiting.
+            return;
+#pragma warning restore CS8774 // Member must have a non-null value when exiting.
+        }
+
+        AddSegment(sizeHint);
+    }
+
+    private void AddSegment(int sizeHint = 0)
+    {
+        if (_currentSegment != null)
+        {
+            // We're adding a segment to the list
+            if (_completedSegments == null)
+            {
+                _completedSegments = new List<CompletedBuffer>();
+            }
+
+            // Position might be less than the segment length if there wasn't enough space to satisfy the sizeHint when
+            // GetMemory was called. In that case we'll take the current segment and call it "completed", but need to
+            // ignore any empty space in it.
+            _completedSegments.Add(new CompletedBuffer(_currentSegment, _position));
+        }
+
+        // Get a new buffer using the minimum segment size, unless the size hint is larger than a single segment.
+        _currentSegment = ArrayPool<byte>.Shared.Rent(Math.Max(_minimumSegmentSize, sizeHint));
+        _position = 0;
+    }
+
+    private async Task CopyToSlowAsync(Stream destination, CancellationToken cancellationToken)
+    {
+        if (_completedSegments != null)
+        {
+            // Copy full segments
+            var count = _completedSegments.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var segment = _completedSegments[i];
+#if NETCOREAPP
+                await destination.WriteAsync(segment.Buffer.AsMemory(0, segment.Length), cancellationToken).ConfigureAwait(false);
+#else
+                await destination.WriteAsync(segment.Buffer, 0, segment.Length, cancellationToken).ConfigureAwait(false);
+#endif
+            }
+        }
+
+        if (_currentSegment is not null)
+        {
+#if NETCOREAPP
+            await destination.WriteAsync(_currentSegment.AsMemory(0, _position), cancellationToken).ConfigureAwait(false);
+#else
+            await destination.WriteAsync(_currentSegment, 0, _position, cancellationToken).ConfigureAwait(false);
+#endif
+        }
+    }
+
+    public byte[] ToArray()
+    {
+        if (_currentSegment == null)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var result = new byte[_bytesWritten];
+
+        var totalWritten = 0;
+
+        if (_completedSegments != null)
+        {
+            // Copy full segments
+            var count = _completedSegments.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var segment = _completedSegments[i];
+                segment.Span.CopyTo(result.AsSpan(totalWritten));
+                totalWritten += segment.Span.Length;
+            }
+        }
+
+        // Copy current incomplete segment
+        _currentSegment.AsSpan(0, _position).CopyTo(result.AsSpan(totalWritten));
+
+        return result;
+    }
+
+    public void CopyTo(Span<byte> span)
+    {
+        Debug.Assert(span.Length >= _bytesWritten);
+
+        if (_currentSegment == null)
+        {
+            return;
+        }
+
+        var totalWritten = 0;
+
+        if (_completedSegments != null)
+        {
+            // Copy full segments
+            var count = _completedSegments.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var segment = _completedSegments[i];
+                segment.Span.CopyTo(span.Slice(totalWritten));
+                totalWritten += segment.Span.Length;
+            }
+        }
+
+        // Copy current incomplete segment
+        _currentSegment.AsSpan(0, _position).CopyTo(span.Slice(totalWritten));
+
+        Debug.Assert(_bytesWritten == totalWritten + _position);
+    }
+
+    public override void Flush() { }
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void WriteByte(byte value)
+    {
+        if (_currentSegment != null && (uint)_position < (uint)_currentSegment.Length)
+        {
+            _currentSegment[_position] = value;
+        }
+        else
+        {
+            AddSegment();
+            _currentSegment[0] = value;
+        }
+
+        _position++;
+        _bytesWritten++;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        var position = _position;
+        if (_currentSegment != null && position < _currentSegment.Length - count)
+        {
+            Buffer.BlockCopy(buffer, offset, _currentSegment, position, count);
+
+            _position = position + count;
+            _bytesWritten += count;
+        }
+        else
+        {
+            BuffersExtensions.Write(this, buffer.AsSpan(offset, count));
+        }
+    }
+
+#if NETCOREAPP
+    public override void Write(ReadOnlySpan<byte> span)
+    {
+        if (_currentSegment != null && span.TryCopyTo(_currentSegment.AsSpan(_position)))
+        {
+            _position += span.Length;
+            _bytesWritten += span.Length;
+        }
+        else
+        {
+            BuffersExtensions.Write(this, span);
+        }
+    }
+#endif
+
+    public WrittenBuffers DetachAndReset()
+    {
+        _completedSegments ??= new List<CompletedBuffer>();
+
+        if (_currentSegment is not null)
+        {
+            _completedSegments.Add(new CompletedBuffer(_currentSegment, _position));
+        }
+
+        var written = new WrittenBuffers(_completedSegments, _bytesWritten);
+
+        _currentSegment = null;
+        _completedSegments = null;
+        _bytesWritten = 0;
+        _position = 0;
+
+        return written;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Reset();
+        }
+    }
+
+    /// <summary>
+    /// Holds the written segments from a MemoryBufferWriter and is no longer attached to a MemoryBufferWriter.
+    /// You are now responsible for calling Dispose on this type to return the memory to the pool.
+    /// </summary>
+    internal readonly ref struct WrittenBuffers
+    {
+        public readonly List<CompletedBuffer> Segments;
+        private readonly int _bytesWritten;
+
+        public WrittenBuffers(List<CompletedBuffer> segments, int bytesWritten)
+        {
+            Segments = segments;
+            _bytesWritten = bytesWritten;
+        }
+
+        public int ByteLength => _bytesWritten;
+
+        public void Dispose()
+        {
+            for (var i = 0; i < Segments.Count; i++)
+            {
+                Segments[i].Return();
+            }
+            Segments.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Holds a byte[] from the pool and a size value. Basically a Memory but guaranteed to be backed by an ArrayPool byte[], so that we know we can return it.
+    /// </summary>
+    internal readonly struct CompletedBuffer
+    {
+        public byte[] Buffer { get; }
+        public int Length { get; }
+
+        public ReadOnlySpan<byte> Span => Buffer.AsSpan(0, Length);
+
+        public CompletedBuffer(byte[] buffer, int length)
+        {
+            Buffer = buffer;
+            Length = length;
+        }
+
+        public void Return()
+        {
+            ArrayPool<byte>.Shared.Return(Buffer);
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocol.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocol.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+
+using Microsoft.AspNetCore.Connections;
+
+namespace Microsoft.AspNetCore.SignalR.Protocol;
+
+#nullable enable
+
+/// <summary>
+/// Implements the SignalR Hub Protocol using MessagePack.
+/// A trimmed version of https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
+/// </summary>
+internal class MessagePackHubProtocol : IHubProtocol
+{
+    private const string ProtocolName = "messagepack";
+    private const int ProtocolVersion = 2;
+    private readonly DefaultMessagePackHubProtocolWorker _worker;
+    private readonly MessagePackSerializerOptions _messagePackSerializerOptions =
+        MessagePackSerializerOptions
+            .Standard
+            .WithResolver(SignalRResolver.Instance)
+            .WithSecurity(MessagePackSecurity.UntrustedData);
+
+    public string Name => ProtocolName;
+
+    public int Version => ProtocolVersion;
+
+    public TransferFormat TransferFormat => TransferFormat.Binary;
+
+    public MessagePackHubProtocol()
+    {
+        _worker = new DefaultMessagePackHubProtocolWorker(_messagePackSerializerOptions);
+    }
+
+    public bool IsVersionSupported(int version)
+    {
+        return version <= Version;
+    }
+
+#if NETSTANDARD2_0
+    public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage? message)
+#else
+    public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, [NotNullWhen(true)] out HubMessage? message)
+#endif
+        => throw new NotImplementedException();
+
+    public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
+        => _worker.WriteMessage(message, output);
+
+    public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
+        => _worker.GetMessageBytes(message);
+
+    internal sealed class SignalRResolver : IFormatterResolver
+    {
+        public static readonly IFormatterResolver Instance = new SignalRResolver();
+
+        public static readonly IReadOnlyList<IFormatterResolver> Resolvers = new IFormatterResolver[]
+        {
+                DynamicEnumAsStringResolver.Instance,
+                ContractlessStandardResolver.Instance,
+        };
+
+        public IMessagePackFormatter<T>? GetFormatter<T>()
+        {
+            return Cache<T>.Formatter;
+        }
+
+        private static class Cache<T>
+        {
+            public static readonly IMessagePackFormatter<T>? Formatter = ResolveFormatter();
+
+            private static IMessagePackFormatter<T>? ResolveFormatter()
+            {
+                foreach (var resolver in Resolvers)
+                {
+                    var formatter = resolver.GetFormatter<T>();
+                    if (formatter != null)
+                    {
+                        return formatter;
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocolWorker.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/MessagePackHubProtocol/MessagePackHubProtocolWorker.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using MessagePack;
+
+using Microsoft.AspNetCore.Internal;
+
+namespace Microsoft.AspNetCore.SignalR.Protocol;
+
+#nullable enable
+
+/// <summary>
+/// A trimmed version of  https://github.com/dotnet/aspnetcore/blob/0825def633c99d9fdd74e47e69bcde3935a5fe74/
+/// </summary>
+internal abstract class MessagePackHubProtocolWorker
+{
+    private const int ErrorResult = 1;
+    private const int VoidResult = 2;
+    private const int NonVoidResult = 3;
+
+    protected abstract object? DeserializeObject(ref MessagePackReader reader, Type type, string field);
+
+    public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
+    {
+        var memoryBufferWriter = MemoryBufferWriter.Get();
+
+        try
+        {
+            var writer = new MessagePackWriter(memoryBufferWriter);
+
+            // Write message to a buffer so we can get its length
+            WriteMessageCore(message, ref writer);
+
+            // Write length then message to output
+            BinaryMessageFormatter.WriteLengthPrefix(memoryBufferWriter.Length, output);
+            memoryBufferWriter.CopyTo(output);
+        }
+        finally
+        {
+            MemoryBufferWriter.Return(memoryBufferWriter);
+        }
+    }
+
+    public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
+    {
+        var memoryBufferWriter = MemoryBufferWriter.Get();
+
+        try
+        {
+            var writer = new MessagePackWriter(memoryBufferWriter);
+
+            // Write message to a buffer so we can get its length
+            WriteMessageCore(message, ref writer);
+
+            var dataLength = memoryBufferWriter.Length;
+            var prefixLength = BinaryMessageFormatter.LengthPrefixLength(memoryBufferWriter.Length);
+
+            var array = new byte[dataLength + prefixLength];
+            var span = array.AsSpan();
+
+            // Write length then message to output
+            var written = BinaryMessageFormatter.WriteLengthPrefix(memoryBufferWriter.Length, span);
+            Debug.Assert(written == prefixLength);
+            memoryBufferWriter.CopyTo(span.Slice(prefixLength));
+
+            return array;
+        }
+        finally
+        {
+            MemoryBufferWriter.Return(memoryBufferWriter);
+        }
+    }
+
+    private void WriteMessageCore(HubMessage message, ref MessagePackWriter writer)
+    {
+        switch (message)
+        {
+            case InvocationMessage invocationMessage:
+                WriteInvocationMessage(invocationMessage, ref writer);
+                break;
+            case CompletionMessage completionMessage:
+                WriteCompletionMessage(completionMessage, ref writer);
+                break;
+            default:
+                throw new NotSupportedException($"Not supported message type: {message.GetType().Name}");
+        }
+
+        writer.Flush();
+    }
+
+    private void WriteArgument(object? argument, ref MessagePackWriter writer)
+    {
+        if (argument == null)
+        {
+            writer.WriteNil();
+        }
+#if NET8_0_OR_GREATER
+        else if (argument is RawResult result)
+        {
+            writer.WriteRaw(result.RawSerializedData);
+        }
+#endif
+        else
+        {
+            Serialize(ref writer, argument.GetType(), argument);
+        }
+    }
+
+    protected abstract void Serialize(ref MessagePackWriter writer, Type type, object value);
+
+    private static void WriteStreamIds(string[]? streamIds, ref MessagePackWriter writer)
+    {
+        if (streamIds != null)
+        {
+            writer.WriteArrayHeader(streamIds.Length);
+            foreach (var streamId in streamIds)
+            {
+                writer.Write(streamId);
+            }
+        }
+        else
+        {
+            writer.WriteArrayHeader(0);
+        }
+    }
+
+    private void WriteInvocationMessage(InvocationMessage message, ref MessagePackWriter writer)
+    {
+        writer.WriteArrayHeader(6);
+
+        writer.Write(HubProtocolConstants.InvocationMessageType);
+        PackHeaders(message.Headers, ref writer);
+        if (string.IsNullOrEmpty(message.InvocationId))
+        {
+            writer.WriteNil();
+        }
+        else
+        {
+            writer.Write(message.InvocationId);
+        }
+        writer.Write(message.Target);
+
+        if (message.Arguments is null)
+        {
+            writer.WriteArrayHeader(0);
+        }
+        else
+        {
+            writer.WriteArrayHeader(message.Arguments.Length);
+            foreach (var arg in message.Arguments)
+            {
+                WriteArgument(arg, ref writer);
+            }
+        }
+#if NET6_0_OR_GREATER
+        WriteStreamIds(message.StreamIds, ref writer);
+#endif
+    }
+
+    private void WriteCompletionMessage(CompletionMessage message, ref MessagePackWriter writer)
+    {
+        var resultKind =
+            message.Error != null ? ErrorResult :
+            message.HasResult ? NonVoidResult :
+            VoidResult;
+
+        writer.WriteArrayHeader(4 + (resultKind != VoidResult ? 1 : 0));
+        writer.Write(HubProtocolConstants.CompletionMessageType);
+        PackHeaders(message.Headers, ref writer);
+        writer.Write(message.InvocationId);
+        writer.Write(resultKind);
+        switch (resultKind)
+        {
+            case ErrorResult:
+                writer.Write(message.Error);
+                break;
+            case NonVoidResult:
+                WriteArgument(message.Result, ref writer);
+                break;
+        }
+    }
+
+    private static void PackHeaders(IDictionary<string, string>? headers, ref MessagePackWriter writer)
+    {
+        if (headers != null)
+        {
+            writer.WriteMapHeader(headers.Count);
+            if (headers.Count > 0)
+            {
+                foreach (var header in headers)
+                {
+                    writer.Write(header.Key);
+                    writer.Write(header.Value);
+                }
+            }
+        }
+        else
+        {
+            writer.WriteMapHeader(0);
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Text;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
+
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
@@ -41,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
         {
             var ctx = new DefaultHttpContext();
             var req = ctx.Request;
-            req.Headers.Add("Authorization", new StringValues(tokenString));
+            req.Headers.Append("Authorization", new StringValues(tokenString));
 
             Action<TokenValidationParameters> configureTokenValidationParameters = parameters =>
             {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Utils/TestHelpers.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Utils/TestHelpers.cs
@@ -68,13 +68,13 @@ namespace SignalRServiceExtension.Tests.Utils
             var context = new DefaultHttpContext();
             context.Request.ContentType = contentType;
             context.Request.Method = "Post";
-            context.Request.Headers.Add(Constants.AsrsHubNameHeader, hub);
-            context.Request.Headers.Add(Constants.AsrsCategory, category);
-            context.Request.Headers.Add(Constants.AsrsEvent, @event);
-            context.Request.Headers.Add(Constants.AsrsConnectionIdHeader, connectionId);
+            context.Request.Headers.Append(Constants.AsrsHubNameHeader, hub);
+            context.Request.Headers.Append(Constants.AsrsCategory, category);
+            context.Request.Headers.Append(Constants.AsrsEvent, @event);
+            context.Request.Headers.Append(Constants.AsrsConnectionIdHeader, connectionId);
             if (signatures != null)
             {
-                context.Request.Headers.Add(Constants.AsrsSignature, string.Join(",", signatures));
+                context.Request.Headers.Append(Constants.AsrsSignature, string.Join(",", signatures));
             }
             context.Request.Body = content == null ? Stream.Null : new MemoryStream(content);
 


### PR DESCRIPTION
As `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package 1.x contains vulnerable `MessagePack` dependency, and later version of `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` is not compatible on .NET Standard 2.0 framework, we implemented the MessagePack hub protocol with `MessagePack` 2.x version by ourselves.

The changes here are similar to #47649

This fix is already merged in 2.0.0. However, as some customers cannot upgrade to 2.0.0, we apply the fix to 1.x version. 

* Why isn't the updated version in this PR 1.15.0?
    1.15.0 is already released, and it contains some dependencies that are not compatible with function bundles v3. Therefore, we apply the hotfix to 1.14.0.

The pipeline failed with error message: 
```
Run cat > payload.json << 'EOF'
You must install or update .NET to run this application.

App: /home/runner/.dotnet/tools/github-event-processor
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
.NET location: /usr/lib/dotnet

The following frameworks were found:
  8.0.15 at [/usr/lib/dotnet/shared/Microsoft.NETCore.App]
```

I've tried to cherry-pick commit [Update installed event processor version for net6 to net8 update](https://github.com/Azure/azure-sdk-for-net/commit/909e113ba4ba235cb712ccefa54bd624a47bb8d4), and commit [Sync .github/workflows directory with azure-sdk-tools for PR 9134](https://github.com/Azure/azure-sdk-for-net/commit/84f54f7d898f606a4dee71bc692d9977b7883383), which removed script `cat > payload.json << 'EOF'` at all, but they didn't solve the issue. Please help to look into it. Feel free to update on my branch.