### PR TITLE
Fix core pipeline failure

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/assets.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/keyvault/Azure.Security.KeyVault.Keys",
-  "Tag": "net/keyvault/Azure.Security.KeyVault.Keys_4ff0b56582"
+  "Tag": "net/keyvault/Azure.Security.KeyVault.Keys_8691bc60be"
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverLiveTests.cs
@@ -93,7 +93,6 @@ namespace Azure.Security.KeyVault.Keys.Tests
         }
 
         [RecordedTest]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/50620")]
         public async Task ResolveSecretId()
         {
             SecretClient secretClient = GetSecretClient();


### PR DESCRIPTION
One of the Azure.KeyVault.Keys test is failing after KeyVault Secrets moved to the newest service version. Turns out this test relied on Secrets so there is a mismatch in the recordings for the versions.

This PR fixes https://github.com/Azure/azure-sdk-for-net/issues/50620 by re-recording such tests.