### PR TITLE
Move nuget push to use windows image

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -105,8 +105,8 @@ stages:
 
                 pool:
                   name: azsdk-pool
-                  image: ubuntu-22.04
-                  os: linux
+                  image: windows-2022 # Nuget publish requires .NET framework on windows to handle the auth
+                  os: windows
 
                 templateContext:
                   type: releaseJob  # Required, this indicates this deployment job is a release job
@@ -131,7 +131,6 @@ stages:
                         - task: 1ES.PublishNuget@1
                           displayName: Publish to DevOps Feed
                           inputs:
-                            useDotNetTask: true
                             packageParentPath: '$(Pipeline.Workspace)'
                             packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                             publishVstsFeed: ${{ parameters.DevOpsFeedID }}
@@ -289,8 +288,8 @@ stages:
 
         pool:
           name: azsdk-pool
-          image: ubuntu-22.04
-          os: linux
+          image: windows-2022 # Nuget publish requires .NET framework on windows to handle the auth
+          os: windows
 
         templateContext:
           type: releaseJob 

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -105,7 +105,7 @@ stages:
 
                 pool:
                   name: azsdk-pool
-                  image: ubuntu-24.04
+                  image: ubuntu-22.04
                   os: linux
 
                 templateContext:
@@ -123,7 +123,6 @@ stages:
                         - task: 1ES.PublishNuget@1
                           displayName: Publish ${{artifact.name}} package to NuGet.org
                           inputs:
-                            useDotNetTask: true
                             packageParentPath: '$(Pipeline.Workspace)'
                             packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)//${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                             nuGetFeedType: external
@@ -290,7 +289,7 @@ stages:
 
         pool:
           name: azsdk-pool
-          image: ubuntu-24.04
+          image: ubuntu-22.04
           os: linux
 
         templateContext:
@@ -320,7 +319,6 @@ stages:
                   - task: 1ES.PublishNuget@1
                     displayName: 'Publish to DevOps Feed'
                     inputs:
-                      useDotNetTask: true
                       packageParentPath: '$(Pipeline.Workspace)'
                       packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                       publishVstsFeed: $(DevOpsFeedID)


### PR DESCRIPTION
Currently ubuntu 24.04 no longer has mono installed and so the NugetCommand push no longer works. Using the DonetCoreCLR task to push doesn't work either with because it fails with "Error: DotNetCore currently does not support using an encrypted Api Key." (see https://github.com/microsoft/azure-pipelines-tasks/issues/7160 for details).

After looking around we are switching our publishing to run on windows as that will always have .NET installed and doesn't rely on mono at all.
