### PR TITLE
Update daily publishing to use a releaseJob

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -313,15 +313,15 @@ stages:
             deploy:
               steps:
                 - pwsh: |
-                  # For safety default to publishing to the private feed.
-                  # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr
-                  $devopsFeedId = '590cfd2a-581c-4dcb-a12e-6568ce786175/fa8b2d77-74d9-48d7-bb96-badb2b9c6ca4'
-                  if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-net') {
-                    $devopsFeedId = '${{ parameters.DevOpsFeedID }}'
-                  }
-                  echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
-                  echo "Using DevopsFeedId = $devopsFeedId"
-                displayName: Setup DevOpsFeedId
+                    # For safety default to publishing to the private feed.
+                    # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr
+                    $devopsFeedId = '590cfd2a-581c-4dcb-a12e-6568ce786175/fa8b2d77-74d9-48d7-bb96-badb2b9c6ca4'
+                    if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-net') {
+                      $devopsFeedId = '${{ parameters.DevOpsFeedID }}'
+                    }
+                    echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
+                    echo "Using DevopsFeedId = $devopsFeedId"
+                  displayName: Setup DevOpsFeedId
                 
       - job: PublishDocsToNightlyBranch
         dependsOn: PublishPackages

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -104,8 +104,8 @@ stages:
                 dependsOn: TagRepository
 
                 pool:
-                  name: azsdk-pool-mms-ubuntu-2004-general
-                  image: azsdk-pool-mms-ubuntu-2004-1espt
+                  name: azsdk-pool
+                  image: ubuntu-24.04
                   os: linux
 
                 templateContext:
@@ -287,8 +287,8 @@ stages:
         environment: none
 
         pool:
-          name: $(LINUXPOOL)
-          image: $(LINUXVMIMAGE)
+          name: azsdk-pool
+          image: ubuntu-24.04
           os: linux
 
         templateContext:

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -299,15 +299,6 @@ stages:
               artifactName: ${{parameters.ArtifactName}}-signed
               targetPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
 
-          outputParentDirectory: '$(Pipeline.Workspace)'
-          outputs:
-            - ${{ each artifact in parameters.Artifacts }}:
-              - output: nuget
-                displayName: 'Publish to DevOps Feed'
-                packageParentPath: '$(Pipeline.Workspace)'
-                packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
-                publishVstsFeed: $(DevOpsFeedID)
-
         strategy:
           runOnce:
             deploy:
@@ -322,6 +313,14 @@ stages:
                     echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
                     echo "Using DevopsFeedId = $devopsFeedId"
                   displayName: Setup DevOpsFeedId
+
+                - ${{ each artifact in parameters.Artifacts }}:
+                  - task: 1ES.PublishNuget@1
+                    displayName: 'Publish to DevOps Feed'
+                    inputs:
+                      packageParentPath: '$(Pipeline.Workspace)'
+                      packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
+                      publishVstsFeed: $(DevOpsFeedID)
                 
       - job: PublishDocsToNightlyBranch
         dependsOn: PublishPackages

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -123,6 +123,7 @@ stages:
                         - task: 1ES.PublishNuget@1
                           displayName: Publish ${{artifact.name}} package to NuGet.org
                           inputs:
+                            useDotNetTask: true
                             packageParentPath: '$(Pipeline.Workspace)'
                             packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)//${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                             nuGetFeedType: external
@@ -131,6 +132,7 @@ stages:
                         - task: 1ES.PublishNuget@1
                           displayName: Publish to DevOps Feed
                           inputs:
+                            useDotNetTask: true
                             packageParentPath: '$(Pipeline.Workspace)'
                             packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                             publishVstsFeed: ${{ parameters.DevOpsFeedID }}
@@ -318,6 +320,7 @@ stages:
                   - task: 1ES.PublishNuget@1
                     displayName: 'Publish to DevOps Feed'
                     inputs:
+                      useDotNetTask: true
                       packageParentPath: '$(Pipeline.Workspace)'
                       packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                       publishVstsFeed: $(DevOpsFeedID)

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -281,14 +281,24 @@ stages:
       - template: /eng/pipelines/templates/variables/image.yml
     dependsOn: Signing
     jobs:
-      - job: PublishPackages
+      - deployment: PublishPackages
         condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'))))
         displayName: Publish package to daily feed
+        environment: none
+
         pool:
-          name: $(WINDOWSPOOL)
-          image: $(WINDOWSVMIMAGE)
-          os: windows
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE)
+          os: linux
+
         templateContext:
+          type: releaseJob 
+          isProduction: true
+          inputs: 
+            - input: pipelineArtifact
+              artifactName: ${{parameters.ArtifactName}}-signed
+              targetPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
+
           outputParentDirectory: '$(Pipeline.Workspace)'
           outputs:
             - ${{ each artifact in parameters.Artifacts }}:
@@ -298,22 +308,21 @@ stages:
                 packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                 publishVstsFeed: $(DevOpsFeedID)
 
-        steps:
-          - checkout: none
-          - download: current
-            displayName: Download ${{parameters.ArtifactName}}-signed
-            artifact: ${{parameters.ArtifactName}}-signed
-          - pwsh: |
-              # For safety default to publishing to the private feed.
-              # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr
-              $devopsFeedId = '590cfd2a-581c-4dcb-a12e-6568ce786175/fa8b2d77-74d9-48d7-bb96-badb2b9c6ca4'
-              if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-net') {
-                $devopsFeedId = '${{ parameters.DevOpsFeedID }}'
-              }
-              echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
-              echo "Using DevopsFeedId = $devopsFeedId"
-            displayName: Setup DevOpsFeedId
-
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - pwsh: |
+                  # For safety default to publishing to the private feed.
+                  # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr
+                  $devopsFeedId = '590cfd2a-581c-4dcb-a12e-6568ce786175/fa8b2d77-74d9-48d7-bb96-badb2b9c6ca4'
+                  if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-net') {
+                    $devopsFeedId = '${{ parameters.DevOpsFeedID }}'
+                  }
+                  echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
+                  echo "Using DevopsFeedId = $devopsFeedId"
+                displayName: Setup DevOpsFeedId
+                
       - job: PublishDocsToNightlyBranch
         dependsOn: PublishPackages
         condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'))))


### PR DESCRIPTION
Switch to using a releaseJob so that we don't need redundant scanning or to check out the repo, which currently fails in the private repo. 