### PR TITLE
[EnySys] Remove test-specific ClientModel version

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -414,7 +414,6 @@
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />
-    <PackageReference Update="System.ClientModel" Version="1.4.2" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the version entry for `System.ClientModel` specific to tests.  Libraries should be getting their reference transitively via `Azure.Core` rather than directly, so there's no reason for tests to be using a specific version.