### PR TITLE
Fix ArmClient's CanUseTagResourceAsync to be fully async

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmClient.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmClient.cs
@@ -102,7 +102,8 @@ namespace Azure.ResourceManager
         {
             if (_canUseTagResource == null)
             {
-                var tagRp = await GetDefaultSubscription(cancellationToken).GetResourceProviderAsync(TagResource.ResourceType.Namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var defaultSubscription = await GetDefaultSubscriptionAsync(cancellationToken).ConfigureAwait(false);
+                var tagRp = await defaultSubscription.GetResourceProviderAsync(TagResource.ResourceType.Namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
                 _canUseTagResource = tagRp.Value.Data.ResourceTypes.Any(rp => rp.ResourceType == TagResource.ResourceType.Type);
             }
             return _canUseTagResource.Value;


### PR DESCRIPTION
This PR fixes the `CanUseTagResourceAsync` method in the `ArmClient` class to be fully async. It's currently using both a sync and async pattern, which can lead to issues.