### PR TITLE
Use ImageOverride in docindex.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1161,6 +1161,7 @@
 /eng/common/pipelines/codeowners-linter.yml                        @jsquire
 /sdk/eventhub/tests.data.yml                                       @serkantkaraca @sjkwak
 /sdk/servicebus/tests.data.yml                                     @shankarsama @EldertGrootenboer
+/eng/pipelines/docindex.yml                                        @danieljurek @hallipr @weshaggard @benbp
 
 # Add owners for package dependency changes
 /eng/Packages.Data.props                                           @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @tg-msft @jsquire @m-nash @ArthurMa1978 @jorgerangel-msft

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -33,7 +33,8 @@ jobs:
 
   - job: UpdateDocsMsBuildConfig
     pool:
-      name: $(LINUXPOOL)
+      name: azsdk-pool
+      demands: ImageOverride -equals ubuntu-22.04
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs
     steps:

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -33,8 +33,9 @@ jobs:
 
   - job: UpdateDocsMsBuildConfig
     pool:
-      name: azsdk-pool
-      demands: ImageOverride -equals ubuntu-22.04
+      name: $(LINUXPOOL)
+      demands: ImageOverride -equals $(LINUXVMIMAGE)
+
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs
     steps:

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -34,7 +34,7 @@ jobs:
   - job: UpdateDocsMsBuildConfig
     pool:
       name: $(LINUXPOOL)
-      demands: ImageOverride -equals $(LINUXVMIMAGE)
+      demands: $(LinuxImageDemand)
 
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -25,3 +25,5 @@ variables:
   - name: MACOS
     value: macOS
 
+  - name: LinuxImageDemand
+    value: ImageOverride -equals $(LINUXVMIMAGE)


### PR DESCRIPTION
Example successful docindex run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4900278&view=results

This uses variables in image.yml. When the images are updated in those variables the docindex pipeline will follow from those changes.