### PR TITLE
[Search] Addressing IndexStatsSummary tests' flakiness

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/SearchIndexClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchIndexClientTests.cs
@@ -142,22 +142,8 @@ namespace Azure.Search.Documents.Tests
             Assert.AreEqual(200, response.GetRawResponse().Status);
             Assert.IsNotNull(response.Value);
             Assert.IsNotNull(response.Value.IndexesStatistics);
-            Assert.AreEqual(1, response.Value.IndexesStatistics.Count);
-            Assert.AreEqual(resources.IndexName, response.Value.IndexesStatistics[0].Name);
-        }
-
-        [Test]
-        [ServiceVersion(Min = SearchClientOptions.ServiceVersion.V2025_03_01_Preview)]
-        public async Task GetIndexStatsSummaryWithNoIndexes()
-        {
-            await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);
-
-            SearchIndexClient client = resources.GetIndexClient();
-            Response<ListIndexStatsSummary> response = await client.GetIndexStatsSummaryAsync();
-            Assert.AreEqual(200, response.GetRawResponse().Status);
-            Assert.IsNotNull(response.Value);
-            Assert.IsNotNull(response.Value.IndexesStatistics);
-            Assert.AreEqual(0, response.Value.IndexesStatistics.Count);
+            Assert.GreaterOrEqual(response.Value.IndexesStatistics.Count, 1);
+            Assert.True(response.Value.IndexesStatistics.Any(summary => summary.Name == resources.IndexName));
         }
 
         [Test]

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
@@ -175,6 +175,7 @@ namespace Azure.Search.Documents.Tests
         /// <returns>A new TestResources context.</returns>
         public static async Task<SearchResources> CreateWithEmptyIndexAsync<T>(SearchTestBase fixture, bool isSample = false)
         {
+            // TODO: consider setting up RequiresCleanup so the index is deleted at the end of the test run.
             var resources = new SearchResources(fixture);
             await resources.CreateSearchServiceAndIndexAsync(isSample, name =>
                 new SearchIndex(name)
@@ -195,6 +196,7 @@ namespace Azure.Search.Documents.Tests
         /// <returns>A new TestResources context.</returns>
         public static async Task<SearchResources> CreateWithEmptyHotelsIndexAsync(SearchTestBase fixture, bool isSample = false)
         {
+            // TODO: consider setting up RequiresCleanup so the index is deleted at the end of the test run.
             var resources = new SearchResources(fixture);
             await resources.CreateSearchServiceAndIndexAsync(isSample);
             return resources;
@@ -211,6 +213,7 @@ namespace Azure.Search.Documents.Tests
         /// <returns>A new TestResources context.</returns>
         public static async Task<SearchResources> CreateWithHotelsIndexAsync(SearchTestBase fixture, bool isSample = false)
         {
+            // TODO: consider setting up RequiresCleanup so the index is deleted at the end of the test run.
             var resources = new SearchResources(fixture);
             await resources.CreateSearchServiceIndexAndDocumentsAsync(isSample);
             return resources;
@@ -230,6 +233,7 @@ namespace Azure.Search.Documents.Tests
         /// <returns>A new <see cref="SearchResources"/> context.</returns>
         public static async Task<SearchResources> CreateWithBlobStorageAsync(SearchTestBase fixture, bool populate = false, bool isSample = false)
         {
+            // TODO: consider setting up RequiresCleanup so the index is deleted at the end of the test run.
             var resources = new SearchResources(fixture);
             await resources.CreateHotelsBlobContainerAsync(populate, isSample);
             return resources;
@@ -249,6 +253,7 @@ namespace Azure.Search.Documents.Tests
         /// <returns>A new <see cref="SearchResources"/> context.</returns>
         public static async Task<SearchResources> CreateWithBlobStorageAndIndexAsync(SearchTestBase fixture, bool populate = false, bool isSample = false)
         {
+            // TODO: consider setting up RequiresCleanup so the index is deleted at the end of the test run.
             var resources = new SearchResources(fixture);
 
             // Keep them ordered or records may not match seeded random names.
@@ -271,6 +276,8 @@ namespace Azure.Search.Documents.Tests
         /// <returns>The shared TestResources context.</returns>
         public static async Task<SearchResources> GetSharedHotelsIndexAsync(SearchTestBase fixture, bool isSample = false)
         {
+            // TODO: consider whether we should delete the index at the end of the test run here.
+            //       SharedSearchResources seems to purposely cache the index.
             await SharedSearchResources.EnsureInitialized(async () => await CreateWithHotelsIndexAsync(fixture, isSample), isSample);
 
             // Clone it for the current fixture (note that setting these values


### PR DESCRIPTION
It turns out that the flakiness in the `IndexStatsSummary` tests was due to the fact that many of the tests we have do not clean up created indexes after the test run. This was affecting the `IndexStatsSummary` API because it depends on the state of the service.

For this reason, we're:
- Removing `GetIndexStatsSummaryWithNoIndexes` because we can't guarantee there will be no indexes during the test run. This doesn't impact test coverage on the SDK side.
- Updating test `GetIndexStatsSummary` to support the scenario where more than one index is returned.