### PR TITLE
[AzureMonitor] fix AOT warnings (part 5)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
@@ -7,6 +7,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Diagnostics.CodeAnalysis;
     using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
     using ExceptionDocument = Models.Exception;
@@ -118,7 +119,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
         public string ETag => info.ETag;
 
-        private static void AddMetric<TTelemetry>(
+        private static void AddMetric<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTelemetry>(
           DerivedMetricInfo metricInfo,
           List<DerivedMetric<TTelemetry>> metrics,
           out CollectionConfigurationError[] errors)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DerivedMetric.cs
@@ -5,6 +5,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq.Expressions;
     using System.Reflection;
@@ -16,7 +17,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
     /// which defines which field to use as a value, and an aggregation which dictates the algorithm of arriving at
     /// a single reportable value within a second.
     /// </summary>
-    internal class DerivedMetric<TTelemetry> where TTelemetry : DocumentIngress
+    internal class DerivedMetric<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTelemetry> where TTelemetry : DocumentIngress
     {
         private const string ProjectionCount = "Count()";
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DocumentStream.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DocumentStream.cs
@@ -6,6 +6,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Diagnostics.CodeAnalysis;
     using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
     using ExceptionDocument = Models.Exception;
 
@@ -88,7 +89,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
             return CheckFilters(traceFilterGroups, document, out errors);
         }
 
-        private static bool CheckFilters<TTelemetry>(
+        private static bool CheckFilters<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTelemetry>(
             List<FilterConjunctionGroup<TTelemetry>> filterGroups,
             TTelemetry document,
             out CollectionConfigurationError[] errors)
@@ -121,7 +122,10 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
             return leastOneConjunctionGroupPassed;
         }
 
-        private static bool CheckFiltersGeneric<TTelemetry>(TTelemetry document, FilterConjunctionGroup<TTelemetry> filterGroup, List<CollectionConfigurationError> errorList)
+        private static bool CheckFiltersGeneric<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTelemetry>(
+            TTelemetry document,
+            FilterConjunctionGroup<TTelemetry> filterGroup,
+            List<CollectionConfigurationError> errorList)
             where TTelemetry : DocumentIngress
         {
             bool filterPassed = false;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -370,10 +370,12 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
         {
             try
             {
-                Type propertyType = fieldName.Split(FieldNameTrainSeparator)
-                    .Aggregate(
-                        typeof(TTelemetry),
-                        (type, propertyName) => type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public).PropertyType);
+                Type propertyType = typeof(TTelemetry);
+
+                foreach (string propertyName in fieldName.Split(FieldNameTrainSeparator))
+                {
+                    propertyType = GetPropertyType(propertyType, propertyName);
+                }
 
                 if (fieldName == "Duration")
                 {
@@ -399,6 +401,16 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     string.Format(CultureInfo.InvariantCulture, "Error finding property {0} in the type {1}", fieldName, typeof(TTelemetry).FullName),
                     e);
             }
+        }
+
+        private static Type GetPropertyType(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type,
+            string propertyName)
+        {
+            PropertyInfo propertyInfo = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)
+                ?? throw new ArgumentOutOfRangeException(nameof(propertyName), $"Property '{propertyName}' not found on type '{type.FullName}'");
+
+            return propertyInfo.PropertyType;
         }
 
         [SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Justification = "Argument exceptions are valid.")]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/Filter.cs
@@ -19,7 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
     /// The filter's configuration (condition) is specified in a <see cref="FilterInfo"/> DTO.
     /// </summary>
     /// <typeparam name="TTelemetry">Type of telemetry documents.</typeparam>
-    internal class Filter<TTelemetry> where TTelemetry : DocumentIngress
+    internal class Filter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTelemetry> where TTelemetry : DocumentIngress
     {
         private const string FieldNameCustomDimensionsPrefix = "CustomDimensions.";
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/FilterConjunctionGroup.cs
@@ -5,13 +5,14 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
     /// <summary>
     /// Defines an AND group of filters.
     /// </summary>
-    internal class FilterConjunctionGroup<TTelemetry> where TTelemetry : DocumentIngress
+    internal class FilterConjunctionGroup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTelemetry> where TTelemetry : DocumentIngress
     {
         private readonly FilterConjunctionGroupInfo info;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/LiveMetricsClientManager.MetricsCollection.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/LiveMetricsClientManager.MetricsCollection.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.DataCollection;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 {
@@ -219,7 +220,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             return metricAccumulators;
         }
 
-        private void ApplyFilters<TTelemetry>(
+        private void ApplyFilters<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTelemetry>(
             Dictionary<string, AccumulatedValues> metricAccumulators,
             IEnumerable<DerivedMetric<TTelemetry>> metrics,
             TTelemetry telemetry,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/FilterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/Filtering/FilterTests.cs
@@ -1747,5 +1747,35 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Tests.Filtering
         }
 
         #endregion
+
+        [Fact]
+        public void GetFieldType_CorrectlyDiscoversNestedType()
+        {
+            // ARRANGE
+            string fieldName = "Parent.Child.GrandChild";
+
+            // ACT
+            Filter<DocumentMockWithNestedProperties>.FieldNameType fieldNameType;
+            Type result = Filter<DocumentMockWithNestedProperties>.GetFieldType(fieldName, out fieldNameType);
+
+            // ASSERT
+            Assert.Equal(typeof(string), result);
+            Assert.Equal(Filter<DocumentMockWithNestedProperties>.FieldNameType.FieldName, fieldNameType);
+        }
+
+        internal class DocumentMockWithNestedProperties : DocumentIngress
+        {
+            public ParentType Parent { get; set; } = new ParentType();
+
+            public class ParentType
+            {
+                public ChildType Child { get; set; } = new ChildType();
+
+                public class ChildType
+                {
+                    public string GrandChild { get; set; } = "TestValue";
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
working towards https://github.com/Azure/azure-sdk-for-net/pull/49600

This PR fixes 2 out of 4 warnings.
These warnings are the same as https://github.com/Azure/azure-sdk-for-net/pull/49665

Issues Addressed:

## IL2090: "DynamicallyAccessedMembers attribute mismatch or missing for generic type parameters."
- Updated all generic `TTelemetry` methods to include the `[DynamicallyAccessedMembers]` attribute.
  - `CollectionConfiguration.cs`
  - `DerivedMetric.cs`
  - `DocumentStream.cs`
  - `FilterConjunctionGroup.cs`
  - `LiveMetricsClientManager.MetricsCollection.cs`

- This ensures proper handling of reflection-based access patterns, improving compatibility with trimming in .NET.


## IL2070: "Reflection access requires DynamicallyAccessedMembers attribute on the target type or member."
- Introduced a new helper method `GetPropertyType` to replace an aggregate expression.
- This change allows the application of the `[DynamicallyAccessedMembers]` attribute to type.GetProperty() calls, ensuring compliance with linker requirements and improving maintainability.



