### PR TITLE
[Translation] Ignore failing test

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/TranslationOperationLiveTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/TranslationOperationLiveTests.cs
@@ -408,6 +408,7 @@ namespace Azure.AI.Translation.Document.Tests
         }
 
         [RecordedTest]
+        [Ignore("Test is failing and needs to be recorded.  Tracking: #50669")]
         public async Task DocumentTranslationWithGlossary()
         {
             Uri source = await CreateSourceContainerAsync(oneTestDocuments);


### PR DESCRIPTION
# Summary

The focus of these changes is to ignore a test with an outdated recording that is causing failures in CI and release pipelines.

## References and Resources

- [[Translation] DocumentTranslationWithGlossary stale recording (#50669)](https://github.com/Azure/azure-sdk-for-net/issues/50669)
