### PR TITLE
Fix tables test resources API versions

### DIFF
--- a/sdk/tables/test-resources.json
+++ b/sdk/tables/test-resources.json
@@ -133,7 +133,7 @@
             "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('primaryAccountName'))]"
           ],
           "type": "Microsoft.DocumentDB/databaseAccounts/tableRoleDefinitions",
-          "apiVersion": "2024-05-15",
+          "apiVersion": "2024-08-15",
           "name": "[concat(variables('primaryAccountName'), '/', guid(variables('customCosmosRoleName')))]",
           "properties": {
             "roleName": "[variables('customCosmosRoleName')]",
@@ -153,7 +153,7 @@
             "[resourceId('Microsoft.DocumentDB/databaseAccounts/tableRoleDefinitions', variables('primaryAccountName'), guid(variables('customCosmosRoleName')))]"
           ],
           "type": "Microsoft.DocumentDB/databaseAccounts/tableRoleAssignments",
-          "apiVersion": "2024-05-15",
+          "apiVersion": "2024-08-15",
           "name": "[concat(variables('primaryAccountName'), '/', guid(variables('customCosmosRoleName')))]",
           "properties": {
             "scope": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', variables('primaryAccountName'))]",


### PR DESCRIPTION
This PR updates the table role assignment API version as the current version being used is no longer supported & is [causing issues](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4842460&view=logs&j=57600039-55d9-5a78-af96-af60f1386279&t=3a5d2998-9f72-5655-f613-7f46c7ccb5e8) when deploying new resources : 

`Showing 1 out of 1 error(s).
     | Status Message: The API version used by you [2024-05-15] is invalid or
     | too old to be used for RBAC support. Please use a preview API version
     | later than [2024-08-15]`