### PR TITLE
[Event Hubs] Preserve system property broker types

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
+
 ### Other Changes
 
 ## 5.12.1 (2025-04-09)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
+- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
 
 ### Other Changes
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
+
 ### Other Changes
 
 ## 5.12.1 (2025-04-09)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
+- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
 
 ### Other Changes
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
@@ -173,7 +173,13 @@ namespace Azure.Messaging.EventHubs.Amqp
             if ((instance.HasSection(AmqpMessageSection.MessageAnnotations))
                 && (instance.MessageAnnotations.TryGetValue(AmqpProperty.SequenceNumber.ToString(), out var value)))
             {
-                return (long)value;
+                return value switch
+                {
+                    string stringValue when long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue) => longValue,
+                    long longValue => longValue,
+                    int intValue => intValue,
+                    _ => (long)value
+                };
             }
 
             return defaultValue;
@@ -215,7 +221,13 @@ namespace Azure.Messaging.EventHubs.Amqp
             if ((instance.HasSection(AmqpMessageSection.MessageAnnotations))
                 && (instance.MessageAnnotations.TryGetValue(AmqpProperty.EnqueuedTime.ToString(), out var value)))
             {
-                return (DateTimeOffset)value;
+                return value switch
+                {
+                    DateTime dateValue => new DateTimeOffset(dateValue, TimeSpan.Zero),
+                    long longValue => new DateTimeOffset(longValue, TimeSpan.Zero),
+                    DateTimeOffset dateTimeOffsetValue => dateTimeOffsetValue,
+                    _ => (DateTimeOffset)value
+                };
             }
 
             return defaultValue;
@@ -231,7 +243,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         public static void SetEnqueuedTime(this AmqpAnnotatedMessage instance,
                                            DateTimeOffset enqueueTime)
         {
-            instance.MessageAnnotations[AmqpProperty.EnqueuedTime.ToString()] = enqueueTime;
+            instance.MessageAnnotations[AmqpProperty.EnqueuedTime.ToString()] = enqueueTime.UtcDateTime;
         }
 
         /// <summary>
@@ -283,7 +295,12 @@ namespace Azure.Messaging.EventHubs.Amqp
             if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
                 && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.PartitionLastEnqueuedSequenceNumber.ToString(), out var value)))
             {
-                return (long)value;
+                return value switch
+                {
+                    string stringValue when long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue) => longValue,
+                    long longValue => longValue,
+                    _ => (long)value
+                };
             }
 
             return defaultValue;
@@ -299,7 +316,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <returns>The offset of the last event published to the partition, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
         ///
         public static string GetLastPartitionOffset(this AmqpAnnotatedMessage instance,
-                                                   string defaultValue = default)
+                                                    string defaultValue = default)
         {
             if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
                 && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.PartitionLastEnqueuedOffset.ToString(), out var value)))
@@ -325,7 +342,13 @@ namespace Azure.Messaging.EventHubs.Amqp
             if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
                 && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.PartitionLastEnqueuedTimeUtc.ToString(), out var value)))
             {
-                return (DateTimeOffset)value;
+                return value switch
+                {
+                    DateTime dateValue => new DateTimeOffset(dateValue, TimeSpan.Zero),
+                    long longValue => new DateTimeOffset(longValue, TimeSpan.Zero),
+                    DateTimeOffset dateTimeOffsetValue => dateTimeOffsetValue,
+                    _ => (DateTimeOffset)value
+                };
             }
 
             return defaultValue;
@@ -346,10 +369,48 @@ namespace Azure.Messaging.EventHubs.Amqp
             if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
                 && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.LastPartitionPropertiesRetrievalTimeUtc.ToString(), out var value)))
             {
-                return (DateTimeOffset)value;
+                return value switch
+                {
+                    DateTime dateValue => new DateTimeOffset(dateValue, TimeSpan.Zero),
+                    long longValue => new DateTimeOffset(longValue, TimeSpan.Zero),
+                    DateTimeOffset dateTimeOffsetValue => dateTimeOffsetValue,
+                    _ => (DateTimeOffset)value
+                };
             }
 
             return defaultValue;
+        }
+
+        /// <summary>
+        ///   Retrieves the value for a specific message annotation of an <see cref="AmqpAnnotatedMessage" />
+        ///   in normalized form.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="key">The key of the message annotation value to retrieve.</param>
+        ///
+        /// <returns>The normalized value for the specified <paramref name="key"/>, if present in the <paramref name="instance"/>; otherwise, the default value for the key.</returns>
+        ///
+        public static object GetMessageAnnotationNormalizedValue(this AmqpAnnotatedMessage instance,
+                                                                 string key)
+        {
+            if (!instance.HasSection(AmqpMessageSection.MessageAnnotations))
+            {
+                return null;
+            }
+
+            return key switch
+            {
+                _ when key == AmqpProperty.EnqueuedTime.ToString() => GetEnqueuedTime(instance, default),
+                _ when key == AmqpProperty.SequenceNumber.ToString() => GetSequenceNumber(instance, default),
+                _ when instance.MessageAnnotations.TryGetValue(key, out var value) => value switch
+                {
+                    AmqpMessageId id => id.ToString(),
+                    AmqpAddress address => address.ToString(),
+                    _ => value
+                },
+                _ => null
+            };
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpSystemProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpSystemProperties.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -25,8 +26,8 @@ namespace Azure.Messaging.EventHubs.Amqp
     internal class AmqpSystemProperties : IReadOnlyDictionary<string, object>
     {
         /// <summary>The set of system properties that are sourced from the Properties section of the <see cref="AmqpAnnotatedMessage" />.</summary>
-        private static readonly string[] PropertySectionNames = new[]
-        {
+        private static readonly string[] PropertySectionNames =
+        [
            Properties.MessageIdName,
            Properties.UserIdName,
            Properties.ToName,
@@ -40,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Amqp
            Properties.GroupIdName,
            Properties.GroupSequenceName,
            Properties.ReplyToGroupIdName
-        };
+        ];
 
         /// <summary>The AMQP message to use as the source for the system properties data.</summary>
         private readonly AmqpAnnotatedMessage _amqpMessage;
@@ -130,12 +131,15 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 if (_amqpMessage.HasSection(AmqpMessageSection.MessageAnnotations))
                 {
-                    return _amqpMessage.MessageAnnotations[key] switch
+                    var annotationValue = _amqpMessage.GetMessageAnnotationNormalizedValue(key);
+
+                    // If the value came back as null, only return it if the key exists.  Otherwise, allow
+                    // the KeyNotFoundException to be thrown.
+
+                    if ((annotationValue != null) || (_amqpMessage.MessageAnnotations.ContainsKey(key)))
                     {
-                        AmqpMessageId id => id.ToString(),
-                        AmqpAddress address => address.ToString(),
-                        object value => value
-                    };
+                        return annotationValue;
+                    }
                 }
 
                 // If no section was available to delegate to, mimic the behavior of the standard dictionary implementation.
@@ -196,7 +200,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 {
                     foreach (var name in _amqpMessage.MessageAnnotations.Keys)
                     {
-                        yield return _amqpMessage.MessageAnnotations[name];
+                        yield return _amqpMessage.GetMessageAnnotationNormalizedValue(name);
                     }
                 }
             }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
+- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
 
 ### Other Changes
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract.  Going forward, the original original data types will be preserved on the AMQP representation of the message and type normalization only applied to the .NET `EventData` projection.
+
 ### Other Changes
 
 ## 6.5.1 (2025-04-09)


### PR DESCRIPTION
# Summary 

The focus of these changes is to fix a bug where the data types of broker-owned properties were being adjusted when an event was read by the client, causing the underlying AMQP data to be mutated.  This resulted in binary changes when the AMQP message was serialized and unintentionally altered the service contract. Going forward, the original original data types will be preserved on the AMQP representation of the message and type
normalization only applied to the .NET `EventData` projection.

Also, because @swathipil told me to fix this or she would keep sending deep dish casseroles and insisting they were pizza.   This makes @LarryOsterman sad.