### PR TITLE
Prepare release for Azure.Core 1.46.1

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.47.0-beta.1 (Unreleased)
+## 1.46.1 (2025-05-09)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Adopt System.ClientModel 1.4.1
 
 ## 1.46.0 (2025-05-06)
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.47.0-beta.1</Version>
+    <Version>1.46.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.46.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>


### PR DESCRIPTION
Supports https://github.com/Azure/azure-sdk-for-net/issues/48292

Push a new version of Azure.Core that depends on the new System.ClientModel 1.4.1
