### PR TITLE
[KeyVault] Update Secrets with service version 7.6

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -18,6 +18,8 @@ Thank you to our developer community members who helped to make the Key Vault cl
 
 ### Other Changes
 
+- The default service version is now "7.6".
+
 ## 4.8.0-beta.1 (2025-04-08)
 
 ### Features Added

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -18,8 +18,6 @@ Thank you to our developer community members who helped to make the Key Vault cl
 
 ### Other Changes
 
-- The default service version is now "7.6".
-
 ## 4.8.0-beta.1 (2025-04-08)
 
 ### Features Added

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 4.8.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 4.8.0 (2025-06-13)
 
 ### Other Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- The default service version is now "7.6".
+
 ## 4.8.0-beta.1 (2025-04-08)
 
 ### Other Changes

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net8.0.cs
@@ -95,7 +95,7 @@ namespace Azure.Security.KeyVault.Secrets
     }
     public partial class SecretClientOptions : Azure.Core.ClientOptions
     {
-        public SecretClientOptions(Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion version = Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion.V7_6_Preview_2) { }
+        public SecretClientOptions(Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion version = Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion.V7_6) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -106,7 +106,7 @@ namespace Azure.Security.KeyVault.Secrets
             V7_3 = 3,
             V7_4 = 4,
             V7_5 = 5,
-            V7_6_Preview_2 = 6,
+            V7_6 = 6,
         }
     }
     public static partial class SecretModelFactory

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.netstandard2.0.cs
@@ -95,7 +95,7 @@ namespace Azure.Security.KeyVault.Secrets
     }
     public partial class SecretClientOptions : Azure.Core.ClientOptions
     {
-        public SecretClientOptions(Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion version = Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion.V7_6_Preview_2) { }
+        public SecretClientOptions(Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion version = Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion.V7_6) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -106,7 +106,7 @@ namespace Azure.Security.KeyVault.Secrets
             V7_3 = 3,
             V7_4 = 4,
             V7_5 = 5,
-            V7_6_Preview_2 = 6,
+            V7_6 = 6,
         }
     }
     public static partial class SecretModelFactory

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/assets.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/keyvault/Azure.Security.KeyVault.Secrets",
-  "Tag": "net/keyvault/Azure.Security.KeyVault.Secrets_720b7c78bb"
+  "Tag": "net/keyvault/Azure.Security.KeyVault.Secrets_aadac0af4e"
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Secrets client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Secrets client library</AssemblyTitle>
-    <Version>4.8.0-beta.2</Version>
+    <Version>4.8.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.7.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Secrets;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Secrets
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V7_6_Preview_2;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V7_6;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client library.
@@ -57,7 +57,7 @@ namespace Azure.Security.KeyVault.Secrets
             /// <summary>
             /// The Key Vault API version 7.6-preview.2.
             /// </summary>
-            V7_6_Preview_2 = 6,
+            V7_6 = 6,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -97,7 +97,7 @@ namespace Azure.Security.KeyVault.Secrets
                 ServiceVersion.V7_3 => "7.3",
                 ServiceVersion.V7_4 => "7.4",
                 ServiceVersion.V7_5 => "7.5",
-                ServiceVersion.V7_6_Preview_2 => "7.6-preview.2",
+                ServiceVersion.V7_6 => "7.6",
                 _ => throw new ArgumentException(Version.ToString()),
             };
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretsTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretsTestBase.cs
@@ -20,7 +20,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         SecretClientOptions.ServiceVersion.V7_2,
         SecretClientOptions.ServiceVersion.V7_1,
         SecretClientOptions.ServiceVersion.V7_0,
-        SecretClientOptions.ServiceVersion.V7_6_Preview_2)]
+        SecretClientOptions.ServiceVersion.V7_6)]
     public abstract class SecretsTestBase : RecordedTestBase<KeyVaultTestEnvironment>
     {
         protected TimeSpan PollingInterval => Recording.Mode == RecordedTestMode.Playback


### PR DESCRIPTION
This PR prepares KeyVault Secrets for 4.8.0 release:
- Replaces preview version `7.6-preview.2` with `7.6`.
- Re-records tests.