### PR TITLE
Fix naming of model factory

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Utilities/TypeNameUtilities.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Utilities/TypeNameUtilities.cs
@@ -8,7 +8,6 @@ namespace Azure.Generator.Utilities
     internal static class TypeNameUtilities
     {
         private const string AzurePackageNamespacePrefix = "Azure.";
-        private const string AzureMgmtPackageNamespacePrefix = "Azure.ResourceManager.";
 
         /// <summary>
         /// Returns the name of the RP from the package name using the following:
@@ -22,9 +21,10 @@ namespace Azure.Generator.Utilities
             var segments = packageName.Split('.');
             if (packageName.StartsWith(AzurePackageNamespacePrefix))
             {
-                if (packageName.StartsWith(AzureMgmtPackageNamespacePrefix))
+                if (segments.Length > 2)
                 {
-                    return string.Join("", segments.Skip(2)); // skips "Azure" and "ResourceManager"
+                    // skips "Azure" and the following segment
+                    return string.Join("", segments.Skip(2));
                 }
 
                 return string.Join("", segments.Skip(1));

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/ModelFactoryVisitorTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Generator.Tests.Visitors
             var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().SingleOrDefault();
 
             Assert.IsNotNull(modelFactory);
-            Assert.AreEqual("MessagingSomeServiceModelFactory", modelFactory!.Type.Name);
+            Assert.AreEqual("SomeServiceModelFactory", modelFactory!.Type.Name);
         }
 
         [Test]

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/special-headers/client-request-id/src/Generated/XmsClientRequestIdClientBuilderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/special-headers/client-request-id/src/Generated/XmsClientRequestIdClientBuilderExtensions.cs
@@ -12,7 +12,7 @@ using Azure.SpecialHeaders.XmsClientRequestId;
 
 namespace Microsoft.Extensions.Azure
 {
-    public static partial class SpecialHeadersXmsClientRequestIdClientBuilderExtensions
+    public static partial class XmsClientRequestIdClientBuilderExtensions
     {
         public static IAzureClientBuilder<XmsClientRequestIdClient, XmsClientRequestIdClientOptions> AddXmsClientRequestIdClient<TBuilder>(this TBuilder builder, Uri endpoint)
             where TBuilder : IAzureClientFactoryBuilder => throw null;


### PR DESCRIPTION
Uses the last segment of the namespace for model factory/client builder extension naming. This matches the pattern commonly used in existing data plane libraries. For mgmt, the behavior is unchanged.