### PR TITLE
[AppService] Fix for issue #49676

### DIFF
--- a/sdk/websites/Azure.ResourceManager.AppService/CHANGELOG.md
+++ b/sdk/websites/Azure.ResourceManager.AppService/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix dserialization method for `AppServiceApiDefinitionInfo` class to allow empty url string.
+- Fix deserialization method for `AppServiceApiDefinitionInfo` class to allow empty url string.
 
 ### Other Changes
 

--- a/sdk/websites/Azure.ResourceManager.AppService/CHANGELOG.md
+++ b/sdk/websites/Azure.ResourceManager.AppService/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix dserialization method for `AppServiceApiDefinitionInfo` class to allow empty url string.
+
 ### Other Changes
 
 ## 1.4.0 (2025-05-23)

--- a/sdk/websites/Azure.ResourceManager.AppService/src/Generated/Models/AppServiceApiDefinitionInfo.Serialization.cs
+++ b/sdk/websites/Azure.ResourceManager.AppService/src/Generated/Models/AppServiceApiDefinitionInfo.Serialization.cs
@@ -84,7 +84,7 @@ namespace Azure.ResourceManager.AppService.Models
             {
                 if (property.NameEquals("url"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    if (property.Value.ValueKind == JsonValueKind.Null || property.Value.ValueKind == JsonValueKind.String && property.Value.GetString().Length == 0)
                     {
                         continue;
                     }

--- a/sdk/websites/Azure.ResourceManager.AppService/src/autorest.md
+++ b/sdk/websites/Azure.ResourceManager.AppService/src/autorest.md
@@ -744,6 +744,7 @@ prepend-rp-prefix:
 models-to-treat-empty-string-as-null:
   - WebAppBackupData
   - WebSiteInstanceStatusData
+  - AppServiceApiDefinitionInfo
 
 directive:
 # operation removal - should be temporary

--- a/sdk/websites/Azure.ResourceManager.AppService/tests/TestsCase/ApiDefinitionInfoTests.cs
+++ b/sdk/websites/Azure.ResourceManager.AppService/tests/TestsCase/ApiDefinitionInfoTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ClientModel.Primitives;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Azure.ResourceManager.AppService.Models;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.AppService.Tests.TestsCase
+{
+    public class ApiDefinitionInfoTests
+    {
+        [TestCase("{\"url\":null}")]
+        [TestCase("{\"url\":\"\"}")]
+        public void DeserializeAppServiceApiDefinitionInfo_UrlNullOrEmpty_ResultsInNullUri(string json)
+        {
+            var options = new ModelReaderWriterOptions("J");
+            using var doc = JsonDocument.Parse(json);
+            var result = AppServiceApiDefinitionInfo.DeserializeAppServiceApiDefinitionInfo(doc.RootElement, options);
+            Assert.IsNull(result.Uri);
+        }
+
+        [Test]
+        public void Serialize_OmitsUrl_WhenUriIsNull()
+        {
+            var info = new AppServiceApiDefinitionInfo();
+            using var memoryStream = new MemoryStream();
+            var writer = new Utf8JsonWriter(memoryStream);
+            var options = new ModelReaderWriterOptions("J");
+
+            ((IJsonModel<AppServiceApiDefinitionInfo>)info).Write(writer, options);
+            writer.Flush();
+
+            string output = Encoding.UTF8.GetString(memoryStream.ToArray());
+            StringAssert.DoesNotContain("\"url\"", output);
+        }
+    }
+}


### PR DESCRIPTION
This is PR for issue #49676
Fix dserialization method for `AppServiceApiDefinitionInfo` class to allow empty url string.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
