### PR TITLE
Make Azure.ResourceManager AOT-compatible

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientOptions.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientOptions.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text.Json;
 using Azure.Core;
 using Azure.ResourceManager.Resources;
+using Azure.ResourceManager;
 
 namespace Azure.ResourceManager
 {
@@ -47,12 +48,13 @@ namespace Azure.ResourceManager
             var assembly = Assembly.GetExecutingAssembly();
             using (Stream stream = assembly.GetManifestResourceStream(profile.GetManifestName()))
             {
-                var allProfile = BinaryData.FromStream(stream).ToObjectFromJson<Dictionary<string, Dictionary<string, object>>>();
+                var span = BinaryData.FromStream(stream).ToMemory().Span;
+                var allProfile = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, JsonElement>>>(span, ArmClientOptionsJsonContext.Default.DictionaryStringDictionaryStringJsonElement);
                 var armProfile = allProfile["resource-manager"];
                 foreach (var keyValuePair in armProfile)
                 {
                     var namespaceName = keyValuePair.Key;
-                    var element = (JsonElement)keyValuePair.Value;
+                    var element = keyValuePair.Value;
 
                     foreach (var apiVersionProperty in element.EnumerateObject())
                     {

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientOptionsJsonContext.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientOptionsJsonContext.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Azure.ResourceManager
+{
+    [JsonSourceGenerationOptions(WriteIndented = false)]
+    [JsonSerializable(typeof(Dictionary<string, Dictionary<string, JsonElement>>))]
+    internal partial class ArmClientOptionsJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmEnvironment.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmEnvironment.cs
@@ -77,6 +77,6 @@ namespace Azure.ResourceManager
         }
 
         /// <inheritdoc />
-        public override string ToString() => JsonSerializer.Serialize(this);
+        public override string ToString() => JsonSerializer.Serialize(this, ArmEnvironmentJsonContext.Default.ArmEnvironment);
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmEnvironmentJsonContext.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmEnvironmentJsonContext.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.ResourceManager
+{
+    [JsonSourceGenerationOptions(WriteIndented = false)]
+    [JsonSerializable(typeof(ArmEnvironment))]
+    internal partial class ArmEnvironmentJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Azure.ResourceManager.csproj
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Azure.ResourceManager.csproj
@@ -9,6 +9,7 @@
     <PackageTags>azure;management;resource</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <UseDefaultNamespaceAndOutputFolder>false</UseDefaultNamespaceAndOutputFolder>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/ManagedServiceIdentity.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/ManagedServiceIdentity.Serialization.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Azure.Core;
+using Azure.ResourceManager.Models;
 
 [assembly: CodeGenSuppressType("ManagedServiceIdentity")]
 namespace Azure.ResourceManager.Models


### PR DESCRIPTION
There were only two places which were not AOT compatible:

1. Use of non-source generated JSON.
2. One method which uses non-generated configuration bindings, which I've simply marked incompatible for now.

Note: almost all of this code was generated by VS Code CoPilot w/ Agent Mode. If you're interested in the prompts I used and the chat session, contact me privately and I'd be happy to share the whole session.