### PR TITLE
Add dependency @azure-tools/typespec-azure-rulesets

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
@@ -1229,13 +1229,10 @@
             "doc": "The additional info.",
             "type": {
              "$id": "152",
-             "kind": "model",
-             "name": "ErrorAdditionalInfoInfo",
-             "namespace": "Azure.ResourceManager.CommonTypes",
-             "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorAdditionalInfo.info.anonymous",
-             "usage": "Output,Json,Exception,LroInitial,LroPolling,LroFinalEnvelope",
-             "decorators": [],
-             "properties": []
+             "kind": "unknown",
+             "name": "unknown",
+             "crossLanguageDefinitionId": "",
+             "decorators": []
             },
             "optional": true,
             "readOnly": true,
@@ -1293,9 +1290,6 @@
   },
   {
    "$ref": "146"
-  },
-  {
-   "$ref": "152"
   },
   {
    "$id": "159",

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.17",
         "@azure-tools/typespec-azure-core": "0.56.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.56.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.56.2",
+        "@azure-tools/typespec-azure-rulesets": "0.56.1",
         "@azure-tools/typespec-client-generator-core": "0.56.2",
         "@eslint/js": "^9.2.0",
         "@types/node": "~22.7.5",
@@ -132,9 +133,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.56.0.tgz",
-      "integrity": "sha512-S95n4h6RDo0ksOuo1tmXnwvqxiYy8jHLdPDvMFb4ZRRyZzZFKPA9tXeu0s4EJTWrpD7RwS9/UtnJlKS6gbaycA==",
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.56.2.tgz",
+      "integrity": "sha512-h1xYafwdSxtdu7Aqyicg7cG65rHGRw+e/H880JYlzJ41lniwPc1ci6yJmoeab8EgiQjbjoGAvVY1gYTLbFrESw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -147,10 +148,26 @@
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": "^0.56.0",
         "@typespec/compiler": "^1.0.0",
-        "@typespec/http": "^1.0.0",
+        "@typespec/http": "^1.0.1",
         "@typespec/openapi": "^1.0.0",
         "@typespec/rest": "^0.70.0",
         "@typespec/versioning": "^0.70.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-rulesets": {
+      "version": "0.56.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.56.1.tgz",
+      "integrity": "sha512-szK986vhfAZ5W2EIBH8nReOfw1zl1cryc5cs5nCEEbUf1GTq9e302Fky9CfwBLEeqTrtsJEZYtIRtchKmytVaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "^0.56.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.56.1",
+        "@azure-tools/typespec-client-generator-core": "^0.56.0",
+        "@typespec/compiler": "^1.0.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -42,7 +42,8 @@
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.17",
     "@azure-tools/typespec-azure-core": "0.56.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.56.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.56.2",
+    "@azure-tools/typespec-azure-rulesets": "0.56.1",
     "@azure-tools/typespec-client-generator-core": "0.56.2",
     "@eslint/js": "^9.2.0",
     "@types/node": "~22.7.5",


### PR DESCRIPTION
When try to generate SDK with mgmt emitter, got error:
> error import-not-found: Couldn't resolve import "@azure-tools/typespec-azure-rulesets"