### PR TITLE
[Identity] Update AzurePowerShellCredential to handle Get-AzAccessToken breaking change

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support in `AzurePowerShellCredential` for the Az.Accounts 5.0.0+ (Az 14.0.0+) breaking change where `Get-AzAccessToken` returns `PSSecureAccessToken` with a `SecureString` Token property instead of plaintext.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
@@ -333,7 +333,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        public async Task AuthenticateWithAzurePowerShellCredential_Az14_SecureToken()
+        public async Task AuthenticateWithAzurePowerShellCredential_HandlesSecureStringToken()
         {
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzurePowerShellSecureString(TimeSpan.FromSeconds(30));
             var testProcess = new TestProcess { Output = processOutput };
@@ -358,8 +358,8 @@ namespace Azure.Identity.Tests
             var b = Convert.FromBase64String(commandString);
             commandString = Encoding.Unicode.GetString(b);
 
-            Assert.That(commandString, Does.Contain("$isAz14NewFormat = $m.Version -ge [version]'5.0.0'"));
-            Assert.That(commandString, Does.Contain("ConvertFrom-SecureString -SecureString $token.Token"));
+            Assert.That(commandString, Does.Contain("if ($token.Token -is [System.Security.SecureString])"));
+            Assert.That(commandString, Does.Contain("[System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($token.Token)"));
         }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
@@ -349,10 +349,12 @@ namespace Azure.Identity.Tests
             Assert.AreEqual(expectedExpiresOn, actualToken.ExpiresOn);
 
             // Verify PowerShell script checks for and handles Az.Accounts module version 5.0.0+
-            var iStart = testProcess.StartInfo.Arguments.IndexOf("EncodedCommand");
-            iStart = testProcess.StartInfo.Arguments.IndexOf('\"', iStart) + 1;
-            var iEnd = testProcess.StartInfo.Arguments.IndexOf('\"', iStart);
-            var commandString = testProcess.StartInfo.Arguments.Substring(iStart, iEnd - iStart);
+            var match = System.Text.RegularExpressions.Regex.Match(testProcess.StartInfo.Arguments, "EncodedCommand\\s*\"([^\"]+)\"");
+            if (!match.Success)
+            {
+                throw new InvalidOperationException("Failed to extract the encoded command from the arguments.");
+            }
+            var commandString = match.Groups[1].Value;
             var b = Convert.FromBase64String(commandString);
             commandString = Encoding.Unicode.GetString(b);
 

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -79,6 +79,15 @@ namespace Azure.Identity.Tests
             return (token, expiresOn, xml);
         }
 
+        public static (string Token, DateTimeOffset ExpiresOn, string Json) CreateTokenForAzurePowerShellSecureString(TimeSpan expiresOffset)
+        {
+            var expiresOn = DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.Add(expiresOffset).ToUnixTimeSeconds());
+            var token = TokenGenerator.GenerateToken(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), expiresOn.UtcDateTime);
+            // Simulate Az 14.0+ output with secure string token as returned by our PowerShell script after conversion
+            var xml = @$"<Object Type=""System.Management.Automation.PSCustomObject""><Property Name=""Token"" Type=""System.String"">{token}</Property><Property Name=""ExpiresOn"" Type=""System.Int64"">{expiresOn.UtcDateTime.Ticks}</Property></Object>";
+            return (token, expiresOn, xml);
+        }
+
         public static (string Token, DateTimeOffset ExpiresOn, string Json) CreateTokenForVisualStudio() => CreateTokenForVisualStudio(TimeSpan.FromSeconds(30));
 
         public static (string Token, DateTimeOffset ExpiresOn, string Json) CreateTokenForVisualStudio(TimeSpan expiresOffset)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/50515

More information on the breaking change: [Migration Guide for Az 14.0.0](https://learn.microsoft.com/en-us/powershell/azure/migrate-az-14.0.0?view=azps-14.1.0#get-azaccesstoken)
