### PR TITLE
[Extensions] Support for federated managed identity

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   - `tenantId` : The tenant where the target resource was created
   - `clientId` : The client identifier for the application, which must be granted access on the target resource
-  - `managedIdentityClientId` : The user-assigned managed identity which you configured as a Federated Identity Credential (FIC)
+  - One of [`managedIdentityClientId`, `objectId`, `resourceId`] : The user-assigned managed identity which you configured as a Federated Identity Credential (FIC)
   - `azureCloud`: One of the following Azure cloud environments:
     - `public` for Entra ID Global cloud
     - `usgov` for Entra ID US Government

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Features Added
 
+- Added support for [federated managed identity](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity?tabs=microsoft-entra-admin-center#azureidentity) support in the client factory by specifying configuration item `credential` as "managedidentityasfederatedidentity" and providing the following named configuration items:
+
+  - `tenantId` : The tenant where the target resource was created
+  - `clientId` : The client identifier for the application, which must be granted access on the target resource
+  - `managedIdentityClientId` : The managed identity which you configured as a Federated Identity Credential (FIC)
+  - `federatedAudience`: One of the following token audiences, specific to the cloud that you're running in:
+    - `api://AzureADTokenExchange` for Entra ID Global cloud
+    - `api://AzureADTokenExchangeUSGov` for Entra ID US Government
+    - `api://AzureADTokenExchangeChina` for Entra ID China operated by 21Vianet
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -9,10 +9,10 @@
   - `tenantId` : The tenant where the target resource was created
   - `clientId` : The client identifier for the application, which must be granted access on the target resource
   - `managedIdentityClientId` : The managed identity which you configured as a Federated Identity Credential (FIC)
-  - `federatedAudience`: One of the following token audiences, specific to the cloud that you're running in:
-    - `api://AzureADTokenExchange` for Entra ID Global cloud
-    - `api://AzureADTokenExchangeUSGov` for Entra ID US Government
-    - `api://AzureADTokenExchangeChina` for Entra ID China operated by 21Vianet
+  - `azureCloud`: One of the following Azure cloud environments:
+    - `public` for Entra ID Global cloud
+    - `usgov` for Entra ID US Government
+    - `china` for Entra ID China operated by 21Vianet
 
 ### Breaking Changes
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   - `tenantId` : The tenant where the target resource was created
   - `clientId` : The client identifier for the application, which must be granted access on the target resource
-  - `managedIdentityClientId` : The managed identity which you configured as a Federated Identity Credential (FIC)
+  - `managedIdentityClientId` : The user-assigned managed identity which you configured as a Federated Identity Credential (FIC)
   - `azureCloud`: One of the following Azure cloud environments:
     - `public` for Entra ID Global cloud
     - `usgov` for Entra ID US Government

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added support for [federated managed identity](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity?tabs=microsoft-entra-admin-center#azureidentity) support in the client factory by specifying configuration item `credential` as "managedidentityasfederatedidentity" and providing the following named configuration items:
+- Added support for [managed identity as a federated identity credential](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity?tabs=microsoft-entra-admin-center#azureidentity) in the client factory by specifying configuration item `credential` as "managedidentityasfederatedidentity" and providing the following named configuration items:
 
   - `tenantId` : The tenant where the target resource was created
   - `clientId` : The client identifier for the application, which must be granted access on the target resource

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/AzureCloud.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/AzureCloud.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Extensions.Azure
+{
+    internal static class AzureCloud
+    {
+        public const string Public = "public";
+        public const string USGov = "usgov";
+        public const string China = "china";
+    }
+}

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Extensions.Azure
                     string.IsNullOrWhiteSpace(clientId) ||
                     string.IsNullOrWhiteSpace(azureCloud))
                 {
-                    throw new ArgumentException("For managed federated identity, 'tenantId', 'clientId', 'azureCloud', and one of ['managedIdentityClientId', 'resourceId', 'objectId'] must be specified via environment variables or the configuration.");
+                    throw new ArgumentException("For managed identity as a federated identity credential, 'tenantId', 'clientId', 'azureCloud', and one of ['managedIdentityClientId', 'resourceId', 'objectId'] must be specified via environment variables or the configuration.");
                 }
 
                 if (!string.IsNullOrWhiteSpace(resourceId))

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ManagedFederatedIdentityCredential.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ManagedFederatedIdentityCredential.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Azure.Internal
         /// </summary>
         /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal.</param>
-        /// <param name="managedIdentityId">The managed identity which has been configured as a Federated Identity Credential (FIC).  May be a client id, resource id, or object id.</param>
+        /// <param name="managedIdentityId">The user-assigned managed identity which has been configured as a Federated Identity Credential (FIC).  May be a client id, resource id, or object id.</param>
         /// <param name="azureCloud">
         ///     The name of the cloud where the managed identity is configured.  Valid values are:
         ///       <list type="bullet">
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Azure.Internal
         /// </summary>
         /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal.</param>
-        /// <param name="managedIdentityId">The managed identity which has been configured as a Federated Identity Credential (FIC).  May be a client id, resource id, or object id.</param>
+        /// <param name="managedIdentityId">The user-assigned managed identity which has been configured as a Federated Identity Credential (FIC).  May be a client id, resource id, or object id.</param>
         /// <param name="azureCloud">
         ///     The name of the cloud where the managed identity is configured.  Valid values are:
         ///       <list type="bullet">
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.Azure.Internal
         /// </summary>
         /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal.</param>
-        /// <param name="managedIdentityId">The managed identity which has been configured as a Federated Identity Credential (FIC).  May be a client id, resource id, or object id.</param>
+        /// <param name="managedIdentityId">The user-assigned managed identity which has been configured as a Federated Identity Credential (FIC).  May be a client id, resource id, or object id.</param>
         /// <param name="azureCloud">
         ///     The name of the cloud where the managed identity is configured.  Valid values are:
         ///       <list type="bullet">

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ManagedFederatedIdentityCredential.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ManagedFederatedIdentityCredential.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+
+namespace Microsoft.Extensions.Azure.Internal
+{
+    internal class ManagedFederatedIdentityCredential : TokenCredential
+    {
+        private readonly ManagedIdentityCredential _managedIdentityCredential;
+        private readonly ClientAssertionCredential _clientAssertionCredential;
+
+        /// <summary>
+        ///   Gets the set of additionally allowed tenants.
+        /// </summary>
+        public IList<string> AdditionallyAllowedTenants { get; }
+        /// <summary>
+        /// Creates an instance of the ManagedFederatedIdentityCredential with a synchronous callback that provides a signed client assertion to authenticate against Microsoft Entra ID.
+        /// </summary>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
+        /// <param name="clientId">The client (application) ID of the service principal.</param>
+        /// <param name="managedIdentityClientId">The managed identity which has been configured as a Federated Identity Credential (FIC).</param>
+        /// <param name="federatedAudience">
+        ///     The audience for the federated credential, specific to the cloud.  Valid values are:
+        ///       <list type="bullet">
+        ///         <item>
+        ///           <term>api://AzureADTokenExchange</term>
+        ///           <description>Entra ID Global cloud</description>
+        ///         </item>
+        ///         <item>
+        ///           <term>api://AzureADTokenExchangeUSGov</term>
+        ///           <description>Entra ID US Government</description>
+        ///         </item>
+        ///         <item>
+        ///           <term>api://AzureADTokenExchangeChina</term>
+        ///           <description>Entra ID China operated by 21Vianet</description>
+        ///         </item>
+        ///       </list>
+        /// </param>
+        /// <param name="additionallyAllowedTenants">The set of </param>
+        public ManagedFederatedIdentityCredential(string tenantId, string clientId, string managedIdentityClientId, string federatedAudience, IEnumerable<string> additionallyAllowedTenants = default)
+        {
+            ClientAssertionCredentialOptions clientAssertionOptions = null;
+
+            if (additionallyAllowedTenants != null)
+            {
+                clientAssertionOptions = new();
+
+                foreach (var tenant in additionallyAllowedTenants)
+                {
+                    clientAssertionOptions.AdditionallyAllowedTenants.Add(tenant);
+                }
+
+                AdditionallyAllowedTenants = clientAssertionOptions.AdditionallyAllowedTenants;
+            }
+            else
+            {
+                AdditionallyAllowedTenants = new List<string>();
+            }
+
+            _managedIdentityCredential = new ManagedIdentityCredential(managedIdentityClientId);
+            _clientAssertionCredential = new ClientAssertionCredential(
+                tenantId,
+                clientId,
+                async token =>
+                    (await _managedIdentityCredential
+                        .GetTokenAsync(new TokenRequestContext([$"{federatedAudience}/.default"]))
+                        .ConfigureAwait(false))
+                    .Token,
+                clientAssertionOptions
+            );
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagedFederatedIdentityCredential"/> class.
+        /// </summary>
+        protected ManagedFederatedIdentityCredential()
+        {
+        }
+
+        /// <summary>
+        /// Gets an <see cref="T:Azure.Core.AccessToken" /> for the specified set of scopes.
+        /// </summary>
+        /// <param name="requestContext">The <see cref="T:Azure.Core.TokenRequestContext" /> with authentication information.</param>
+        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken" /> to use.</param>
+        /// <returns>
+        /// A valid <see cref="T:Azure.Core.AccessToken" />.
+        /// </returns>
+        /// <remarks>
+        /// Caching and management of the lifespan for the <see cref="T:Azure.Core.AccessToken" /> is considered the responsibility of the caller: each call should request a fresh token being requested.
+        /// </remarks>
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken) => _clientAssertionCredential.GetToken(requestContext, cancellationToken);
+
+        /// <summary>
+        /// Gets an <see cref="T:Azure.Core.AccessToken" /> for the specified set of scopes.
+        /// </summary>
+        /// <param name="requestContext">The <see cref="T:Azure.Core.TokenRequestContext" /> with authentication information.</param>
+        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken" /> to use.</param>
+        /// <returns>
+        /// A valid <see cref="T:Azure.Core.AccessToken" />.
+        /// </returns>
+        /// <remarks>
+        /// Caching and management of the lifespan for the <see cref="T:Azure.Core.AccessToken" /> is considered the responsibility of the caller: each call should request a fresh token being requested.
+        /// </remarks>
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken) => _clientAssertionCredential.GetTokenAsync(requestContext, cancellationToken);
+    }
+}

--- a/sdk/extensions/ci.yml
+++ b/sdk/extensions/ci.yml
@@ -37,7 +37,7 @@ extends:
       safeName: AzureExtensionsAspNetCoreConfigurationSecrets
     - name: Microsoft.Azure.WebJobs.Extensions.Clients
       safeName: MicrosoftAzureWebJobsExtensionsClients
-    CheckAOTCompat: true
+    CheckAOTCompat: false
     AOTTestInputs:
     - ArtifactName: Microsoft.Extensions.Azure
       ExpectedWarningsFilepath: None

--- a/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
+++ b/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
@@ -407,6 +407,7 @@ namespace Azure.Identity
             }
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Parameters to this method are primitive and are trimmer safe.")]
         [Event(ManagedIdentitySourceAttemptedEvent, Level = EventLevel.Informational, Message = ManagedIdentitySourceAttemptedMessage)]
         public void ManagedIdentitySourceAttempted(string source, bool isSelected)
         {


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-net/issues/49454

# Summary

The focus of these changes is to add federated managed identity credential support to the `Microsoft.Extensions.Azure` package.

## Resources and references

- [[FEATURE REQ] Support federated identity credentials with managed identity (#49454)](https://github.com/Azure/azure-sdk-for-net/issues/49454)
- [Configure an application to trust a managed identity](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity?tabs=microsoft-entra-admin-center#azureidentity)

