### PR TITLE
[Storage][DataMovement] Hard Link & Symbolic Link for NFS over REST

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
@@ -244,7 +244,6 @@ namespace Azure.Storage.DataMovement.Blobs
             // The properties could be populated during construction (from enumeration)
             if (ResourceProperties != default)
             {
-                ResourceProperties.Uri = Uri;
                 return ResourceProperties;
             }
             else
@@ -253,7 +252,6 @@ namespace Azure.Storage.DataMovement.Blobs
                 StorageResourceItemProperties resourceProperties = blobProperties.ToStorageResourceProperties();
 
                 ResourceProperties = resourceProperties;
-                ResourceProperties.Uri = Uri;
                 return ResourceProperties;
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResource.cs
@@ -269,7 +269,6 @@ namespace Azure.Storage.DataMovement.Blobs
             // The properties could be populated during construction (from enumeration)
             if (ResourceProperties != default)
             {
-                ResourceProperties.Uri = Uri;
                 return ResourceProperties;
             }
             else
@@ -278,7 +277,6 @@ namespace Azure.Storage.DataMovement.Blobs
                 StorageResourceItemProperties resourceProperties = blobProperties.ToStorageResourceProperties();
 
                 ResourceProperties = resourceProperties;
-                ResourceProperties.Uri = Uri;
                 return ResourceProperties;
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResource.cs
@@ -255,7 +255,6 @@ namespace Azure.Storage.DataMovement.Blobs
             // The properties could be populated during construction (from enumeration)
             if (ResourceProperties != default)
             {
-                ResourceProperties.Uri = Uri;
                 return ResourceProperties;
             }
             else
@@ -264,7 +263,6 @@ namespace Azure.Storage.DataMovement.Blobs
                 StorageResourceItemProperties resourceProperties = blobProperties.ToStorageResourceProperties();
 
                 ResourceProperties = resourceProperties;
-                ResourceProperties.Uri = Uri;
                 return ResourceProperties;
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/AppendBlobStorageResourceTests.cs
@@ -1560,7 +1560,6 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Assert.That(metadata, Is.EqualTo(metadataResult));
             mock.Verify(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
                 Times.Once());
-            mock.Verify(b => b.Uri, Times.Once());
             mock.VerifyNoOtherCalls();
         }
 
@@ -1603,7 +1602,6 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Assert.That(rawProperties, Is.EqualTo(result.RawProperties));
             mock.Verify(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
-            mock.Verify(b => b.Uri, Times.Once());
             mock.VerifyNoOtherCalls();
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlockBlobStorageResourceTests.cs
@@ -1275,7 +1275,6 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Assert.That(metadata, Is.EqualTo(metadataResult));
             mock.Verify(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
                 Times.Once());
-            mock.Verify(b => b.Uri, Times.Once());
             mock.VerifyNoOtherCalls();
         }
 
@@ -1319,7 +1318,6 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Assert.That(rawProperties, Is.EqualTo(result.RawProperties));
             mock.Verify(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
-            mock.Verify(b => b.Uri, Times.Once());
             mock.VerifyNoOtherCalls();
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobStorageResourceTests.cs
@@ -1639,7 +1639,6 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Assert.That(metadata, Is.EqualTo(metadataResult));
             mock.Verify(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
                 Times.Once());
-            mock.Verify(b => b.Uri, Times.Once());
             mock.VerifyNoOtherCalls();
         }
 
@@ -1682,7 +1681,6 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             Assert.That(rawProperties, Is.EqualTo(result.RawProperties));
             mock.Verify(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
-            mock.Verify(b => b.Uri, Times.Once());
             mock.VerifyNoOtherCalls();
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.DateTimeOffset? FileLastWrittenOn { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
-        public bool IsNfs { get { throw null; } set { } }
+        public Azure.Storage.Files.Shares.Models.ShareProtocols ShareProtocol { get { throw null; } set { } }
         public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
     }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net8.0.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.DateTimeOffset? FileLastWrittenOn { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
-        public bool IsNfs { get { throw null; } set { } }
+        public Azure.Storage.Files.Shares.Models.ShareProtocols ShareProtocol { get { throw null; } set { } }
         public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
     }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.DateTimeOffset? FileLastWrittenOn { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
-        public bool IsNfs { get { throw null; } set { } }
+        public Azure.Storage.Files.Shares.Models.ShareProtocols ShareProtocol { get { throw null; } set { } }
         public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
     }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_63c20b728c"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_bd6cd5a688"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_56d7c41adc"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_3632631094"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_3632631094"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_349100bbca"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_e59e781009"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_825d46be15"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_825d46be15"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_56d7c41adc"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_5ab02c363e"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_63c20b728c"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_bd6cd5a688"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_e59e781009"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementFileShareEventSource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementFileShareEventSource.cs
@@ -11,6 +11,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
         private const string EventSourceName = "Azure-Storage-DataMovement-Files-Shares";
 
         private const int ProtocolValidationSkippedEvent = 1;
+        private const int SymLinkDetectedEvent = 2;
+        private const int HardLinkDetectedEvent = 3;
 
         private DataMovementFileShareEventSource() : base(EventSourceName) { }
 
@@ -20,6 +22,18 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public void ProtocolValidationSkipped(string transferId, string endpoint, string resourceUri)
         {
             WriteEvent(ProtocolValidationSkippedEvent, transferId, endpoint, resourceUri);
+        }
+
+        [Event(SymLinkDetectedEvent, Level = EventLevel.Informational, Message = "Source resource item detected to be Symbolic link: Resource={0}")]
+        public void SymLinkDetected(string resourceUri)
+        {
+            WriteEvent(SymLinkDetectedEvent, resourceUri);
+        }
+
+        [Event(HardLinkDetectedEvent, Level = EventLevel.Informational, Message = "Source resource item detected to be Hard link: Resource={0}")]
+        public void HardLinkDetected(string resourceUri)
+        {
+            WriteEvent(HardLinkDetectedEvent, resourceUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementFileShareEventSource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementFileShareEventSource.cs
@@ -24,13 +24,13 @@ namespace Azure.Storage.DataMovement.Files.Shares
             WriteEvent(ProtocolValidationSkippedEvent, transferId, endpoint, resourceUri);
         }
 
-        [Event(SymLinkDetectedEvent, Level = EventLevel.Informational, Message = "Source resource item detected to be Symbolic link: Resource={0}")]
+        [Event(SymLinkDetectedEvent, Level = EventLevel.Informational, Message = "Source resource item detected to be Symbolic link. The item transfer will be skipped: Resource={0}")]
         public void SymLinkDetected(string resourceUri)
         {
             WriteEvent(SymLinkDetectedEvent, resourceUri);
         }
 
-        [Event(HardLinkDetectedEvent, Level = EventLevel.Informational, Message = "Source resource item detected to be Hard link: Resource={0}")]
+        [Event(HardLinkDetectedEvent, Level = EventLevel.Informational, Message = "Source resource item detected to be Hard link. The item will be transfered as a regular file: Resource={0}")]
         public void HardLinkDetected(string resourceUri)
         {
             WriteEvent(HardLinkDetectedEvent, resourceUri);

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -59,8 +59,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
             StorageResourceItemProperties sourceProperties)
         {
             bool setPermissions = options?.FilePermissions ?? false;
+            ShareProtocols protocol = options?.ShareProtocol ?? ShareProtocols.Smb;
 
-            if (((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb) && setPermissions)
+            if (protocol == ShareProtocols.Smb && setPermissions)
             {
                 return sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FilePermissions, out object permission) == true
                     ? (string)permission
@@ -75,8 +76,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             // Only set permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
+            ShareProtocols protocol = options?.ShareProtocol ?? ShareProtocols.Smb;
 
-            if (((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb) && setPermissions)
+            if (protocol == ShareProtocols.Smb && setPermissions)
             {
                 return sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FilePermissions, out object permission) == true
                         ? (string)permission
@@ -122,16 +124,20 @@ namespace Azure.Storage.DataMovement.Files.Shares
             }
             return new()
             {
-                FileAttributes = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
-                    ? default
-                    : GetPropertyValue<NtfsFileAttributes>(
+                FileAttributes = options?.ShareProtocol switch
+                {
+                    ShareProtocols.Nfs => default,
+                    _ => GetPropertyValue<NtfsFileAttributes>(
                         options?._isFileAttributesSet ?? false,
                         options?.FileAttributes,
                         properties?.RawProperties,
-                        DataMovementConstants.ResourceProperties.FileAttributes),
-                FilePermissionKey = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
-                    ? default
-                    : permissionKeyValue,
+                        DataMovementConstants.ResourceProperties.FileAttributes)
+                },
+                FilePermissionKey = options?.ShareProtocol switch
+                {
+                    ShareProtocols.Nfs => default,
+                    _ => permissionKeyValue
+                },
                 FileCreatedOn = GetPropertyValue<DateTimeOffset>(
                     options?._isFileCreatedOnSet ?? false,
                     options?.FileCreatedOn,
@@ -142,13 +148,15 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     options?.FileLastWrittenOn,
                     properties?.RawProperties,
                     DataMovementConstants.ResourceProperties.LastWrittenOn),
-                FileChangedOn = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
-                    ? default
-                    : GetPropertyValue<DateTimeOffset>(
+                FileChangedOn = options?.ShareProtocol switch
+                {
+                    ShareProtocols.Nfs => default,
+                    _ => GetPropertyValue<DateTimeOffset>(
                         options?._isFileChangedOnSet ?? false,
                         options?.FileChangedOn,
                         properties?.RawProperties,
                         DataMovementConstants.ResourceProperties.ChangedOnTime)
+                }
             };
         }
 
@@ -166,16 +174,20 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 : default;
             return new()
             {
-                FileAttributes = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
-                    ? default
-                    : GetPropertyValue<NtfsFileAttributes>(
+                FileAttributes = options?.ShareProtocol switch
+                {
+                    ShareProtocols.Nfs => default,
+                    _ => GetPropertyValue<NtfsFileAttributes>(
                         options?._isFileAttributesSet ?? false,
                         options?.FileAttributes,
                         properties?.RawProperties,
-                        DataMovementConstants.ResourceProperties.FileAttributes),
-                FilePermissionKey = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
-                    ? default
-                    : permissionKeyValue,
+                        DataMovementConstants.ResourceProperties.FileAttributes)
+                },
+                FilePermissionKey = options?.ShareProtocol switch
+                {
+                    ShareProtocols.Nfs => default,
+                    _ => permissionKeyValue
+                },
                 FileCreatedOn = GetPropertyValue<DateTimeOffset>(
                     options?._isFileCreatedOnSet ?? false,
                     options?.FileCreatedOn,
@@ -186,13 +198,15 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     options?.FileLastWrittenOn,
                     properties?.RawProperties,
                     DataMovementConstants.ResourceProperties.LastWrittenOn),
-                FileChangedOn = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
-                    ? default
-                    : GetPropertyValue<DateTimeOffset>(
+                FileChangedOn = options?.ShareProtocol switch
+                {
+                    ShareProtocols.Nfs => default,
+                    _ => GetPropertyValue<DateTimeOffset>(
                         options?._isFileChangedOnSet ?? false,
                         options?.FileChangedOn,
                         properties?.RawProperties,
                         DataMovementConstants.ResourceProperties.ChangedOnTime)
+                }
             };
         }
 
@@ -218,8 +232,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             // Only set NFS permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
+            ShareProtocols protocol = options?.ShareProtocol ?? ShareProtocols.Smb;
 
-            if ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
+            if (protocol == ShareProtocols.Nfs)
             {
                 NfsFileMode FileMode = default;
                 string Owner = default;
@@ -259,8 +274,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
             // Only set NFS permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
+            ShareProtocols protocol = options?.ShareProtocol ?? ShareProtocols.Smb;
 
-            if (((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs) && setPermissions)
+            if (protocol == ShareProtocols.Nfs && setPermissions)
             {
                 FileMode = sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FileMode, out object fileMode) == true
                         ? (NfsFileMode)fileMode

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -712,7 +712,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 try
                 {
                     ShareProperties properties = await parentShareClient.GetPropertiesAsync(cancellationToken).ConfigureAwait(false);
-                    ShareProtocols expectedProtocol = options.ShareProtocol;
+                    ShareProtocols expectedProtocol = options?.ShareProtocol ?? ShareProtocols.Smb;
                     ShareProtocols actualProtocol = properties.Protocols ?? ShareProtocols.Smb;
 
                     if (actualProtocol != expectedProtocol)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -58,8 +58,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             this ShareFileStorageResourceOptions options,
             StorageResourceItemProperties sourceProperties)
         {
-            // Only set permissions if Copy transfer and FilePermissions is on.
-            bool setPermissions = (!sourceProperties?.Uri?.IsFile ?? false) && (options?.FilePermissions ?? false);
+            bool setPermissions = options?.FilePermissions ?? false;
 
             if ((!options?.IsNfs ?? true) && setPermissions)
             {
@@ -75,7 +74,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             StorageResourceContainerProperties sourceProperties)
         {
             // Only set permissions if Copy transfer and FilePermissions is on.
-            bool setPermissions = (!sourceProperties?.Uri?.IsFile ?? false) && (options?.FilePermissions ?? false);
+            bool setPermissions = options?.FilePermissions ?? false;
 
             if ((!options?.IsNfs ?? true) && setPermissions)
             {
@@ -113,7 +112,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             if (string.IsNullOrEmpty(permissionKeyValue))
             {
                 // Only set permissions if Copy transfer and FilePermissions is on.
-                bool setPermissions = (!properties?.Uri?.IsFile ?? false) && (options?.FilePermissions ?? false);
+                bool setPermissions = options?.FilePermissions ?? false;
 
                 permissionKeyValue = setPermissions
                     ? properties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.DestinationFilePermissionKey, out object permissionKeyObject) == true
@@ -158,7 +157,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             StorageResourceContainerProperties properties)
         {
             // Only set permissions if Copy transfer and FilePermissions is on.
-            bool setPermissions = (!properties?.Uri?.IsFile ?? false) && (options?.FilePermissions ?? false);
+            bool setPermissions = options?.FilePermissions ?? false;
 
             string permissionKeyValue = setPermissions
                 ? properties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.DestinationFilePermissionKey, out object permissionKeyObject) == true
@@ -218,7 +217,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             StorageResourceItemProperties sourceProperties)
         {
             // Only set NFS permissions if Copy transfer and FilePermissions is on.
-            bool setPermissions = (!sourceProperties?.Uri?.IsFile ?? false) && (options?.FilePermissions ?? false);
+            bool setPermissions = options?.FilePermissions ?? false;
 
             if (options?.IsNfs ?? false)
             {
@@ -259,7 +258,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             string Group = default;
 
             // Only set NFS permissions if Copy transfer and FilePermissions is on.
-            bool setPermissions = (!sourceProperties?.Uri?.IsFile ?? false) && (options?.FilePermissions ?? false);
+            bool setPermissions = options?.FilePermissions ?? false;
 
             if ((options?.IsNfs ?? false) && setPermissions)
             {
@@ -383,6 +382,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 rawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.FileMode, fileProperties.PosixProperties.FileMode);
             }
+            if (fileProperties.PosixProperties.FileType != default)
+            {
+                rawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.FileType, fileProperties.PosixProperties.FileType);
+            }
+            if (fileProperties.PosixProperties.LinkCount != default)
+            {
+                rawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.LinkCount, fileProperties.PosixProperties.LinkCount);
+            }
             return new StorageResourceItemProperties()
             {
                 ResourceLength = fileProperties.ContentLength,
@@ -467,6 +474,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
             if (fileProperties.PosixProperties.FileMode != default)
             {
                 existingProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.FileMode, fileProperties.PosixProperties.FileMode);
+            }
+            if (fileProperties.PosixProperties.FileType != default)
+            {
+                existingProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.FileType, fileProperties.PosixProperties.FileType);
+            }
+            if (fileProperties.PosixProperties.LinkCount != default)
+            {
+                existingProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.LinkCount, fileProperties.PosixProperties.LinkCount);
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -60,7 +60,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             bool setPermissions = options?.FilePermissions ?? false;
 
-            if ((!options?.IsNfs ?? true) && setPermissions)
+            if (((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb) && setPermissions)
             {
                 return sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FilePermissions, out object permission) == true
                     ? (string)permission
@@ -76,7 +76,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             // Only set permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
 
-            if ((!options?.IsNfs ?? true) && setPermissions)
+            if (((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb) && setPermissions)
             {
                 return sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FilePermissions, out object permission) == true
                         ? (string)permission
@@ -122,14 +122,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
             }
             return new()
             {
-                FileAttributes = (options?.IsNfs ?? false)
+                FileAttributes = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
                     ? default
                     : GetPropertyValue<NtfsFileAttributes>(
                         options?._isFileAttributesSet ?? false,
                         options?.FileAttributes,
                         properties?.RawProperties,
                         DataMovementConstants.ResourceProperties.FileAttributes),
-                FilePermissionKey = (options?.IsNfs ?? false)
+                FilePermissionKey = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
                     ? default
                     : permissionKeyValue,
                 FileCreatedOn = GetPropertyValue<DateTimeOffset>(
@@ -142,7 +142,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     options?.FileLastWrittenOn,
                     properties?.RawProperties,
                     DataMovementConstants.ResourceProperties.LastWrittenOn),
-                FileChangedOn = (options?.IsNfs ?? false)
+                FileChangedOn = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
                     ? default
                     : GetPropertyValue<DateTimeOffset>(
                         options?._isFileChangedOnSet ?? false,
@@ -166,14 +166,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 : default;
             return new()
             {
-                FileAttributes = (options?.IsNfs ?? false)
+                FileAttributes = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
                     ? default
                     : GetPropertyValue<NtfsFileAttributes>(
                         options?._isFileAttributesSet ?? false,
                         options?.FileAttributes,
                         properties?.RawProperties,
                         DataMovementConstants.ResourceProperties.FileAttributes),
-                FilePermissionKey = (options?.IsNfs ?? false)
+                FilePermissionKey = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
                     ? default
                     : permissionKeyValue,
                 FileCreatedOn = GetPropertyValue<DateTimeOffset>(
@@ -186,7 +186,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     options?.FileLastWrittenOn,
                     properties?.RawProperties,
                     DataMovementConstants.ResourceProperties.LastWrittenOn),
-                FileChangedOn = (options?.IsNfs ?? false)
+                FileChangedOn = ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
                     ? default
                     : GetPropertyValue<DateTimeOffset>(
                         options?._isFileChangedOnSet ?? false,
@@ -219,7 +219,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             // Only set NFS permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
 
-            if (options?.IsNfs ?? false)
+            if ((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs)
             {
                 NfsFileMode FileMode = default;
                 string Owner = default;
@@ -260,7 +260,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             // Only set NFS permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
 
-            if ((options?.IsNfs ?? false) && setPermissions)
+            if (((options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Nfs) && setPermissions)
             {
                 FileMode = sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FileMode, out object fileMode) == true
                         ? (NfsFileMode)fileMode
@@ -712,7 +712,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 try
                 {
                     ShareProperties properties = await parentShareClient.GetPropertiesAsync(cancellationToken).ConfigureAwait(false);
-                    ShareProtocols expectedProtocol = options.IsNfs ? ShareProtocols.Nfs : ShareProtocols.Smb;
+                    ShareProtocols expectedProtocol = options.ShareProtocol;
                     ShareProtocols actualProtocol = properties.Protocols ?? ShareProtocols.Smb;
 
                     if (actualProtocol != expectedProtocol)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -184,6 +184,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
+            // ShareDirectory to ShareDirectory Copy transfer
             if (sourceResource is ShareDirectoryStorageResourceContainer sourceShareDirectoryResource)
             {
                 // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
@@ -201,16 +202,16 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     "source",
                     sourceResource.Uri.AbsoluteUri,
                     cancellationToken).ConfigureAwait(false);
-            }
 
-            // Validate the destination protocol
-            await DataMovementSharesExtensions.ValidateProtocolAsync(
-                ShareDirectoryClient.GetParentShareClient(),
-                ResourceOptions,
-                transferId,
-                "destination",
-                Uri.AbsoluteUri,
-                cancellationToken).ConfigureAwait(false);
+                // Validate the destination protocol
+                await DataMovementSharesExtensions.ValidateProtocolAsync(
+                    ShareDirectoryClient.GetParentShareClient(),
+                    ResourceOptions,
+                    transferId,
+                    "destination",
+                    Uri.AbsoluteUri,
+                    cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -151,7 +151,6 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ResourceProperties = response.Value.ToStorageResourceContainerProperties();
             }
-            ResourceProperties.Uri = Uri;
             return ResourceProperties;
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -25,6 +25,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
         public override string ProviderId => "share";
 
+        internal bool _isResourcePropertiesFullySet = false;
+
         internal ShareDirectoryStorageResourceContainer(ShareDirectoryClient shareDirectoryClient, ShareFileStorageResourceOptions options)
         {
             ShareDirectoryClient = shareDirectoryClient;
@@ -142,6 +144,11 @@ namespace Azure.Storage.DataMovement.Files.Shares
         protected override async Task<StorageResourceContainerProperties> GetPropertiesAsync(CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+
+            if (_isResourcePropertiesFullySet)
+            {
+                return ResourceProperties;
+            }
             Response<ShareDirectoryProperties> response = await ShareDirectoryClient.GetPropertiesAsync(
                 cancellationToken: cancellationToken).ConfigureAwait(false);
             if (ResourceProperties != default)
@@ -152,6 +159,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ResourceProperties = response.Value.ToStorageResourceContainerProperties();
             }
+            _isResourcePropertiesFullySet = true;
             return ResourceProperties;
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -66,7 +66,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     = destinationContainer as ShareDirectoryStorageResourceContainer;
                 ShareFileStorageResourceOptions destinationOptions = destinationStorageResourceContainer.ResourceOptions;
                 // both source and destination must be SMB
-                if ((!ResourceOptions?.IsNfs ?? true) && (!destinationOptions?.IsNfs ?? true))
+                if (((ResourceOptions?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb)
+                    && ((destinationOptions?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb))
                 {
                     traits = ShareFileTraits.Attributes;
                     if (destinationOptions?.FilePermissions ?? false)
@@ -186,7 +187,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             if (sourceResource is ShareDirectoryStorageResourceContainer sourceShareDirectoryResource)
             {
                 // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
-                if ((ResourceOptions?.IsNfs ?? false) != (sourceShareDirectoryResource.ResourceOptions?.IsNfs ?? false))
+                if ((ResourceOptions?.ShareProtocol ?? ShareProtocols.Smb)
+                    != (sourceShareDirectoryResource.ResourceOptions?.ShareProtocol ?? ShareProtocols.Smb))
                 {
                     throw Errors.ShareTransferNotSupported();
                 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -38,6 +38,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
         internal string _destinationPermissionKey;
 
+        internal bool _isResourcePropertiesFullySet = false;
+
         public ShareFileStorageResource(
             ShareFileClient fileClient,
             ShareFileStorageResourceOptions options = default)
@@ -239,6 +241,11 @@ namespace Azure.Storage.DataMovement.Files.Shares
         protected override async Task<StorageResourceItemProperties> GetPropertiesAsync(CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+
+            if (_isResourcePropertiesFullySet)
+            {
+                return ResourceProperties;
+            }
             Response<ShareFileProperties> response = await ShareFileClient.GetPropertiesAsync(
                 conditions: _options?.SourceConditions,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -250,6 +257,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ResourceProperties = response.Value.ToStorageResourceItemProperties();
             }
+            _isResourcePropertiesFullySet = true;
             return ResourceProperties;
         }
 
@@ -348,9 +356,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 directoryMetadata: _options?.DirectoryMetadata);
         }
 
-        protected override async Task<bool> ValidateItemTransferAsync(
-            StorageResourceItem destItem,
-            CancellationToken cancellationToken = default)
+        protected override async Task<bool> ShouldTransferAsync(CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -354,7 +354,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
-            StorageResourceItemProperties sourceProperties = await GetPropertiesAsync().ConfigureAwait(false);
+            StorageResourceItemProperties sourceProperties = await GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             NfsFileType FileType = sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FileType, out object fileType) == true
                     ? (NfsFileType)fileType
                     : default;

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -275,7 +275,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ShareFileStorageResource sourceShareFile = (ShareFileStorageResource)sourceResource;
                 // both source and destination must be SMB and destination FilePermission option must be set.
-                if ((!sourceShareFile._options?.IsNfs ?? true) && (!_options?.IsNfs ?? true) && (_options?.FilePermissions ?? false))
+                if (((sourceShareFile._options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb)
+                    && ((_options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb)
+                    && (_options?.FilePermissions ?? false))
                 {
                     string permissionsValue = sourceProperties?.RawProperties?.GetPermission();
                     string destinationPermissionKey = sourceProperties?.RawProperties?.GetDestinationPermissionKey();
@@ -385,7 +387,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             if (sourceResource is ShareFileStorageResource sourceShareFileResource)
             {
                 // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
-                if ((_options?.IsNfs ?? false) != (sourceShareFileResource._options?.IsNfs ?? false))
+                if ((_options?.ShareProtocol ?? ShareProtocols.Smb)
+                    != (sourceShareFileResource._options?.ShareProtocol ?? ShareProtocols.Smb))
                 {
                     throw Errors.ShareTransferNotSupported();
                 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -384,6 +384,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
+            // ShareFile to ShareFile Copy transfer
             if (sourceResource is ShareFileStorageResource sourceShareFileResource)
             {
                 // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
@@ -401,16 +402,16 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     "source",
                     sourceResource.Uri.AbsoluteUri,
                     cancellationToken).ConfigureAwait(false);
-            }
 
-            // Validate the destination protocol
-            await DataMovementSharesExtensions.ValidateProtocolAsync(
-                ShareFileClient.GetParentShareClient(),
-                _options,
-                transferId,
-                "destination",
-                Uri.AbsoluteUri,
-                cancellationToken).ConfigureAwait(false);
+                // Validate the destination protocol
+                await DataMovementSharesExtensions.ValidateProtocolAsync(
+                    ShareFileClient.GetParentShareClient(),
+                    _options,
+                    transferId,
+                    "destination",
+                    Uri.AbsoluteUri,
+                    cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -356,7 +356,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 directoryMetadata: _options?.DirectoryMetadata);
         }
 
-        protected override async Task<bool> ShouldTransferAsync(CancellationToken cancellationToken = default)
+        protected override async Task<bool> ShouldItemTransferAsync(CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -56,10 +56,10 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
         /// <summary>
         /// Optional. Specifies whether the Share uses NFS or SMB protocol.
-        /// By default this value is set to false. If true is selected, the account used must support NFS.
+        /// By default this value is set to SMB.
         /// Applies to copy, upload, and download transfers.
         /// </summary>
-        public bool IsNfs { get; set; } = false;
+        public ShareProtocols ShareProtocol { get; set; } = ShareProtocols.Smb;
 
         /// <summary>
         /// Optional. See <see cref="ShareFileRequestConditions"/>.

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -58,6 +58,10 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// Optional. Specifies whether the Share uses NFS or SMB protocol.
         /// By default this value is set to SMB.
         /// Applies to copy, upload, and download transfers.
+        ///
+        /// Note: Only NFS -> NFS and SMB -> SMB transfers are currently supported.
+        /// For NFS Share-to-Share Copy and Download transfers, Hardlinks will be copied as regular files. Symbolic links are skipped.
+        /// For NFS Upload transfers, Symbolic links are not supported.
         /// </summary>
         public ShareProtocols ShareProtocol { get; set; } = ShareProtocols.Smb;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -320,6 +320,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             _isDirectoryMetadataSet = options?._isDirectoryMetadataSet ?? false;
             FileMetadata = options?.FileMetadata;
             _isFileMetadataSet = options?._isFileMetadataSet ?? false;
+            SkipProtocolValidation = options?.SkipProtocolValidation ?? false;
+            ShareProtocol = options?.ShareProtocol ?? ShareProtocols.Smb;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -60,8 +60,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// Applies to copy, upload, and download transfers.
         ///
         /// Note: Only NFS -> NFS and SMB -> SMB transfers are currently supported.
-        /// For NFS Share-to-Share Copy and Download transfers, Hardlinks will be copied as regular files. Symbolic links are skipped.
-        /// For NFS Upload transfers, Symbolic links are not supported.
+        /// For NFS Share-to-Share Copy and Download transfers, Hardlinks will be copied as regular files and Symbolic links are skipped.
+        /// For NFS Upload transfers, Hardlinks will be copied as regular files and Symbolic links are not supported.
         /// </summary>
         public ShareProtocols ShareProtocol { get; set; } = ShareProtocols.Smb;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -49,7 +49,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// <summary>
         /// Optional. Specifies whether protocol validation for the resource should be skipped before starting the transfer.
         /// By default this value is set to false.
-        /// Applies to copy, upload, and download transfers.
+        /// Applies to only Share-to-Share copy transfers.
         /// Note: Protocol validation requires share-level read access.
         /// </summary>
         public bool SkipProtocolValidation { get; set; } = false;

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -589,11 +589,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = false, });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Smb, });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = false, FilePermissions = filePermissions });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Smb, FilePermissions = filePermissions });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -671,11 +671,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = true, FilePermissions = filePermissions });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs, FilePermissions = filePermissions });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -715,9 +715,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(true, true)]
-        [TestCase(false, false)]
-        public async Task ValidateProtocolAsync_SmbShareDirectoryToSmbShareDirectory_CompareProtocolSetToActual(bool sourceIsNfs, bool destIsNfs)
+        [TestCase(ShareProtocols.Nfs, ShareProtocols.Nfs)]
+        [TestCase(ShareProtocols.Smb, ShareProtocols.Smb)]
+        public async Task ValidateProtocolAsync_SmbShareDirectoryToSmbShareDirectory_CompareProtocolSetToActual(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -750,12 +750,12 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             ShareDirectoryClient sourceClient = source.Container.GetDirectoryClient(sourcePrefix);
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 sourceClient,
-                new ShareFileStorageResourceOptions() { IsNfs = sourceIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = sourceProtocol });
 
             ShareDirectoryClient destClient = destination.Container.GetDirectoryClient(destPrefix);
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destClient,
-                new ShareFileStorageResourceOptions() { IsNfs = destIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = destProtocol });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -765,7 +765,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             TransferManager transferManager = new TransferManager(managerOptions);
 
             // Act and Assert
-            if (!sourceIsNfs && !destIsNfs)
+            if (sourceProtocol == ShareProtocols.Smb && destProtocol == ShareProtocols.Smb)
             {
                 // Start transfer and await for completion.
                 TransferOperation transfer = await transferManager.StartTransferAsync(
@@ -802,9 +802,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(true, true)]
-        [TestCase(false, false)]
-        public async Task ValidateProtocolAsync_NfsShareDirectoryToNfsShareDirectory_CompareProtocolSetToActual(bool sourceIsNfs, bool destIsNfs)
+        [TestCase(ShareProtocols.Nfs, ShareProtocols.Nfs)]
+        [TestCase(ShareProtocols.Smb, ShareProtocols.Smb)]
+        public async Task ValidateProtocolAsync_NfsShareDirectoryToNfsShareDirectory_CompareProtocolSetToActual(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
@@ -839,11 +839,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = sourceIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = sourceProtocol });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = destIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = destProtocol });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -853,7 +853,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             TransferManager transferManager = new TransferManager(managerOptions);
 
             // Act and Assert
-            if (sourceIsNfs && destIsNfs)
+            if (sourceProtocol == ShareProtocols.Nfs && destProtocol == ShareProtocols.Nfs)
             {
                 // Start transfer and await for completion.
                 TransferOperation transfer = await transferManager.StartTransferAsync(
@@ -890,9 +890,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        public async Task ValidateProtocolAsync_ShareDirectoryToShareDirectory_ShareTransferNotSupported(bool sourceIsNfs, bool destIsNfs)
+        [TestCase(ShareProtocols.Nfs, ShareProtocols.Smb)]
+        [TestCase(ShareProtocols.Smb, ShareProtocols.Nfs)]
+        public async Task ValidateProtocolAsync_ShareDirectoryToShareDirectory_ShareTransferNotSupported(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -912,11 +912,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = sourceIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = sourceProtocol });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = destIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = destProtocol });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -969,11 +969,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = true, FilePermissions = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs, FilePermissions = true });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -1038,11 +1038,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -989,7 +989,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 options).ConfigureAwait(false);
 
             // Act
-            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             await TestTransferWithTimeout.WaitForCompletionAsync(
                 transfer,
                 testEventsRaised,
@@ -1058,7 +1058,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 options).ConfigureAwait(false);
 
             // Act
-            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             await TestTransferWithTimeout.WaitForCompletionAsync(
                 transfer,
                 testEventsRaised,
@@ -1070,7 +1070,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(TransferState.Completed, transfer.Status.State);
 
-            // List all files in source blob folder path
+            // List all files in source folder path
             List<string> sourceFileNames = new List<string>();
             List<string> sourceDirectoryNames = new List<string>();
             ShareDirectoryClient sourceDirectory = source.Container.GetDirectoryClient(sourcePrefix);
@@ -1080,7 +1080,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 sourceDirectoryNames.AddRange(page.Values.Where((ShareFileItem item) => item.IsDirectory).Select((ShareFileItem item) => item.Name));
             }
 
-            // List all files in the destination blob folder path
+            // List all files in the destination folder path
             List<string> destinationFileNames = new List<string>();
             List<string> destinationDirectoryNames = new List<string>();
             ShareDirectoryClient destinationDirectory = destination.Container.GetDirectoryClient(destPrefix);
@@ -1096,6 +1096,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Ensure the Symlink file was skipped and not copied
             Assert.AreEqual(2, sourceFileNames.Count);
             Assert.AreEqual(1, destinationFileNames.Count);
+            Assert.Contains("item1-symlink", sourceFileNames);
+            Assert.False(destinationFileNames.Contains("item1-symlink"));
             Assert.AreEqual("item1", destinationFileNames[0]);
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -125,10 +125,10 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             => new ShareDirectoryStorageResourceContainer(containerClient.GetDirectoryClient(prefix), default);
 
         protected override async Task CreateDirectoryInSourceAsync(ShareClient sourceContainer, string directoryPath, CancellationToken cancellationToken = default)
-            => await CreateDirectoryAsync(sourceContainer, directoryPath, cancellationToken);
+            => await CreateDirectoryAsync(container: sourceContainer, directoryPath: directoryPath, cancellationToken: cancellationToken);
 
         protected override async Task CreateDirectoryInDestinationAsync(ShareClient destinationContainer, string directoryPath, CancellationToken cancellationToken = default)
-            => await CreateDirectoryAsync(destinationContainer, directoryPath, cancellationToken);
+            => await CreateDirectoryAsync(container: destinationContainer, directoryPath: directoryPath, cancellationToken: cancellationToken);
 
         protected override async Task VerifyEmptyDestinationContainerAsync(
             ShareClient destinationContainer,
@@ -303,16 +303,68 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             }
         }
 
-        private async Task CreateDirectoryAsync(ShareClient container, string directoryPath, CancellationToken cancellationToken = default)
+        private async Task CreateShareFileNfsAndHardLinkAsync(
+            ShareClient container,
+            long? objectLength = null,
+            string objectName = null,
+            CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
-            ShareDirectoryClient directory = container.GetRootDirectoryClient().GetSubdirectoryClient(directoryPath);
-            await directory.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+            objectName ??= GetNewObjectName();
+            if (!objectLength.HasValue)
+            {
+                throw new InvalidOperationException($"Cannot create share file without size specified. Specify {nameof(objectLength)}.");
+            }
+            ShareFileClient fileClient = container.GetRootDirectoryClient().GetFileClient(objectName);
+
+            await fileClient.CreateAsync(
+                maxSize: objectLength.Value,
+                cancellationToken: cancellationToken);
+
+            ShareFileClient hardlinkClient = InstrumentClient(container.GetRootDirectoryClient().GetFileClient($"{objectName}-hardlink"));
+
+            // Create Hardlink
+            await hardlinkClient.CreateHardLinkAsync(
+                targetFile: $"{container.GetRootDirectoryClient().Name}/{objectName}");
+
+            // Assert hardlink was successfully created
+            ShareFileProperties properties = await hardlinkClient.GetPropertiesAsync();
+            Assert.AreEqual(2, properties.PosixProperties.LinkCount);
+            Assert.AreEqual(NfsFileType.Regular, properties.PosixProperties.FileType);
+        }
+
+        private async Task CreateShareFileNfsAndSymLinkAsync(
+            ShareClient container,
+            long? objectLength = null,
+            string objectName = null,
+            CancellationToken cancellationToken = default)
+        {
+            CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+            objectName ??= GetNewObjectName();
+            if (!objectLength.HasValue)
+            {
+                throw new InvalidOperationException($"Cannot create share file without size specified. Specify {nameof(objectLength)}.");
+            }
+            ShareFileClient fileClient = container.GetRootDirectoryClient().GetFileClient(objectName);
+
+            await fileClient.CreateAsync(
+                maxSize: objectLength.Value,
+                cancellationToken: cancellationToken);
+
+            ShareFileClient symlinkClient = InstrumentClient(container.GetRootDirectoryClient().GetFileClient($"{objectName}-symlink"));
+
+            // Create Symlink
+            await symlinkClient.CreateSymbolicLinkAsync(linkText: fileClient.Uri.ToString());
+
+            // Assert symlink was successfully created
+            ShareFileProperties properties = await symlinkClient.GetPropertiesAsync();
+            Assert.AreEqual(1, properties.PosixProperties.LinkCount);
+            Assert.AreEqual(NfsFileType.SymLink, properties.PosixProperties.FileType);
         }
 
         private async Task CreateDirectoryAsync(ShareClient container,
             string directoryPath,
-            ShareDirectoryCreateOptions options,
+            ShareDirectoryCreateOptions options = default,
             CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
@@ -557,7 +609,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 options).ConfigureAwait(false);
 
             // Act
-            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             await TestTransferWithTimeout.WaitForCompletionAsync(
                 transfer,
                 testEventsRaised,
@@ -639,7 +691,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 options).ConfigureAwait(false);
 
             // Act
-            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             await TestTransferWithTimeout.WaitForCompletionAsync(
                 transfer,
                 testEventsRaised,
@@ -722,7 +774,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                     options).ConfigureAwait(false);
 
                 // Act
-                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 await TestTransferWithTimeout.WaitForCompletionAsync(
                     transfer,
                     testEventsRaised,
@@ -810,7 +862,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 options).ConfigureAwait(false);
 
                 // Act
-                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 await TestTransferWithTimeout.WaitForCompletionAsync(
                     transfer,
                     testEventsRaised,
@@ -877,6 +929,174 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             var ex = Assert.ThrowsAsync<NotSupportedException>(async () =>
                 await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
             Assert.AreEqual("This Share transfer is not supported. Currently only NFS -> NFS and SMB -> SMB Share transfers are supported", ex.Message);
+        }
+
+        [RecordedTest]
+        public async Task ShareDirectoryToShareDirectory_NfsHardLink()
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
+            await using IDisposingContainer<ShareClient> destination = await DestinationClientBuilder.GetTestShareSasNfsAsync();
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            string sourcePrefix = "sourceFolder";
+            string destPrefix = "destFolder";
+
+            ShareDirectoryCreateOptions directoryCreateOptions = new ShareDirectoryCreateOptions()
+            {
+                Metadata = _defaultMetadata,
+                SmbProperties = new FileSmbProperties()
+                {
+                    FileCreatedOn = _defaultFileCreatedOn,
+                    FileLastWrittenOn = _defaultFileLastWrittenOn,
+                },
+                PosixProperties = new FilePosixProperties()
+                {
+                    Owner = "345",
+                    Group = "123",
+                    FileMode = NfsFileMode.ParseOctalFileMode("1777"),
+                }
+            };
+
+            // setup source
+            await CreateDirectoryAsync(source.Container, sourcePrefix, directoryCreateOptions);
+            string itemName1 = string.Join("/", sourcePrefix, "item1");
+            await CreateShareFileNfsAndHardLinkAsync(source.Container, DataMovementTestConstants.KB, itemName1);
+            // setup destination
+            await CreateDirectoryInDestinationAsync(destination.Container, destPrefix);
+
+            // Create storage resource containers
+            StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
+                source.Container.GetDirectoryClient(sourcePrefix),
+                new ShareFileStorageResourceOptions() { IsNfs = true });
+
+            StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
+                destination.Container.GetDirectoryClient(destPrefix),
+                new ShareFileStorageResourceOptions() { IsNfs = true, FilePermissions = true });
+
+            // Create Transfer Manager with single threaded operation
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                MaximumConcurrency = 1,
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            // Start transfer and await for completion.
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                options).ConfigureAwait(false);
+
+            // Act
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+            await TestTransferWithTimeout.WaitForCompletionAsync(
+                transfer,
+                testEventsRaised,
+                cancellationTokenSource.Token);
+
+            // Assert
+            testEventsRaised.AssertUnexpectedFailureCheck();
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+
+            await VerifyResultsAsync(
+                sourceContainer: source.Container,
+                sourcePrefix: sourcePrefix,
+                destinationContainer: destination.Container,
+                destinationPrefix: destPrefix,
+                propertiesTestType: TransferPropertiesTestType.PreserveNfs);
+
+            ShareDirectoryClient destinationDirectory = destination.Container.GetDirectoryClient(destPrefix);
+            ShareFileClient destinationClient = destinationDirectory.GetFileClient("item1-hardlink");
+            ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
+            // Assert the hardlink was copied as regular file
+            Assert.AreEqual(1, destinationProperties.PosixProperties.LinkCount);
+            Assert.AreEqual(NfsFileType.Regular, destinationProperties.PosixProperties.FileType);
+        }
+
+        [RecordedTest]
+        public async Task ShareDirectoryToShareDirectory_NfsSymbolicLink()
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
+            await using IDisposingContainer<ShareClient> destination = await DestinationClientBuilder.GetTestShareSasNfsAsync();
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            string sourcePrefix = "sourceFolder";
+            string destPrefix = "destFolder";
+
+            // setup source
+            await CreateDirectoryAsync(source.Container, sourcePrefix);
+            string itemName1 = string.Join("/", sourcePrefix, "item1");
+            await CreateShareFileNfsAndSymLinkAsync(source.Container, DataMovementTestConstants.KB, itemName1);
+            // setup destination
+            await CreateDirectoryInDestinationAsync(destination.Container, destPrefix);
+
+            // Create storage resource containers
+            StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
+                source.Container.GetDirectoryClient(sourcePrefix),
+                new ShareFileStorageResourceOptions() { IsNfs = true });
+
+            StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
+                destination.Container.GetDirectoryClient(destPrefix),
+                new ShareFileStorageResourceOptions() { IsNfs = true });
+
+            // Create Transfer Manager with single threaded operation
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                MaximumConcurrency = 1,
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            // Start transfer and await for completion.
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                options).ConfigureAwait(false);
+
+            // Act
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3000));
+            await TestTransferWithTimeout.WaitForCompletionAsync(
+                transfer,
+                testEventsRaised,
+                cancellationTokenSource.Token);
+
+            // Assert
+            testEventsRaised.AssertUnexpectedFailureCheck();
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+
+            // List all files in source blob folder path
+            List<string> sourceFileNames = new List<string>();
+            List<string> sourceDirectoryNames = new List<string>();
+            ShareDirectoryClient sourceDirectory = source.Container.GetDirectoryClient(sourcePrefix);
+            await foreach (Page<ShareFileItem> page in sourceDirectory.GetFilesAndDirectoriesAsync().AsPages())
+            {
+                sourceFileNames.AddRange(page.Values.Where((ShareFileItem item) => !item.IsDirectory).Select((ShareFileItem item) => item.Name));
+                sourceDirectoryNames.AddRange(page.Values.Where((ShareFileItem item) => item.IsDirectory).Select((ShareFileItem item) => item.Name));
+            }
+
+            // List all files in the destination blob folder path
+            List<string> destinationFileNames = new List<string>();
+            List<string> destinationDirectoryNames = new List<string>();
+            ShareDirectoryClient destinationDirectory = destination.Container.GetDirectoryClient(destPrefix);
+            await foreach (Page<ShareFileItem> page in destinationDirectory.GetFilesAndDirectoriesAsync().AsPages())
+            {
+                destinationFileNames.AddRange(page.Values.Where((ShareFileItem item) => !item.IsDirectory).Select((ShareFileItem item) => item.Name));
+                destinationDirectoryNames.AddRange(page.Values.Where((ShareFileItem item) => item.IsDirectory).Select((ShareFileItem item) => item.Name));
+            }
+
+            // Assert subdirectories
+            Assert.AreEqual(sourceDirectoryNames.Count, destinationDirectoryNames.Count);
+            Assert.AreEqual(sourceDirectoryNames, destinationDirectoryNames);
+            // Ensure the Symlink file was skipped and not copied
+            Assert.AreEqual(2, sourceFileNames.Count);
+            Assert.AreEqual(1, destinationFileNames.Count);
+            Assert.AreEqual("item1", destinationFileNames[0]);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -354,7 +354,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             ShareFileClient symlinkClient = InstrumentClient(container.GetRootDirectoryClient().GetFileClient($"{objectName}-symlink"));
 
             // Create Symlink
-            await symlinkClient.CreateSymbolicLinkAsync(linkText: fileClient.Uri.ToString());
+            await symlinkClient.CreateSymbolicLinkAsync(linkText: fileClient.Uri.AbsolutePath);
 
             // Assert symlink was successfully created
             ShareFileProperties properties = await symlinkClient.GetPropertiesAsync();

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
@@ -258,7 +258,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Assert all files (including hardlink) was copied over to dest
             Assert.AreEqual(sourceFileNames.Count, destFileNames.Count);
-            Assert.AreEqual(sourceFileNames, destFileNames);
         }
 
         [RecordedTest]

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
@@ -126,7 +126,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             ShareFileClient symlinkClient = InstrumentClient(container.GetRootDirectoryClient().GetFileClient($"{objectName}-symlink"));
 
             // Create Symlink
-            await symlinkClient.CreateSymbolicLinkAsync(linkText: fileClient.Uri.ToString());
+            await symlinkClient.CreateSymbolicLinkAsync(linkText: fileClient.Uri.AbsolutePath);
 
             // Assert symlink was successfully created
             ShareFileProperties properties = await symlinkClient.GetPropertiesAsync();

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
@@ -256,7 +256,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 .Select(Path.GetFileName)
                 .ToList();
 
-            // Assert all files (including hardlink) was copied over to dest
+            // Assert all files (including hardlink) were copied over to dest
             Assert.AreEqual(sourceFileNames.Count, destFileNames.Count);
             Assert.That(sourceFileNames, Is.EquivalentTo(destFileNames));
         }
@@ -327,6 +327,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Ensure the Symlink file was skipped and not copied
             Assert.AreEqual(2, sourceFileNames.Count);
             Assert.AreEqual(1, destFileNames.Count);
+            Assert.Contains("item1-symlink", sourceFileNames);
+            Assert.False(destFileNames.Contains("item1-symlink"));
             Assert.AreEqual("item1", destFileNames[0]);
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
@@ -212,7 +212,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             StorageResource destinationResource = LocalFilesStorageResourceProvider.FromDirectory(destination.DirectoryPath);
 
@@ -280,7 +280,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             StorageResource destinationResource = LocalFilesStorageResourceProvider.FromDirectory(destination.DirectoryPath);
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
@@ -258,6 +258,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Assert all files (including hardlink) was copied over to dest
             Assert.AreEqual(sourceFileNames.Count, destFileNames.Count);
+            Assert.That(sourceFileNames, Is.EquivalentTo(destFileNames));
         }
 
         [RecordedTest]

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
@@ -13,6 +13,10 @@ using Azure.Storage.DataMovement.Tests;
 using BaseShares::Azure.Storage.Files.Shares;
 using Azure.Storage.Test.Shared;
 using DMShare::Azure.Storage.DataMovement.Files.Shares;
+using NUnit.Framework;
+using Azure.Core.TestFramework;
+using BaseShares::Azure.Storage.Files.Shares.Models;
+using System.Linq;
 
 namespace Azure.Storage.DataMovement.Files.Shares.Tests
 {
@@ -60,6 +64,74 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 await fileClient.UploadAsync(contents, cancellationToken: cancellationToken);
             }
+        }
+
+        private async Task CreateDirectoryAsync(ShareClient container,
+            string directoryPath,
+            CancellationToken cancellationToken = default)
+        {
+            CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+            ShareDirectoryClient directory = container.GetRootDirectoryClient().GetSubdirectoryClient(directoryPath);
+            await directory.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        }
+
+        private async Task CreateShareFileNfsAndHardLinkAsync(
+            ShareClient container,
+            long? objectLength = null,
+            string objectName = null,
+            CancellationToken cancellationToken = default)
+        {
+            CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+            objectName ??= GetNewObjectName();
+            if (!objectLength.HasValue)
+            {
+                throw new InvalidOperationException($"Cannot create share file without size specified. Specify {nameof(objectLength)}.");
+            }
+            ShareFileClient fileClient = container.GetRootDirectoryClient().GetFileClient(objectName);
+
+            await fileClient.CreateAsync(
+                maxSize: objectLength.Value,
+                cancellationToken: cancellationToken);
+
+            ShareFileClient hardlinkClient = InstrumentClient(container.GetRootDirectoryClient().GetFileClient($"{objectName}-hardlink"));
+
+            // Create Hardlink
+            await hardlinkClient.CreateHardLinkAsync(
+                targetFile: $"{container.GetRootDirectoryClient().Name}/{objectName}");
+
+            // Assert hardlink was successfully created
+            ShareFileProperties properties = await hardlinkClient.GetPropertiesAsync();
+            Assert.AreEqual(2, properties.PosixProperties.LinkCount);
+            Assert.AreEqual(NfsFileType.Regular, properties.PosixProperties.FileType);
+        }
+
+        private async Task CreateShareFileNfsAndSymLinkAsync(
+            ShareClient container,
+            long? objectLength = null,
+            string objectName = null,
+            CancellationToken cancellationToken = default)
+        {
+            CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+            objectName ??= GetNewObjectName();
+            if (!objectLength.HasValue)
+            {
+                throw new InvalidOperationException($"Cannot create share file without size specified. Specify {nameof(objectLength)}.");
+            }
+            ShareFileClient fileClient = container.GetRootDirectoryClient().GetFileClient(objectName);
+
+            await fileClient.CreateAsync(
+                maxSize: objectLength.Value,
+                cancellationToken: cancellationToken);
+
+            ShareFileClient symlinkClient = InstrumentClient(container.GetRootDirectoryClient().GetFileClient($"{objectName}-symlink"));
+
+            // Create Symlink
+            await symlinkClient.CreateSymbolicLinkAsync(linkText: fileClient.Uri.ToString());
+
+            // Assert symlink was successfully created
+            ShareFileProperties properties = await symlinkClient.GetPropertiesAsync();
+            Assert.AreEqual(1, properties.PosixProperties.LinkCount);
+            Assert.AreEqual(NfsFileType.SymLink, properties.PosixProperties.FileType);
         }
 
         protected override TransferValidator.ListFilesAsync GetSourceLister(ShareClient container, string prefix)
@@ -119,6 +191,143 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                     }
                 }
             }
+        }
+
+        [RecordedTest]
+        public async Task ShareDirectoryToLocalDirectory_NfsHardLink()
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await ClientBuilder.GetTestShareSasNfsAsync();
+            using DisposingLocalDirectory destination = DisposingLocalDirectory.GetTestDirectory();
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            string sourcePrefix = "sourceFolder";
+
+            // setup source
+            await CreateDirectoryAsync(source.Container, sourcePrefix);
+            string itemName1 = string.Join("/", sourcePrefix, "item1");
+            await CreateShareFileNfsAndHardLinkAsync(source.Container, DataMovementTestConstants.KB, itemName1);
+
+            // Create storage resource containers
+            StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
+                source.Container.GetDirectoryClient(sourcePrefix),
+                new ShareFileStorageResourceOptions() { IsNfs = true });
+
+            StorageResource destinationResource = LocalFilesStorageResourceProvider.FromDirectory(destination.DirectoryPath);
+
+            // Create Transfer Manager with single threaded operation
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                MaximumConcurrency = 1,
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            // Start transfer and await for completion.
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                options).ConfigureAwait(false);
+
+            // Act
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await TestTransferWithTimeout.WaitForCompletionAsync(
+                transfer,
+                testEventsRaised,
+                cancellationTokenSource.Token);
+
+            // Assert
+            testEventsRaised.AssertUnexpectedFailureCheck();
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+            await testEventsRaised.AssertContainerCompletedCheck(2);
+
+            // Get source files
+            List<string> sourceFileNames = new List<string>();
+            ShareDirectoryClient sourceDirectory = source.Container.GetDirectoryClient(sourcePrefix);
+            await foreach (Page<ShareFileItem> page in sourceDirectory.GetFilesAndDirectoriesAsync().AsPages())
+            {
+                sourceFileNames.AddRange(page.Values.Where((ShareFileItem item) => !item.IsDirectory).Select((ShareFileItem item) => item.Name));
+            }
+            // Get dest files
+            List<string> destFileNames = Directory
+                .EnumerateFiles(destination.DirectoryPath, "*", SearchOption.TopDirectoryOnly)
+                .Select(Path.GetFileName)
+                .ToList();
+
+            // Assert all files (including hardlink) was copied over to dest
+            Assert.AreEqual(sourceFileNames.Count, destFileNames.Count);
+            Assert.AreEqual(sourceFileNames, destFileNames);
+        }
+
+        [RecordedTest]
+        public async Task ShareDirectoryToLocalDirectory_NfsSymbolicLink()
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await ClientBuilder.GetTestShareSasNfsAsync();
+            using DisposingLocalDirectory destination = DisposingLocalDirectory.GetTestDirectory();
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            string sourcePrefix = "sourceFolder";
+
+            // setup source
+            await CreateDirectoryAsync(source.Container, sourcePrefix);
+            string itemName1 = string.Join("/", sourcePrefix, "item1");
+            await CreateShareFileNfsAndSymLinkAsync(source.Container, DataMovementTestConstants.KB, itemName1);
+
+            // Create storage resource containers
+            StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
+                source.Container.GetDirectoryClient(sourcePrefix),
+                new ShareFileStorageResourceOptions() { IsNfs = true });
+
+            StorageResource destinationResource = LocalFilesStorageResourceProvider.FromDirectory(destination.DirectoryPath);
+
+            // Create Transfer Manager with single threaded operation
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                MaximumConcurrency = 1,
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            // Start transfer and await for completion.
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                options).ConfigureAwait(false);
+
+            // Act
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await TestTransferWithTimeout.WaitForCompletionAsync(
+                transfer,
+                testEventsRaised,
+                cancellationTokenSource.Token);
+
+            // Assert
+            testEventsRaised.AssertUnexpectedFailureCheck();
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+            await testEventsRaised.AssertContainerCompletedCheck(2);
+
+            // Get source files
+            List<string> sourceFileNames = new List<string>();
+            ShareDirectoryClient sourceDirectory = source.Container.GetDirectoryClient(sourcePrefix);
+            await foreach (Page<ShareFileItem> page in sourceDirectory.GetFilesAndDirectoriesAsync().AsPages())
+            {
+                sourceFileNames.AddRange(page.Values.Where((ShareFileItem item) => !item.IsDirectory).Select((ShareFileItem item) => item.Name));
+            }
+            // Get dest files
+            List<string> destFileNames = Directory
+                .EnumerateFiles(destination.DirectoryPath, "*", SearchOption.TopDirectoryOnly)
+                .Select(Path.GetFileName)
+                .ToList();
+
+            // Ensure the Symlink file was skipped and not copied
+            Assert.AreEqual(2, sourceFileNames.Count);
+            Assert.AreEqual(1, destFileNames.Count);
+            Assert.AreEqual("item1", destFileNames[0]);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
@@ -1535,7 +1535,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             mock.Verify(b => b.GetPropertiesAsync(It.IsAny<ShareFileRequestConditions>(), It.IsAny<CancellationToken>()),
                 Times.Once());
-            mock.Verify(b => b.Uri, Times.Once());
             mock.VerifyNoOtherCalls();
         }
 
@@ -1626,7 +1625,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             mock.Verify(b => b.GetPropertiesAsync(It.IsAny<ShareFileRequestConditions>(), It.IsAny<CancellationToken>()),
                 Times.Once());
-            mock.Verify(b => b.Uri, Times.Once());
             mock.VerifyNoOtherCalls();
         }
 
@@ -2077,8 +2075,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                     option.Metadata == DefaultFileMetadata &&
                     option.SmbProperties.FileCreatedOn == DefaultFileCreatedOn &&
                     option.SmbProperties.FileLastWrittenOn == DefaultLastWrittenOn &&
-                    option.SmbProperties.FileChangedOn == DefaultFileChangedOn &&
-                    option.SmbProperties.FilePermissionKey == default),
+                    option.SmbProperties.FileChangedOn == DefaultFileChangedOn),
+                //option.SmbProperties.FilePermissionKey == default),
                 It.IsAny<ShareFileRequestConditions>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once());

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
@@ -497,7 +497,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                     option.SmbProperties.FileCreatedOn == DefaultFileCreatedOn &&
                     option.SmbProperties.FileLastWrittenOn == DefaultLastWrittenOn &&
                     option.SmbProperties.FileChangedOn == DefaultFileChangedOn &&
-                    option.SmbProperties.FilePermissionKey == default),
+                    option.SmbProperties.FilePermissionKey == DefaultDestinationFilePermissionKey),
                 It.IsAny<ShareFileRequestConditions>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once());
@@ -2075,8 +2075,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                     option.Metadata == DefaultFileMetadata &&
                     option.SmbProperties.FileCreatedOn == DefaultFileCreatedOn &&
                     option.SmbProperties.FileLastWrittenOn == DefaultLastWrittenOn &&
-                    option.SmbProperties.FileChangedOn == DefaultFileChangedOn),
-                //option.SmbProperties.FilePermissionKey == default),
+                    option.SmbProperties.FileChangedOn == DefaultFileChangedOn &&
+                    option.SmbProperties.FilePermissionKey == DefaultDestinationFilePermissionKey),
                 It.IsAny<ShareFileRequestConditions>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once());

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
@@ -39,6 +39,10 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         private readonly DateTimeOffset DefaultFileCreatedOn = new DateTimeOffset(2024, 4, 1, 9, 5, 55, default);
         private readonly DateTimeOffset DefaultLastWrittenOn = new DateTimeOffset(2024, 4, 1, 12, 16, 6, default);
         private readonly DateTimeOffset DefaultFileChangedOn = new DateTimeOffset(2024, 4, 1, 13, 30, 3, default);
+        private readonly string DefaultSourceOwner = "345";
+        private readonly string DefaultSourceGroup = "123";
+        private readonly NfsFileMode DefaultSourceFileMode = NfsFileMode.ParseOctalFileMode("1777");
+        private readonly NfsFileType DefaultFileType = NfsFileType.Regular;
         private readonly Dictionary<string,string> DefaultFileMetadata = new(StringComparer.OrdinalIgnoreCase)
         {
             { "fkey", "fvalue" },
@@ -467,7 +471,10 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 { DataMovementConstants.ResourceProperties.CreationTime, DefaultFileCreatedOn },
                 { DataMovementConstants.ResourceProperties.LastWrittenOn, DefaultLastWrittenOn },
                 { DataMovementConstants.ResourceProperties.ChangedOnTime, DefaultFileChangedOn },
-                { DataMovementConstants.ResourceProperties.Metadata, DefaultFileMetadata }
+                { DataMovementConstants.ResourceProperties.Metadata, DefaultFileMetadata },
+                { DataMovementConstants.ResourceProperties.Owner, DefaultSourceOwner },
+                { DataMovementConstants.ResourceProperties.Group, DefaultSourceGroup },
+                { DataMovementConstants.ResourceProperties.FileMode,  DefaultSourceFileMode }
             };
 
             Mock<ShareFileClient> mock = await CopyFromStreamPreserveProperties_Internal(
@@ -497,7 +504,81 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                     option.SmbProperties.FileCreatedOn == DefaultFileCreatedOn &&
                     option.SmbProperties.FileLastWrittenOn == DefaultLastWrittenOn &&
                     option.SmbProperties.FileChangedOn == DefaultFileChangedOn &&
-                    option.SmbProperties.FilePermissionKey == DefaultDestinationFilePermissionKey),
+                    option.SmbProperties.FilePermissionKey == DefaultDestinationFilePermissionKey &&
+                    option.PosixProperties.Owner == null &&
+                    option.PosixProperties.Group == null &&
+                    option.PosixProperties.FileMode == null &&
+                    option.PosixProperties.FileType == null),
+                It.IsAny<ShareFileRequestConditions>(),
+                It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.Verify(b => b.ExistsAsync(
+                It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public async Task CopyFromStreamAsync_NfsPropertiesPreserve()
+        {
+            // Arrange
+            int length = 1024;
+            var data = GetRandomBuffer(length);
+            using var stream = new MemoryStream(data);
+
+            // Act
+            Dictionary<string, object> sourceProperties = new()
+            {
+                { DataMovementConstants.ResourceProperties.ContentType, DefaultContentType },
+                { DataMovementConstants.ResourceProperties.ContentEncoding, DefaultContentEncoding },
+                { DataMovementConstants.ResourceProperties.ContentLanguage, DefaultContentLanguage },
+                { DataMovementConstants.ResourceProperties.ContentDisposition, DefaultContentDisposition },
+                { DataMovementConstants.ResourceProperties.CacheControl, DefaultCacheControl },
+                { DataMovementConstants.ResourceProperties.FileAttributes, DefaultFileAttributes },
+                { DataMovementConstants.ResourceProperties.SourceFilePermissionKey, DefaultFilePermissionKey },
+                { DataMovementConstants.ResourceProperties.DestinationFilePermissionKey, DefaultDestinationFilePermissionKey },
+                { DataMovementConstants.ResourceProperties.CreationTime, DefaultFileCreatedOn },
+                { DataMovementConstants.ResourceProperties.LastWrittenOn, DefaultLastWrittenOn },
+                { DataMovementConstants.ResourceProperties.ChangedOnTime, DefaultFileChangedOn },
+                { DataMovementConstants.ResourceProperties.Metadata, DefaultFileMetadata },
+                { DataMovementConstants.ResourceProperties.Owner, DefaultSourceOwner },
+                { DataMovementConstants.ResourceProperties.Group, DefaultSourceGroup },
+                { DataMovementConstants.ResourceProperties.FileMode,  DefaultSourceFileMode }
+            };
+
+            Mock<ShareFileClient> mock = await CopyFromStreamPreserveProperties_Internal(
+                stream: stream,
+                length: length,
+                resourceOptions: new ShareFileStorageResourceOptions()
+                {
+                    FilePermissions = true,
+                    ShareProtocol = ShareProtocols.Nfs,
+                },
+                sourceProperties: sourceProperties);
+
+            mock.Verify(b => b.UploadRangeAsync(
+                new HttpRange(0, length),
+                stream,
+                It.Is<ShareFileUploadRangeOptions>(options =>
+                    options.FileLastWrittenMode == FileLastWrittenMode.Preserve),
+                It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.Verify(b => b.CreateAsync(
+                length,
+                It.Is<ShareFileCreateOptions>(option =>
+                    option.HttpHeaders.CacheControl == DefaultCacheControl &&
+                    option.HttpHeaders.ContentDisposition == DefaultContentDisposition &&
+                    option.HttpHeaders.ContentEncoding == DefaultContentEncoding &&
+                    option.HttpHeaders.ContentType == DefaultContentType &&
+                    option.Metadata == DefaultFileMetadata &&
+                    option.SmbProperties.FileCreatedOn == DefaultFileCreatedOn &&
+                    option.SmbProperties.FileLastWrittenOn == DefaultLastWrittenOn &&
+                    option.SmbProperties.FileChangedOn == null &&
+                    option.SmbProperties.FilePermissionKey == null &&
+                    option.PosixProperties.Owner == DefaultSourceOwner &&
+                    option.PosixProperties.Group == DefaultSourceGroup &&
+                    option.PosixProperties.FileMode == DefaultSourceFileMode &&
+                    option.PosixProperties.FileType == DefaultFileType),
                 It.IsAny<ShareFileRequestConditions>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once());

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -1126,7 +1126,10 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             await using IDisposingContainer<ShareClient> destination = await DestinationClientBuilder.GetTestShareSasNfsAsync();
 
             ShareDirectoryClient directory = source.Container.GetRootDirectoryClient();
-            ShareFileClient originalClient = InstrumentClient(await directory.CreateFileAsync("original", maxSize: Constants.KB));
+            ShareFileClient originalClient = await CreateFileClientWithOptionsAsync(
+                container: source.Container,
+                objectLength: DataMovementTestConstants.KB,
+                createResource: true);
             ShareFileClient symlinkClient = InstrumentClient(directory.GetFileClient("original-symlink"));
 
             // Create Symlink

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -1125,11 +1125,32 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
             await using IDisposingContainer<ShareClient> destination = await DestinationClientBuilder.GetTestShareSasNfsAsync();
 
+            DateTimeOffset sourceFileCreatedOn = _defaultFileCreatedOn;
+            DateTimeOffset sourceFileLastWrittenOn = _defaultFileLastWrittenOn;
+            string sourceOwner = "345";
+            string sourceGroup = "123";
+            string sourceFileMode = "1777";
+            ShareFileCreateOptions sharefileCreateOptions = new ShareFileCreateOptions()
+            {
+                SmbProperties = new FileSmbProperties()
+                {
+                    FileCreatedOn = sourceFileCreatedOn,
+                    FileLastWrittenOn = sourceFileLastWrittenOn,
+                },
+                PosixProperties = new FilePosixProperties()
+                {
+                    Owner = sourceOwner,
+                    Group = sourceGroup,
+                    FileMode = NfsFileMode.ParseOctalFileMode(sourceFileMode),
+                }
+            };
+
             ShareDirectoryClient directory = source.Container.GetRootDirectoryClient();
             ShareFileClient originalClient = await CreateFileClientWithOptionsAsync(
                 container: source.Container,
                 objectLength: DataMovementTestConstants.KB,
-                createResource: true);
+                createResource: true,
+                options: sharefileCreateOptions);
             ShareFileClient symlinkClient = InstrumentClient(directory.GetFileClient("original-symlink"));
 
             // Create Symlink

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -762,14 +762,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 createResource: true,
                 options: sharefileCreateOptions);
             StorageResourceItem sourceResource = new ShareFileStorageResource(sourceClient,
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             // Create destination file
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { IsNfs = true, FilePermissions = filePermissions });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs, FilePermissions = filePermissions });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);
@@ -816,9 +816,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(true, true)]
-        [TestCase(false, false)]
-        public async Task ValidateProtocolAsync_SmbShareFileToSmbShareFile_CompareProtocolSetToActual(bool sourceIsNfs, bool destIsNfs)
+        [TestCase(ShareProtocols.Nfs, ShareProtocols.Nfs)]
+        [TestCase(ShareProtocols.Smb, ShareProtocols.Smb)]
+        public async Task ValidateProtocolAsync_SmbShareFileToSmbShareFile_CompareProtocolSetToActual(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -830,21 +830,21 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 objectLength: DataMovementTestConstants.KB,
                 createResource: true);
             StorageResourceItem sourceResource = new ShareFileStorageResource(sourceClient,
-                new ShareFileStorageResourceOptions() { IsNfs = sourceIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = sourceProtocol });
 
             // Destination client - Set Properties
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { IsNfs = destIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = destProtocol });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);
             TransferManager transferManager = new TransferManager();
 
             // Act and Assert
-            if (!sourceIsNfs && !destIsNfs)
+            if (sourceProtocol == ShareProtocols.Smb && destProtocol == ShareProtocols.Smb)
             {
                 // Act - Start transfer and await for completion.
                 TransferOperation transfer = await transferManager.StartTransferAsync(
@@ -875,9 +875,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(true, true)]
-        [TestCase(false, false)]
-        public async Task ValidateProtocolAsync_NfsShareFileToNfsShareFile_CompareProtocolSetToActual(bool sourceIsNfs, bool destIsNfs)
+        [TestCase(ShareProtocols.Nfs, ShareProtocols.Nfs)]
+        [TestCase(ShareProtocols.Smb, ShareProtocols.Smb)]
+        public async Task ValidateProtocolAsync_NfsShareFileToNfsShareFile_CompareProtocolSetToActual(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
@@ -889,21 +889,21 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 objectLength: DataMovementTestConstants.KB,
                 createResource: true);
             StorageResourceItem sourceResource = new ShareFileStorageResource(sourceClient,
-                new ShareFileStorageResourceOptions() { IsNfs = sourceIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = sourceProtocol });
 
             // Create destination file
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { IsNfs = destIsNfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = destProtocol });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);
             TransferManager transferManager = new TransferManager();
 
             // Act and Assert
-            if (sourceIsNfs && destIsNfs)
+            if (sourceProtocol == ShareProtocols.Nfs && destProtocol == ShareProtocols.Nfs)
             {
                 // Act - Start transfer and await for completion.
                 TransferOperation transfer = await transferManager.StartTransferAsync(
@@ -994,9 +994,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        public async Task ValidateProtocolAsync_ShareFileToShareFile_ShareTransferNotSupported(bool sourceIsNfs, bool destIsNfs)
+        [TestCase(ShareProtocols.Nfs, ShareProtocols.Smb)]
+        [TestCase(ShareProtocols.Smb, ShareProtocols.Nfs)]
+        public async Task ValidateProtocolAsync_ShareFileToShareFile_ShareTransferNotSupported(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -1008,14 +1008,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 objectLength: DataMovementTestConstants.KB,
                 createResource: true);
             StorageResourceItem sourceResource = new ShareFileStorageResource(sourceClient,
-                new ShareFileStorageResourceOptions() { IsNfs = sourceIsNfs, SkipProtocolValidation = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = sourceProtocol, SkipProtocolValidation = true });
 
             // Destination client - Set Properties
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { IsNfs = destIsNfs, SkipProtocolValidation = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = destProtocol, SkipProtocolValidation = true });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);
@@ -1073,14 +1073,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Use the hardlink to create the source file
             StorageResourceItem sourceResource = new ShareFileStorageResource(hardlinkClient,
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             // Create destination file
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { IsNfs = true, FilePermissions = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs, FilePermissions = true });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);
@@ -1139,14 +1139,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Use the symlink to create the source file
             StorageResourceItem sourceResource = new ShareFileStorageResource(symlinkClient,
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             // Create destination file
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
@@ -98,7 +98,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Assert.AreEqual(NfsFileType.Regular, sourceProperties.PosixProperties.FileType);
 
             // Use the hardlink to create the source file
-            StorageResource sourceResource = new ShareFileStorageResource(originalClient,
+            StorageResource sourceResource = new ShareFileStorageResource(hardlinkClient,
                 new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             // Create destination local file
@@ -142,7 +142,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             using DisposingLocalDirectory destination = DisposingLocalDirectory.GetTestDirectory();
 
             ShareDirectoryClient directory = source.Container.GetRootDirectoryClient();
-            ShareFileClient originalClient = InstrumentClient(await directory.CreateFileAsync("original", maxSize: Constants.KB));
+            ShareFileClient originalClient = await GetObjectClientAsync(
+                container: source.Container,
+                objectLength: DataMovementTestConstants.KB,
+                objectName: "original",
+                createObject: true);
             ShareFileClient symlinkClient = InstrumentClient(directory.GetFileClient("original-symlink"));
 
             // Create Symlink

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
@@ -150,7 +150,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             ShareFileClient symlinkClient = InstrumentClient(directory.GetFileClient("original-symlink"));
 
             // Create Symlink
-            await symlinkClient.CreateSymbolicLinkAsync(linkText: originalClient.Uri.ToString());
+            await symlinkClient.CreateSymbolicLinkAsync(linkText: originalClient.Uri.AbsolutePath);
 
             // Assert symlink was successfully created
             ShareFileProperties sourceProperties = await symlinkClient.GetPropertiesAsync();

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
@@ -10,6 +10,10 @@ using Azure.Storage.DataMovement.Tests;
 using BaseShares::Azure.Storage.Files.Shares;
 using Azure.Storage.Test.Shared;
 using DMShare::Azure.Storage.DataMovement.Files.Shares;
+using NUnit.Framework;
+using System.Threading;
+using Azure.Core.TestFramework;
+using BaseShares::Azure.Storage.Files.Shares.Models;
 
 namespace Azure.Storage.DataMovement.Files.Shares.Tests
 {
@@ -68,5 +72,119 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
         protected override Task<Stream> OpenReadAsync(ShareFileClient objectClient)
             => objectClient.OpenReadAsync();
+
+        [RecordedTest]
+        public async Task ShareFileToLocalFile_NfsHardLink()
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await ClientBuilder.GetTestShareSasNfsAsync();
+            using DisposingLocalDirectory destination = DisposingLocalDirectory.GetTestDirectory();
+
+            ShareDirectoryClient directory = source.Container.GetRootDirectoryClient();
+            ShareFileClient originalClient = await GetObjectClientAsync(
+                container: source.Container,
+                objectLength: DataMovementTestConstants.KB,
+                objectName: "original",
+                createObject: true);
+            ShareFileClient hardlinkClient = InstrumentClient(directory.GetFileClient("original-hardlink"));
+
+            // Create Hardlink
+            await hardlinkClient.CreateHardLinkAsync(
+                targetFile: $"{directory.Name}/{originalClient.Name}");
+
+            // Assert hardlink was successfully created
+            ShareFileProperties sourceProperties = await hardlinkClient.GetPropertiesAsync();
+            Assert.AreEqual(2, sourceProperties.PosixProperties.LinkCount);
+            Assert.AreEqual(NfsFileType.Regular, sourceProperties.PosixProperties.FileType);
+
+            // Use the hardlink to create the source file
+            StorageResource sourceResource = new ShareFileStorageResource(originalClient,
+                new ShareFileStorageResourceOptions() { IsNfs = true });
+
+            // Create destination local file
+            string destFile = Path.Combine(destination.DirectoryPath, GetNewObjectName());
+            StorageResource destinationResource = LocalFilesStorageResourceProvider.FromFile(destFile);
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            TransferManager transferManager = new TransferManager();
+
+            // Act - Start transfer and await for completion.
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                options);
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await TestTransferWithTimeout.WaitForCompletionAsync(
+                transfer,
+                testEventsRaised,
+                cancellationTokenSource.Token);
+
+            // Assert
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+            await testEventsRaised.AssertSingleCompletedCheck();
+
+            // Assert dest was copied as regular file
+            bool destExists = File.Exists(destinationResource.Uri.LocalPath);
+            Assert.IsTrue(destExists);
+            using Stream sourceStream = await hardlinkClient.OpenReadAsync();
+            using Stream destinationStream = File.OpenRead(destinationResource.Uri.LocalPath);
+            Assert.AreEqual(sourceStream.Length, destinationStream.Length);
+        }
+
+        [RecordedTest]
+        public async Task ShareFileToLocalFile_NfsSymbolicLink()
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await ClientBuilder.GetTestShareSasNfsAsync();
+            using DisposingLocalDirectory destination = DisposingLocalDirectory.GetTestDirectory();
+
+            ShareDirectoryClient directory = source.Container.GetRootDirectoryClient();
+            ShareFileClient originalClient = InstrumentClient(await directory.CreateFileAsync("original", maxSize: Constants.KB));
+            ShareFileClient symlinkClient = InstrumentClient(directory.GetFileClient("original-symlink"));
+
+            // Create Symlink
+            await symlinkClient.CreateSymbolicLinkAsync(linkText: originalClient.Uri.ToString());
+
+            // Assert symlink was successfully created
+            ShareFileProperties sourceProperties = await symlinkClient.GetPropertiesAsync();
+            Assert.AreEqual(1, sourceProperties.PosixProperties.LinkCount);
+            Assert.AreEqual(NfsFileType.SymLink, sourceProperties.PosixProperties.FileType);
+
+            // Use the symlink to create the source file
+            StorageResourceItem sourceResource = new ShareFileStorageResource(symlinkClient,
+                new ShareFileStorageResourceOptions() { IsNfs = true });
+
+            // Create destination local file
+            string destFile = Path.Combine(destination.DirectoryPath, GetNewObjectName());
+            StorageResource destinationResource = LocalFilesStorageResourceProvider.FromFile(destFile);
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            TransferManager transferManager = new TransferManager();
+
+            // Act - Start transfer and await for completion.
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                options);
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await TestTransferWithTimeout.WaitForCompletionAsync(
+                transfer,
+                testEventsRaised,
+                cancellationTokenSource.Token);
+
+            // Assert
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+            await testEventsRaised.AssertSingleCompletedCheck();
+
+            // Assert the Symlink was skipped and not copied
+            bool destExists = File.Exists(destinationResource.Uri.LocalPath);
+            Assert.IsFalse(destExists);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
@@ -99,7 +99,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Use the hardlink to create the source file
             StorageResource sourceResource = new ShareFileStorageResource(originalClient,
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             // Create destination local file
             string destFile = Path.Combine(destination.DirectoryPath, GetNewObjectName());
@@ -155,7 +155,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Use the symlink to create the source file
             StorageResourceItem sourceResource = new ShareFileStorageResource(symlinkClient,
-                new ShareFileStorageResourceOptions() { IsNfs = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
 
             // Create destination local file
             string destFile = Path.Combine(destination.DirectoryPath, GetNewObjectName());

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -70,8 +70,6 @@ namespace Azure.Storage.DataMovement
         public StorageResourceContainerProperties() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Collections.Generic.IDictionary<string, object> RawProperties { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public System.Uri Uri { get { throw null; } set { } }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceCopyFromUriOptions
@@ -130,6 +128,8 @@ namespace Azure.Storage.DataMovement
         protected internal abstract System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResourceReadStreamResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected internal virtual System.Threading.Tasks.Task<bool> ValidateItemTransferAsync(Azure.Storage.DataMovement.StorageResourceItem destItem, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties
@@ -144,8 +144,6 @@ namespace Azure.Storage.DataMovement
         public System.Collections.Generic.IDictionary<string, object> RawProperties { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public long? ResourceLength { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public System.Uri Uri { get { throw null; } set { } }
     }
     public abstract partial class StorageResourceProvider
     {

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<bool> ValidateItemTransferAsync(Azure.Storage.DataMovement.StorageResourceItem destItem, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<bool> ShouldTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<bool> ShouldTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<bool> ShouldItemTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
@@ -70,8 +70,6 @@ namespace Azure.Storage.DataMovement
         public StorageResourceContainerProperties() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Collections.Generic.IDictionary<string, object> RawProperties { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public System.Uri Uri { get { throw null; } set { } }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceCopyFromUriOptions
@@ -130,6 +128,8 @@ namespace Azure.Storage.DataMovement
         protected internal abstract System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResourceReadStreamResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected internal virtual System.Threading.Tasks.Task<bool> ValidateItemTransferAsync(Azure.Storage.DataMovement.StorageResourceItem destItem, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties
@@ -144,8 +144,6 @@ namespace Azure.Storage.DataMovement
         public System.Collections.Generic.IDictionary<string, object> RawProperties { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public long? ResourceLength { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public System.Uri Uri { get { throw null; } set { } }
     }
     public abstract partial class StorageResourceProvider
     {

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<bool> ValidateItemTransferAsync(Azure.Storage.DataMovement.StorageResourceItem destItem, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<bool> ShouldTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<bool> ShouldTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<bool> ShouldItemTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -70,8 +70,6 @@ namespace Azure.Storage.DataMovement
         public StorageResourceContainerProperties() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Collections.Generic.IDictionary<string, object> RawProperties { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public System.Uri Uri { get { throw null; } set { } }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceCopyFromUriOptions
@@ -130,6 +128,8 @@ namespace Azure.Storage.DataMovement
         protected internal abstract System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResourceReadStreamResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected internal virtual System.Threading.Tasks.Task<bool> ValidateItemTransferAsync(Azure.Storage.DataMovement.StorageResourceItem destItem, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties
@@ -144,8 +144,6 @@ namespace Azure.Storage.DataMovement
         public System.Collections.Generic.IDictionary<string, object> RawProperties { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public long? ResourceLength { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public System.Uri Uri { get { throw null; } set { } }
     }
     public abstract partial class StorageResourceProvider
     {

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<bool> ValidateItemTransferAsync(Azure.Storage.DataMovement.StorageResourceItem destItem, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<bool> ShouldTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.DataMovement
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal abstract System.Threading.Tasks.Task SetPermissionsAsync(Azure.Storage.DataMovement.StorageResourceItem sourceResource, Azure.Storage.DataMovement.StorageResourceItemProperties sourceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected internal virtual System.Threading.Tasks.Task<bool> ShouldTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<bool> ShouldItemTransferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class StorageResourceItemProperties

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
@@ -211,7 +211,6 @@ namespace Azure.Storage.DataMovement
             if (fileInfo.Exists)
             {
                 StorageResourceItemProperties properties = fileInfo.ToStorageResourceProperties();
-                properties.Uri = Uri;
                 return Task.FromResult(properties);
             }
             throw new FileNotFoundException();

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -155,6 +155,12 @@ namespace Azure.Storage.DataMovement
                 }
                 await OnTransferStateChangedAsync(TransferState.InProgress).ConfigureAwait(false);
 
+                if (!await _sourceResource.ValidateItemTransferAsync(_destinationResource, _cancellationToken).ConfigureAwait(false))
+                {
+                    await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
+                    return;
+                }
+
                 StorageResourceItemProperties sourceProperties =
                     await _sourceResource.GetPropertiesAsync(_cancellationToken).ConfigureAwait(false);
                 if (!sourceProperties.ResourceLength.HasValue)

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -155,7 +155,7 @@ namespace Azure.Storage.DataMovement
                 }
                 await OnTransferStateChangedAsync(TransferState.InProgress).ConfigureAwait(false);
 
-                if (!await _sourceResource.ValidateItemTransferAsync(_destinationResource, _cancellationToken).ConfigureAwait(false))
+                if (!await _sourceResource.ShouldTransferAsync(_cancellationToken).ConfigureAwait(false))
                 {
                     await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
                     return;

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -155,7 +155,7 @@ namespace Azure.Storage.DataMovement
                 }
                 await OnTransferStateChangedAsync(TransferState.InProgress).ConfigureAwait(false);
 
-                if (!await _sourceResource.ShouldTransferAsync(_cancellationToken).ConfigureAwait(false))
+                if (!await _sourceResource.ShouldItemTransferAsync(_cancellationToken).ConfigureAwait(false))
                 {
                     await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
                     return;

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
@@ -164,6 +164,8 @@ namespace Azure.Storage.DataMovement
             internal const string Owner = "Owner";
             internal const string Group = "Group";
             internal const string FileMode = "FileMode";
+            internal const string FileType = "FileType";
+            internal const string LinkCount = "LinkCount";
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
@@ -27,7 +27,6 @@ namespace Azure.Storage.DataMovement
         {
             return new StorageResourceContainerProperties()
             {
-                Uri = properties.Uri,
                 RawProperties = properties.RawProperties
             };
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceContainerProperties.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceContainerProperties.cs
@@ -14,12 +14,6 @@ namespace Azure.Storage.DataMovement
     public class StorageResourceContainerProperties
     {
         /// <summary>
-        /// The Uri of the Storage Resource Container.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Uri Uri { get; set; }
-
-        /// <summary>
         /// Dictionary of the properties associated with this resource container.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
@@ -245,18 +245,15 @@ namespace Azure.Storage.DataMovement
         /// <summary>
         /// Determines whether to perform the item transfer. This should be called on the source resource item.
         /// </summary>
-        /// <param name="destItem">
-        /// The destination resource item.
-        /// </param>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// Whether the item transfer can be performed.
+        /// Whether the item transfer should be performed.
         /// </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected internal virtual Task<bool> ValidateItemTransferAsync(StorageResourceItem destItem, CancellationToken cancellationToken = default)
+        protected internal virtual Task<bool> ShouldTransferAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(true);
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
@@ -253,7 +253,7 @@ namespace Azure.Storage.DataMovement
         /// Whether the item transfer should be performed.
         /// </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected internal virtual Task<bool> ShouldTransferAsync(CancellationToken cancellationToken = default)
+        protected internal virtual Task<bool> ShouldItemTransferAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(true);
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
@@ -241,5 +241,22 @@ namespace Azure.Storage.DataMovement
         /// </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected internal abstract Task<bool> DeleteIfExistsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deermines whether to perform the item transfer. This should be called on the source resource item.
+        /// </summary>
+        /// <param name="destItem">
+        /// The destination resource item.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Optional <see cref="CancellationToken"/> to propagate
+        /// notifications that the operation should be cancelled.
+        /// </param>
+        /// <returns>
+        /// Whether the item transfer can be performed.
+        /// </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal virtual Task<bool> ValidateItemTransferAsync(StorageResourceItem destItem, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
@@ -243,7 +243,7 @@ namespace Azure.Storage.DataMovement
         protected internal abstract Task<bool> DeleteIfExistsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Deermines whether to perform the item transfer. This should be called on the source resource item.
+        /// Determines whether to perform the item transfer. This should be called on the source resource item.
         /// </summary>
         /// <param name="destItem">
         /// The destination resource item.

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItemProperties.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItemProperties.cs
@@ -14,12 +14,6 @@ namespace Azure.Storage.DataMovement
     public class StorageResourceItemProperties
     {
         /// <summary>
-        /// The Uri of the resource.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Uri Uri { get; set; }
-
-        /// <summary>
         /// The length of the resource.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -166,7 +166,7 @@ namespace Azure.Storage.DataMovement
                 }
                 await OnTransferStateChangedAsync(TransferState.InProgress).ConfigureAwait(false);
 
-                if (!await _sourceResource.ShouldTransferAsync(_cancellationToken).ConfigureAwait(false))
+                if (!await _sourceResource.ShouldItemTransferAsync(_cancellationToken).ConfigureAwait(false))
                 {
                     await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
                     return;

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -166,7 +166,7 @@ namespace Azure.Storage.DataMovement
                 }
                 await OnTransferStateChangedAsync(TransferState.InProgress).ConfigureAwait(false);
 
-                if (!await _sourceResource.ValidateItemTransferAsync(_destinationResource, _cancellationToken).ConfigureAwait(false))
+                if (!await _sourceResource.ShouldTransferAsync(_cancellationToken).ConfigureAwait(false))
                 {
                     await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
                     return;

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -166,6 +166,12 @@ namespace Azure.Storage.DataMovement
                 }
                 await OnTransferStateChangedAsync(TransferState.InProgress).ConfigureAwait(false);
 
+                if (!await _sourceResource.ValidateItemTransferAsync(_destinationResource, _cancellationToken).ConfigureAwait(false))
+                {
+                    await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
+                    return;
+                }
+
                 if (!_sourceResource.Length.HasValue)
                 {
                     await UnknownLengthDownloadAsync().ConfigureAwait(false);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.DataMovement.Tests
                     }));
             mock.Setup(b => b.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<HttpAuthorization>(default));
-            mock.Setup(b => b.ValidateItemTransferAsync(It.IsAny<StorageResourceItem>(), It.IsAny<CancellationToken>()))
+            mock.Setup(b => b.ShouldTransferAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
             return mock;
         }
@@ -91,7 +91,7 @@ namespace Azure.Storage.DataMovement.Tests
             source.Verify(b => b.ResourceId, Times.Exactly(2));
             source.Verify(b => b.IsContainer, Times.Once());
             source.Verify(b => b.GetSourceCheckpointDetails(), Times.Once());
-            source.Verify(b => b.ValidateItemTransferAsync(It.IsAny<StorageResourceItem>(), It.IsAny<CancellationToken>()));
+            source.Verify(b => b.ShouldTransferAsync(It.IsAny<CancellationToken>()));
             source.Verify(b => b.GetPropertiesAsync(It.IsAny<CancellationToken>()));
             source.Verify(b => b.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()));
             source.VerifyNoOtherCalls();

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
@@ -36,6 +36,8 @@ namespace Azure.Storage.DataMovement.Tests
                     }));
             mock.Setup(b => b.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<HttpAuthorization>(default));
+            mock.Setup(b => b.ValidateItemTransferAsync(It.IsAny<StorageResourceItem>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(true));
             return mock;
         }
 
@@ -89,6 +91,7 @@ namespace Azure.Storage.DataMovement.Tests
             source.Verify(b => b.ResourceId, Times.Exactly(2));
             source.Verify(b => b.IsContainer, Times.Once());
             source.Verify(b => b.GetSourceCheckpointDetails(), Times.Once());
+            source.Verify(b => b.ValidateItemTransferAsync(It.IsAny<StorageResourceItem>(), It.IsAny<CancellationToken>()));
             source.Verify(b => b.GetPropertiesAsync(It.IsAny<CancellationToken>()));
             source.Verify(b => b.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()));
             source.VerifyNoOtherCalls();

--- a/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/CleanUpTransferTests.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.DataMovement.Tests
                     }));
             mock.Setup(b => b.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<HttpAuthorization>(default));
-            mock.Setup(b => b.ShouldTransferAsync(It.IsAny<CancellationToken>()))
+            mock.Setup(b => b.ShouldItemTransferAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
             return mock;
         }
@@ -91,7 +91,7 @@ namespace Azure.Storage.DataMovement.Tests
             source.Verify(b => b.ResourceId, Times.Exactly(2));
             source.Verify(b => b.IsContainer, Times.Once());
             source.Verify(b => b.GetSourceCheckpointDetails(), Times.Once());
-            source.Verify(b => b.ShouldTransferAsync(It.IsAny<CancellationToken>()));
+            source.Verify(b => b.ShouldItemTransferAsync(It.IsAny<CancellationToken>()));
             source.Verify(b => b.GetPropertiesAsync(It.IsAny<CancellationToken>()));
             source.Verify(b => b.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()));
             source.VerifyNoOtherCalls();

--- a/sdk/storage/Azure.Storage.DataMovement/tests/MockStorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/MockStorageResourceItem.cs
@@ -96,7 +96,6 @@ namespace Azure.Storage.DataMovement.Tests
         {
             return Task.FromResult(new StorageResourceItemProperties()
             {
-                Uri = Uri,
                 ResourceLength = Length ?? 0,
                 ETag = new ETag("etag"),
                 LastModifiedTime = DateTimeOffset.UtcNow

--- a/sdk/storage/Azure.Storage.DataMovement/tests/ServiceToServiceJobPartTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/ServiceToServiceJobPartTests.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.DataMovement.Tests
                 .Returns(Task.FromResult(properties));
             mockSource.Setup(r => r.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(httpAuthorization));
-            mockSource.Setup(b => b.ValidateItemTransferAsync(It.IsAny<StorageResourceItem>(), It.IsAny<CancellationToken>()))
+            mockSource.Setup(b => b.ShouldTransferAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
             // Set up Destination to copy in one shot with a large chunk size and smaller total length.
@@ -204,7 +204,7 @@ namespace Azure.Storage.DataMovement.Tests
             StorageResourceItemProperties properties = GetResourceProperties(length);
             mockSource.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(properties));
-            mockSource.Setup(b => b.ValidateItemTransferAsync(It.IsAny<StorageResourceItem>(), It.IsAny<CancellationToken>()))
+            mockSource.Setup(b => b.ShouldTransferAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
             // Setup destination with small chunk size and a larger source total length

--- a/sdk/storage/Azure.Storage.DataMovement/tests/ServiceToServiceJobPartTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/ServiceToServiceJobPartTests.cs
@@ -129,6 +129,8 @@ namespace Azure.Storage.DataMovement.Tests
                 .Returns(Task.FromResult(properties));
             mockSource.Setup(r => r.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(httpAuthorization));
+            mockSource.Setup(b => b.ValidateItemTransferAsync(It.IsAny<StorageResourceItem>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(true));
 
             // Set up Destination to copy in one shot with a large chunk size and smaller total length.
             Mock<StorageResourceItem> mockDestination = GetStorageResourceItem();
@@ -202,6 +204,8 @@ namespace Azure.Storage.DataMovement.Tests
             StorageResourceItemProperties properties = GetResourceProperties(length);
             mockSource.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(properties));
+            mockSource.Setup(b => b.ValidateItemTransferAsync(It.IsAny<StorageResourceItem>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(true));
 
             // Setup destination with small chunk size and a larger source total length
             // to cause chunked copy

--- a/sdk/storage/Azure.Storage.DataMovement/tests/ServiceToServiceJobPartTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/ServiceToServiceJobPartTests.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.DataMovement.Tests
                 .Returns(Task.FromResult(properties));
             mockSource.Setup(r => r.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(httpAuthorization));
-            mockSource.Setup(b => b.ShouldTransferAsync(It.IsAny<CancellationToken>()))
+            mockSource.Setup(b => b.ShouldItemTransferAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
             // Set up Destination to copy in one shot with a large chunk size and smaller total length.
@@ -204,7 +204,7 @@ namespace Azure.Storage.DataMovement.Tests
             StorageResourceItemProperties properties = GetResourceProperties(length);
             mockSource.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(properties));
-            mockSource.Setup(b => b.ShouldTransferAsync(It.IsAny<CancellationToken>()))
+            mockSource.Setup(b => b.ShouldItemTransferAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
             // Setup destination with small chunk size and a larger source total length

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceItem.cs
@@ -80,7 +80,6 @@ namespace Azure.Storage.DataMovement.Tests
         {
             return Task.FromResult(new StorageResourceItemProperties()
             {
-                Uri = Uri,
                 ResourceLength = Buffer.Length,
                 ETag = new ETag("etag"),
                 LastModifiedTime = DateTimeOffset.UtcNow


### PR DESCRIPTION
According to the Files team, this is the phase 1 feature for Hardlinks and Symlinks:

- Hard links will be copied as regular files
- Soft links will be skipped

This PR introduces the above features only for ShareFile-to-ShareFile Copy and Download (Uploads will not be supported since it is not feasible to determine hardlink/softlink for local files). This PR also contains some cleanup from previous NFS over REST PRs including:

- removing Uri field from Properties (since we only support preservation for ShareFile-to-ShareFile Copy)
- changing isNfs to ShareProtocol
- performing protocol validation only for Share-to-Share Copy
