### PR TITLE
[Service Bus] Fix Batch Delete Limit

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -35,7 +35,7 @@ namespace Azure.Messaging.ServiceBus
     public class ServiceBusReceiver : IAsyncDisposable
     {
         /// <summary>The maximum number of messages to delete in a single batch.  This cap is established and enforced by the service.</summary>
-        internal const int MaxDeleteMessageCount = 4000;
+        internal const int MaxDeleteMessageCount = 500;
 
         /// <summary>The set of default options to use for initialization when no explicit options were provided.</summary>
         private static ServiceBusReceiverOptions s_defaultOptions;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -648,7 +648,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         [Test]
         public async Task DeleteMessagesForCountPassesTheCurrentDate()
         {
-            var expectedCount = 2000;
+            var expectedCount = 400;
             var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
             var mockTransportReceiver = new Mock<TransportReceiver>();
 
@@ -696,8 +696,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         {
             using var cancellationSource = new CancellationTokenSource();
 
-            var requestedCount = 2500;
-            var expectedCount = 2000;
+            var requestedCount = 500;
+            var expectedCount = 400;
             var expectedDate = new DateTimeOffset(2015, 10, 27, 0, 0, 0, 0, TimeSpan.Zero);
             var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
             var mockTransportReceiver = new Mock<TransportReceiver>();


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the message limit applied to the preview batch delete feature, as the service thresholds have changed. 