### PR TITLE
[Storage] [DataMovement] Fixed issue where transfers added concurrently to local checkpointer throws

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed issue where transfers added concurrently to the local checkpointer would throw collision exceptions
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Fixed issue where transfers added concurrently to the local checkpointer would throw collision exceptions
+- Fixed issue where transfers added concurrently to the local checkpointer would throw collision exceptions intermittently.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
@@ -51,6 +51,9 @@ namespace Azure.Storage
         public static ArgumentException CollisionJobPart(string transferId, int jobPart)
             => throw new ArgumentException($"Job Part Collision Checkpointer: The job part {jobPart} for transfer id {transferId}, already exists in the checkpointer.");
 
+        public static ArgumentException CollisionJobPlanFile(string transferId)
+            => throw new ArgumentException($"Job Plan File collision checkpointer: The job {transferId}, already exists in the checkpointer.");
+
         public static ArgumentException MissingCheckpointerPath(string directoryPath)
             => throw new ArgumentException($"Could not initialize the LocalTransferCheckpointer because the folderPath passed does not exist. Please create the {directoryPath}, folder path first.");
 


### PR DESCRIPTION
 Fixed issue where transfers added concurrently to local checkpointer throws collision exceptions intermittently.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
