### PR TITLE
Add back update-mgmt-ci.ps1

### DIFF
--- a/eng/scripts/Update-Mgmt-CI.ps1
+++ b/eng/scripts/Update-Mgmt-CI.ps1
@@ -4,4 +4,3 @@ $packagesPath = "$PSScriptRoot/../../sdk"
 
 #add path for each mgmt library into Azure.ResourceManager
 RegisterMgmtSDKToMgmtCoreClient -packagesPath $packagesPath
-

--- a/eng/scripts/Update-Mgmt-CI.ps1
+++ b/eng/scripts/Update-Mgmt-CI.ps1
@@ -1,0 +1,7 @@
+. (Join-Path $PSScriptRoot automation GenerateAndBuildLib.ps1)
+
+$packagesPath = "$PSScriptRoot/../../sdk"
+
+#add path for each mgmt library into Azure.ResourceManager
+RegisterMgmtSDKToMgmtCoreClient -packagesPath $packagesPath
+


### PR DESCRIPTION
This script was deleted in the PR: [Deprecated script of updating ci.yml for mgmt sdk](https://github.com/Azure/azure-sdk-for-net/pull/50248/). But it is still mentioned in Generate from scratch part of this [doc ](https://eng.ms/docs/products/azure-developer-experience/develop/sdk-generate-mgmt-dotnet). Furthermore, the new added version will only update the resourcemanager/ci.mgmt.yml: adding the new created SDK package path into the trigger include paths.