### PR TITLE
fix: support deserializing timespan properties

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue where `TimeSpan` properties in strongly typed table entities were not being deserialized.
 
 ### Other Changes
 

--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 - Fixed an issue where `TimeSpan` properties in strongly typed table entities were not being deserialized.
+- Fixed an issue when deserializing strongly typed table entities with enum properties. Enum values that aren't defined in the enum type are now skipped during deserialization of the table entity.
 
 ### Other Changes
 

--- a/sdk/tables/Azure.Data.Tables/assets.json
+++ b/sdk/tables/Azure.Data.Tables/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/tables/Azure.Data.Tables",
-  "Tag": "net/tables/Azure.Data.Tables_9bdee2bad4"
+  "Tag": "net/tables/Azure.Data.Tables_f74f623264"
 }

--- a/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
@@ -161,7 +161,7 @@ namespace Azure.Data.Tables
             }
             else if (typeof(T).IsEnum)
             {
-                if (!Enum.IsDefined(memberInfo.Type, propertyValue))
+                if (!Enum.IsDefined(memberInfo.Type, propertyValue as string))
                     return false;
 
                 value = (T)Enum.Parse(memberInfo.Type, propertyValue as string);
@@ -171,7 +171,7 @@ namespace Azure.Data.Tables
                      typeof(T).GetGenericArguments() is { Length: 1 } arguments &&
                      arguments[0].IsEnum)
             {
-                if (!Enum.IsDefined(arguments[0], propertyValue))
+                if (!Enum.IsDefined(arguments[0], propertyValue as string))
                     return false;
 
                 value = (T)Enum.Parse(arguments[0], propertyValue as string);

--- a/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
@@ -161,6 +161,9 @@ namespace Azure.Data.Tables
             }
             else if (typeof(T).IsEnum)
             {
+                if (!Enum.IsDefined(memberInfo.Type, propertyValue))
+                    return false;
+
                 value = (T)Enum.Parse(memberInfo.Type, propertyValue as string);
             }
             else if (typeof(T).IsGenericType &&
@@ -168,6 +171,9 @@ namespace Azure.Data.Tables
                      typeof(T).GetGenericArguments() is { Length: 1 } arguments &&
                      arguments[0].IsEnum)
             {
+                if (!Enum.IsDefined(arguments[0], propertyValue))
+                    return false;
+
                 value = (T)Enum.Parse(arguments[0], propertyValue as string);
             }
             else if (typeof(T) == typeof(ETag))

--- a/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
@@ -139,32 +139,40 @@ namespace Azure.Data.Tables
             {
                 value = (T)(object) DateTime.Parse(propertyValue as string, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
             }
+            else if (typeof(T) == typeof(TimeSpan))
+            {
+                value = (T)(object)TypeFormatters.ParseTimeSpan(propertyValue as string, "P");
+            }
+            else if (typeof(T) == typeof(TimeSpan?))
+            {
+                value = (T)(object)TypeFormatters.ParseTimeSpan(propertyValue as string, "P");
+            }
             else if (typeof(T) == typeof(string))
             {
-                value = (T)(object) (propertyValue as string);
+                value = (T)(object)(propertyValue as string);
             }
             else if (typeof(T) == typeof(int))
             {
-                value = (T)(object) (int)propertyValue;
+                value = (T)(object)(int)propertyValue;
             }
             else if (typeof(T) == typeof(int?))
             {
-                value = (T)(object) (int?)propertyValue;
+                value = (T)(object)(int?)propertyValue;
             }
             else if (typeof(T).IsEnum)
             {
-                value = (T)Enum.Parse(memberInfo.Type, propertyValue as string );
+                value = (T)Enum.Parse(memberInfo.Type, propertyValue as string);
             }
             else if (typeof(T).IsGenericType &&
                      typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>) &&
                      typeof(T).GetGenericArguments() is { Length: 1 } arguments &&
                      arguments[0].IsEnum)
             {
-                value = (T)Enum.Parse(arguments[0], propertyValue as string );
+                value = (T)Enum.Parse(arguments[0], propertyValue as string);
             }
             else if (typeof(T) == typeof(ETag))
             {
-                value = (T)(object) new ETag(propertyValue as string);
+                value = (T)(object)new ETag(propertyValue as string);
             }
 
             return true;

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientLiveTests.cs
@@ -937,6 +937,29 @@ namespace Azure.Data.Tables.Tests
             Assert.That(updatedEntity[propertyName], Is.EqualTo(updatedValue), $"The property value should be {updatedValue}");
         }
 
+        [RecordedTest]
+        public async Task TimespanPropertyInCustomEntityCanBeUpsertedAndRead()
+        {
+            const string rowKeyValue = "1";
+            DateTime date1 = new DateTime(2010, 1, 1, 8, 0, 15);
+            DateTime date2 = new DateTime(2010, 8, 18, 13, 30, 30);
+            TimeSpan interval = date2 - date1;
+            var entity = new TimeSpanTestEntity { PartitionKey = PartitionKeyValue, RowKey = rowKeyValue, TimespanProperty = interval, };
+
+            // Create the new entity.
+            await client.UpsertEntityAsync(entity, TableUpdateMode.Replace).ConfigureAwait(false);
+
+            // Fetch the created entity from the service.
+            var retrievedEntity = (await client.QueryAsync<TimeSpanTestEntity>($"PartitionKey eq '{PartitionKeyValue}' and RowKey eq '{rowKeyValue}'")
+                .ToEnumerableAsync()
+                .ConfigureAwait(false)).Single();
+
+            Assert.IsNotNull(retrievedEntity, "The entity should not be null");
+            Assert.IsTrue(TimeSpan.Compare(
+                retrievedEntity!.TimespanProperty.Value, retrievedEntity!.TimespanProperty.Value) == 0,
+                "The property value should be equal to the original value");
+        }
+
         /// <summary>
         /// Validates the functionality of the TableClient.
         /// </summary>

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientLiveTests.cs
@@ -956,7 +956,7 @@ namespace Azure.Data.Tables.Tests
 
             Assert.IsNotNull(retrievedEntity, "The entity should not be null");
             Assert.IsTrue(TimeSpan.Compare(
-                retrievedEntity!.TimespanProperty.Value, retrievedEntity!.TimespanProperty.Value) == 0,
+                retrievedEntity!.TimespanProperty.Value, interval) == 0,
                 "The property value should be equal to the original value");
         }
 

--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceLiveTestsBase.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceLiveTestsBase.cs
@@ -421,6 +421,15 @@ namespace Azure.Data.Tables.Tests
             public ETag ETag { get; set; }
         }
 
+        public class TimeSpanTestEntity : ITableEntity
+        {
+            public string PartitionKey { get; set; }
+            public string RowKey { get; set; }
+            public DateTimeOffset? Timestamp { get; set; }
+            public ETag ETag { get; set; }
+            public TimeSpan? TimespanProperty { get; set; }
+        }
+
         public class ComplexEntity : ITableEntity
         {
             public const int NumberOfNonNullProperties = 28;


### PR DESCRIPTION
This PR addresses an issue where `TimeSpan` properties within strongly-typed table entities were not being deserialized.

fixes: https://github.com/Azure/azure-sdk-for-net/issues/49221