### PR TITLE
[CODEOWNERS] Update Cloud Machine label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -189,10 +189,10 @@
 # ServiceLabel: %Bot Service
 # ServiceOwners:                                                   @sgellock
 
-# PRLabel: %Cloud Machine
+# PRLabel: %Azure Projects
 /sdk/cloudmachine/                                                 @christothes @KrzysztofCwalina
 
-# ServiceLabel: %Cloud Machine
+# ServiceLabel: %Azure Projects
 # AzureSdkOwners:                                                  @christothes @KrzysztofCwalina
 
 # PRLabel: %Cognitive - Language


### PR DESCRIPTION
# Summary

The focus of these changes is to update the `Cloud Machine` to its new name `Azure Projects`.
