### PR TITLE
[Storage] Bumped Blob package version in Packages.Data.props; Changed DMLib blobs to use a PackageReference of Blobs

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -131,7 +131,7 @@
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.7.0" />
     <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
     <PackageReference Update="Azure.Storage.Common" Version="12.22.0" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.23.0" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.24.1" />
     <PackageReference Update="Azure.Storage.Queues" Version="12.21.0" />
     <PackageReference Update="Azure.Storage.Files.Shares" Version="12.21.0" />
     <PackageReference Update="Azure.Storage.DataMovement" Version="12.0.0" />
@@ -328,7 +328,7 @@
     <PackageReference Update="Azure.Search.Documents" Version="11.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.23.0" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.24.1" />
     <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.21.0" />
     <PackageReference Update="BenchmarkDotNet" Version="0.13.4" />
     <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.4" />

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Storage.Blobs" />
-    <!-- This PackageReference is commented out because Azure.Storage.Blob is included as a PackageReference above. -->
+    <!-- The ProjectReference is commented out because Azure.Storage.Blobs is now included via PackageReference above. -->
     <!-- It is retained here for reference in case the dependency needs to be switched back to a ProjectReference in the future. -->
     <!-- <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" /> -->
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.DataMovement\src\Azure.Storage.DataMovement.csproj" />

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -21,8 +21,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <!-- <PackageReference Include="Azure.Storage.Blobs" />-->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <!-- This PackageReference is commented out because Azure.Storage.Blob is included as a PackageReference above. -->
+    <!-- It is retained here for reference in case the dependency needs to be switched back to a ProjectReference in the future. -->
+    <!-- <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" /> -->
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.DataMovement\src\Azure.Storage.DataMovement.csproj" />
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>


### PR DESCRIPTION
- Bumped the Azure.Storage.Blobs package version in the Packages.Data.props
- Changed Azure.Storage.DataMovement.Blobs to use a PackageReference of Azure.Storage.Blobs over a ProjectReference

Since we released 12.24.1 of Azure.Storage.Blobs we can have the DataMovement Blobs package stop pointing at the project reference and start pointing at 12.24.1 instead. This is to take in the changes in the blobs package where we added the ability to set the Premium Access Tier on a Page Blob on Creation.