### PR TITLE
Update shared source to use new overload

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -278,7 +278,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20250430.1" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20250422.1" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20250310.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <!-- Note: Upgrading the .NET SDK version needs to be synchronized with the autorest.csharp repository -->
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="All"/>

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -278,7 +278,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20250430.1" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20250310.1" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20250422.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <!-- Note: Upgrading the .NET SDK version needs to be synchronized with the autorest.csharp repository -->
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="All"/>

--- a/sdk/core/Azure.Core/src/Internal/GenericOperationSource.cs
+++ b/sdk/core/Azure.Core/src/Internal/GenericOperationSource.cs
@@ -17,6 +17,9 @@ namespace Azure.Core
             => new ValueTask<T>(CreateResult(response));
 
         private T CreateResult(Response response)
+            // This call will never be invoked with a collection of models, so we can safely disable the warning
+#pragma warning disable AZC0150 // Use ModelReaderWriter overloads with ModelReaderWriterContext
             => ModelReaderWriter.Read<T>(response.Content)!;
+#pragma warning restore AZC0150 // Use ModelReaderWriter overloads with ModelReaderWriterContext
     }
 }

--- a/sdk/core/Azure.Core/src/RehydrationToken.Serialization.cs
+++ b/sdk/core/Azure.Core/src/RehydrationToken.Serialization.cs
@@ -140,7 +140,7 @@ namespace Azure.Core
             switch (format)
             {
                 case "J":
-                    return ModelReaderWriter.Write(this, options);
+                    return ModelReaderWriter.Write(this, options, AzureCoreContext.Default);
                 default:
                     throw new FormatException($"The model {nameof(RehydrationToken)} does not support '{options.Format}' format.");
             }

--- a/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
+++ b/sdk/core/Azure.Core/src/Shared/NextLinkOperationImplementation.cs
@@ -99,7 +99,7 @@ namespace Azure.Core
 
             // TODO: Once we remove NextLinkOperationImplementation from internal shared and make it internal to Azure.Core only in https://github.com/Azure/azure-sdk-for-net/issues/43260
             // We can access the internal members from RehydrationToken directly
-            var data = ModelReaderWriter.Write(rehydrationToken!, ModelReaderWriterOptions.Json);
+            var data = ModelReaderWriter.Write(rehydrationToken!, ModelReaderWriterOptions.Json, AzureCoreContext.Default);
             using var document = JsonDocument.Parse(data);
             var lroDetails = document.RootElement;
 
@@ -228,7 +228,7 @@ namespace Azure.Core
             {"version":"{{RehydrationTokenVersion}}","id":{{ConstructStringValue(operationId)}},"requestMethod":"{{requestMethod}}","initialUri":"{{startRequestUri.AbsoluteUri}}","nextRequestUri":"{{nextRequestUri}}","headerSource":"{{headerSource}}","finalStateVia":"{{finalStateVia}}","lastKnownLocation":{{ConstructStringValue(lastKnownLocation)}}}
             """;
             var data = new BinaryData(json);
-            return ModelReaderWriter.Read<RehydrationToken>(data);
+            return ModelReaderWriter.Read<RehydrationToken>(data, ModelReaderWriterOptions.Json, AzureCoreContext.Default);
         }
 
         private static string? ConstructStringValue(string? value) => value is null ? "null" : $"\"{value}\"";


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/48292

Updates shared source to honor AZC0150 in prep for https://github.com/Azure/azure-sdk-for-net/issues/49746.

Once https://github.com/Azure/autorest.csharp/issues/5237 goes in we can bump the analyzer version
