### PR TITLE
Bump azure.core version in packages.data.props

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -111,7 +111,7 @@
     <PackageReference Update="Azure.AI.Projects" Version="1.0.0-beta.2" />
     <PackageReference Update="Azure.Communication.Identity" Version="1.3.1" />
     <PackageReference Update="Azure.Communication.Common" Version="1.3.0" />
-    <PackageReference Update="Azure.Core" Version="1.44.1" />
+    <PackageReference Update="Azure.Core" Version="1.46.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.3.1" />
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.36" />
     <PackageReference Update="Azure.Core.Expressions.DataFactory" Version="1.0.0" />
@@ -300,7 +300,7 @@
   <ItemGroup Condition="('$(IsTestProject)' == 'true') OR ('$(IsTestSupportProject)' == 'true') OR ('$(IsPerfProject)' == 'true') OR ('$(IsStressProject)' == 'true') OR ('$(IsSamplesProject)' == 'true')">
     <PackageReference Update="ApprovalTests" Version="3.0.22" />
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
-    <PackageReference Update="Azure.Core" Version="1.44.1" />
+    <PackageReference Update="Azure.Core" Version="1.46.0" />
     <PackageReference Update="Azure.Identity" Version="1.13.1" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.17.0" />
     <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.12.0" />

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 
   <Choose>

--- a/sdk/openai/Azure.AI.OpenAI/tests/Azure.AI.OpenAI.Tests.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Azure.AI.OpenAI.Tests.csproj
@@ -23,7 +23,6 @@
       management for transitive dependencies.
       -->
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/openai/tools/TestFramework/src/OpenAI.TestFramework.csproj
+++ b/sdk/openai/tools/TestFramework/src/OpenAI.TestFramework.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Moq" />
     <PackageReference Include="System.ValueTuple" />
-    <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/openai/tools/TestFramework/src/OpenAI.TestFramework.csproj
+++ b/sdk/openai/tools/TestFramework/src/OpenAI.TestFramework.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Moq" />
     <PackageReference Include="System.ValueTuple" />
+    <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/48292

Bumps Azure.Core to latest 1.46.0 in packages.data.props

Removes some explicit references in azure.ai.openai that are no longer needed.