### PR TITLE
Allow for publishing to DevOps feed instead of nuget

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -2,8 +2,8 @@ parameters:
   Artifacts: []
   TestPipeline: false
   ArtifactName: 'not-specified'
-  # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
-  DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
+  DevFeed: 'public/azure-sdk-for-net'
+  PublicFeed: Nuget.org
 
 stages:
   - stage: Signing
@@ -98,7 +98,7 @@ stages:
 
             - ${{if ne(artifact.skipPublishPackage, 'true')}}:
               - deployment: PublishPackage
-                displayName: Publish package to Nuget.org and DevOps Feed
+                displayName: Publish package to ${{ parameters.PublicFeed }} and Dev Feed
                 condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
                 environment: package-publish
                 dependsOn: TagRepository
@@ -121,19 +121,22 @@ stages:
                     deploy:
                       steps:
                         - task: 1ES.PublishNuget@1
-                          displayName: Publish ${{artifact.name}} package to NuGet.org
+                          displayName: Publish ${{ artifact.name }} package to ${{ parameters.PublicFeed }}
                           inputs:
                             packageParentPath: '$(Pipeline.Workspace)'
                             packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)//${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
-                            nuGetFeedType: external
-                            publishFeedCredentials: Nuget.org
+                            ${{ if eq(parameters.PublicFeed, 'Nuget.org') }}
+                              nuGetFeedType: external
+                              publishFeedCredentials: Nuget.org
+                            ${{ if ne(parameters.PublicFeed, 'Nuget.org') }}
+                              publishVstsFeed: ${{ parameters.PublicFeed }}
 
                         - task: 1ES.PublishNuget@1
-                          displayName: Publish to DevOps Feed
+                          displayName: Publish to Dev Feed
                           inputs:
                             packageParentPath: '$(Pipeline.Workspace)'
                             packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
-                            publishVstsFeed: ${{ parameters.DevOpsFeedID }}
+                            publishVstsFeed: ${{ parameters.DevFeed }}
 
               - ${{if ne(artifact.skipSymbolsUpload, 'true')}}:
                 - job: UploadSymbols
@@ -305,10 +308,9 @@ stages:
               steps:
                 - pwsh: |
                     # For safety default to publishing to the private feed.
-                    # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr
-                    $devopsFeedId = '590cfd2a-581c-4dcb-a12e-6568ce786175/fa8b2d77-74d9-48d7-bb96-badb2b9c6ca4'
+                    $devopsFeedId = 'internal/azure-sdk-for-net-pr'
                     if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-net') {
-                      $devopsFeedId = '${{ parameters.DevOpsFeedID }}'
+                      $devopsFeedId = '${{ parameters.DevFeed }}'
                     }
                     echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
                     echo "Using DevopsFeedId = $devopsFeedId"

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -100,7 +100,8 @@ stages:
               - deployment: PublishPackage
                 displayName: Publish package to ${{ parameters.PublicFeed }} and Dev Feed
                 condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-                environment: package-publish
+                #environment: package-publish
+                environment: none
                 dependsOn: TagRepository
 
                 pool:
@@ -125,10 +126,10 @@ stages:
                           inputs:
                             packageParentPath: '$(Pipeline.Workspace)'
                             packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)//${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
-                            ${{ if eq(parameters.PublicFeed, 'Nuget.org') }}
+                            ${{ if eq(parameters.PublicFeed, 'Nuget.org') }}:
                               nuGetFeedType: external
                               publishFeedCredentials: Nuget.org
-                            ${{ if ne(parameters.PublicFeed, 'Nuget.org') }}
+                            ${{ if ne(parameters.PublicFeed, 'Nuget.org') }}:
                               publishVstsFeed: ${{ parameters.PublicFeed }}
 
                         - task: 1ES.PublishNuget@1

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -4,6 +4,7 @@ parameters:
   ArtifactName: 'not-specified'
   DevFeed: 'public/azure-sdk-for-net'
   PublicFeed: Nuget.org
+  PublicPublishEnvironment: package-publish
 
 stages:
   - stage: Signing
@@ -100,8 +101,7 @@ stages:
               - deployment: PublishPackage
                 displayName: Publish package to ${{ parameters.PublicFeed }} and Dev Feed
                 condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-                #environment: package-publish
-                environment: none
+                environment: ${{ parameters.PublicPublishEnvironment }}
                 dependsOn: TagRepository
 
                 pool:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -62,7 +62,7 @@ parameters:
     default: 'Nuget.org'
   - name: PublicPublishEnvironment
     type: string
-    default: publish-package
+    default: package-publish
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -111,4 +111,5 @@ extends:
             ${{ if eq(parameters.ServiceDirectory, 'template') }}:
               TestPipeline: true
             ArtifactName: packages
+            PublicFeed: 'Nuget.org'
 

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -57,6 +57,9 @@ parameters:
   - name: ExcludePaths
     type: object
     default: []
+  - name: PublicFeed
+    type: string
+    default: 'Nuget.org'
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -111,5 +114,5 @@ extends:
             ${{ if eq(parameters.ServiceDirectory, 'template') }}:
               TestPipeline: true
             ArtifactName: packages
-            PublicFeed: 'Nuget.org'
+            PublicFeed: ${{ parameters.PublicFeed }}
 

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -60,6 +60,9 @@ parameters:
   - name: PublicFeed
     type: string
     default: 'Nuget.org'
+  - name: PublicPublishEnvironment
+    type: string
+    default: publish-package
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -115,4 +118,5 @@ extends:
               TestPipeline: true
             ArtifactName: packages
             PublicFeed: ${{ parameters.PublicFeed }}
+            PublicPublishEnvironment: ${{ parameters.PublicPublishEnvironment }}
 

--- a/eng/scripts/smoketest/Get-Package-Version.ps1
+++ b/eng/scripts/smoketest/Get-Package-Version.ps1
@@ -1,6 +1,3 @@
-param(
-    [string]$ArtifactsPath
-)
 . (Join-Path $PSScriptRoot ../../common/scripts/common.ps1)
 $ErrorActionPreference = 'Continue'
 

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -1,5 +1,11 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 
+parameters:
+  - name: ReleaseToDevOpsOnly
+    displayName: 'Release package to DevOps feed instead of Nuget.org'
+    type: boolean
+    default: false
+
 trigger:
   branches:
     include:
@@ -45,6 +51,8 @@ pr:
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
+    ${{ if eq(parameters.ReleaseToDevOpsOnly, 'true') }}:
+      PublicFeed: 'public/storage-staging'
     SDKType: client
     ServiceDirectory: storage
     BuildSnippets: false

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -1,5 +1,11 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 
+parameters:
+  - name: SoftGA
+    displayName: 'Release package to DevOps feed instead of Nuget.org'
+    type: boolean
+    default: false
+
 trigger:
   branches:
     include:
@@ -36,6 +42,8 @@ pr:
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
+    ${{ if eq(parameters.SoftGA, 'true') }}:
+      PublicFeed: 'internal/azure-sdk-for-net-pr'
     ServiceDirectory: template
     ArtifactName: packages
     Artifacts:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -1,7 +1,7 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 
 parameters:
-  - name: SoftGA
+  - name: ReleaseToDevOpsOnly
     displayName: 'Release package to DevOps feed instead of Nuget.org'
     type: boolean
     default: false
@@ -42,8 +42,8 @@ pr:
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
-    ${{ if eq(parameters.SoftGA, 'true') }}:
-      PublicFeed: 'internal/azure-sdk-for-net-pr'
+    ${{ if eq(parameters.ReleaseToDevOpsOnly, 'true') }}:
+      PublicFeed: 'public/storage-staging'
     ServiceDirectory: template
     ArtifactName: packages
     Artifacts:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -5,6 +5,10 @@ parameters:
     displayName: 'Release package to DevOps feed instead of Nuget.org'
     type: boolean
     default: false
+  - name: AutoApproveRelease
+    displayName: 'Automatically approve the release stage'
+    type: boolean
+    default: false
 
 trigger:
   branches:
@@ -44,6 +48,8 @@ extends:
   parameters:
     ${{ if eq(parameters.ReleaseToDevOpsOnly, 'true') }}:
       PublicFeed: 'public/storage-staging'
+    ${{ if eq(parameters.AutoApproveRelease, 'true') }}:
+      PublicPublishEnvironment: none
     ServiceDirectory: template
     ArtifactName: packages
     Artifacts:


### PR DESCRIPTION
Add feature to enable the Storage team to release to a devops feed instead of public nuget.org for releases. This allows them to do a soft GA where consumers can use the latest GA from the Devops feed if they know their regions have the new storage features. The GA will get published to nuget.org once all the regions have the new features. 