### PR TITLE
fix storage ci.yml issue.

### DIFF
--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -9,10 +9,6 @@ trigger:
   paths:
     include:
     - sdk/storage/
-    - sdk/storage/Azure.Storage.DataMovement/
-    - sdk/storage/Azure.Storage.DataMovement.Blobs/
-    - sdk/storage/Azure.Storage.DataMovement.Files/
-    - sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/
     exclude:
     - sdk/storage/Azure.ResourceManager.Storage/
     - sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

fix [issue 50137](https://github.com/Azure/azure-sdk-for-net/issues/50137). 

As mentioned on the issue page, the current format of the storage ci.yml file does not work well with one script used in the Auto spec PR generation.  As For the change itself, since the path sdk/storage is already included, I assume it's safe to delete the other include paths.
