### PR TITLE
[Storage][DataMovement] Checkpointing for NFS over REST

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
@@ -40,9 +40,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.DateTimeOffset? FileLastWrittenOn { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
-        public Azure.Storage.Files.Shares.Models.ShareProtocols ShareProtocol { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Files.Shares.ShareProtocol ShareProtocol { get { throw null; } set { } }
         public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
+    }
+    public enum ShareProtocol : byte
+    {
+        Smb = (byte)1,
+        Nfs = (byte)2,
     }
 }
 namespace Azure.Storage.Files.Shares

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net8.0.cs
@@ -40,9 +40,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.DateTimeOffset? FileLastWrittenOn { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
-        public Azure.Storage.Files.Shares.Models.ShareProtocols ShareProtocol { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Files.Shares.ShareProtocol ShareProtocol { get { throw null; } set { } }
         public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
+    }
+    public enum ShareProtocol : byte
+    {
+        Smb = (byte)1,
+        Nfs = (byte)2,
     }
 }
 namespace Azure.Storage.Files.Shares

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
@@ -40,9 +40,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public System.DateTimeOffset? FileLastWrittenOn { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public bool? FilePermissions { get { throw null; } set { } }
-        public Azure.Storage.Files.Shares.Models.ShareProtocols ShareProtocol { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Files.Shares.ShareProtocol ShareProtocol { get { throw null; } set { } }
         public bool SkipProtocolValidation { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
+    }
+    public enum ShareProtocol : byte
+    {
+        Smb = (byte)1,
+        Nfs = (byte)2,
     }
 }
 namespace Azure.Storage.Files.Shares

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementShareConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementShareConstants.cs
@@ -17,6 +17,13 @@ namespace Azure.Storage.DataMovement.Files.Shares
             // Prior to Source Files Schema Version 1, the SourceCheckpointDetails was empty and Version was not present.
             internal const int SchemaVersion_1 = 1;
             internal const int SchemaVersion = SchemaVersion_1;
+
+            internal const int VersionEncodedSize = IntSizeInBytes;
+            internal const int ShareProtocolEncodedSize = OneByte;
+
+            internal const int VersionIndex = 0;
+            internal const int ShareProtocolIndex = VersionIndex + VersionEncodedSize;
+            internal const int DataSize = ShareProtocolIndex + ShareProtocolEncodedSize;
         }
 
         internal class DestinationCheckpointDetails
@@ -32,6 +39,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             internal const int VersionEncodedSize = IntSizeInBytes;
             internal const int PreserveEncodedSize = OneByte;
             internal const int OffsetLengthEncodedSize = IntSizeInBytes;
+            internal const int ShareProtocolEncodedSize = OneByte;
 
             internal const int VersionIndex = 0;
 
@@ -81,7 +89,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
             internal const int DirectoryMetadataOffsetIndex = PreserveDirectoryMetadataIndex + PreserveEncodedSize;
             internal const int DirectoryMetadataLengthIndex = DirectoryMetadataOffsetIndex + OffsetLengthEncodedSize;
 
-            internal const int VariableLengthStartIndex = DirectoryMetadataLengthIndex + OffsetLengthEncodedSize;
+            internal const int ShareProtocolIndex = DirectoryMetadataLengthIndex + OffsetLengthEncodedSize;
+
+            internal const int VariableLengthStartIndex = ShareProtocolIndex + ShareProtocolEncodedSize;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementShareConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementShareConstants.cs
@@ -14,13 +14,20 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
         internal class SourceCheckpointDetails
         {
-            internal const int DataSize = 0;
+            // Prior to Source Files Schema Version 1, the SourceCheckpointDetails was empty and Version was not present.
+            internal const int SchemaVersion_1 = 1;
+            internal const int SchemaVersion = SchemaVersion_1;
         }
 
         internal class DestinationCheckpointDetails
         {
+            // Destination Files Schema Versions 1 and 2 were the beta version of the schema and do not need to be serialized and deserialized backwards compatible.
+            // Only Destination Files Schema Versions 3 and beyond need to be backwards compatible.
             internal const int SchemaVersion_3 = 3;
-            internal const int SchemaVersion = SchemaVersion_3;
+            internal const int SchemaVersion_4 = 4;
+            internal const int SchemaVersion = SchemaVersion_4;
+            internal const int MinValidSchemaVersion = SchemaVersion_3;
+            internal const int MaxValidSchemaVersion = SchemaVersion_4;
 
             internal const int VersionEncodedSize = IntSizeInBytes;
             internal const int PreserveEncodedSize = OneByte;

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/DataMovementSharesExtensions.cs
@@ -59,9 +59,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
             StorageResourceItemProperties sourceProperties)
         {
             bool setPermissions = options?.FilePermissions ?? false;
-            ShareProtocols protocol = options?.ShareProtocol ?? ShareProtocols.Smb;
+            ShareProtocol protocol = options?.ShareProtocol ?? ShareProtocol.Smb;
 
-            if (protocol == ShareProtocols.Smb && setPermissions)
+            if (protocol == ShareProtocol.Smb && setPermissions)
             {
                 return sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FilePermissions, out object permission) == true
                     ? (string)permission
@@ -76,9 +76,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             // Only set permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
-            ShareProtocols protocol = options?.ShareProtocol ?? ShareProtocols.Smb;
+            ShareProtocol protocol = options?.ShareProtocol ?? ShareProtocol.Smb;
 
-            if (protocol == ShareProtocols.Smb && setPermissions)
+            if (protocol == ShareProtocol.Smb && setPermissions)
             {
                 return sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FilePermissions, out object permission) == true
                         ? (string)permission
@@ -126,7 +126,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 FileAttributes = options?.ShareProtocol switch
                 {
-                    ShareProtocols.Nfs => default,
+                    ShareProtocol.Nfs => default,
                     _ => GetPropertyValue<NtfsFileAttributes>(
                         options?._isFileAttributesSet ?? false,
                         options?.FileAttributes,
@@ -135,7 +135,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 },
                 FilePermissionKey = options?.ShareProtocol switch
                 {
-                    ShareProtocols.Nfs => default,
+                    ShareProtocol.Nfs => default,
                     _ => permissionKeyValue
                 },
                 FileCreatedOn = GetPropertyValue<DateTimeOffset>(
@@ -150,7 +150,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     DataMovementConstants.ResourceProperties.LastWrittenOn),
                 FileChangedOn = options?.ShareProtocol switch
                 {
-                    ShareProtocols.Nfs => default,
+                    ShareProtocol.Nfs => default,
                     _ => GetPropertyValue<DateTimeOffset>(
                         options?._isFileChangedOnSet ?? false,
                         options?.FileChangedOn,
@@ -176,7 +176,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 FileAttributes = options?.ShareProtocol switch
                 {
-                    ShareProtocols.Nfs => default,
+                    ShareProtocol.Nfs => default,
                     _ => GetPropertyValue<NtfsFileAttributes>(
                         options?._isFileAttributesSet ?? false,
                         options?.FileAttributes,
@@ -185,7 +185,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 },
                 FilePermissionKey = options?.ShareProtocol switch
                 {
-                    ShareProtocols.Nfs => default,
+                    ShareProtocol.Nfs => default,
                     _ => permissionKeyValue
                 },
                 FileCreatedOn = GetPropertyValue<DateTimeOffset>(
@@ -200,7 +200,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     DataMovementConstants.ResourceProperties.LastWrittenOn),
                 FileChangedOn = options?.ShareProtocol switch
                 {
-                    ShareProtocols.Nfs => default,
+                    ShareProtocol.Nfs => default,
                     _ => GetPropertyValue<DateTimeOffset>(
                         options?._isFileChangedOnSet ?? false,
                         options?.FileChangedOn,
@@ -232,9 +232,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
         {
             // Only set NFS permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
-            ShareProtocols protocol = options?.ShareProtocol ?? ShareProtocols.Smb;
+            ShareProtocol protocol = options?.ShareProtocol ?? ShareProtocol.Smb;
 
-            if (protocol == ShareProtocols.Nfs)
+            if (protocol == ShareProtocol.Nfs)
             {
                 NfsFileMode FileMode = default;
                 string Owner = default;
@@ -274,9 +274,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
             // Only set NFS permissions if Copy transfer and FilePermissions is on.
             bool setPermissions = options?.FilePermissions ?? false;
-            ShareProtocols protocol = options?.ShareProtocol ?? ShareProtocols.Smb;
+            ShareProtocol protocol = options?.ShareProtocol ?? ShareProtocol.Smb;
 
-            if (protocol == ShareProtocols.Nfs && setPermissions)
+            if (protocol == ShareProtocol.Nfs && setPermissions)
             {
                 FileMode = sourceProperties?.RawProperties?.TryGetValue(DataMovementConstants.ResourceProperties.FileMode, out object fileMode) == true
                         ? (NfsFileMode)fileMode
@@ -728,8 +728,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 try
                 {
                     ShareProperties properties = await parentShareClient.GetPropertiesAsync(cancellationToken).ConfigureAwait(false);
-                    ShareProtocols expectedProtocol = options?.ShareProtocol ?? ShareProtocols.Smb;
-                    ShareProtocols actualProtocol = properties.Protocols ?? ShareProtocols.Smb;
+                    ShareProtocol expectedProtocol = options?.ShareProtocol ?? ShareProtocol.Smb;
+                    ShareProtocols effectiveProtocol = properties.Protocols ?? ShareProtocols.Smb;
+                    ShareProtocol actualProtocol = effectiveProtocol == ShareProtocols.Smb ? ShareProtocol.Smb : ShareProtocol.Nfs;
 
                     if (actualProtocol != expectedProtocol)
                     {

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -68,8 +68,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     = destinationContainer as ShareDirectoryStorageResourceContainer;
                 ShareFileStorageResourceOptions destinationOptions = destinationStorageResourceContainer.ResourceOptions;
                 // both source and destination must be SMB
-                if (((ResourceOptions?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb)
-                    && ((destinationOptions?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb))
+                if (((ResourceOptions?.ShareProtocol ?? ShareProtocol.Smb) == ShareProtocol.Smb)
+                    && ((destinationOptions?.ShareProtocol ?? ShareProtocol.Smb) == ShareProtocol.Smb))
                 {
                     traits = ShareFileTraits.Attributes;
                     if (destinationOptions?.FilePermissions ?? false)
@@ -196,8 +196,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             if (sourceResource is ShareDirectoryStorageResourceContainer sourceShareDirectoryResource)
             {
                 // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
-                if ((ResourceOptions?.ShareProtocol ?? ShareProtocols.Smb)
-                    != (sourceShareDirectoryResource.ResourceOptions?.ShareProtocol ?? ShareProtocols.Smb))
+                if ((ResourceOptions?.ShareProtocol ?? ShareProtocol.Smb)
+                    != (sourceShareDirectoryResource.ResourceOptions?.ShareProtocol ?? ShareProtocol.Smb))
                 {
                     throw Errors.ShareTransferNotSupported();
                 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -96,7 +96,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
         protected override StorageResourceCheckpointDetails GetSourceCheckpointDetails()
         {
-            return new ShareFileSourceCheckpointDetails();
+            return new ShareFileSourceCheckpointDetails(shareProtocol: ResourceOptions?.ShareProtocol ?? ShareProtocol.Smb);
         }
 
         protected override StorageResourceCheckpointDetails GetDestinationCheckpointDetails()
@@ -124,7 +124,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 isFileMetadataSet: ResourceOptions?._isFileMetadataSet ?? false,
                 fileMetadata: ResourceOptions?.FileMetadata,
                 isDirectoryMetadataSet: ResourceOptions?._isDirectoryMetadataSet ?? false,
-                directoryMetadata: ResourceOptions?.DirectoryMetadata)
+                directoryMetadata: ResourceOptions?.DirectoryMetadata,
+                shareProtocol: ResourceOptions?.ShareProtocol ?? ShareProtocol.Smb)
             {
             };
         }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileDestinationCheckpointDetails.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileDestinationCheckpointDetails.cs
@@ -90,6 +90,11 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public bool IsDirectoryMetadataSet;
         private byte[] _directoryMetadataBytes;
 
+        /// <summary>
+        /// Share Protocol for destination files/directories.
+        /// </summary>
+        public ShareProtocol ShareProtocol;
+
         public override int Length => CalculateLength();
 
         public ShareFileDestinationCheckpointDetails(
@@ -115,7 +120,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             bool isFileMetadataSet,
             Metadata fileMetadata,
             bool isDirectoryMetadataSet,
-            Metadata directoryMetadata)
+            Metadata directoryMetadata,
+            ShareProtocol shareProtocol)
         {
             Version = DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion;
             CacheControl = cacheControl;
@@ -162,6 +168,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             DirectoryMetadata = directoryMetadata;
             IsDirectoryMetadataSet = isDirectoryMetadataSet;
             _directoryMetadataBytes = directoryMetadata != default ? Encoding.UTF8.GetBytes(directoryMetadata.DictionaryToString()) : Array.Empty<byte>();
+
+            ShareProtocol = shareProtocol;
         }
 
         protected override void Serialize(Stream stream)
@@ -244,6 +252,9 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 writer.Write(_directoryMetadataBytes);
             }
+
+            // ShareProtocol
+            writer.Write((byte)ShareProtocol);
         }
 
         internal static ShareFileDestinationCheckpointDetails Deserialize(Stream stream)
@@ -254,7 +265,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
             // Version
             int version = reader.ReadInt32();
-            if (version != DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion)
+            if (version < DataMovementShareConstants.DestinationCheckpointDetails.MinValidSchemaVersion
+                || version > DataMovementShareConstants.DestinationCheckpointDetails.MaxValidSchemaVersion)
             {
                 throw Storage.Errors.UnsupportedJobSchemaVersionHeader(version);
             }
@@ -366,6 +378,15 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 directoryMetadataString = Encoding.UTF8.GetString(reader.ReadBytes(directoryMetadataLength));
             }
 
+            // ShareProtocol
+            ShareProtocol shareProtocol = ShareProtocol.Smb;
+            bool shareProtocolSupport = version >= DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion_4;
+            if (shareProtocolSupport)
+            {
+                shareProtocol = (ShareProtocol)reader.ReadByte();
+            }
+
+            // When deserializing, the version of the new CheckpointDetails is always the latest version.
             return new(
                 isContentTypeSet: isContentTypeSet,
                 contentType: contentType,
@@ -389,7 +410,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 isFileMetadataSet: isFileMetadataSet,
                 fileMetadata: fileMetadataString?.ToDictionary(nameof(fileMetadataString)),
                 isDirectoryMetadataSet: isDirectoryMetadataSet,
-                directoryMetadata: directoryMetadataString?.ToDictionary(nameof(directoryMetadataString)));
+                directoryMetadata: directoryMetadataString?.ToDictionary(nameof(directoryMetadataString)),
+                shareProtocol: shareProtocol);
         }
 
         private int CalculateLength()
@@ -440,6 +462,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 length += _directoryMetadataBytes.Length;
             }
+            // ShareProtocol
+            length += sizeof(byte);
             return length;
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileSourceCheckpointDetails.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileSourceCheckpointDetails.cs
@@ -18,7 +18,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// </summary>
         public ShareProtocol ShareProtocol;
 
-        public override int Length => CalculateLength();
+        public override int Length => DataMovementShareConstants.SourceCheckpointDetails.DataSize;
 
         public ShareFileSourceCheckpointDetails(
             ShareProtocol shareProtocol)
@@ -58,16 +58,6 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
             // When deserializing, the version of the new CheckpointDetails is always the latest version.
             return new(shareProtocol: shareProtocol);
-        }
-
-        private int CalculateLength()
-        {
-            int length = 0;
-
-            length += sizeof(int); // Version
-            length += sizeof(byte); // ShareProtocol
-
-            return length;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileSourceCheckpointDetails.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileSourceCheckpointDetails.cs
@@ -2,17 +2,72 @@
 // Licensed under the MIT License.
 
 using System.IO;
+using Azure.Storage.Common;
 
 namespace Azure.Storage.DataMovement.Files.Shares
 {
     internal class ShareFileSourceCheckpointDetails : StorageResourceCheckpointDetailsInternal
     {
-        public override int Length => 0;
+        /// <summary>
+        /// Schema version.
+        /// </summary>
+        public int Version;
+
+        /// <summary>
+        /// Share Protocol for source files/directories.
+        /// </summary>
+        public ShareProtocol ShareProtocol;
+
+        public override int Length => CalculateLength();
+
+        public ShareFileSourceCheckpointDetails(
+            ShareProtocol shareProtocol)
+        {
+            Version = DataMovementShareConstants.SourceCheckpointDetails.SchemaVersion;
+            ShareProtocol = shareProtocol;
+        }
 
         protected override void Serialize(Stream stream)
         {
+            Argument.AssertNotNull(stream, nameof(stream));
+            BinaryWriter writer = new(stream);
+
+            // Version
+            writer.Write(Version);
+
+            // ShareProtocol
+            writer.Write((byte)ShareProtocol);
         }
 
-        internal static ShareFileSourceCheckpointDetails Deserialize(Stream stream) => new();
+        internal static ShareFileSourceCheckpointDetails Deserialize(Stream stream)
+        {
+            Argument.AssertNotNull(stream, nameof(stream));
+            BinaryReader reader = new BinaryReader(stream);
+
+            ShareProtocol shareProtocol = ShareProtocol.Smb;
+            // If it is version 1+ (before version 1, stream is empty and Version did not exist)
+            if (stream.Length > 0)
+            {
+                int version = reader.ReadInt32();
+                if (version != DataMovementShareConstants.SourceCheckpointDetails.SchemaVersion)
+                {
+                    throw Storage.Errors.UnsupportedJobSchemaVersionHeader(version);
+                }
+                shareProtocol = (ShareProtocol)reader.ReadByte();
+            }
+
+            // When deserializing, the version of the new CheckpointDetails is always the latest version.
+            return new(shareProtocol: shareProtocol);
+        }
+
+        private int CalculateLength()
+        {
+            int length = 0;
+
+            length += sizeof(int); // Version
+            length += sizeof(byte); // ShareProtocol
+
+            return length;
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -283,8 +283,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ShareFileStorageResource sourceShareFile = (ShareFileStorageResource)sourceResource;
                 // both source and destination must be SMB and destination FilePermission option must be set.
-                if (((sourceShareFile._options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb)
-                    && ((_options?.ShareProtocol ?? ShareProtocols.Smb) == ShareProtocols.Smb)
+                if (((sourceShareFile._options?.ShareProtocol ?? ShareProtocol.Smb) == ShareProtocol.Smb)
+                    && ((_options?.ShareProtocol ?? ShareProtocol.Smb) == ShareProtocol.Smb)
                     && (_options?.FilePermissions ?? false))
                 {
                     string permissionsValue = sourceProperties?.RawProperties?.GetPermission();
@@ -394,8 +394,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
             if (sourceResource is ShareFileStorageResource sourceShareFileResource)
             {
                 // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
-                if ((_options?.ShareProtocol ?? ShareProtocols.Smb)
-                    != (sourceShareFileResource._options?.ShareProtocol ?? ShareProtocols.Smb))
+                if ((_options?.ShareProtocol ?? ShareProtocol.Smb)
+                    != (sourceShareFileResource._options?.ShareProtocol ?? ShareProtocol.Smb))
                 {
                     throw Errors.ShareTransferNotSupported();
                 }
@@ -428,7 +428,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public static InvalidOperationException ShareFileAlreadyExists(string pathName)
             => new InvalidOperationException($"Share File `{pathName}` already exists. Cannot overwrite file.");
 
-        public static ArgumentException ProtocolSetMismatch(string endpoint, ShareProtocols setProtocol, ShareProtocols actualProtocol)
+        public static ArgumentException ProtocolSetMismatch(string endpoint, ShareProtocol setProtocol, ShareProtocol actualProtocol)
             => new ArgumentException($"The Protocol set on the {endpoint} '{setProtocol}' does not match the actual Protocol of the share '{actualProtocol}'.");
 
         public static UnauthorizedAccessException ProtocolValidationAuthorizationFailure(RequestFailedException ex, string endpoint)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -325,7 +325,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
         protected override StorageResourceCheckpointDetails GetSourceCheckpointDetails()
         {
-            return new ShareFileSourceCheckpointDetails();
+            return new ShareFileSourceCheckpointDetails(shareProtocol: _options?.ShareProtocol ?? ShareProtocol.Smb);
         }
 
         protected override StorageResourceCheckpointDetails GetDestinationCheckpointDetails()
@@ -353,7 +353,8 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 isFileMetadataSet: _options?._isFileMetadataSet ?? false,
                 fileMetadata: _options?.FileMetadata,
                 isDirectoryMetadataSet: _options?._isDirectoryMetadataSet ?? false,
-                directoryMetadata: _options?.DirectoryMetadata);
+                directoryMetadata: _options?.DirectoryMetadata,
+                shareProtocol: _options?.ShareProtocol ?? ShareProtocol.Smb);
         }
 
         protected override async Task<bool> ShouldItemTransferAsync(CancellationToken cancellationToken = default)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -194,12 +194,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
         }
 
         /// <summary>
-        /// To preserve the key of the file permission.
-        /// If set to true, the permission key will be preserved from the source Share to the destination Share.
-        /// This requires a <see href="https://learn.microsoft.com/en-us/rest/api/storageservices/create-permission">Create Share Permissions</see> operation,
+        /// To preserve the file permissions. This is intended to be set on the destination Share.
+        /// If set to true, the permissions will be preserved from the source Share to the destination Share.
+        /// For SMB, this requires a <see href="https://learn.microsoft.com/en-us/rest/api/storageservices/create-permission">Create Share Permissions</see> operation,
         /// which is a operation called on the Destination Share, which requires Share level permissions.
         ///
-        /// By default the permission key will not be preserved from the source Share to the destination Share. If explicitly set to null, the File Permissions will not be preserved.
+        /// By default the file permissions will not be preserved from the source Share to the destination Share. If explicitly set to null, the File Permissions will not be preserved.
         /// Applies only to copy transfers.
         /// </summary>
         public bool? FilePermissions { get; set; }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -63,7 +63,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// For NFS Share-to-Share Copy and Download transfers, Hardlinks will be copied as regular files and Symbolic links are skipped.
         /// For NFS Upload transfers, Hardlinks will be copied as regular files and Symbolic links are not supported.
         /// </summary>
-        public ShareProtocols ShareProtocol { get; set; } = ShareProtocols.Smb;
+        public ShareProtocol ShareProtocol { get; set; } = ShareProtocol.Smb;
 
         /// <summary>
         /// Optional. See <see cref="ShareFileRequestConditions"/>.
@@ -321,7 +321,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             FileMetadata = options?.FileMetadata;
             _isFileMetadataSet = options?._isFileMetadataSet ?? false;
             SkipProtocolValidation = options?.SkipProtocolValidation ?? false;
-            ShareProtocol = options?.ShareProtocol ?? ShareProtocols.Smb;
+            ShareProtocol = options?.ShareProtocol ?? ShareProtocol.Smb;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareProtocol.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareProtocol.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Storage.DataMovement.Files.Shares
+{
+    /// <summary>
+    /// Protocol that can be set on a Share.
+    /// </summary>
+    public enum ShareProtocol : byte
+    {
+        /// <summary>
+        /// SMB
+        /// </summary>
+        Smb = 1,
+
+        /// <summary>
+        /// NFS
+        /// </summary>
+        Nfs = 2
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/RehydrateShareResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/RehydrateShareResourceTests.cs
@@ -66,6 +66,28 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             return mock;
         }
 
+        private static Mock<TransferProperties> GetProperties(
+            string transferId,
+            string sourcePath,
+            string destinationPath,
+            string sourceProviderId,
+            string destinationProviderId,
+            bool isContainer,
+            byte[] sourceBytes,
+            ShareFileDestinationCheckpointDetails destinationCheckpointDetails)
+        {
+            var mock = new Mock<TransferProperties>(MockBehavior.Strict);
+            mock.Setup(p => p.TransferId).Returns(transferId);
+            mock.Setup(p => p.SourceUri).Returns(new Uri(sourcePath));
+            mock.Setup(p => p.DestinationUri).Returns(new Uri(destinationPath));
+            mock.Setup(p => p.SourceProviderId).Returns(sourceProviderId);
+            mock.Setup(p => p.DestinationProviderId).Returns(destinationProviderId);
+            mock.Setup(p => p.SourceCheckpointDetails).Returns(sourceBytes);
+            mock.Setup(p => p.DestinationCheckpointDetails).Returns(GetBytesDestination(destinationCheckpointDetails));
+            mock.Setup(p => p.IsContainer).Returns(isContainer);
+            return mock;
+        }
+
         [Test]
         public async Task RehydrateFile(
             [Values(true, false)] bool isSource)
@@ -82,8 +104,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 ShareProviderId,
                 ShareProviderId,
                 isContainer: false,
-                new ShareFileSourceCheckpointDetails(),
-                new ShareFileDestinationCheckpointDetails(false, null, false, null, false, null, false, null, false, null, false, null, false, false, null, false, null, false, null, false,  null, false, null)).Object;
+                new ShareFileSourceCheckpointDetails(ShareProtocol.Nfs),
+                new ShareFileDestinationCheckpointDetails(false, null, false, null, false, null, false, null, false, null, false, null, false, false, null, false, null, false, null, false, null, false, null, ShareProtocol.Nfs)).Object;
 
             StorageResource storageResource = isSource
                 ? await new ShareFilesStorageResourceProvider(_tokenCredential).FromSourceInternalHookAsync(transferProperties)
@@ -94,7 +116,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [Test]
-        public async Task RehydrateFile_DestinationOptions()
+        public async Task RehydrateFile_DestinationOptions_LatestVersion()
         {
             string transferId = Guid.NewGuid().ToString();
             string sourcePath = "https://storageaccount.file.core.windows.net/share/dir1/file1";
@@ -130,7 +152,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 directoryMetadata: new Dictionary<string, string>
                 {
                     {  r.NextString(8),  r.NextString(8) }
-                });
+                },
+                shareProtocol: ShareProtocol.Nfs);
             TransferProperties transferProperties = GetProperties(
                 transferId,
                 sourcePath,
@@ -138,9 +161,10 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 ShareProviderId,
                 ShareProviderId,
                 isContainer: false,
-                new ShareFileSourceCheckpointDetails(),
+                new ShareFileSourceCheckpointDetails(ShareProtocol.Nfs),
                 originalDestinationData).Object;
 
+            // Serializes and deserialized the checkpoint details
             ShareFileStorageResource storageResource = (ShareFileStorageResource)
                 await new ShareFilesStorageResourceProvider(_tokenCredential).FromDestinationInternalHookAsync(transferProperties);
 
@@ -169,6 +193,214 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Assert.That(storageResource._options.FileLastWrittenOn, Is.EqualTo(originalDestinationData.FileLastWrittenOn));
             Assert.That(storageResource._options._isFileChangedOnSet, Is.EqualTo(originalDestinationData.IsFileChangedOnSet));
             Assert.That(storageResource._options.FileChangedOn, Is.EqualTo(originalDestinationData.FileChangedOn));
+            Assert.That(storageResource._options.ShareProtocol, Is.EqualTo(originalDestinationData.ShareProtocol));
+        }
+
+        [Test]
+        public async Task RehydrateFile_DestinationOptions_Version3()
+        {
+            string transferId = Guid.NewGuid().ToString();
+            string sourcePath = "https://storageaccount.file.core.windows.net/share/dir1/file1";
+            string destinationPath = "https://storageaccount.file.core.windows.net/share/dir2/file2";
+
+            Random r = new();
+            ShareFileDestinationCheckpointDetails originalDestinationData = new(
+                isContentTypeSet: true,
+                contentType: "text/plain",
+                isContentEncodingSet: true,
+                contentEncoding: new string[] { "gzip" },
+                isContentLanguageSet: true,
+                contentLanguage: new string[] { "en-US" },
+                isContentDispositionSet: true,
+                contentDisposition: "inline",
+                isCacheControlSet: true,
+                cacheControl: "no-cache",
+                isFileAttributesSet: true,
+                fileAttributes: NtfsFileAttributes.Archive,
+                filePermissions: true,
+                isFileLastWrittenOnSet: true,
+                fileLastWrittenOn: DateTimeOffset.Now,
+                isFileChangedOnSet: true,
+                fileChangedOn: DateTimeOffset.Now,
+                isFileCreatedOnSet: true,
+                fileCreatedOn: DateTimeOffset.Now,
+                isFileMetadataSet: true,
+                fileMetadata: new Dictionary<string, string>
+                {
+                                {  r.NextString(8),  r.NextString(8) }
+                },
+                isDirectoryMetadataSet: true,
+                directoryMetadata: new Dictionary<string, string>
+                {
+                                {  r.NextString(8),  r.NextString(8) }
+                },
+                shareProtocol: ShareProtocol.Nfs)
+            {
+                // Set to Version 3
+                Version = DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion_3
+            };
+            TransferProperties transferProperties = GetProperties(
+                transferId,
+                sourcePath,
+                destinationPath,
+                ShareProviderId,
+                ShareProviderId,
+                isContainer: false,
+                new ShareFileSourceCheckpointDetails(ShareProtocol.Nfs),
+                originalDestinationData).Object;
+
+            // Serializes and deserialized the checkpoint details
+            ShareFileStorageResource storageResource = (ShareFileStorageResource)
+                await new ShareFilesStorageResourceProvider(_tokenCredential).FromDestinationInternalHookAsync(transferProperties);
+
+            Assert.That(destinationPath, Is.EqualTo(storageResource.Uri.AbsoluteUri));
+            Assert.That(storageResource, Is.TypeOf<ShareFileStorageResource>());
+            Assert.That(storageResource._options._isContentTypeSet, Is.EqualTo(originalDestinationData.IsContentTypeSet));
+            Assert.That(storageResource._options.ContentType, Is.EqualTo(originalDestinationData.ContentType));
+            Assert.That(storageResource._options._isContentEncodingSet, Is.EqualTo(originalDestinationData.IsContentEncodingSet));
+            Assert.That(storageResource._options.ContentEncoding, Is.EqualTo(originalDestinationData.ContentEncoding));
+            Assert.That(storageResource._options._isContentLanguageSet, Is.EqualTo(originalDestinationData.IsContentLanguageSet));
+            Assert.That(storageResource._options.ContentLanguage, Is.EqualTo(originalDestinationData.ContentLanguage));
+            Assert.That(storageResource._options._isContentDispositionSet, Is.EqualTo(originalDestinationData.IsContentDispositionSet));
+            Assert.That(storageResource._options.ContentDisposition, Is.EqualTo(originalDestinationData.ContentDisposition));
+            Assert.That(storageResource._options._isCacheControlSet, Is.EqualTo(originalDestinationData.IsCacheControlSet));
+            Assert.That(storageResource._options.CacheControl, Is.EqualTo(originalDestinationData.CacheControl));
+            Assert.That(storageResource._options._isFileMetadataSet, Is.EqualTo(originalDestinationData.IsFileMetadataSet));
+            Assert.That(storageResource._options.FileMetadata, Is.EqualTo(originalDestinationData.FileMetadata));
+            Assert.That(storageResource._options._isDirectoryMetadataSet, Is.EqualTo(originalDestinationData.IsDirectoryMetadataSet));
+            Assert.That(storageResource._options.DirectoryMetadata, Is.EqualTo(originalDestinationData.DirectoryMetadata));
+            Assert.That(storageResource._options._isFileAttributesSet, Is.EqualTo(originalDestinationData.IsFileAttributesSet));
+            Assert.That(storageResource._options.FileAttributes, Is.EqualTo(originalDestinationData.FileAttributes));
+            Assert.IsTrue(storageResource._options.FilePermissions);
+            Assert.That(storageResource._options._isFileCreatedOnSet, Is.EqualTo(originalDestinationData.IsFileCreatedOnSet));
+            Assert.That(storageResource._options.FileCreatedOn, Is.EqualTo(originalDestinationData.FileCreatedOn));
+            Assert.That(storageResource._options._isFileLastWrittenOnSet, Is.EqualTo(originalDestinationData.IsFileLastWrittenOnSet));
+            Assert.That(storageResource._options.FileLastWrittenOn, Is.EqualTo(originalDestinationData.FileLastWrittenOn));
+            Assert.That(storageResource._options._isFileChangedOnSet, Is.EqualTo(originalDestinationData.IsFileChangedOnSet));
+            Assert.That(storageResource._options.FileChangedOn, Is.EqualTo(originalDestinationData.FileChangedOn));
+            // From version 3, the ShareProtocol does not get copied over so it is set to default value of SMB.
+            Assert.That(storageResource._options.ShareProtocol, Is.Not.EqualTo(originalDestinationData.ShareProtocol));
+            Assert.That(storageResource._options.ShareProtocol, Is.EqualTo(ShareProtocol.Smb));
+        }
+
+        [Test]
+        public async Task RehydrateFile_SourceOptions_LatestVersion()
+        {
+            string transferId = Guid.NewGuid().ToString();
+            string sourcePath = "https://storageaccount.file.core.windows.net/share/dir1/file1";
+            string destinationPath = "https://storageaccount.file.core.windows.net/share/dir2/file2";
+
+            Random r = new();
+            ShareFileDestinationCheckpointDetails originalDestinationData = new(
+                isContentTypeSet: true,
+                contentType: "text/plain",
+                isContentEncodingSet: true,
+                contentEncoding: new string[] { "gzip" },
+                isContentLanguageSet: true,
+                contentLanguage: new string[] { "en-US" },
+                isContentDispositionSet: true,
+                contentDisposition: "inline",
+                isCacheControlSet: true,
+                cacheControl: "no-cache",
+                isFileAttributesSet: true,
+                fileAttributes: NtfsFileAttributes.Archive,
+                filePermissions: true,
+                isFileLastWrittenOnSet: true,
+                fileLastWrittenOn: DateTimeOffset.Now,
+                isFileChangedOnSet: true,
+                fileChangedOn: DateTimeOffset.Now,
+                isFileCreatedOnSet: true,
+                fileCreatedOn: DateTimeOffset.Now,
+                isFileMetadataSet: true,
+                fileMetadata: new Dictionary<string, string>
+                {
+                    {  r.NextString(8),  r.NextString(8) }
+                },
+                isDirectoryMetadataSet: true,
+                directoryMetadata: new Dictionary<string, string>
+                {
+                    {  r.NextString(8),  r.NextString(8) }
+                },
+                shareProtocol: ShareProtocol.Nfs);
+            ShareFileSourceCheckpointDetails originalSourceData = new ShareFileSourceCheckpointDetails(ShareProtocol.Nfs);
+            TransferProperties transferProperties = GetProperties(
+                transferId,
+                sourcePath,
+                destinationPath,
+                ShareProviderId,
+                ShareProviderId,
+                isContainer: false,
+                originalSourceData,
+                originalDestinationData).Object;
+
+            // Serializes and deserialized the checkpoint details
+            ShareFileStorageResource storageResource = (ShareFileStorageResource)
+                await new ShareFilesStorageResourceProvider(_tokenCredential).FromSourceInternalHookAsync(transferProperties);
+
+            Assert.That(sourcePath, Is.EqualTo(storageResource.Uri.AbsoluteUri));
+            Assert.That(storageResource, Is.TypeOf<ShareFileStorageResource>());
+            Assert.That(storageResource._options.ShareProtocol, Is.EqualTo(originalSourceData.ShareProtocol));
+        }
+
+        [Test]
+        public async Task RehydrateFile_SourceOptions_FirstVersion()
+        {
+            string transferId = Guid.NewGuid().ToString();
+            string sourcePath = "https://storageaccount.file.core.windows.net/share/dir1/file1";
+            string destinationPath = "https://storageaccount.file.core.windows.net/share/dir2/file2";
+
+            Random r = new();
+            ShareFileDestinationCheckpointDetails originalDestinationData = new(
+                isContentTypeSet: true,
+                contentType: "text/plain",
+                isContentEncodingSet: true,
+                contentEncoding: new string[] { "gzip" },
+                isContentLanguageSet: true,
+                contentLanguage: new string[] { "en-US" },
+                isContentDispositionSet: true,
+                contentDisposition: "inline",
+                isCacheControlSet: true,
+                cacheControl: "no-cache",
+                isFileAttributesSet: true,
+                fileAttributes: NtfsFileAttributes.Archive,
+                filePermissions: true,
+                isFileLastWrittenOnSet: true,
+                fileLastWrittenOn: DateTimeOffset.Now,
+                isFileChangedOnSet: true,
+                fileChangedOn: DateTimeOffset.Now,
+                isFileCreatedOnSet: true,
+                fileCreatedOn: DateTimeOffset.Now,
+                isFileMetadataSet: true,
+                fileMetadata: new Dictionary<string, string>
+                {
+                    {  r.NextString(8),  r.NextString(8) }
+                },
+                isDirectoryMetadataSet: true,
+                directoryMetadata: new Dictionary<string, string>
+                {
+                    {  r.NextString(8),  r.NextString(8) }
+                },
+                shareProtocol: ShareProtocol.Nfs);
+            // In the "first" version, the source deserialize stream is empty
+            byte[] sourceBytes = Array.Empty<byte>();
+            TransferProperties transferProperties = GetProperties(
+                transferId,
+                sourcePath,
+                destinationPath,
+                ShareProviderId,
+                ShareProviderId,
+                isContainer: false,
+                sourceBytes,
+                originalDestinationData).Object;
+
+            // Serializes and deserialized the checkpoint details
+            ShareFileStorageResource storageResource = (ShareFileStorageResource)
+                await new ShareFilesStorageResourceProvider(_tokenCredential).FromSourceInternalHookAsync(transferProperties);
+
+            Assert.That(sourcePath, Is.EqualTo(storageResource.Uri.AbsoluteUri));
+            Assert.That(storageResource, Is.TypeOf<ShareFileStorageResource>());
+            // Deserialization from the "first" version by default sets the ShareProtocol to SMB.
+            Assert.That(storageResource._options.ShareProtocol, Is.EqualTo(ShareProtocol.Smb));
         }
 
         [Test]
@@ -196,8 +428,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 ShareProviderId,
                 ShareProviderId,
                 isContainer: true,
-                new ShareFileSourceCheckpointDetails(),
-                new ShareFileDestinationCheckpointDetails(false, null, false, null, false, null, false, null, false, null, false, null, false, false, null, false, null, false, null, false, null, false, null)).Object;
+                new ShareFileSourceCheckpointDetails(ShareProtocol.Nfs),
+                new ShareFileDestinationCheckpointDetails(false, null, false, null, false, null, false, null, false, null, false, null, false, false, null, false, null, false, null, false, null, false, null, ShareProtocol.Nfs)).Object;
 
             StorageResource storageResource = isSource
                 ? await new ShareFilesStorageResourceProvider(_tokenCredential).FromSourceInternalHookAsync(transferProperties)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDestinationCheckpointDetailsTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDestinationCheckpointDetailsTests.cs
@@ -474,25 +474,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [Test]
-        public void Serialize_Version3()
-        {
-            // Latest Version
-            byte[] expected = CreateSerializedSetValues_Version3();
-
-            ShareFileDestinationCheckpointDetails data = CreateSetSampleValues();
-            data.Version = DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion_3;
-
-            byte[] actual;
-            using (MemoryStream stream = new())
-            {
-                data.SerializeInternal(stream);
-                actual = stream.ToArray();
-            }
-
-            Assert.That(expected, Is.EqualTo(actual));
-        }
-
-        [Test]
         public void Deserialize_LatestVersion()
         {
             byte[] serialized = CreateSerializedSetValues_LatestVersion();
@@ -511,9 +492,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         {
             byte[] serialized = CreateSerializedSetValues_Version3();
             ShareFileDestinationCheckpointDetails expected = CreateSetSampleValues();
-            // We are expecting that after deserialization, the version is bumped to latest version
-            Assert.That(expected.Version, Is.EqualTo(DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion));
-            // We are expecting that after deserialization, the ShareProtocol is set to default value (SMB)
             expected.ShareProtocol = ShareProtocol.Smb;
 
             ShareFileDestinationCheckpointDetails deserialized;
@@ -524,6 +502,10 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // When deserializing, Version gets bumped to the latest version and ShareProtocol is set to default value (SMB)
             AssertEquals(deserialized, expected);
+            // We are expecting that after deserialization, the version is bumped to latest version
+            Assert.That(deserialized.Version, Is.EqualTo(DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion));
+            // We are expecting that after deserialization, the ShareProtocol is set to default value (SMB)
+            Assert.That(deserialized.ShareProtocol, Is.EqualTo(ShareProtocol.Smb));
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDestinationCheckpointDetailsTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDestinationCheckpointDetailsTests.cs
@@ -298,6 +298,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             writer.WritePreservablePropertyOffset(true, cacheControl.Length, ref currentVariableLengthIndex);
             writer.WritePreservablePropertyOffset(true, fileMetadata.Length, ref currentVariableLengthIndex);
             writer.WritePreservablePropertyOffset(true, directoryMetadata.Length, ref currentVariableLengthIndex);
+            writer.Write((byte)ShareProtocol.Nfs);
             writer.Write((int)DefaultFileAttributes);
             writer.Write(fileCreatedOn);
             writer.Write(fileLastWrittenOn);
@@ -309,7 +310,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             writer.Write(cacheControl);
             writer.Write(fileMetadata);
             writer.Write(directoryMetadata);
-            writer.Write((byte)ShareProtocol.Nfs);
 
             return stream.ToArray();
         }
@@ -345,6 +345,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             writer.WritePreservablePropertyOffset(true, cacheControl.Length, ref currentVariableLengthIndex);
             writer.WritePreservablePropertyOffset(true, fileMetadata.Length, ref currentVariableLengthIndex);
             writer.WritePreservablePropertyOffset(true, directoryMetadata.Length, ref currentVariableLengthIndex);
+            writer.Write((byte)ShareProtocol.Nfs);
             writer.Write((int)DefaultFileAttributes);
             writer.Write(fileCreatedOn);
             writer.Write(fileLastWrittenOn);
@@ -356,7 +357,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             writer.Write(cacheControl);
             writer.Write(fileMetadata);
             writer.Write(directoryMetadata);
-            writer.Write((byte)ShareProtocol.Nfs);
 
             return stream.ToArray();
         }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDestinationCheckpointDetailsTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDestinationCheckpointDetailsTests.cs
@@ -2,16 +2,15 @@
 // Licensed under the MIT License.
 extern alias BaseShares;
 extern alias DMShare;
-
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using BaseShares::Azure.Storage.Files.Shares.Models;
 using Azure.Storage.Test;
+using BaseShares::Azure.Storage.Files.Shares.Models;
+using DMShare::Azure.Storage.DataMovement.Files.Shares;
 using NUnit.Framework;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
-using DMShare::Azure.Storage.DataMovement.Files.Shares;
 
 namespace Azure.Storage.DataMovement.Files.Shares.Tests
 {
@@ -62,7 +61,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 false,
                 default,
                 false,
-                default);
+                default,
+                ShareProtocol.Smb);
 
         private ShareFileDestinationCheckpointDetails CreateNoPreserveValues()
         => new ShareFileDestinationCheckpointDetails(
@@ -88,7 +88,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 true,
                 default,
                 true,
-                default);
+                default,
+                ShareProtocol.Smb);
 
         private ShareFileDestinationCheckpointDetails CreatePreserveValues()
         => new ShareFileDestinationCheckpointDetails(
@@ -114,7 +115,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 false,
                 default,
                 false,
-                default);
+                default,
+                ShareProtocol.Smb);
 
         private ShareFileDestinationCheckpointDetails CreateSetSampleValues()
         => new ShareFileDestinationCheckpointDetails(
@@ -140,7 +142,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 isFileMetadataSet: true,
                 fileMetadata: DefaultFileMetadata,
                 isDirectoryMetadataSet: true,
-                directoryMetadata: DefaultDirectoryMetadata);
+                directoryMetadata: DefaultDirectoryMetadata,
+                shareProtocol: ShareProtocol.Nfs);
 
         private void AssertEquals(ShareFileDestinationCheckpointDetails left, ShareFileDestinationCheckpointDetails right)
         {
@@ -212,6 +215,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             {
                 Assert.That(left.DirectoryMetadata, Is.EqualTo(right.DirectoryMetadata));
             }
+
+            Assert.That(left.ShareProtocol, Is.EqualTo(right.ShareProtocol));
         }
 
         private byte[] CreateSerializedPreserve()
@@ -233,9 +238,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             writer.WritePreservablePropertyOffset(false, 0, ref currentVariableLengthIndex);
             writer.WritePreservablePropertyOffset(false, 0, ref currentVariableLengthIndex);
             writer.WritePreservablePropertyOffset(false, 0, ref currentVariableLengthIndex);
-            writer.WritePreservablePropertyOffset(false, 0, ref currentVariableLengthIndex);
-            writer.WritePreservablePropertyOffset(false, 0, ref currentVariableLengthIndex);
-            writer.WritePreservablePropertyOffset(false, 0, ref currentVariableLengthIndex);
+            writer.Write((byte)ShareProtocol.Smb);
 
             return stream.ToArray();
         }
@@ -259,14 +262,12 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             writer.WritePreservablePropertyOffset(true, 0, ref currentVariableLengthIndex);
             writer.WritePreservablePropertyOffset(true, 0, ref currentVariableLengthIndex);
             writer.WritePreservablePropertyOffset(true, 0, ref currentVariableLengthIndex);
-            writer.WritePreservablePropertyOffset(true, 0, ref currentVariableLengthIndex);
-            writer.WritePreservablePropertyOffset(true, 0, ref currentVariableLengthIndex);
-            writer.WritePreservablePropertyOffset(true, 0, ref currentVariableLengthIndex);
+            writer.Write((byte)ShareProtocol.Smb);
 
             return stream.ToArray();
         }
 
-        private byte[] CreateSerializedSetValues()
+        private byte[] CreateSerializedSetValues_LatestVersion()
         {
             using MemoryStream stream = new();
             using BinaryWriter writer = new(stream);
@@ -308,6 +309,54 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             writer.Write(cacheControl);
             writer.Write(fileMetadata);
             writer.Write(directoryMetadata);
+            writer.Write((byte)ShareProtocol.Nfs);
+
+            return stream.ToArray();
+        }
+
+        private byte[] CreateSerializedSetValues_Version3()
+        {
+            using MemoryStream stream = new();
+            using BinaryWriter writer = new(stream);
+
+            bool preserveFilePermission = false;
+            byte[] fileCreatedOn = Encoding.UTF8.GetBytes(DefaultFileCreatedOn.Value.ToString("o"));
+            byte[] fileLastWrittenOn = Encoding.UTF8.GetBytes(DefaultFileLastWrittenOn.Value.ToString("o"));
+            byte[] fileChangedOn = Encoding.UTF8.GetBytes(DefaultFileChangedOn.Value.ToString("o"));
+            byte[] contentType = Encoding.UTF8.GetBytes(DefaultContentType);
+            byte[] contentEncoding = Encoding.UTF8.GetBytes(string.Join(",", DefaultContentEncoding));
+            byte[] contentLanguage = Encoding.UTF8.GetBytes(string.Join(",", DefaultContentLanguage));
+            byte[] contentDisposition = Encoding.UTF8.GetBytes(DefaultContentDisposition);
+            byte[] cacheControl = Encoding.UTF8.GetBytes(DefaultCacheControl);
+            byte[] fileMetadata = Encoding.UTF8.GetBytes(DefaultFileMetadata.DictionaryToString());
+            byte[] directoryMetadata = Encoding.UTF8.GetBytes(DefaultDirectoryMetadata.DictionaryToString());
+
+            int currentVariableLengthIndex = DataMovementShareConstants.DestinationCheckpointDetails.VariableLengthStartIndex;
+            writer.Write(DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion_3);
+            writer.WritePreservablePropertyOffset(true, DataMovementConstants.IntSizeInBytes, ref currentVariableLengthIndex);
+            writer.Write(preserveFilePermission);
+            writer.WritePreservablePropertyOffset(true, fileCreatedOn.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, fileLastWrittenOn.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, fileChangedOn.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, contentType.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, contentEncoding.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, contentLanguage.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, contentDisposition.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, cacheControl.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, fileMetadata.Length, ref currentVariableLengthIndex);
+            writer.WritePreservablePropertyOffset(true, directoryMetadata.Length, ref currentVariableLengthIndex);
+            writer.Write((int)DefaultFileAttributes);
+            writer.Write(fileCreatedOn);
+            writer.Write(fileLastWrittenOn);
+            writer.Write(fileChangedOn);
+            writer.Write(contentType);
+            writer.Write(contentEncoding);
+            writer.Write(contentLanguage);
+            writer.Write(contentDisposition);
+            writer.Write(cacheControl);
+            writer.Write(fileMetadata);
+            writer.Write(directoryMetadata);
+            writer.Write((byte)ShareProtocol.Nfs);
 
             return stream.ToArray();
         }
@@ -341,6 +390,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Assert.IsNull(data.FileMetadata);
             Assert.IsFalse(data.IsDirectoryMetadataSet);
             Assert.IsNull(data.DirectoryMetadata);
+            Assert.That(ShareProtocol.Smb, Is.EqualTo(data.ShareProtocol));
         }
 
         [Test]
@@ -372,6 +422,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Assert.That(data.FileMetadata, Is.EqualTo(DefaultFileMetadata));
             Assert.IsTrue(data.IsDirectoryMetadataSet);
             Assert.That(data.DirectoryMetadata, Is.EqualTo(DefaultDirectoryMetadata));
+            Assert.That(data.ShareProtocol, Is.EqualTo(ShareProtocol.Nfs));
         }
 
         [Test]
@@ -403,12 +454,13 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Assert.IsNull(data.FileMetadata);
             Assert.IsFalse(data.IsDirectoryMetadataSet);
             Assert.IsNull(data.DirectoryMetadata);
+            Assert.That(ShareProtocol.Smb, Is.EqualTo(data.ShareProtocol));
         }
 
         [Test]
-        public void Serialize()
+        public void Serialize_LatestVersion()
         {
-            byte[] expected = CreateSerializedSetValues();
+            byte[] expected = CreateSerializedSetValues_LatestVersion();
 
             ShareFileDestinationCheckpointDetails data = CreateSetSampleValues();
             byte[] actual;
@@ -422,9 +474,28 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [Test]
-        public void Deserialize()
+        public void Serialize_Version3()
         {
-            byte[] serialized = CreateSerializedSetValues();
+            // Latest Version
+            byte[] expected = CreateSerializedSetValues_Version3();
+
+            ShareFileDestinationCheckpointDetails data = CreateSetSampleValues();
+            data.Version = DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion_3;
+
+            byte[] actual;
+            using (MemoryStream stream = new())
+            {
+                data.SerializeInternal(stream);
+                actual = stream.ToArray();
+            }
+
+            Assert.That(expected, Is.EqualTo(actual));
+        }
+
+        [Test]
+        public void Deserialize_LatestVersion()
+        {
+            byte[] serialized = CreateSerializedSetValues_LatestVersion();
             ShareFileDestinationCheckpointDetails deserialized;
 
             using (MemoryStream stream = new(serialized))
@@ -433,6 +504,26 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             }
 
             AssertEquals(deserialized, CreateSetSampleValues());
+        }
+
+        [Test]
+        public void Deserialize_Version3()
+        {
+            byte[] serialized = CreateSerializedSetValues_Version3();
+            ShareFileDestinationCheckpointDetails expected = CreateSetSampleValues();
+            // We are expecting that after deserialization, the version is bumped to latest version
+            Assert.That(expected.Version, Is.EqualTo(DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion));
+            // We are expecting that after deserialization, the ShareProtocol is set to default value (SMB)
+            expected.ShareProtocol = ShareProtocol.Smb;
+
+            ShareFileDestinationCheckpointDetails deserialized;
+            using (MemoryStream stream = new(serialized))
+            {
+                deserialized = ShareFileDestinationCheckpointDetails.Deserialize(stream);
+            }
+
+            // When deserializing, Version gets bumped to the latest version and ShareProtocol is set to default value (SMB)
+            AssertEquals(deserialized, expected);
         }
 
         [Test]
@@ -464,9 +555,12 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [Test]
-        public void Deserialize_IncorrectSchemaVersion()
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(5)]
+        [TestCase(9)]
+        public void Deserialize_IncorrectSchemaVersion(int incorrectSchemaVersion)
         {
-            int incorrectSchemaVersion = 1;
             ShareFileDestinationCheckpointDetails data = CreatePreserveValues();
             data.Version = incorrectSchemaVersion;
 
@@ -479,7 +573,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [Test]
-        public void RoundTrip()
+        public void RoundTrip_LatestVersion()
         {
             ShareFileDestinationCheckpointDetails original = CreateSetSampleValues();
             using MemoryStream serialized = new();
@@ -488,6 +582,47 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             ShareFileDestinationCheckpointDetails deserialized = ShareFileDestinationCheckpointDetails.Deserialize(serialized);
 
             AssertEquals(original, deserialized);
+        }
+
+        [Test]
+        public void RoundTrip_Version3()
+        {
+            ShareFileDestinationCheckpointDetails original = CreateSetSampleValues();
+            original.Version = DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion_3;
+            using MemoryStream serialized = new();
+            original.SerializeInternal(serialized);
+            serialized.Position = 0;
+            ShareFileDestinationCheckpointDetails deserialized = ShareFileDestinationCheckpointDetails.Deserialize(serialized);
+
+            // During round trip when deserializing, Version gets bumped to the latest version
+            Assert.That(original.Version, Is.Not.EqualTo(deserialized.Version));
+            Assert.That(deserialized.Version, Is.EqualTo(DataMovementShareConstants.DestinationCheckpointDetails.SchemaVersion_4));
+            Assert.That(original.IsFileAttributesSet, Is.EqualTo(deserialized.IsFileAttributesSet));
+            Assert.That(original.FileAttributes, Is.EqualTo(deserialized.FileAttributes));
+            Assert.That(original.FilePermission, Is.EqualTo(deserialized.FilePermission));
+            Assert.That(original.IsFileCreatedOnSet, Is.EqualTo(deserialized.IsFileCreatedOnSet));
+            Assert.That(original.FileCreatedOn.Value, Is.EqualTo(deserialized.FileCreatedOn.Value));
+            Assert.That(original.IsFileLastWrittenOnSet, Is.EqualTo(deserialized.IsFileLastWrittenOnSet));
+            Assert.That(original.FileLastWrittenOn.Value, Is.EqualTo(deserialized.FileLastWrittenOn.Value));
+            Assert.That(original.IsFileChangedOnSet, Is.EqualTo(deserialized.IsFileChangedOnSet));
+            Assert.That(original.FileChangedOn.Value, Is.EqualTo(deserialized.FileChangedOn.Value));
+            Assert.That(original.IsContentTypeSet, Is.EqualTo(deserialized.IsContentTypeSet));
+            Assert.That(original.ContentType, Is.EqualTo(deserialized.ContentType));
+            Assert.That(original.IsContentEncodingSet, Is.EqualTo(deserialized.IsContentEncodingSet));
+            Assert.That(original.ContentEncoding, Is.EqualTo(deserialized.ContentEncoding));
+            Assert.That(original.IsContentLanguageSet, Is.EqualTo(deserialized.IsContentLanguageSet));
+            Assert.That(original.ContentLanguage, Is.EqualTo(deserialized.ContentLanguage));
+            Assert.That(original.IsContentDispositionSet, Is.EqualTo(deserialized.IsContentDispositionSet));
+            Assert.That(original.ContentDisposition, Is.EqualTo(deserialized.ContentDisposition));
+            Assert.That(original.IsCacheControlSet, Is.EqualTo(deserialized.IsCacheControlSet));
+            Assert.That(original.CacheControl, Is.EqualTo(deserialized.CacheControl));
+            Assert.That(original.IsFileMetadataSet, Is.EqualTo(deserialized.IsFileMetadataSet));
+            Assert.That(original.FileMetadata, Is.EqualTo(deserialized.FileMetadata));
+            Assert.That(original.IsDirectoryMetadataSet, Is.EqualTo(deserialized.IsDirectoryMetadataSet));
+            Assert.That(original.DirectoryMetadata, Is.EqualTo(deserialized.DirectoryMetadata));
+            // From version 3, the ShareProtocol does not get copied over so it is set to default value of SMB.
+            Assert.That(original.ShareProtocol, Is.Not.EqualTo(deserialized.ShareProtocol));
+            Assert.That(deserialized.ShareProtocol, Is.EqualTo(ShareProtocol.Smb));
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -589,11 +589,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Smb, });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Smb, });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Smb, FilePermissions = filePermissions });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Smb, FilePermissions = filePermissions });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -671,11 +671,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs, FilePermissions = filePermissions });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs, FilePermissions = filePermissions });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -715,9 +715,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(ShareProtocols.Nfs, ShareProtocols.Nfs)]
-        [TestCase(ShareProtocols.Smb, ShareProtocols.Smb)]
-        public async Task ValidateProtocolAsync_SmbShareDirectoryToSmbShareDirectory_CompareProtocolSetToActual(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
+        [TestCase(ShareProtocol.Nfs, ShareProtocol.Nfs)]
+        [TestCase(ShareProtocol.Smb, ShareProtocol.Smb)]
+        public async Task ValidateProtocolAsync_SmbShareDirectoryToSmbShareDirectory_CompareProtocolSetToActual(ShareProtocol sourceProtocol, ShareProtocol destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -765,7 +765,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             TransferManager transferManager = new TransferManager(managerOptions);
 
             // Act and Assert
-            if (sourceProtocol == ShareProtocols.Smb && destProtocol == ShareProtocols.Smb)
+            if (sourceProtocol == ShareProtocol.Smb && destProtocol == ShareProtocol.Smb)
             {
                 // Start transfer and await for completion.
                 TransferOperation transfer = await transferManager.StartTransferAsync(
@@ -802,9 +802,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(ShareProtocols.Nfs, ShareProtocols.Nfs)]
-        [TestCase(ShareProtocols.Smb, ShareProtocols.Smb)]
-        public async Task ValidateProtocolAsync_NfsShareDirectoryToNfsShareDirectory_CompareProtocolSetToActual(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
+        [TestCase(ShareProtocol.Nfs, ShareProtocol.Nfs)]
+        [TestCase(ShareProtocol.Smb, ShareProtocol.Smb)]
+        public async Task ValidateProtocolAsync_NfsShareDirectoryToNfsShareDirectory_CompareProtocolSetToActual(ShareProtocol sourceProtocol, ShareProtocol destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
@@ -853,7 +853,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             TransferManager transferManager = new TransferManager(managerOptions);
 
             // Act and Assert
-            if (sourceProtocol == ShareProtocols.Nfs && destProtocol == ShareProtocols.Nfs)
+            if (sourceProtocol == ShareProtocol.Nfs && destProtocol == ShareProtocol.Nfs)
             {
                 // Start transfer and await for completion.
                 TransferOperation transfer = await transferManager.StartTransferAsync(
@@ -890,9 +890,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(ShareProtocols.Nfs, ShareProtocols.Smb)]
-        [TestCase(ShareProtocols.Smb, ShareProtocols.Nfs)]
-        public async Task ValidateProtocolAsync_ShareDirectoryToShareDirectory_ShareTransferNotSupported(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
+        [TestCase(ShareProtocol.Nfs, ShareProtocol.Smb)]
+        [TestCase(ShareProtocol.Smb, ShareProtocol.Nfs)]
+        public async Task ValidateProtocolAsync_ShareDirectoryToShareDirectory_ShareTransferNotSupported(ShareProtocol sourceProtocol, ShareProtocol destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -969,11 +969,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs, FilePermissions = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs, FilePermissions = true });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -1038,11 +1038,11 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
                 destination.Container.GetDirectoryClient(destPrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             // Create Transfer Manager with single threaded operation
             TransferManagerOptions managerOptions = new TransferManagerOptions()

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
@@ -212,7 +212,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             StorageResource destinationResource = LocalFilesStorageResourceProvider.FromDirectory(destination.DirectoryPath);
 
@@ -280,7 +280,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Create storage resource containers
             StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
                 source.Container.GetDirectoryClient(sourcePrefix),
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             StorageResource destinationResource = LocalFilesStorageResourceProvider.FromDirectory(destination.DirectoryPath);
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
@@ -620,7 +620,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 resourceOptions: new ShareFileStorageResourceOptions()
                 {
                     FilePermissions = true,
-                    ShareProtocol = ShareProtocols.Nfs
+                    ShareProtocol = ShareProtocol.Nfs
                 },
                 sourceProperties: sourceProperties);
 
@@ -1164,7 +1164,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Tuple<Mock<StorageResourceItem>, Mock<ShareFileClient>> mockTuple =
                 await CopyFromUriAsyncPreserveProperties_Internal(
                     length,
-                    resourceOptions: new() { FilePermissions = true, ShareProtocol = ShareProtocols.Nfs },
+                    resourceOptions: new() { FilePermissions = true, ShareProtocol = ShareProtocol.Nfs },
                     new StorageResourceItemProperties()
                     {
                         ResourceLength = length,
@@ -1730,7 +1730,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Tuple<Mock<StorageResourceItem>, Mock<ShareFileClient>> mockTuple =
                 await CopyBlockFromUriAsyncPreserveProperties_Internal(
                     length,
-                    resourceOptions: new() { FilePermissions = true, ShareProtocol = ShareProtocols.Nfs },
+                    resourceOptions: new() { FilePermissions = true, ShareProtocol = ShareProtocol.Nfs },
                     new StorageResourceItemProperties()
                     {
                         ResourceLength = length,
@@ -2564,7 +2564,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 new()
                 {
                     FilePermissions = true,
-                    ShareProtocol = ShareProtocols.Nfs
+                    ShareProtocol = ShareProtocol.Nfs
                 });
             StorageResourceItemProperties properties = new()
             {

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -763,14 +763,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 createResource: true,
                 options: sharefileCreateOptions);
             StorageResourceItem sourceResource = new ShareFileStorageResource(sourceClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             // Create destination file
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs, FilePermissions = filePermissions });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs, FilePermissions = filePermissions });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);
@@ -817,9 +817,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(ShareProtocols.Nfs, ShareProtocols.Nfs)]
-        [TestCase(ShareProtocols.Smb, ShareProtocols.Smb)]
-        public async Task ValidateProtocolAsync_SmbShareFileToSmbShareFile_CompareProtocolSetToActual(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
+        [TestCase(ShareProtocol.Nfs, ShareProtocol.Nfs)]
+        [TestCase(ShareProtocol.Smb, ShareProtocol.Smb)]
+        public async Task ValidateProtocolAsync_SmbShareFileToSmbShareFile_CompareProtocolSetToActual(ShareProtocol sourceProtocol, ShareProtocol destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -845,7 +845,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             TransferManager transferManager = new TransferManager();
 
             // Act and Assert
-            if (sourceProtocol == ShareProtocols.Smb && destProtocol == ShareProtocols.Smb)
+            if (sourceProtocol == ShareProtocol.Smb && destProtocol == ShareProtocol.Smb)
             {
                 // Act - Start transfer and await for completion.
                 TransferOperation transfer = await transferManager.StartTransferAsync(
@@ -876,9 +876,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(ShareProtocols.Nfs, ShareProtocols.Nfs)]
-        [TestCase(ShareProtocols.Smb, ShareProtocols.Smb)]
-        public async Task ValidateProtocolAsync_NfsShareFileToNfsShareFile_CompareProtocolSetToActual(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
+        [TestCase(ShareProtocol.Nfs, ShareProtocol.Nfs)]
+        [TestCase(ShareProtocol.Smb, ShareProtocol.Smb)]
+        public async Task ValidateProtocolAsync_NfsShareFileToNfsShareFile_CompareProtocolSetToActual(ShareProtocol sourceProtocol, ShareProtocol destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
@@ -904,7 +904,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             TransferManager transferManager = new TransferManager();
 
             // Act and Assert
-            if (sourceProtocol == ShareProtocols.Nfs && destProtocol == ShareProtocols.Nfs)
+            if (sourceProtocol == ShareProtocol.Nfs && destProtocol == ShareProtocol.Nfs)
             {
                 // Act - Start transfer and await for completion.
                 TransferOperation transfer = await transferManager.StartTransferAsync(
@@ -995,9 +995,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(ShareProtocols.Nfs, ShareProtocols.Smb)]
-        [TestCase(ShareProtocols.Smb, ShareProtocols.Nfs)]
-        public async Task ValidateProtocolAsync_ShareFileToShareFile_ShareTransferNotSupported(ShareProtocols sourceProtocol, ShareProtocols destProtocol)
+        [TestCase(ShareProtocol.Nfs, ShareProtocol.Smb)]
+        [TestCase(ShareProtocol.Smb, ShareProtocol.Nfs)]
+        public async Task ValidateProtocolAsync_ShareFileToShareFile_ShareTransferNotSupported(ShareProtocol sourceProtocol, ShareProtocol destProtocol)
         {
             // Arrange
             await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
@@ -1074,14 +1074,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Use the hardlink to create the source file
             StorageResourceItem sourceResource = new ShareFileStorageResource(hardlinkClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             // Create destination file
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs, FilePermissions = true });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs, FilePermissions = true });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);
@@ -1144,14 +1144,14 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Use the symlink to create the source file
             StorageResourceItem sourceResource = new ShareFileStorageResource(symlinkClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             // Create destination file
             ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
                 container: destination.Container,
                 createResource: false);
             StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             TransferOptions options = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferDownloadTests.cs
@@ -99,7 +99,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Use the hardlink to create the source file
             StorageResource sourceResource = new ShareFileStorageResource(hardlinkClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             // Create destination local file
             string destFile = Path.Combine(destination.DirectoryPath, GetNewObjectName());
@@ -159,7 +159,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Use the symlink to create the source file
             StorageResourceItem sourceResource = new ShareFileStorageResource(symlinkClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocols.Nfs });
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
 
             // Create destination local file
             string destFile = Path.Combine(destination.DirectoryPath, GetNewObjectName());

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareSourceCheckpointDetailsTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareSourceCheckpointDetailsTests.cs
@@ -1,28 +1,48 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 extern alias DMShare;
-
 using System;
 using System.IO;
-using NUnit.Framework;
+using Azure.Storage.Test;
 using DMShare::Azure.Storage.DataMovement.Files.Shares;
+using NUnit.Framework;
 
 namespace Azure.Storage.DataMovement.Files.Shares.Tests
 {
     public class ShareSourceCheckpointDetailsTests
     {
-        [Test]
-        public void Ctor()
+        private byte[] CreateSerializedSetValues_LatestVersion()
         {
-            ShareFileSourceCheckpointDetails data = new();
+            using MemoryStream stream = new();
+            using BinaryWriter writer = new(stream);
+
+            writer.Write(DataMovementShareConstants.SourceCheckpointDetails.SchemaVersion);
+            writer.Write((byte)ShareProtocol.Nfs);
+
+            return stream.ToArray();
+        }
+
+        private void AssertEquals(ShareFileSourceCheckpointDetails left, ShareFileSourceCheckpointDetails right)
+        {
+            Assert.That(left.Version, Is.EqualTo(right.Version));
+            Assert.That(left.ShareProtocol, Is.EqualTo(right.ShareProtocol));
         }
 
         [Test]
-        public void Serialize()
+        public void Ctor()
         {
-            byte[] expected = Array.Empty<byte>();
+            ShareFileSourceCheckpointDetails data = new(ShareProtocol.Nfs);
 
-            ShareFileSourceCheckpointDetails data = new();
+            Assert.That(DataMovementShareConstants.SourceCheckpointDetails.SchemaVersion, Is.EqualTo(data.Version));
+            Assert.That(ShareProtocol.Nfs, Is.EqualTo(data.ShareProtocol));
+        }
+
+        [Test]
+        public void Serialize_LatestVersion()
+        {
+            byte[] expected = CreateSerializedSetValues_LatestVersion();
+
+            ShareFileSourceCheckpointDetails data = new(ShareProtocol.Nfs);
             byte[] actual;
             using (MemoryStream stream = new())
             {
@@ -34,14 +54,48 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [Test]
-        public void Deserialize()
+        public void Deserialize_LatestVersion()
         {
+            byte[] serialized = CreateSerializedSetValues_LatestVersion();
             ShareFileSourceCheckpointDetails deserialized;
 
-            using (MemoryStream stream = new())
+            using (MemoryStream stream = new(serialized))
             {
-                deserialized = ShareFileSourceCheckpointDetails.Deserialize(Stream.Null);
+                deserialized = ShareFileSourceCheckpointDetails.Deserialize(stream);
             }
+
+            ShareFileSourceCheckpointDetails expected = new(ShareProtocol.Nfs);
+
+            AssertEquals(deserialized, expected);
+        }
+
+        [Test]
+        [TestCase(0)]
+        [TestCase(2)]
+        [TestCase(3)]
+        public void Deserialize_IncorrectSchemaVersion(int incorrectSchemaVersion)
+        {
+            ShareFileSourceCheckpointDetails data = new(ShareProtocol.Nfs);
+            data.Version = incorrectSchemaVersion;
+
+            using MemoryStream dataStream = new MemoryStream();
+            data.SerializeInternal(dataStream);
+            dataStream.Position = 0;
+            TestHelper.AssertExpectedException(
+                () => ShareFileSourceCheckpointDetails.Deserialize(dataStream),
+                new ArgumentException($"The checkpoint file schema version {incorrectSchemaVersion} is not supported by this version of the SDK."));
+        }
+
+        [Test]
+        public void RoundTrip_LatestVersion()
+        {
+            ShareFileSourceCheckpointDetails original = new(ShareProtocol.Nfs);
+            using MemoryStream serialized = new();
+            original.SerializeInternal(serialized);
+            serialized.Position = 0;
+            ShareFileSourceCheckpointDetails deserialized = ShareFileSourceCheckpointDetails.Deserialize(serialized);
+
+            AssertEquals(original, deserialized);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareSourceCheckpointDetailsTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareSourceCheckpointDetailsTests.cs
@@ -64,9 +64,25 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 deserialized = ShareFileSourceCheckpointDetails.Deserialize(stream);
             }
 
-            ShareFileSourceCheckpointDetails expected = new(ShareProtocol.Nfs);
+            Assert.That(deserialized.Version, Is.EqualTo(DataMovementShareConstants.SourceCheckpointDetails.SchemaVersion));
+            Assert.That(deserialized.ShareProtocol, Is.EqualTo(ShareProtocol.Nfs));
+        }
 
-            AssertEquals(deserialized, expected);
+        [Test]
+        public void Deserialize_Version0()
+        {
+            byte[] serialized = new byte[0]; // Version 0 has no data
+            ShareFileSourceCheckpointDetails deserialized;
+
+            using (MemoryStream stream = new(serialized))
+            {
+                deserialized = ShareFileSourceCheckpointDetails.Deserialize(stream);
+            }
+
+            // We are expecting that after deserialization, the version is bumped to latest version
+            Assert.That(deserialized.Version, Is.EqualTo(DataMovementShareConstants.SourceCheckpointDetails.SchemaVersion));
+            // We are expecting that after deserialization, the ShareProtocol is set to default value (SMB)
+            Assert.That(deserialized.ShareProtocol, Is.EqualTo(ShareProtocol.Smb));
         }
 
         [Test]


### PR DESCRIPTION
This PR introduces Checkpointing for NFS over REST with backwards compatibility, specifically for ShareDestination and ShareSource. It also contains some refactoring and cleanup as well.