### PR TITLE
[Authentication] No-Auth and 3rd Party Auth test coverage

### DIFF
--- a/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
+++ b/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
@@ -195,8 +195,15 @@ public class AuthenticationTokenProviderTests
             options.Transport = new MockPipelineTransport("foo",
             m =>
             {
-                // Assert that the request has no authentication headers
-                Assert.IsFalse(m.Request.Headers.TryGetValue("Authorization", out _), "Request should not have an Authorization header.");
+                m.TryGetProperty(typeof(GetTokenOptions), out var flowsObj);
+                if (
+                    flowsObj == null ||
+                    (flowsObj is Dictionary<string, object>[] flowsArr && flowsArr.Length == 0)
+                )
+                {
+                    // Only assert no Authorization header if operation does not override the service level flows.
+                    Assert.IsFalse(m.Request.Headers.TryGetValue("Authorization", out _), "Request should not have an Authorization header.");
+                }
                 return new MockPipelineResponse(200);
             });
             ClientPipeline pipeline = ClientPipeline.Create(options,

--- a/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
+++ b/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
@@ -139,7 +139,7 @@ public class AuthenticationTokenProviderTests
 
         /// <summary>
         /// This operation does not require authentication.
-        /// It will override the service level flows by passing an emtpy array of flows.
+        /// It will override the service level flows by passing an empty array of flows.
         /// </summary>
         public ClientResult GetNoAuth()
         {

--- a/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
+++ b/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
@@ -42,9 +42,6 @@ public class AuthenticationTokenProviderTests
         AuthenticationTokenProvider provider = new ClientCredentialTokenProvider("myClientId", "myClientSecret");
         var client = new FooClient(new Uri("http://localhost"), provider);
         var result = client.GetNoAuth();
-
-        Assert.IsNotNull(result);
-        Assert.AreEqual(200, result.Status);
     }
 
     [Test]
@@ -54,11 +51,7 @@ public class AuthenticationTokenProviderTests
         AuthenticationTokenProvider provider = new ClientCredentialTokenProvider("myClientId", "myClientSecret");
         var client = new NoAuthClient(new Uri("http://localhost"), provider);
         var result = client.GetWithAuth();
-
-                Assert.IsNotNull(result);
-        Assert.AreEqual(200, result.Status);
     }
-
 
     public class FooClient
     {
@@ -78,7 +71,6 @@ public class AuthenticationTokenProviderTests
             }
         ];
 
-
         /// <summary>
         /// This is an example of how you can override the flows for a specific operation.
         /// The operation can have its own flows, or it can use the service level flows.
@@ -90,7 +82,6 @@ public class AuthenticationTokenProviderTests
                 { GetTokenOptions.RefreshUrlPropertyName, "https://myauthserver.com/refresh"}
             }
         ];
-
 
         /// <summary>
         /// This is an example of how you can define a no-authentication flow.
@@ -165,6 +156,8 @@ public class AuthenticationTokenProviderTests
 
     public class NoAuthClient
     {
+        private static readonly string readScope = "read";
+
         /// <summary>
         /// This is an example of how no-authentication flows are defined at the service level,
         /// by passing an empty array of flows.

--- a/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
+++ b/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
@@ -88,7 +88,6 @@ public class AuthenticationTokenProviderTests
         /// This flow can be used for operations that do not require authentication.
         /// It will override the service level flows and any operation specific flows.
         /// </summary>
-        private readonly IReadOnlyDictionary<string, object> noAuthFlows = new Dictionary<string, object>();
         private readonly IReadOnlyDictionary<string, object> emptyFlows = new Dictionary<string, object>();
 
         private ClientPipeline _pipeline;

--- a/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
+++ b/sdk/core/System.ClientModel/tests/Auth/AuthenticationTokenProviderTests.cs
@@ -88,9 +88,8 @@ public class AuthenticationTokenProviderTests
         /// This flow can be used for operations that do not require authentication.
         /// It will override the service level flows and any operation specific flows.
         /// </summary>
-        private readonly Dictionary<string, object>[] noAuthFlows = [];
-
-        private readonly IReadOnlyDictionary<string, object> _emptyProperties = new Dictionary<string, object>();
+        private readonly IReadOnlyDictionary<string, object> noAuthFlows = new Dictionary<string, object>();
+        private readonly IReadOnlyDictionary<string, object> emptyFlows = new Dictionary<string, object>();
 
         private ClientPipeline _pipeline;
 
@@ -145,7 +144,8 @@ public class AuthenticationTokenProviderTests
         {
             var message = _pipeline.CreateMessage();
             message.ResponseClassifier = PipelineMessageClassifier.Create([200]);
-            message.SetProperty(typeof(GetTokenOptions), noAuthFlows); //This is an example of how you can override the flows for a specific operation.
+            message.SetProperty(typeof(GetTokenOptions), new[] { emptyFlows });
+
             PipelineRequest request = message.Request;
             request.Method = "GET";
             request.Uri = new Uri("https://localhost/noAuth");


### PR DESCRIPTION
This PR solves https://github.com/Azure/azure-sdk-for-net/issues/49155 by integrating more test scenarios for no auth, as well as documenting the existing ones.

These are the different permutations that we are testing:

- Client with service level flows defined. (Client with Auth)
  - Operation that uses the same flows as the ones defined in the client.
  - Operation that does not require auth, will override the client flows with an empty array.
- Client with no flows defined at service level. (No-Auth Client)
  - Operation that does not require auth whose requests won't have an authorization header.
  - Operation that does require authentication, will use its operation-level defined flows.
