### PR TITLE
[Identity] Update target framework in Identity integration projects to net8.0

### DIFF
--- a/sdk/identity/Azure.Identity/integration/Integration.Identity.Common/Integration.Identity.Common.csproj
+++ b/sdk/identity/Azure.Identity/integration/Integration.Identity.Common/Integration.Identity.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk/identity/Azure.Identity/integration/Integration.Identity.Func/Integration.Identity.Func.csproj
+++ b/sdk/identity/Azure.Identity/integration/Integration.Identity.Func/Integration.Identity.Func.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/identity/Azure.Identity/integration/WebApp/Integration.Identity.WebApp.csproj
+++ b/sdk/identity/Azure.Identity/integration/WebApp/Integration.Identity.WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
While working in https://github.com/Azure/azure-sdk-for-net/pull/49889 I found that the integration projects inside Identity are targeting net6.0, which is causing dependency version issues.

This PR addresses those changes by targeting net8.0 since 6.0 is now deprecated.