### PR TITLE
[AzureMonitor] fix AOT warnings (part 6)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -270,12 +270,16 @@ While AOT is supported, automatic configuration binding from `appsettings.json` 
 This is due to .NET limitations on reflection-based binding APIs (such as `ConfigurationBinder.Bind` and `Get<T>()`) in AOT scenarios.  
   
 **Workaround:**  
-In AOT scenarios, you must configure `AzureMonitorExporterOptions` programmatically in your application code. For example:
-```csharp
-builder.Services.AddOpenTelemetry()
-    .UseAzureMonitorExporter(options =>
-    {
-        options.ConnectionString = "<your-connection-string>";
-        // Set other options as needed
-    });
-```
+In AOT scenarios, you can configure the Azure Monitor Exporter using one of the following approaches:
+
+- **Environment Variable:** Set the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable to configure the connection string.
+
+- **Programmatic Configuration:** Set the `AzureMonitorExporterOptions` directly in your application code:
+    ```csharp
+    builder.Services.AddOpenTelemetry()
+        .UseAzureMonitorExporter(options =>
+        {
+            options.ConnectionString = "<your-connection-string>";
+            // Set other options as needed
+        });
+    ```

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -259,3 +259,23 @@ For more information on Azure SDK, please refer to [this website](https://azure.
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) for details on contribution process.
+
+## AOT (Ahead-of-Time) Support
+
+This library supports usage in .NET applications compiled with [AOT (Ahead-of-Time) compilation](https://learn.microsoft.com/dotnet/core/deploying/native-aot/).
+All core features of the Azure Monitor Exporter are compatible with AOT, including telemetry export for traces, metrics, and logs.
+
+**Important:**  
+While AOT is supported, automatic configuration binding from `appsettings.json` or other `IConfiguration` sources is **not** supported in AOT-compiled applications.
+This is due to .NET limitations on reflection-based binding APIs (such as `ConfigurationBinder.Bind` and `Get<T>()`) in AOT scenarios.  
+  
+**Workaround:**  
+In AOT scenarios, you must configure `AzureMonitorExporterOptions` programmatically in your application code. For example:
+```csharp
+builder.Services.AddOpenTelemetry()
+    .UseAzureMonitorExporter(options =>
+    {
+        options.ConnectionString = "<your-connection-string>";
+        // Set other options as needed
+    });
+```

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 using Microsoft.Extensions.Configuration;
@@ -29,7 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 if (_configuration != null)
                 {
-                    _configuration.GetSection(AzureMonitorExporterSectionFromConfig).Bind(options);
+                    BindOptionsSectionWithSuppression(_configuration, options);
 
                     // IConfiguration can read from EnvironmentVariables or InMemoryCollection if configured to do so.
                     var connectionStringFromIConfig = _configuration[EnvironmentVariableConstants.APPLICATIONINSIGHTS_CONNECTION_STRING];
@@ -50,6 +51,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 AzureMonitorExporterEventSource.Log.ConfigureFailed(ex);
             }
+        }
+
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Binding options is a known source of trim warnings; this is a deliberate usage.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Binding options is a known source of AOT warnings; this is a deliberate usage.")]
+        private static void BindOptionsSectionWithSuppression(IConfiguration configuration, AzureMonitorExporterOptions options)
+        {
+            configuration.GetSection(AzureMonitorExporterSectionFromConfig).Bind(options);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
@@ -30,7 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 if (_configuration != null)
                 {
-                    BindOptionsSectionWithSuppression(_configuration, options);
+                    BindIConfigurationOptions(_configuration, options);
 
                     // IConfiguration can read from EnvironmentVariables or InMemoryCollection if configured to do so.
                     var connectionStringFromIConfig = _configuration[EnvironmentVariableConstants.APPLICATIONINSIGHTS_CONNECTION_STRING];
@@ -55,7 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Binding options is a known source of trim warnings; this is a deliberate usage.")]
         [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Binding options is a known source of AOT warnings; this is a deliberate usage.")]
-        private static void BindOptionsSectionWithSuppression(IConfiguration configuration, AzureMonitorExporterOptions options)
+        private static void BindIConfigurationOptions(IConfiguration configuration, AzureMonitorExporterOptions options)
         {
             configuration.GetSection(AzureMonitorExporterSectionFromConfig).Bind(options);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/OpenTelemetryBuilderExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Tests/OpenTelemetryBuilderExtensionsTests.cs
@@ -1,0 +1,343 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpenTelemetry;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Tests
+{
+    public class OpenTelemetryBuilderExtensionsTests
+    {
+        private const string ApplicationInsightsConnectionString = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConfiguresConnectionStringFromAppsettings()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:ConnectionString", "InstrumentationKey=test-key")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            Assert.Equal("InstrumentationKey=test-key", options.ConnectionString);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConfiguresSamplingRatioFromAppsettings()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:SamplingRatio", "0.5")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            Assert.Equal(0.5f, options.SamplingRatio);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConfiguresStorageDirectoryFromAppsettings()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:StorageDirectory", "/custom/storage/path")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            Assert.Equal("/custom/storage/path", options.StorageDirectory);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConfiguresDisableOfflineStorageFromAppsettings()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:DisableOfflineStorage", "true")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            Assert.True(options.DisableOfflineStorage);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConfiguresEnableLiveMetricsFromAppsettings()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:EnableLiveMetrics", "false")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            Assert.False(options.EnableLiveMetrics);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConfiguresVersionFromAppsettings()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:Version", "v2_1")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            Assert.Equal(AzureMonitorExporterOptions.ServiceVersion.v2_1, options.Version);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConfiguresConnectionStringFromEnvVar()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>(ApplicationInsightsConnectionString, "InstrumentationKey=env-var-key")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            Assert.Equal("InstrumentationKey=env-var-key", options.ConnectionString);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConfiguresMultipleOptionsFromAppsettings()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:ConnectionString", "InstrumentationKey=test-key"),
+                new KeyValuePair<string, string?>("AzureMonitorExporter:SamplingRatio", "0.25"),
+                new KeyValuePair<string, string?>("AzureMonitorExporter:DisableOfflineStorage", "true"),
+                new KeyValuePair<string, string?>("AzureMonitorExporter:EnableLiveMetrics", "false"),
+                new KeyValuePair<string, string?>("AzureMonitorExporter:StorageDirectory", "/test/path")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            Assert.Equal("InstrumentationKey=test-key", options.ConnectionString);
+            Assert.Equal(0.25f, options.SamplingRatio);
+            Assert.True(options.DisableOfflineStorage);
+            Assert.False(options.EnableLiveMetrics);
+            Assert.Equal("/test/path", options.StorageDirectory);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ConnectionStringEnvVarOverridesSectionValue()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:ConnectionString", "InstrumentationKey=section-key"),
+                new KeyValuePair<string, string?>(ApplicationInsightsConnectionString, "InstrumentationKey=env-var-key")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            // The value from the environment variable should take precedence
+            Assert.Equal("InstrumentationKey=env-var-key", options.ConnectionString);
+        }
+
+        [Fact]
+        public void UseAzureMonitorExporter_ProgrammaticOptionsOverrideConfiguration()
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:ConnectionString", "InstrumentationKey=config-key"),
+                new KeyValuePair<string, string?>("AzureMonitorExporter:SamplingRatio", "0.5")
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter(options =>
+            {
+                options.ConnectionString = "InstrumentationKey=programmatic-key";
+                options.SamplingRatio = 0.75f;
+            });
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+            // Programmatic options should override configuration values
+            Assert.Equal("InstrumentationKey=programmatic-key", options.ConnectionString);
+            Assert.Equal(0.75f, options.SamplingRatio);
+        }
+
+        /// <summary>
+        /// The AzureMonitorExporterOptions class inherits a base class ClientOptions.
+        /// The base class has several other public properties availabel for users.
+        /// This test is to ensure that we don't inadvertantly break those configuration options.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void UseAzureMonitorExporter_ClientOptionsDiagnosticsLoggingEnabledFromAppsettings(bool isLoggingEnabled)
+        {
+            // Arrange
+            var configValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("AzureMonitorExporter:ConnectionString", "InstrumentationKey=test-key"),
+                new KeyValuePair<string, string?>("AzureMonitorExporter:Diagnostics:IsLoggingEnabled", isLoggingEnabled.ToString())
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var builder = new TestOpenTelemetryBuilder(services);
+
+            // Act
+            builder.UseAzureMonitorExporter();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>().CurrentValue;
+
+            // Verify the Diagnostics.IsLoggingEnabled property is set from configuration
+            Assert.Equal(isLoggingEnabled, options.Diagnostics.IsLoggingEnabled);
+        }
+
+        // Test helper class to implement IOpenTelemetryBuilder
+        private class TestOpenTelemetryBuilder : IOpenTelemetryBuilder
+        {
+            public TestOpenTelemetryBuilder(IServiceCollection services)
+            {
+                Services = services;
+            }
+
+            public IServiceCollection Services { get; }
+        }
+    }
+}


### PR DESCRIPTION
working towards https://github.com/Azure/azure-sdk-for-net/pull/49600

This PR suppresses 2 out of 2 warnings.

### Issues Suppressed:

- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\src\DefaultAzureMonitorExporterOptions.cs(32): Trim analysis warning IL2026: Azure.Monitor.OpenTelemetry.Exporter.DefaultAzureMonitorExporterOptions.Configure(AzureMonitorExporterOptions): Using member 'Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(IConfiguration,Object)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Cannot statically analyze the type of instance so its members may be trimmed. 
- C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\src\DefaultAzureMonitorExporterOptions.cs(32): AOT analysis warning IL3050: Azure.Monitor.OpenTelemetry.Exporter.DefaultAzureMonitorExporterOptions.Configure(AzureMonitorExporterOptions): Using member 'Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(IConfiguration,Object)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. Binding strongly typed objects to configuration values requires generating dynamic code at runtime, for example instantiating generic types.


### Discussion

I could not find any suitable fix for the `Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(IConfiguration,Object)`. 
This method uses reflection to map IConfiguration values (such as from an appsettings.json) to the AzureMonitorExporterOptions class. 

I introduced new unit tests around configuration this and tested several suggestions from ChatGPT. None of these suggestions worked. 


