### PR TITLE
Remove checkout from daily publish

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -299,7 +299,7 @@ stages:
                 publishVstsFeed: $(DevOpsFeedID)
 
         steps:
-          - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+          - checkout: none
           - download: current
             displayName: Download ${{parameters.ArtifactName}}-signed
             artifact: ${{parameters.ArtifactName}}-signed


### PR DESCRIPTION
We were checking out when we didn't need to for this publish job. This sparse-checkout was breaking in the private repo so just removing the checkout completely.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
