### PR TITLE
Rewind stream in test before reading

### DIFF
--- a/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
@@ -71,7 +71,7 @@ namespace Azure.Storage.Tests
             PredictableStream originalStream = new PredictableStream();
             PooledMemoryStream arrayPoolStream = new(_pool, bufferPartitionSize);
             originalStream.CopyToExactInternal(arrayPoolStream, dataSize, async: false, cancellationToken: default).EnsureCompleted();
-            originalStream.Position = 0;
+            arrayPoolStream.Position = 0;
 
             // assert it holds the correct amount of data. other tests assert data validity and it's so expensive to do that here.
             // test without blowing up memory


### PR DESCRIPTION
Previously a helper method accomplished this. Now, the library uses standard stream-copy APIs, and must remember to also rewind when needed. Fixes live-only test where this rewind was forgotten in #49416.
