### PR TITLE
Fix NullReferenceException when evaluating `RunStepDetailsUpdate.FunctionName

### DIFF
--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/RunStepDetailsUpdate.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/RunStepDetailsUpdate.cs
@@ -46,7 +46,7 @@ public class RunStepDetailsUpdate : StreamingUpdate
         => _asCodeCall?.CodeInterpreter?.Outputs;
 
     /// <inheritdoc cref="RunStepDeltaFunction.Name"/>
-    public string FunctionName => _asFunctionCall.Function?.Name;
+    public string FunctionName => _asFunctionCall?.Function?.Name;
 
     /// <inheritdoc cref="RunStepDeltaFunction.Arguments"/>
     public string FunctionArguments => _asFunctionCall?.Function?.Arguments;


### PR DESCRIPTION
`_asFunctionCall` may be null for a non-function related tool.  All other properties support null fall-through.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
