### PR TITLE
Disable outbound access

### DIFF
--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -419,7 +419,7 @@
         },
         {
           "type": "Microsoft.Network/virtualNetworks",
-          "apiVersion": "2020-05-01",
+          "apiVersion": "2023-11-01",
           "name": "[concat(variables('vmName'), '-vnet')]",
           "location": "[variables('location')]",
           "properties": {

--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -432,7 +432,8 @@
               {
                 "name": "default",
                 "properties": {
-                  "addressPrefix": "10.0.0.0/24"
+                  "addressPrefix": "10.0.0.0/24",
+                  "defaultoutboundaccess": false
                 }
               }
             ]


### PR DESCRIPTION
As part of [SFI-NS2.6.1](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-networking/sdn-dbansal/sdn-buildout-and-deployments/sdn-fundamentals/service-tag-onboarding/sfi-wiki/related-sfi-items/sfi-ns261moveoffdefaultoutboundaccessfeaturetoothermethodofoutboundconnectivity#step-3-update-subnet-property-defaultoutboundaccess-to-false-for-existing-subnets) we need to disable default outbound network access for vnets.
