### PR TITLE
[KeyVault] Update Certificates with service version 7.6

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.0 (2025-06-12)
+## 4.8.0 (2025-06-16)
 
 ### Acknowledgments
 
@@ -29,7 +29,7 @@ Thank you to our developer community members who helped to make the Key Vault cl
 
 ### Other Changes
 
-- The default service version is now "7.6".
+- The default service version is now "7.6-preview.2".
 
 ## 4.7.0 (2024-10-14)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.0-beta.2 (Unreleased)
+## 4.8.0 (2025-06-12)
 
 ### Acknowledgments
 
@@ -8,15 +8,13 @@ Thank you to our developer community members who helped to make the Key Vault cl
 
 - James Gould _([GitHub](https://github.com/james-gould))_
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Removed additional forward slash in `RestoreCertificateBackup` and `RestoreCertificateBackupAsync`.
 
 ### Other Changes
+
+- The default service version is now "7.6". 
 
 ## 4.8.0-beta.1 (2025-04-08)
 
@@ -31,7 +29,7 @@ Thank you to our developer community members who helped to make the Key Vault cl
 
 ### Other Changes
 
-- The default service version is now "7.6-preview.2".
+- The default service version is now "7.6".
 
 ## 4.7.0 (2024-10-14)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/api/Azure.Security.KeyVault.Certificates.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/api/Azure.Security.KeyVault.Certificates.net8.0.cs
@@ -77,7 +77,7 @@ namespace Azure.Security.KeyVault.Certificates
     }
     public partial class CertificateClientOptions : Azure.Core.ClientOptions
     {
-        public CertificateClientOptions(Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion version = Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion.V7_6_Preview_2) { }
+        public CertificateClientOptions(Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion version = Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion.V7_6) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -88,7 +88,7 @@ namespace Azure.Security.KeyVault.Certificates
             V7_3 = 3,
             V7_4 = 4,
             V7_5 = 5,
-            V7_6_Preview_2 = 6,
+            V7_6 = 6,
         }
     }
     public partial class CertificateContact
@@ -370,6 +370,7 @@ namespace Azure.Security.KeyVault.Certificates
         public System.Uri Id { get { throw null; } }
         public System.Uri KeyId { get { throw null; } }
         public string Name { get { throw null; } }
+        public bool? PreserveCertificateOrder { get { throw null; } }
         public Azure.Security.KeyVault.Certificates.CertificateProperties Properties { get { throw null; } }
         public System.Uri SecretId { get { throw null; } }
     }
@@ -396,7 +397,6 @@ namespace Azure.Security.KeyVault.Certificates
     {
         internal KeyVaultCertificateWithPolicy() { }
         public Azure.Security.KeyVault.Certificates.CertificatePolicy Policy { get { throw null; } }
-        public bool? PreserveCertificateOrder { get { throw null; } }
     }
     public partial class LifetimeAction
     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/api/Azure.Security.KeyVault.Certificates.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/api/Azure.Security.KeyVault.Certificates.netstandard2.0.cs
@@ -77,7 +77,7 @@ namespace Azure.Security.KeyVault.Certificates
     }
     public partial class CertificateClientOptions : Azure.Core.ClientOptions
     {
-        public CertificateClientOptions(Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion version = Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion.V7_6_Preview_2) { }
+        public CertificateClientOptions(Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion version = Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion.V7_6) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Certificates.CertificateClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -88,7 +88,7 @@ namespace Azure.Security.KeyVault.Certificates
             V7_3 = 3,
             V7_4 = 4,
             V7_5 = 5,
-            V7_6_Preview_2 = 6,
+            V7_6 = 6,
         }
     }
     public partial class CertificateContact
@@ -370,6 +370,7 @@ namespace Azure.Security.KeyVault.Certificates
         public System.Uri Id { get { throw null; } }
         public System.Uri KeyId { get { throw null; } }
         public string Name { get { throw null; } }
+        public bool? PreserveCertificateOrder { get { throw null; } }
         public Azure.Security.KeyVault.Certificates.CertificateProperties Properties { get { throw null; } }
         public System.Uri SecretId { get { throw null; } }
     }
@@ -396,7 +397,6 @@ namespace Azure.Security.KeyVault.Certificates
     {
         internal KeyVaultCertificateWithPolicy() { }
         public Azure.Security.KeyVault.Certificates.CertificatePolicy Policy { get { throw null; } }
-        public bool? PreserveCertificateOrder { get { throw null; } }
     }
     public partial class LifetimeAction
     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/assets.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/keyvault/Azure.Security.KeyVault.Certificates",
-  "Tag": "net/keyvault/Azure.Security.KeyVault.Certificates_4f83772441"
+  "Tag": "net/keyvault/Azure.Security.KeyVault.Certificates_42c799d783"
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Certificates client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Certificates client library</AssemblyTitle>
-    <Version>4.8.0-beta.2</Version>
+    <Version>4.8.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.7.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Certificates;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Certificates
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V7_6_Preview_2;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V7_6;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client
@@ -58,7 +58,7 @@ namespace Azure.Security.KeyVault.Certificates
             /// <summary>
             /// The Key Vault API version 7.6 preview 2.
             /// </summary>
-            V7_6_Preview_2 = 6,
+            V7_6 = 6,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -99,7 +99,7 @@ namespace Azure.Security.KeyVault.Certificates
                 ServiceVersion.V7_3 => "7.3",
                 ServiceVersion.V7_4 => "7.4",
                 ServiceVersion.V7_5 => "7.5",
-                ServiceVersion.V7_6_Preview_2 => "7.6-preview.2",
+                ServiceVersion.V7_6 => "7.6",
                 _ => throw new ArgumentException(Version.ToString()),
             };
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/KeyVaultCertificate.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/KeyVaultCertificate.cs
@@ -14,6 +14,7 @@ namespace Azure.Security.KeyVault.Certificates
         private const string KeyIdPropertyName = "kid";
         private const string SecretIdPropertyName = "sid";
         private const string CERPropertyName = "cer";
+        private const string PreserveCertificateOrderPropertyName = "preserveCertOrder";
 
         private string _keyId;
         private string _secretId;
@@ -66,6 +67,12 @@ namespace Azure.Security.KeyVault.Certificates
         /// </remarks>
         public byte[] Cer { get; internal set; }
 
+        /// <summary>
+        /// Gets a value indicating whether the certificate chain preserves its original order.
+        /// The default value is false, which sets the leaf certificate at index 0.
+        /// </summary>
+        public bool? PreserveCertificateOrder { get; internal set; }
+
         internal virtual void ReadProperty(JsonProperty prop)
         {
             switch (prop.Name)
@@ -80,6 +87,10 @@ namespace Azure.Security.KeyVault.Certificates
 
                 case CERPropertyName:
                     Cer = prop.Value.GetBytesFromBase64();
+                    break;
+
+                case PreserveCertificateOrderPropertyName:
+                    PreserveCertificateOrder = prop.Value.GetBoolean();
                     break;
 
                 default:

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/KeyVaultCertificateWithPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/KeyVaultCertificateWithPolicy.cs
@@ -11,7 +11,6 @@ namespace Azure.Security.KeyVault.Certificates
     public class KeyVaultCertificateWithPolicy : KeyVaultCertificate
     {
         private const string PolicyPropertyName = "policy";
-        private const string PreserveCertificateOrderPropertyName = "preserveCertOrder";
 
         internal KeyVaultCertificateWithPolicy(CertificateProperties properties = null) : base(properties)
         {
@@ -22,12 +21,6 @@ namespace Azure.Security.KeyVault.Certificates
         /// </summary>
         public CertificatePolicy Policy { get; internal set; }
 
-        /// <summary>
-        /// Gets a value indicating whether the certificate chain preserves its original order.
-        /// The default value is false, which sets the leaf certificate at index 0.
-        /// </summary>
-        public bool? PreserveCertificateOrder { get; internal set; }
-
         internal override void ReadProperty(JsonProperty prop)
         {
             switch (prop.Name)
@@ -35,10 +28,6 @@ namespace Azure.Security.KeyVault.Certificates
                 case PolicyPropertyName:
                     Policy = new CertificatePolicy();
                     ((IJsonDeserializable)Policy).ReadProperties(prop.Value);
-                    break;
-
-                case PreserveCertificateOrderPropertyName:
-                    PreserveCertificateOrder = prop.Value.GetBoolean();
                     break;
 
                 default:

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
@@ -19,7 +19,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         CertificateClientOptions.ServiceVersion.V7_2,
         CertificateClientOptions.ServiceVersion.V7_1,
         CertificateClientOptions.ServiceVersion.V7_0,
-        CertificateClientOptions.ServiceVersion.V7_6_Preview_2)]
+        CertificateClientOptions.ServiceVersion.V7_6)]
     public abstract class CertificatesTestBase : RecordedTestBase<KeyVaultTestEnvironment>
     {
         protected TimeSpan PollingInterval => Recording.Mode == RecordedTestMode.Playback


### PR DESCRIPTION
This PR updates the service version to 7.6, SDK version to 4.8.0, moved the `PreserveCertificateOrder` to the parent `KeyVaultCertificate` class, and re-record the tests.