### PR TITLE
[Storage] [DataMovement] [Blobs] Backwards Compatibility for Blobs AccessTier

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobDestinationCheckpointDetails.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobDestinationCheckpointDetails.cs
@@ -304,7 +304,8 @@ namespace Azure.Storage.DataMovement.Blobs
 
             // Version
             int version = reader.ReadInt32();
-            if (version != DataMovementBlobConstants.DestinationCheckpointDetails.SchemaVersion)
+            if (version < DataMovementBlobConstants.DestinationCheckpointDetails.MinValidSchemaVersion
+                || version > DataMovementBlobConstants.DestinationCheckpointDetails.MaxValidSchemaVersion)
             {
                 throw Errors.UnsupportedJobSchemaVersionHeader(version);
             }
@@ -340,9 +341,17 @@ namespace Azure.Storage.DataMovement.Blobs
             int cacheControlLength = reader.ReadInt32();
 
             // AccessTier
-            bool isAccessTierSet = reader.ReadBoolean();
+            bool isAccessTierSet = default;
+            if (version >= DataMovementBlobConstants.DestinationCheckpointDetails.SchemaVersion_4)
+            {
+                isAccessTierSet = reader.ReadBoolean();
+            }
             AccessTier? accessTier = default;
             JobPlanAccessTier jobPlanAccessTier = (JobPlanAccessTier)reader.ReadByte();
+            if (version < DataMovementBlobConstants.DestinationCheckpointDetails.SchemaVersion_4)
+            {
+                isAccessTierSet = !jobPlanAccessTier.Equals(JobPlanAccessTier.None);
+            }
             if (isAccessTierSet)
             {
                 accessTier = new AccessTier(jobPlanAccessTier.ToString());

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobConstants.cs
@@ -28,6 +28,8 @@ namespace Azure.Storage.DataMovement.Blobs
             internal const int SchemaVersion_3 = 3;
             internal const int SchemaVersion_4 = 4;
             internal const int SchemaVersion = SchemaVersion_4;
+            internal const int MinValidSchemaVersion = SchemaVersion_3;
+            internal const int MaxValidSchemaVersion = SchemaVersion;
 
             internal const int VersionIndex = 0;
             internal const int PreserveBlobTypeIndex = VersionIndex + IntSizeInBytes;


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net-pr/issues/2183

Is a follow-up to this https://github.com/Azure/azure-sdk-for-net/pull/49231
