### PR TITLE
Default package-name to namespace option

### DIFF
--- a/eng/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/eng/packages/http-client-csharp/emitter/src/emitter.ts
@@ -14,6 +14,7 @@ export async function $onEmit(context: EmitContext<AzureEmitterOptions>) {
     name: "MIT License",
     company: "Microsoft Corporation"
   };
+  context.options["package-name"] ??= context.options["namespace"];
 
   // warn if use-model-namespaces is true, but namespace is not set
   if (context.options["model-namespace"] && !context.options["namespace"]) {

--- a/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
+++ b/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
@@ -63,6 +63,7 @@ describe("Configuration tests", async () => {
     const context = createEmitterContext(program, options);
     $onEmit(context);
     strictEqual(program.diagnostics.length, 0);
+    strictEqual(context.options.namespace, "Test.Namespace");
     strictEqual(context.options["package-name"], "Test.Namespace");
   });
   it("package-name undefined if namespace and package-name not set", async () => {
@@ -79,6 +80,7 @@ describe("Configuration tests", async () => {
     const context = createEmitterContext(program, options);
     $onEmit(context);
     strictEqual(program.diagnostics.length, 0);
+    strictEqual(context.options.namespace, "Test.Namespace");
     strictEqual(context.options["package-name"], "Test.Package");
   });
 });

--- a/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
+++ b/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
@@ -1,5 +1,5 @@
 import { Program } from "@typespec/compiler";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import {
   createEmitterContext,
   createEmitterTestHost,
@@ -19,6 +19,15 @@ describe("Configuration tests", async () => {
           `,
       runner
     );
+    vi.mock("@typespec/http-client-csharp", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@typespec/http-client-csharp")>();
+      return {
+        ...actual,
+        $onEmit: async (context: any) => {
+          // do nothing
+        }
+      };
+    })
   });
 
   it("Diagnostic is logged when model-namespace is set without namespace", async () => {
@@ -47,4 +56,30 @@ describe("Configuration tests", async () => {
     $onEmit(context);
     strictEqual(program.diagnostics.length, 0);
   });
+  it("package-name defaults to namespace", async () => {
+    const options: AzureEmitterOptions = {
+      "namespace": "Test.Namespace"
+    };
+    const context = createEmitterContext(program, options);
+    $onEmit(context);
+    strictEqual(program.diagnostics.length, 0);
+    strictEqual(context.options["package-name"], "Test.Namespace");
+  });
+  it("package-name undefined if namespace and package-name not set", async () => {
+    const context = createEmitterContext(program);
+    $onEmit(context);
+    strictEqual(program.diagnostics.length, 0);
+    strictEqual(context.options["package-name"], undefined);
+  });
+  it("package-name value used if set", async () => {
+    const options: AzureEmitterOptions = {
+      "namespace": "Test.Namespace",
+      "package-name": "Test.Package"
+    };
+    const context = createEmitterContext(program, options);
+    $onEmit(context);
+    strictEqual(program.diagnostics.length, 0);
+    strictEqual(context.options["package-name"], "Test.Package");
+  });
 });
+

--- a/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
+++ b/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
@@ -23,7 +23,7 @@ describe("Configuration tests", async () => {
       const actual = await importOriginal<typeof import("@typespec/http-client-csharp")>();
       return {
         ...actual,
-        $onEmit: async (context: any) => {
+        $onEmit: async () => {
           // do nothing
         }
       };
@@ -70,6 +70,14 @@ describe("Configuration tests", async () => {
     const context = createEmitterContext(program);
     $onEmit(context);
     strictEqual(program.diagnostics.length, 0);
+    strictEqual(context.options["package-name"], undefined);
+  });
+  it("doesn't add package-name key if namespace is undefined", async () => {
+    const context = createEmitterContext(program);
+    $onEmit(context);
+    strictEqual(program.diagnostics.length, 0);
+    // key should not be added if namespace is undefined
+    // and package-name is not set
     strictEqual(context.options["package-name"], undefined);
   });
   it("package-name value used if set", async () => {

--- a/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
+++ b/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
@@ -72,14 +72,6 @@ describe("Configuration tests", async () => {
     strictEqual(program.diagnostics.length, 0);
     strictEqual(context.options["package-name"], undefined);
   });
-  it("doesn't add package-name key if namespace is undefined", async () => {
-    const context = createEmitterContext(program);
-    $onEmit(context);
-    strictEqual(program.diagnostics.length, 0);
-    // key should not be added if namespace is undefined
-    // and package-name is not set
-    strictEqual(context.options["package-name"], undefined);
-  });
   it("package-name value used if set", async () => {
     const options: AzureEmitterOptions = {
       "namespace": "Test.Namespace",

--- a/eng/packages/http-client-csharp/emitter/test/Unit/test-util.ts
+++ b/eng/packages/http-client-csharp/emitter/test/Unit/test-util.ts
@@ -93,7 +93,7 @@ export async function typeSpecCompile(
 export function createEmitterContext(
   program: Program,
   options: AzureEmitterOptions = {}
-): EmitContext<CSharpEmitterOptions> {
+): EmitContext<AzureEmitterOptions> {
   return {
     program: program,
     emitterOutputDir: "./",
@@ -107,7 +107,7 @@ export function createEmitterContext(
       "generate-convenience-methods": true,
       "package-name": undefined
     }
-  } as EmitContext<CSharpEmitterOptions>;
+  } as EmitContext<AzureEmitterOptions>;
 }
 
 /* We always need to pass in the emitter name now that it is required so making a helper to do this. */

--- a/eng/packages/http-client-csharp/emitter/test/Unit/test-util.ts
+++ b/eng/packages/http-client-csharp/emitter/test/Unit/test-util.ts
@@ -8,7 +8,6 @@ import { CompilerOptions, EmitContext, Program } from "@typespec/compiler";
 import { createTestHost, TestHost } from "@typespec/compiler/testing";
 import {
   CSharpEmitterContext,
-  CSharpEmitterOptions,
   createCSharpEmitterContext,
   Logger,
   LoggerLevel,


### PR DESCRIPTION
Namespace is set for majority of azure libraries, but package-name is a new option in the new generator. We should default it to namespace.