### PR TITLE
Align version for System.ClientModel

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -414,7 +414,7 @@
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />
-    <PackageReference Update="System.ClientModel" Version="1.4.1" />
+    <PackageReference Update="System.ClientModel" Version="1.4.2" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />


### PR DESCRIPTION
To fix the downgrade warning of System.ClientModel [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4952740&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=352c26c2-0ff9-5c2d-4ae8-5acc0e1d472e&l=31)
> /mnt/vss/_work/1/s/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local.Tests/TestProjects.Local.Tests.csproj : error NU1605: Warning As Error: Detected package downgrade: System.ClientModel from 1.4.2 to 1.4.1. Reference the package directly from the project to select a different version.  [/mnt/vss/_work/1/s/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management.sln]
/mnt/vss/_work/1/s/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local.Tests/TestProjects.Local.Tests.csproj : error NU1605:  TestProjects.Local.Tests -> Azure.Core 1.46.2 -> System.ClientModel (>= 1.4.2)  [/mnt/vss/_work/1/s/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management.sln]
/mnt/vss/_work/1/s/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local.Tests/TestProjects.Local.Tests.csproj : error NU1605:  TestProjects.Local.Tests -> System.ClientModel (>= 1.4.1) [/mnt/vss/_work/1/s/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management.sln]

