### PR TITLE
Enforce Missing Artifacts for Release

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -130,6 +130,7 @@ jobs:
           parameters:
             PackageInfo: '$(Build.SourcesDirectory)/PackageInfo'
             Restore: true
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
         - pwsh: |
             if ("$(ProjectNames)" -like "*storage*") {

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -34,10 +34,12 @@ steps:
       parameters:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
+
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
       PackageInfo: '$(Build.ArtifactStagingDirectory)/PackageInfo'
       Artifacts: ${{ parameters.Artifacts }}
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - template: /eng/common/pipelines/templates/steps/verify-samples.yml
     parameters:

--- a/eng/pipelines/templates/steps/set-artifact-packages.yml
+++ b/eng/pipelines/templates/steps/set-artifact-packages.yml
@@ -5,6 +5,17 @@ parameters:
   Restore: false
   SetOverrideFile: true
 steps:
+  - ${{ if ne(parameters.ServiceDirectory, 'auto') }}:
+    - pwsh: |
+        $artifacts = '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
+
+        if (!$artifacts) {
+          Write-Host "No artifacts provided on a non-PR build where at least one package must be provided."
+          Write-Host "Check the ci.yml for the service directory `"${{ parameters.ServiceDirectory }}`" for an `"Artifacts`" parameter and ensure it is properly populated."
+          exit 1
+        }
+      displayName: 'Check for valid artifacts'
+
   # Package-Properties folder contains the package properties for all discovered packages that were either A) affected by the PR or
   # B) explicitly present in the service directory. This repo splits the builds into two categories: "mgmt" and "dataplane". While
   # a given directory may contain both, there will be a separate build definition to release the management packages. Due to this


### PR DESCRIPTION
If the user is in a non-PR context, they should provide an artifact list from their `ci.yml`. This PR enforces the presence of that list.