### PR TITLE
[Azure.Developer.LoadTesting] Updated tests to be more stable

### DIFF
--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/assets.json
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/loadtestservice/Azure.Developer.LoadTesting",
-  "Tag": "net/loadtestservice/Azure.Developer.LoadTesting_72afcd7526"
+  "Tag": "net/loadtestservice/Azure.Developer.LoadTesting_577293327e"
 }

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/LoadTestRunClientTest.cs
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/LoadTestRunClientTest.cs
@@ -105,6 +105,8 @@ namespace Azure.Developer.LoadTesting.Tests
         [Category(REQUIRES_TEST_RUN)]
         public async Task GetTestRun()
         {
+            await _testRunOperation.WaitForCompletionAsync();
+
             var testRunResponse = await _loadTestRunClient.GetTestRunAsync(_testRunId);
             var testRun = testRunResponse.Value;
             Assert.NotNull(testRun);
@@ -116,6 +118,8 @@ namespace Azure.Developer.LoadTesting.Tests
         [Category(REQUIRES_TEST_RUN)]
         public async Task GetTestRunFile()
         {
+            await _testRunOperation.WaitForCompletionAsync();
+
             var testRunFileResponse = await _loadTestRunClient.GetTestRunFileAsync(_testRunId, _fileName);
             Assert.NotNull(testRunFileResponse.Value);
             Assert.AreEqual(_fileName, testRunFileResponse.Value.FileName);
@@ -126,6 +130,8 @@ namespace Azure.Developer.LoadTesting.Tests
         [Category(REQUIRES_TEST_RUN)]
         public async Task ListTestRuns()
         {
+            await _testRunOperation.WaitForCompletionAsync();
+
             int pageSizeHint = 2;
             var pagedResponse = _loadTestRunClient.GetTestRunsAsync();
 
@@ -163,6 +169,7 @@ namespace Azure.Developer.LoadTesting.Tests
         [Category(SKIP_DELETE_TEST_RUN)]
         public async Task DeleteTestRun()
         {
+            await _testRunOperation.WaitForCompletionAsync();
             Response response = await _loadTestRunClient.DeleteTestRunAsync(_testRunId);
         }
 
@@ -180,6 +187,8 @@ namespace Azure.Developer.LoadTesting.Tests
         [Category(REQUIRES_TEST_RUN)]
         public async Task CreateOrUpdateAppComponents()
         {
+            await _testRunOperation.WaitForCompletionAsync();
+
             _resourceId = TestEnvironment.ResourceId;
 
             Response response = await _loadTestRunClient.CreateOrUpdateAppComponentsAsync(
@@ -211,6 +220,8 @@ namespace Azure.Developer.LoadTesting.Tests
         [Category(REQUIRES_TEST_RUN)]
         public async Task GetAppComponents()
         {
+            await _testRunOperation.WaitForCompletionAsync();
+
             _resourceId = TestEnvironment.ResourceId;
 
             await _loadTestRunClient.CreateOrUpdateAppComponentsAsync(
@@ -274,12 +285,16 @@ namespace Azure.Developer.LoadTesting.Tests
                 );
             JsonDocument jsonDocument = JsonDocument.Parse(response.Content.ToString());
             Assert.AreEqual(_resourceId, jsonDocument.RootElement.GetProperty("metrics").GetProperty(_resourceId).GetProperty("resourceId").ToString());
+
+            await _testRunOperation.WaitForCompletionAsync();
         }
 
         [Test]
         [Category(REQUIRES_TEST_RUN)]
         public async Task GetServerMetricsConfig()
         {
+            await _testRunOperation.WaitForCompletionAsync();
+
             _resourceId = TestEnvironment.ResourceId;
             await _loadTestRunClient.CreateOrUpdateServerMetricsConfigAsync(
                     _testRunId,

--- a/sdk/loadtestservice/test-resources.bicep
+++ b/sdk/loadtestservice/test-resources.bicep
@@ -1,8 +1,8 @@
 param baseName string = resourceGroup().name
-param location string = 'eastus'
+param location string = 'centralus'
 
 resource loadTests 'Microsoft.LoadTestService/loadTests@2022-12-01' = {
-  name: '${baseName}-loadTests'
+  name: '${baseName}-csharpsdk-loadTests'
   location: location
   properties: {
   }


### PR DESCRIPTION
The tests are instable since test runs are deleted immediately at times causing issues in live runs. Now any tests that dont need a live running test run will wait for test run completion. 

Also updated the resource region to Central US.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
