### PR TITLE
Remove unnecessary serialization override

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureTypeFactory.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureTypeFactory.cs
@@ -94,17 +94,6 @@ namespace Azure.Generator
         }
 
         /// <inheritdoc/>
-        protected override IReadOnlyList<TypeProvider> CreateSerializationsCore(InputType inputType, TypeProvider typeProvider)
-        {
-            if (KnownAzureTypes.IsModelTypeWithoutSerialization(typeProvider.Type))
-            {
-                return [];
-            }
-
-            return base.CreateSerializationsCore(inputType, typeProvider);
-        }
-
-        /// <inheritdoc/>
 #pragma warning disable AZC0014 // Avoid using banned types in public API
         public override ValueExpression DeserializeJsonValue(Type valueType, ScopedApi<JsonElement> element, SerializationFormat format)
 #pragma warning restore AZC0014 // Avoid using banned types in public API

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/KnownAzureTypes.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/KnownAzureTypes.cs
@@ -82,16 +82,6 @@ namespace Azure.Generator.Primitives
             [typeof(ResponseError)] = DeserializeResponseError,
         };
 
-        public static bool IsModelTypeWithoutSerialization(CSharpType type)
-        {
-            if (type.Equals(typeof(ResponseError)))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         public static bool TryGetKnownType(string id, [MaybeNullWhen(false)] out CSharpType type) => _idToTypes.TryGetValue(id, out type);
 
         public static bool TryGetJsonSerializationExpression(Type type, [MaybeNullWhen(false)] out SerializationExpression expression) => _typeToSerializationExpression.TryGetValue(type, out expression);


### PR DESCRIPTION
Since there is no input model for ResponseError, there is no need to filter out the serialization provider.