### PR TITLE
Make converter types public

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/ManagedServiceIdentity.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/ManagedServiceIdentity.Serialization.cs
@@ -246,12 +246,21 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<ManagedServiceIdentity>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class ManagedServiceIdentityConverter : JsonConverter<ManagedServiceIdentity>
+        /// <summary>
+        /// Converter for ManagedServiceIdentity type.
+        /// </summary>
+        public partial class ManagedServiceIdentityConverter : JsonConverter<ManagedServiceIdentity>
         {
+            /// <summary>
+            /// Converter for ManagedServiceIdentity type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, ManagedServiceIdentity model, JsonSerializerOptions options)
             {
                 model.Write(writer, new ModelReaderWriterOptions("W"), options);
             }
+            /// <summary>
+            /// Converter for ManagedServiceIdentity type.
+            /// </summary>
             public override ManagedServiceIdentity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/ManagedServiceIdentityType.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/ManagedServiceIdentityType.cs
@@ -13,13 +13,23 @@ namespace Azure.ResourceManager.Models
     [JsonConverter(typeof(ManagedServiceIdentityTypeConverter))]
     public readonly partial struct ManagedServiceIdentityType : IEquatable<ManagedServiceIdentityType>
     {
-        internal partial class ManagedServiceIdentityTypeConverter : JsonConverter<ManagedServiceIdentityType>
+        /// <summary>
+        /// Converter for ManagedServiceIdentityType type.
+        /// </summary>
+        public partial class ManagedServiceIdentityTypeConverter : JsonConverter<ManagedServiceIdentityType>
         {
+            /// <summary>
+            /// Converter for ManagedServiceIdentityType type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, ManagedServiceIdentityType model, JsonSerializerOptions options)
             {
                 writer.WritePropertyName("type");
                 writer.WriteStringValue(model.ToString());
             }
+
+            /// <summary>
+            /// Converter for ManagedServiceIdentityType type.
+            /// </summary>
             public override ManagedServiceIdentityType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/ArmPlan.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/ArmPlan.Serialization.cs
@@ -274,13 +274,22 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<ArmPlan>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class ArmPlanConverter : JsonConverter<ArmPlan>
+        /// <summary>
+        /// Converter for ArmPlan type.
+        /// </summary>
+        public partial class ArmPlanConverter : JsonConverter<ArmPlan>
         {
+            /// <summary>
+            /// Converter for ArmPlan type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, ArmPlan model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
 
+            /// <summary>
+            /// Converter for ArmPlan type.
+            /// </summary>
             public override ArmPlan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/ArmSku.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/ArmSku.Serialization.cs
@@ -272,13 +272,21 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<ArmSku>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class ArmSkuConverter : JsonConverter<ArmSku>
+        /// <summary>
+        /// Converter for ArmSku type.
+        /// </summary>
+        public partial class ArmSkuConverter : JsonConverter<ArmSku>
         {
+            /// <summary>
+            /// Converter for ArmSku type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, ArmSku model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
-
+            /// <summary>
+            /// Converter for ArmSku type.
+            /// </summary>
             public override ArmSku Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/EncryptionProperties.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/EncryptionProperties.Serialization.cs
@@ -173,13 +173,21 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<EncryptionProperties>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class EncryptionPropertiesConverter : JsonConverter<EncryptionProperties>
+        /// <summary>
+        /// Converter for EncryptionProperties type.
+        /// </summary>
+        public partial class EncryptionPropertiesConverter : JsonConverter<EncryptionProperties>
         {
+            /// <summary>
+            /// Converter for EncryptionProperties type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, EncryptionProperties model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
-
+            /// <summary>
+            /// Converter for EncryptionProperties type.
+            /// </summary>
             public override EncryptionProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/KeyVaultProperties.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/KeyVaultProperties.Serialization.cs
@@ -181,13 +181,21 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<KeyVaultProperties>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class KeyVaultPropertiesConverter : JsonConverter<KeyVaultProperties>
+        /// <summary>
+        /// Converter for KeyVaultProperties type.
+        /// </summary>
+        public partial class KeyVaultPropertiesConverter : JsonConverter<KeyVaultProperties>
         {
+            /// <summary>
+            /// Converter for KeyVaultProperties type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, KeyVaultProperties model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
-
+            /// <summary>
+            /// Converter for KeyVaultProperties type.
+            /// </summary>
             public override KeyVaultProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/OperationStatusResult.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/OperationStatusResult.Serialization.cs
@@ -390,13 +390,21 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<OperationStatusResult>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class OperationStatusResultConverter : JsonConverter<OperationStatusResult>
+        /// <summary>
+        /// Converter for OperationStatusResult type.
+        /// </summary>
+        public partial class OperationStatusResultConverter : JsonConverter<OperationStatusResult>
         {
+            /// <summary>
+            /// Converter for OperationStatusResult type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, OperationStatusResult model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
-
+            /// <summary>
+            /// Converter for OperationStatusResult type.
+            /// </summary>
             public override OperationStatusResult Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/SystemAssignedServiceIdentity.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/SystemAssignedServiceIdentity.Serialization.cs
@@ -193,13 +193,21 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<SystemAssignedServiceIdentity>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class SystemAssignedServiceIdentityConverter : JsonConverter<SystemAssignedServiceIdentity>
+        /// <summary>
+        /// Converter for SystemAssignedServiceIdentity type.
+        /// </summary>
+        public partial class SystemAssignedServiceIdentityConverter : JsonConverter<SystemAssignedServiceIdentity>
         {
+            /// <summary>
+            /// Converter for SystemAssignedServiceIdentity type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, SystemAssignedServiceIdentity model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
-
+            /// <summary>
+            /// Converter for SystemAssignedServiceIdentity type.
+            /// </summary>
             public override SystemAssignedServiceIdentity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/SystemData.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/SystemData.Serialization.cs
@@ -309,13 +309,21 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<SystemData>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class SystemDataConverter : JsonConverter<SystemData>
+        /// <summary>
+        /// Converter for SystemData type.
+        /// </summary>
+        public partial class SystemDataConverter : JsonConverter<SystemData>
         {
+            /// <summary>
+            /// Converter for SystemData type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, SystemData model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
-
+            /// <summary>
+            /// Converter for SystemData type.
+            /// </summary>
             public override SystemData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/UserAssignedIdentity.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/UserAssignedIdentity.Serialization.cs
@@ -173,13 +173,21 @@ namespace Azure.ResourceManager.Models
 
         string IPersistableModel<UserAssignedIdentity>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class UserAssignedIdentityConverter : JsonConverter<UserAssignedIdentity>
+        /// <summary>
+        /// Converter for UserAssignedIdentity type.
+        /// </summary>
+        public partial class UserAssignedIdentityConverter : JsonConverter<UserAssignedIdentity>
         {
+            /// <summary>
+            /// Converter for UserAssignedIdentity type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, UserAssignedIdentity model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
-
+            /// <summary>
+            /// Converter for UserAssignedIdentity type.
+            /// </summary>
             public override UserAssignedIdentity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/Models/SubResource.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/Models/SubResource.Serialization.cs
@@ -96,12 +96,21 @@ namespace Azure.ResourceManager.Resources.Models
 
         string IPersistableModel<SubResource>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class SubResourceConverter : JsonConverter<SubResource>
+        /// <summary>
+        /// Converter for SubResource type.
+        /// </summary>
+        public partial class SubResourceConverter : JsonConverter<SubResource>
         {
+            /// <summary>
+            /// Converter for SubResource type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, SubResource model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model);
             }
+            /// <summary>
+            /// Converter for SubResource type.
+            /// </summary>
             public override SubResource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/Models/WritableSubResource.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/Models/WritableSubResource.Serialization.cs
@@ -103,12 +103,21 @@ namespace Azure.ResourceManager.Resources.Models
 
         string IPersistableModel<WritableSubResource>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class WritableSubResourceConverter : JsonConverter<WritableSubResource>
+        /// <summary>
+        /// Converter for WritableSubResource type.
+        /// </summary>
+        public partial class WritableSubResourceConverter : JsonConverter<WritableSubResource>
         {
+            /// <summary>
+            /// Converter for WritableSubResource type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, WritableSubResource model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model);
             }
+            /// <summary>
+            /// Converter for WritableSubResource type.
+            /// </summary>
             public override WritableSubResource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/ResourceProviderData.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/ResourceProviderData.cs
@@ -47,12 +47,21 @@ namespace Azure.ResourceManager.Resources
         /// <summary> The provider ID. </summary>
         public ResourceIdentifier Id { get; }
 
-        internal partial class ProviderDataConverter : JsonConverter<ResourceProviderData>
+        /// <summary>
+        /// Converter for ResourceProviderData type.
+        /// </summary>
+        public partial class ProviderDataConverter : JsonConverter<ResourceProviderData>
         {
+            /// <summary>
+            /// Converter for ResourceProviderData type.
+            /// </summary>
             public override void Write(Utf8JsonWriter writer, ResourceProviderData providerData, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(providerData);
             }
+            /// <summary>
+            /// Converter for ResourceProviderData type.
+            /// </summary>
             public override ResourceProviderData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/Models/ExtendedLocation.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/Models/ExtendedLocation.Serialization.cs
@@ -185,9 +185,6 @@ namespace Azure.ResourceManager.Resources.Models
             /// <summary>
             /// Converter write method.
             /// </summary>
-            /// <param name="writer"></param>
-            /// <param name="model"></param>
-            /// <param name="options"></param>
             public override void Write(Utf8JsonWriter writer, ExtendedLocation model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
@@ -196,9 +193,6 @@ namespace Azure.ResourceManager.Resources.Models
             /// <summary>
             /// Converter for ExtendedLocation type.
             /// </summary>
-            /// <param name="reader">The JSON reader.</param>
-            /// <param name="typeToConvert">The type to convert.</param>
-            /// <param name="options">The JSON serializer options.</param>
             public override ExtendedLocation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/Models/ExtendedLocation.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/Models/ExtendedLocation.Serialization.cs
@@ -177,13 +177,28 @@ namespace Azure.ResourceManager.Resources.Models
 
         string IPersistableModel<ExtendedLocation>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        internal partial class ExtendedLocationConverter : JsonConverter<ExtendedLocation>
+        /// <summary>
+        /// Json converter for ExtendedLocation.
+        /// </summary>
+        public partial class ExtendedLocationConverter : JsonConverter<ExtendedLocation>
         {
+            /// <summary>
+            /// Converter write method.
+            /// </summary>
+            /// <param name="writer"></param>
+            /// <param name="model"></param>
+            /// <param name="options"></param>
             public override void Write(Utf8JsonWriter writer, ExtendedLocation model, JsonSerializerOptions options)
             {
                 writer.WriteObjectValue(model, ModelSerializationExtensions.WireOptions);
             }
 
+            /// <summary>
+            /// Converter for ExtendedLocation type.
+            /// </summary>
+            /// <param name="reader">The JSON reader.</param>
+            /// <param name="typeToConvert">The type to convert.</param>
+            /// <param name="options">The JSON serializer options.</param>
             public override ExtendedLocation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using var document = JsonDocument.ParseValue(ref reader);


### PR DESCRIPTION
In order to use source-generated JSON, the converter types need to be at least as accessible as the serialized types. This PR changes all public types which have converters to make those converters public.