### PR TITLE
Fix Crashing `SavePackageProps` due to missing clientmodel

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -414,7 +414,6 @@
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />
-    <PackageReference Update="System.ClientModel" Version="1.4.2" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -505,6 +505,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         }
     }
 
+    Write-Host "Found $($packagesWithChanges.Count) packages with changes in the repo at the end of Get-PrPkgProperties"
     $packagesWithChanges | ForEach-Object {
         Write-Host "Package: $($_.Name) Version: $($_.Version) Directory: $($_.DirectoryPath)"
     }

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -505,6 +505,10 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         }
     }
 
+    $packagesWithChanges | ForEach-Object {
+        Write-Host "Package: $($_.Name) Version: $($_.Version) Directory: $($_.DirectoryPath)"
+    }
+
     return $packagesWithChanges
 }
 

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -4,12 +4,6 @@ parameters:
   Container: false
 
 steps:
-  - task: MSBuild@1
-    displayName: Install DevOps Logger
-    condition: and(succeeded(), eq(${{ parameters.Container }}, false))
-    inputs:
-      solution: eng/InstallDevopsLogger.proj
-      msbuildArguments: /p:WorkFolder="$(Agent.WorkFolder)" /p:BuildDirectory="$(Agent.BuildDirectory)"
   # Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
   - task: UseDotNet@2
     displayName: 'Use .NET SDK'

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -40,6 +40,7 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
 
     $pkgPath, $serviceDirectory, $pkgName, $pkgVersion, $sdkType, $isNewSdk, $dllFolder = $projectOutput.Split("' '", [System.StringSplitOptions]::RemoveEmptyEntries).Trim("' ")
     if(!(Test-Path $pkgPath)) {
+      $pkgPathSafeOutput = $projectOutput.Replace("##", "")
       Write-Host "Parsed package path `$pkgPath` does not exist so skipping the package line '$projectOutput'."
       continue
     }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -160,6 +160,8 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
     }
   }
 
+  Write-Host "Right before exiting Get-dotnet-AdditionalValidationPackagesFromPackageSet, additionalValidationPackages count is $($additionalValidationPackages.Count)"
+
   return $additionalValidationPackages
 }
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -94,6 +94,11 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
     $allPackageProps += $pkgProp
   }
 
+  Write-Host "Found $($allPackageProps.Count) packages in $serviceDirectory and returning them."
+  $allPackageProps | ForEach-Object {
+    Write-Host "Package: $($_.Name) Version: $($_.Version) Directory: $($_.DirectoryPath)"
+  }
+
   return $allPackageProps
 }
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -41,7 +41,7 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
     $pkgPath, $serviceDirectory, $pkgName, $pkgVersion, $sdkType, $isNewSdk, $dllFolder = $projectOutput.Split("' '", [System.StringSplitOptions]::RemoveEmptyEntries).Trim("' ")
     if(!(Test-Path $pkgPath)) {
       $pkgPathSafeOutput = $projectOutput.Replace("##", "")
-      Write-Host "Parsed package path `$pkgPath` does not exist so skipping the package line '$projectOutput'."
+      Write-Host "Parsed package path `$pkgPath` does not exist so skipping the package line '$pkgPathSafeOutput'."
       continue
     }
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -28,7 +28,7 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
 
   foreach ($projectOutput in $msbuildOutput)
   {
-    $projectOutput = $projectOutput.Trim().Replace("##vso[task.logissue"), "vso[task.logissue"
+    $projectOutput = $projectOutput.Trim().Replace("##vso[task.logissue", "vso[task.logissue")
 
     if (!$projectOutput) {
       Write-Verbose "Get-AllPackageInfoFromRepo::projectOutput was null or empty, skipping"
@@ -37,8 +37,7 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
 
     $pkgPath, $serviceDirectory, $pkgName, $pkgVersion, $sdkType, $isNewSdk, $dllFolder = $projectOutput.Split("' '", [System.StringSplitOptions]::RemoveEmptyEntries).Trim("' ")
     if(!(Test-Path $pkgPath)) {
-      $pkgPathSafeOutput = $projectOutput.Replace("##", "")
-      Write-Host "Parsed package path `$pkgPath` does not exist so skipping the package line '$pkgPathSafeOutput'."
+      Write-Host "Parsed package path `$pkgPath` does not exist so skipping the package line '$projectOutput'."
       continue
     }
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -28,10 +28,7 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
 
   foreach ($projectOutput in $msbuildOutput)
   {
-    if ($projectOutput -match "^\s*##vso\[task.logissue") {
-      # we cannot print the error message directly, as it will be interpreted as a log issue and crash the build
-      Write-Host $projectOutput.Replace("##vso[task.logissue", "vso[task.logissue")
-    }
+    $projectOutput = $projectOutput.Trim().Replace("##vso[task.logissue"), "vso[task.logissue"
 
     if (!$projectOutput) {
       Write-Verbose "Get-AllPackageInfoFromRepo::projectOutput was null or empty, skipping"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -28,6 +28,11 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
 
   foreach ($projectOutput in $msbuildOutput)
   {
+    if ($projectOutput -match "^\s*##vso\[task.logissue") {
+      # we cannot print the error message directly, as it will be interpreted as a log issue and crash the build
+      Write-Host $projectOutput.Replace("##vso[task.logissue", "vso[task.logissue")
+    }
+
     if (!$projectOutput) {
       Write-Verbose "Get-AllPackageInfoFromRepo::projectOutput was null or empty, skipping"
       continue

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -135,7 +135,7 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
       Write-Host "Failed calculating dependencies for '$TestDependsOnDependency'. Exit code $LASTEXITCODE."
       Write-Host "Dumping erroring build output."
       Write-Host (Get-Content -Raw $buildOutputPath)
-      continue
+      return @()
   }
 
   if (Test-Path $outputFilePath) {


### PR DESCRIPTION
We are using a the Devops Logger. `msbuild` recognizes this. We collect the output of a `dotnet build` and parse it to get the static package info from the repository.

When there is a crash (like what is caused by missing clientmodel) this causes the output of `msbuild` to contain erroneously formatted `##vso` commands that are messing with AzDO. We can't turn off all output because we _need_ the output of the build so we can parse it and get package info.

Instead, we prefilter the results to NOT output the bad lines and break the build.

Once we can see the build error, I will revert the `eng/PAckages.Data.Props` change and add the fix suggested by @weshaggard  to actually prevent us hitting this failure again.