### PR TITLE
[SCM] Address connections API feedback to prepare for release.

### DIFF
--- a/sdk/ai/Azure.AI.Inference/src/Customized/AIInferenceExtensions.cs
+++ b/sdk/ai/Azure.AI.Inference/src/Customized/AIInferenceExtensions.cs
@@ -72,8 +72,8 @@ namespace Azure.AI.Inference
             };
         }
 
-        private record ChatCompletionsClientKey() : IEquatable<object>;
+        private record ChatCompletionsClientKey();
 
-        private record EmbeddingsClientKey() : IEquatable<object>;
+        private record EmbeddingsClientKey();
     }
 }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
@@ -17,6 +17,11 @@ namespace Azure.AI.Projects
         private readonly ConnectionCacheManager _cacheManager;
         private readonly ConnectionsClient _connectionsClient;
 
+        /// <summary> Initializes a new instance of AIProjectClient for mocking. </summary>
+        protected AIProjectClient() : base(maxCacheSize: 100)
+        {
+        }
+
         /// <summary> Initializes a new instance of AzureAIClient. </summary>
         /// <param name="connectionString">The Azure AI Foundry project connection string, in the form `endpoint;subscription_id;resource_group_name;project_name`.</param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>

--- a/sdk/ai/Azure.AI.Projects/src/Generated/AIProjectClient.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Generated/AIProjectClient.cs
@@ -29,11 +29,6 @@ namespace Azure.AI.Projects
         /// <summary> The HTTP pipeline for sending and receiving REST requests and responses. </summary>
         public virtual HttpPipeline Pipeline => _pipeline;
 
-        /// <summary> Initializes a new instance of AIProjectClient for mocking. </summary>
-        protected AIProjectClient()
-        {
-        }
-
         /// <summary> Initializes a new instance of AIProjectClient. </summary>
         /// <param name="endpoint"> The Azure AI Foundry project endpoint, in the form `https://&lt;azure-region&gt;.api.azureml.ms` or `https://&lt;private-link-guid&gt;.&lt;azure-region&gt;.api.azureml.ms`, where &lt;azure-region&gt; is the Azure region where the project is deployed (e.g. westus) and &lt;private-link-guid&gt; is the GUID of the Enterprise private link. </param>
         /// <param name="subscriptionId"> The Azure subscription ID. </param>

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -84,8 +84,8 @@ namespace System.ClientModel.Primitives
     }
     public partial class ClientCache
     {
-        public ClientCache(int maxSize = 100) { }
-        public T GetClient<T>(System.IEquatable<object> clientId, System.Func<T> createClient) where T : class { throw null; }
+        public ClientCache(int maxSize) { }
+        public T GetClient<T>(object clientId, System.Func<T> createClient) where T : class { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ClientConnection
@@ -174,7 +174,7 @@ namespace System.ClientModel.Primitives
     }
     public abstract partial class ConnectionProvider
     {
-        protected ConnectionProvider(int maxCacheSize = 100) { }
+        protected ConnectionProvider(int maxCacheSize) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.ClientModel.Primitives.ClientCache Subclients { get { throw null; } }
         public abstract System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> GetAllConnections();

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
@@ -84,8 +84,8 @@ namespace System.ClientModel.Primitives
     }
     public partial class ClientCache
     {
-        public ClientCache(int maxSize = 100) { }
-        public T GetClient<T>(System.IEquatable<object> clientId, System.Func<T> createClient) where T : class { throw null; }
+        public ClientCache(int maxSize) { }
+        public T GetClient<T>(object clientId, System.Func<T> createClient) where T : class { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ClientConnection
@@ -174,7 +174,7 @@ namespace System.ClientModel.Primitives
     }
     public abstract partial class ConnectionProvider
     {
-        protected ConnectionProvider(int maxCacheSize = 100) { }
+        protected ConnectionProvider(int maxCacheSize) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.ClientModel.Primitives.ClientCache Subclients { get { throw null; } }
         public abstract System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> GetAllConnections();

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -84,8 +84,8 @@ namespace System.ClientModel.Primitives
     }
     public partial class ClientCache
     {
-        public ClientCache(int maxSize = 100) { }
-        public T GetClient<T>(System.IEquatable<object> clientId, System.Func<T> createClient) where T : class { throw null; }
+        public ClientCache(int maxSize) { }
+        public T GetClient<T>(object clientId, System.Func<T> createClient) where T : class { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ClientConnection
@@ -174,7 +174,7 @@ namespace System.ClientModel.Primitives
     }
     public abstract partial class ConnectionProvider
     {
-        protected ConnectionProvider(int maxCacheSize = 100) { }
+        protected ConnectionProvider(int maxCacheSize) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.ClientModel.Primitives.ClientCache Subclients { get { throw null; } }
         public abstract System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> GetAllConnections();

--- a/sdk/core/System.ClientModel/src/Convenience/ClientCache.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ClientCache.cs
@@ -38,6 +38,7 @@ public class ClientCache
         _lock.EnterReadLock();
         try
         {
+            // If the client exists, update its timestamp.
             if (_clients.TryGetValue(clientId, out var cached))
             {
                 cached.LastUsed = Stopwatch.GetTimestamp();

--- a/sdk/core/System.ClientModel/src/Convenience/ClientCache.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ClientCache.cs
@@ -11,7 +11,7 @@ namespace System.ClientModel.Primitives;
 /// </summary>
 public class ClientCache
 {
-    private readonly Dictionary<IEquatable<object>, ClientEntry> _clients = new();
+    private readonly Dictionary<object, ClientEntry> _clients = new();
     private readonly ReaderWriterLockSlim _lock = new(LockRecursionPolicy.SupportsRecursion);
 
     private readonly int _maxSize;
@@ -20,7 +20,7 @@ public class ClientCache
     /// Initializes the ClientCache with a configurable cache size.
     /// </summary>
     /// <param name="maxSize">The maximum number of clients to store in the cache.</param>
-    public ClientCache(int maxSize = 100)
+    public ClientCache(int maxSize)
     {
         _maxSize = maxSize;
     }
@@ -30,22 +30,30 @@ public class ClientCache
     /// Updates the last-used timestamp on every hit.
     /// </summary>
     /// <typeparam name="T">The type of the client.</typeparam>
-    /// <param name="clientId">An equality-comparable key representing the client configuration.</param>
+    /// <param name="clientId">A key representing the client configuration.</param>
     /// <param name="createClient">A factory function to create the client if not cached.</param>
     /// <returns>The cached or newly created client instance.</returns>
-    public T GetClient<T>(IEquatable<object> clientId, Func<T> createClient) where T : class
+    public T GetClient<T>(object clientId, Func<T> createClient) where T : class
     {
-        // If the client exists, update its timestamp.
-        if (_clients.TryGetValue(clientId, out var cached))
+        _lock.EnterReadLock();
+        try
         {
-            cached.LastUsed = Stopwatch.GetTimestamp();
-
-            if (cached.Client is T typedClient)
+            // If the client exists, update its timestamp.
+            if (_clients.TryGetValue(clientId, out var cached))
             {
-                return typedClient;
-            }
+                cached.LastUsed = Stopwatch.GetTimestamp();
 
-            throw new InvalidOperationException($"The clientId is associated with a client of type '{cached.Client.GetType()}', not '{typeof(T)}'.");
+                if (cached.Client is T typedClient)
+                {
+                    return typedClient;
+                }
+
+                throw new InvalidOperationException($"The clientId is associated with a client of type '{cached.Client.GetType()}', not '{typeof(T)}'.");
+            }
+        }
+        finally
+        {
+            _lock.ExitReadLock();
         }
 
         // Client not found in cache, create a new one.

--- a/sdk/core/System.ClientModel/src/Convenience/ConnectionProvider.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ConnectionProvider.cs
@@ -18,7 +18,7 @@ public abstract class ConnectionProvider
     /// Initializes a new instance of the ConnectionProvider class.
     /// </summary>
     /// <param name="maxCacheSize">The maximum number of subclients to store in the cache.</param>
-    protected ConnectionProvider(int maxCacheSize = 100)
+    protected ConnectionProvider(int maxCacheSize)
     {
         _subclients = new ClientCache(maxCacheSize);
     }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIExtensions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIExtensions.cs
@@ -85,9 +85,9 @@ public static class AzureOpenAIExtensions
         return embedding;
     }
 
-    private record AzureOpenAIClientKey() : IEquatable<object>;
+    private record AzureOpenAIClientKey();
 
-    private record ChatClientKey(string? DeploymentName) : IEquatable<object>;
+    private record ChatClientKey(string? DeploymentName);
 
-    private record EmbeddingClientKey(string? DeploymentName) : IEquatable<object>;
+    private record EmbeddingClientKey(string? DeploymentName);
 }

--- a/sdk/search/Azure.Search.Documents/src/SearchExtensions.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchExtensions.cs
@@ -103,9 +103,9 @@ public static class SearchExtensions
         };
     }
 
-    private record SearchClientKey(string IndexName) : IEquatable<object>;
+    private record SearchClientKey(string IndexName);
 
-    private record SearchIndexClientKey() : IEquatable<object>;
+    private record SearchIndexClientKey();
 
-    private record SearchIndexerClientKey() : IEquatable<object>;
+    private record SearchIndexerClientKey();
 }


### PR DESCRIPTION
This PR address the following feedback for connections API  to prepare for SCM release:

- **Key usage**: Changed the `ClientCache.GetClient` method to accept `object` instead of `IEquatable<object>` to avoid the misleading implication that `IEquatable` will be used by the cache for equality comparison. The underlying dictionary uses object equality and does not honor the interface directly.  
- **Thread safety**: In `ClientCache.GetClient` method, wrapped the `TryGetValue` call in a read lock to prevent unsafe concurrent reads while the dictionary may be mutated by other threads.  
- **Constructor**: Removed the default value for the `maxSize` constructor parameter, requiring the caller to specify it explicitly.