### PR TITLE
Wrap the generateCode import in condition

### DIFF
--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -1,39 +1,24 @@
 <Project>
-
+  
   <PropertyGroup>
-    <_AutoRestVersion>https://github.com/Azure/autorest/releases/download/autorest-3.0.6236/autorest-3.0.6236.tgz</_AutoRestVersion>
-    <_AutoRestCoreVersion>3.0.6306</_AutoRestCoreVersion>
-    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200811.1/autorest-csharp-v3-3.0.0-dev.20200811.1.tgz</_AutoRestCSharpVersion>
-    <_SupportsCodeGeneration Condition="'$(IsClientLibrary)' == 'true'">true</_SupportsCodeGeneration>
-    <_DefaultInputName Condition="Exists('$(MSBuildProjectDirectory)/autorest.md')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
-    <AutoRestInput Condition="'$(AutoRestInput)' == ''">$(_DefaultInputName)</AutoRestInput>
-    <!--
-      Allows passing additional AutoRest command line arguments, for example to run in interactive mode
-      use the following command line (remove the space between minus minus): dotnet build /t:GenerateCode /p:AutoRestAdditionalParameters="- -interactive"
-    -->
-    <AutoRestAdditionalParameters></AutoRestAdditionalParameters>
-
-    <_GenerateCode Condition="'$(_SupportsCodeGeneration)' == 'true' AND '$(AutoRestInput)' != ''">true</_GenerateCode>
+    <TypeSpecInput Condition="Exists('$(MSBuildProjectDirectory)/../tsp-location.yaml') and $(MSBuildProjectDirectory.EndsWith('src'))">$(MSBuildProjectDirectory)/../tsp-location.yaml</TypeSpecInput>
+    <_TypeSpecProjectGenerateCommand>npx --no-install --package=@azure-tools/typespec-client-generator-cli --yes tsp-client generate --no-prompt --output-dir $(MSBuildProjectDirectory)/../</_TypeSpecProjectGenerateCommand>
+    <_TypeSpecProjectSyncAndGenerateCommand>npx --no-install --package=@azure-tools/typespec-client-generator-cli --yes tsp-client update --no-prompt --output-dir $(MSBuildProjectDirectory)/../</_TypeSpecProjectSyncAndGenerateCommand>
+    <_SaveInputs Condition="'$(SaveInputs)' == 'true'">--save-inputs</_SaveInputs>
+    <!-- Here we append the generate-test-project configuration to TypespecAdditionalOptions if it is specified -->
+    <TypespecAdditionalOptions Condition="'$(GenerateTestProject)' != '' AND '$(TypespecAdditionalOptions)' != ''">$(TypespecAdditionalOptions)%3Bgenerate-test-project=true</TypespecAdditionalOptions>
+    <TypespecAdditionalOptions Condition="'$(GenerateTestProject)' != '' AND '$(TypespecAdditionalOptions)' == ''">generate-test-project=true</TypespecAdditionalOptions>
+    <_TypespecAdditionalOptions Condition="'$(TypespecAdditionalOptions)' != ''">--emitter-options "$(TypespecAdditionalOptions)"</_TypespecAdditionalOptions>
+    <_LocalSpecRepo Condition="'$(LocalSpecRepo)' != ''">--local-spec-repo $(LocalSpecRepo)</_LocalSpecRepo>
   </PropertyGroup>
 
-  <PropertyGroup>
-  </PropertyGroup>
-
-  <Target Name="GenerateCode" Condition="'$(_GenerateCode)' == 'true'" >
-    <ReadLinesFromFile File="$(AutoRestInput)">
-       <Output TaskParameter="Lines" ItemName="AutoRestInputLines"/>
-    </ReadLinesFromFile>
-
-   <ItemGroup>
-      <GithubUrls Include="$([System.Text.RegularExpressions.Regex]::Match('%(AutoRestInputLines.Identity)', 'https?://(raw.)?github.+'))" />
-      <GithubUrlsWithoutIssues Include="%(GithubUrls.Identity)" Condition="! ($([System.Text.RegularExpressions.Regex]::IsMatch('%(GithubUrls.Identity)', '/issues/\d+')))" />
-      <GithubUrlsWithoutHash Include="%(GithubUrlsWithoutIssues.Identity)" Condition="! ($([System.Text.RegularExpressions.Regex]::IsMatch('%(GithubUrlsWithoutIssues.Identity)', '[\w\d]{40}')))" />
-    </ItemGroup>
-
-    <Error Text="Following GitHub URLs do not contain commit hash: @(GithubUrlsWithoutHash) please use permalinks for code generation inputs (see https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) " Condition="'@(GithubUrlsWithoutHash)' != ''" />
-
-    <RemoveDir Directories="$(MSBuildProjectDirectory)/Generated"/>
-    <Exec Command="npx autorest@$(_AutoRestVersion) --version=$(_AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(_AutoRestCSharpVersion) --output-folder=$(MSBuildProjectDirectory) --title=$(RootNamespace) --namespace=$(RootNamespace) --shared-source-folder=$(AutoRestSharedCodeDirectory).." />
+   <!-- For projects using the new TypeSpec generator, we don't include the Autorest dependency which pulls in the GenerateCode target. 
+   So we need to add it here. -->
+  <Target Name="GenerateCode" Condition="'$(TypeSpecInput)' != ''">
+    <Error Text="You used skipped sync but didn't have the TempTypeSpecFiles in your project directory.  Please run 'dotnet build /t:GenerateCode /p:SaveInputs=true' without SkipSync first at least once" Condition="'$(SkipSync)' == 'true' AND !Exists('$(MSBuildProjectDirectory)/../TempTypeSpecFiles')" />
+    <Exec Command="npm install --prefix $(MSBuildProjectDirectory)/../ @azure-tools/typespec-client-generator-cli --no-save" />
+    <Exec Condition="'$(SkipSync)' == 'true'" Command="$(_TypeSpecProjectGenerateCommand) $(_SaveInputs) $(_TypespecAdditionalOptions) $(_Debug)"/>
+    <Exec Condition="'$(SkipSync)' != 'true'" Command="$(_TypeSpecProjectSyncAndGenerateCommand) $(_SaveInputs) $(_LocalSpecRepo) $(_TypespecAdditionalOptions) $(_Debug)"/>
   </Target>
 
 </Project>

--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -13,6 +13,7 @@
     <!-- Client in this context is any library that is following the new Azure SDK guidelines -->
     <IsGeneratorLibrary Condition="'$(IsGeneratorLibrary)' == '' and $(MSBuildProjectName.StartsWith('Azure.Generator'))">true</IsGeneratorLibrary>
     <IsClientLibrary Condition="'$(IsClientLibrary)' == '' and $(MSBuildProjectName.StartsWith('Azure.'))">true</IsClientLibrary>
+    <IncludeAutorestDependency Condition="'$(IncludeAutorestDependency)' != 'false' and '$(IsClientLibrary)' == 'true'">true</IncludeAutorestDependency>
     <IsFunctionsLibrary Condition="'$(IsFunctionsLibrary)' == '' and $(MSBuildProjectName.StartsWith('Microsoft.Azure.WebJobs.Extensions.'))">true</IsFunctionsLibrary>
     <IsSourceGenerator Condition="'$(IsSourceGenerator)' == '' and $(MSBuildProjectName.EndsWith('.SourceGeneration'))">true</IsSourceGenerator>
 

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -89,7 +89,7 @@
 
   <!-- Add Client SDK Tools -->
   <ItemGroup>
-    <PackageReference Condition="'$(IsClientLibrary)' == 'true'" Include="Microsoft.Azure.AutoRest.CSharp" PrivateAssets="All" />
+    <PackageReference Condition="'$(IncludeAutorestDependency)' == 'true'" Include="Microsoft.Azure.AutoRest.CSharp" PrivateAssets="All" />
 
     <PackageReference Condition="'$(GenerateAPIListing)' == 'true'" Include="Microsoft.DotNet.GenAPI" PrivateAssets="All" />
 
@@ -172,7 +172,7 @@
 
   <Import Project="CodeCoverage.targets" Condition="'$(CollectCoverage)' == 'true'" />
 
-  <Import Project="CodeGeneration.targets" Condition="'$(TemporaryUsePreviousGeneratorVersion)' == 'true'" />
+  <Import Project="CodeGeneration.targets" Condition="'$(IncludeAutorestDependency)' != 'true'" />
 
   <Import Project="Azure.Management.Test.targets" Condition="'$(IsMgmtLibrary)' == 'true' and '$(IsTestProject)' == 'true'" />
 


### PR DESCRIPTION
`TemporaryUsePreviousGeneratorVersion` is not used anywhere so repurposing the existing CodeGeneration.targets to host the new GenerateCode target. We wrap the import of this target in a condition so it doesn't hide the autorest target for non-migrated libraries.