### PR TITLE
fix new project scaffolding.

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
@@ -104,8 +104,11 @@ namespace Azure.Generator.Primitives
 
         private static void TraverseInput(InputClient rootClient, ref bool hasOperation, ref bool hasLongRunningOperation)
         {
-            hasOperation = false;
-            hasLongRunningOperation = false;
+            if (hasOperation && hasLongRunningOperation)
+            {
+                return;
+            }
+
             foreach (var method in rootClient.Methods)
             {
                 hasOperation = true;


### PR DESCRIPTION
fix new project scaffolding: handle the case of multiple root clients. Suppose we have two root clients: one with a long-running operation and one without. The shared files related to the long-running operation may not be included in the generated project file.
