### PR TITLE
[EngSys] Azure Extensions version downgrade

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -241,7 +241,7 @@
     <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Connections" Version="1.2.0" />
     <PackageReference Update="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.11.0" />
+    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.8.0" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />


### PR DESCRIPTION
# Summary

The focus of these changes to move the version of `Microsoft.Extensions.Azure` back to v1.8.0 to preserve the previous earlier transitive references to the Microsoft logging extensions packages.   Once v1.12.0 is released with the updated logging references, this will move forward.