### PR TITLE
Make the builder cache thread safe

### DIFF
--- a/sdk/core/System.ClientModel/gen/ModelReaderWriterContextGenerator.Emitter.cs
+++ b/sdk/core/System.ClientModel/gen/ModelReaderWriterContextGenerator.Emitter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis.Text;
@@ -31,6 +32,7 @@ internal sealed partial class ModelReaderWriterContextGenerator
         {
             var contextName = contextGenerationSpec.Type.Name;
             var namespaces = GetNameSpaces(contextGenerationSpec);
+            namespaces.Add("System.Collections.Concurrent");
 
             var indent = 0;
             var builder = new StringBuilder();
@@ -59,7 +61,7 @@ internal sealed partial class ModelReaderWriterContextGenerator
             builder.AppendLine($"{s_modelReaderWriterTypeBuilder}>> _typeBuilderFactories = new();");
 
             builder.Append(indent, "private readonly ");
-            builder.AppendType(typeof(Dictionary<,>));
+            builder.AppendType(typeof(ConcurrentDictionary<,>));
             builder.Append("<");
             builder.AppendType(typeof(Type));
             builder.Append(", ");
@@ -134,7 +136,7 @@ internal sealed partial class ModelReaderWriterContextGenerator
             builder.AppendLine(indent, "{");
             indent++;
             builder.AppendLine(indent, "builder = factory();");
-            builder.AppendLine(indent, "_typeBuilders.Add(type, builder);");
+            builder.AppendLine(indent, "_typeBuilders.TryAdd(type, builder);");
             builder.AppendLine(indent, "return true;");
             indent--;
             builder.AppendLine(indent, "}");
@@ -147,7 +149,7 @@ internal sealed partial class ModelReaderWriterContextGenerator
                 builder.AppendLine(indent, $"if (kvp.Value.TryGetTypeBuilder(type, out builder))");
                 builder.AppendLine(indent, "{");
                 indent++;
-                builder.AppendLine(indent, $"_typeBuilders.Add(type, builder);");
+                builder.AppendLine(indent, $"_typeBuilders.TryAdd(type, builder);");
                 builder.AppendLine(indent, "return true;");
                 indent--;
                 builder.AppendLine(indent, "}");

--- a/sdk/core/System.ClientModel/tests/gen.unit/CompilationHelper.cs
+++ b/sdk/core/System.ClientModel/tests/gen.unit/CompilationHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ClientModel.Primitives;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -51,6 +52,7 @@ namespace System.ClientModel.SourceGeneration.Tests.Unit
                 MetadataReference.CreateFromFile(Path.Combine(typeof(object).Assembly.Location, "..", "System.Runtime.dll")),
                 MetadataReference.CreateFromFile(typeof(JsonSerializer).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(BinaryData).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(ConcurrentDictionary<,>).Assembly.Location),
 #if NETFRAMEWORK
                 MetadataReference.CreateFromFile(Path.Combine(typeof(object).Assembly.Location, "..", "netstandard.dll")),
                 MetadataReference.CreateFromFile(typeof(ReadOnlyMemory<>).Assembly.Location),


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/48292
