### PR TITLE
[KeyVault] Update Administration with service version 7.6

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.6.0 (2025-06-13)
+## 4.6.0 (2025-06-16)
 
 ### Other Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.6.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 4.6.0 (2025-06-13)
 
 ### Other Changes
+
+- Service version is now `7.6`.
 
 ## 4.6.0-beta.1 (2025-04-08)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/api/Azure.Security.KeyVault.Administration.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/api/Azure.Security.KeyVault.Administration.net8.0.cs
@@ -49,7 +49,7 @@ namespace Azure.Security.KeyVault.Administration
     }
     public partial class KeyVaultAdministrationClientOptions : Azure.Core.ClientOptions
     {
-        public KeyVaultAdministrationClientOptions(Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion version = Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion.V7_6_Preview_2) { }
+        public KeyVaultAdministrationClientOptions(Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion version = Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion.V7_6) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -58,7 +58,7 @@ namespace Azure.Security.KeyVault.Administration
             V7_3 = 2,
             V7_4 = 3,
             V7_5 = 4,
-            V7_6_Preview_2 = 5,
+            V7_6 = 5,
         }
     }
     public static partial class KeyVaultAdministrationModelFactory

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/api/Azure.Security.KeyVault.Administration.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/api/Azure.Security.KeyVault.Administration.netstandard2.0.cs
@@ -49,7 +49,7 @@ namespace Azure.Security.KeyVault.Administration
     }
     public partial class KeyVaultAdministrationClientOptions : Azure.Core.ClientOptions
     {
-        public KeyVaultAdministrationClientOptions(Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion version = Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion.V7_6_Preview_2) { }
+        public KeyVaultAdministrationClientOptions(Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion version = Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion.V7_6) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Administration.KeyVaultAdministrationClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -58,7 +58,7 @@ namespace Azure.Security.KeyVault.Administration
             V7_3 = 2,
             V7_4 = 3,
             V7_5 = 4,
-            V7_6_Preview_2 = 5,
+            V7_6 = 5,
         }
     }
     public static partial class KeyVaultAdministrationModelFactory

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/assets.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/keyvault/Azure.Security.KeyVault.Administration",
-  "Tag": "net/keyvault/Azure.Security.KeyVault.Administration_d0d7c3d864"
+  "Tag": "net/keyvault/Azure.Security.KeyVault.Administration_3a90d36e6a"
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
@@ -3,7 +3,7 @@
 <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Administration client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Administration client library</AssemblyTitle>
-    <Version>4.6.0-beta.2</Version>
+    <Version>4.6.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.5.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Administration;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/CreateOrUpdateRoleDefinitionOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/CreateOrUpdateRoleDefinitionOptions.cs
@@ -47,7 +47,7 @@ namespace Azure.Security.KeyVault.Administration
         public Guid RoleDefinitionName { get; }
 
         /// <summary>
-        /// Gets the display name of this role definition. Defaults to the <see cref="RoleDefinitionName"/>.
+        /// Gets the display name of this role definition.
         /// </summary>
         public string RoleName { get; set; }
 
@@ -75,7 +75,7 @@ namespace Azure.Security.KeyVault.Administration
             RoleDefinitionProperties properties = new()
             {
                 RoleType = roleType,
-                RoleName = string.IsNullOrEmpty(RoleName) ? RoleDefinitionName.ToString() : RoleName,
+                RoleName = RoleName,
                 Description = Description,
             };
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/CreateOrUpdateRoleDefinitionOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/CreateOrUpdateRoleDefinitionOptions.cs
@@ -75,7 +75,7 @@ namespace Azure.Security.KeyVault.Administration
             RoleDefinitionProperties properties = new()
             {
                 RoleType = roleType,
-                RoleName = RoleName,
+                RoleName = string.IsNullOrEmpty(RoleName) ? RoleDefinitionName.ToString() : RoleName,
                 Description = Description,
             };
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Generated/KeyVaultAdministrationClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Generated/KeyVaultAdministrationClientOptions.cs
@@ -13,6 +13,6 @@ namespace Azure.Security.KeyVault.Administration
     /// <summary> Client options for Azure.Security.KeyVault.Administration library clients. </summary>
     public partial class KeyVaultAdministrationClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V7_6_Preview_2;
+        private const ServiceVersion LatestVersion = ServiceVersion.V7_6;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Generated/Models/Versions.Serialization.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Generated/Models/Versions.Serialization.cs
@@ -15,6 +15,7 @@ namespace Azure.Security.KeyVault.Administration.Models
         {
             Versions.V75 => "7.5",
             Versions.V76Preview2 => "7.6-preview.2",
+            Versions.V76 => "7.6",
             _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown Versions value.")
         };
 
@@ -22,6 +23,7 @@ namespace Azure.Security.KeyVault.Administration.Models
         {
             if (StringComparer.OrdinalIgnoreCase.Equals(value, "7.5")) return Versions.V75;
             if (StringComparer.OrdinalIgnoreCase.Equals(value, "7.6-preview.2")) return Versions.V76Preview2;
+            if (StringComparer.OrdinalIgnoreCase.Equals(value, "7.6")) return Versions.V76;
             throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown Versions value.");
         }
     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Generated/Models/Versions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Generated/Models/Versions.cs
@@ -13,6 +13,8 @@ namespace Azure.Security.KeyVault.Administration.Models
         /// <summary> The 7.5 API version. </summary>
         V75,
         /// <summary> The 7.6-preview.2 API version. </summary>
-        V76Preview2
+        V76Preview2,
+        /// <summary> The 7.6 API version. </summary>
+        V76
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAdministrationClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAdministrationClientOptions.cs
@@ -62,7 +62,7 @@ namespace Azure.Security.KeyVault.Administration
             /// <summary>
             /// Service version "7.6-preview.1".
             /// </summary>
-            V7_6_Preview_2 = 5,
+            V7_6 = 5,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -79,7 +79,7 @@ namespace Azure.Security.KeyVault.Administration
                 ServiceVersion.V7_3 => "7.3",
                 ServiceVersion.V7_4 => "7.4",
                 ServiceVersion.V7_5 => "7.5",
-                ServiceVersion.V7_6_Preview_2 => "7.6-preview.2",
+                ServiceVersion.V7_6 => "7.6",
                 _ => throw new ArgumentOutOfRangeException(nameof(Version), Version, null)
             };
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlClientLiveTests.cs
@@ -43,6 +43,7 @@ namespace Azure.Security.KeyVault.Administration.Tests
 
             CreateOrUpdateRoleDefinitionOptions options = new(KeyVaultRoleScope.Global, name)
             {
+                RoleName = name.ToString(),
                 Description = description,
                 Permissions =
                 {
@@ -122,6 +123,7 @@ namespace Azure.Security.KeyVault.Administration.Tests
 
             CreateOrUpdateRoleDefinitionOptions options = new(KeyVaultRoleScope.Global, name)
             {
+                RoleName = name.ToString(),
                 Description = description,
                 Permissions =
                 {

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlClientLiveTests.cs
@@ -77,6 +77,7 @@ namespace Azure.Security.KeyVault.Administration.Tests
 
             CreateOrUpdateRoleDefinitionOptions options = new(KeyVaultRoleScope.Global, name)
             {
+                RoleName = name.ToString(),
                 Description = description,
                 Permissions =
                 {

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AdministrationTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AdministrationTestBase.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Administration.Tests
     /// Base class for recorded Administration tests.
     /// </summary>
     [ClientTestFixture(
-        KeyVaultAdministrationClientOptions.ServiceVersion.V7_6_Preview_2,
+        KeyVaultAdministrationClientOptions.ServiceVersion.V7_6,
         KeyVaultAdministrationClientOptions.ServiceVersion.V7_5,
         KeyVaultAdministrationClientOptions.ServiceVersion.V7_4,
         KeyVaultAdministrationClientOptions.ServiceVersion.V7_3,

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tsp-location.yaml
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/keyvault/Security.KeyVault.Administration
-commit: b0a48bcbffead733affe03944ef09f5e8d12f8c8
+commit: 4b61462dbf0a0cc3bf0513d1c6358dd7bc889276
 repo: Azure/azure-rest-api-specs
 
 additionalDirectories:


### PR DESCRIPTION
This PR regenerates the Key Vault Administration package with version 7.6, updates the service version, re-records the test, updates the changelog, and fixes a problem with `RoleDefinition` where `RoleName` was not being defaulted to `RoleDefinitionName`.