### PR TITLE
[KeyVault] Fix ShareLink sample project 

### DIFF
--- a/sdk/keyvault/samples/sharelink/ShareLink.csproj
+++ b/sdk/keyvault/samples/sharelink/ShareLink.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="System.CommandLine" VersionOverride="2.0.0-beta1.21216.1" />
+    <PackageReference Include="Azure.Core" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsSample)' == 'true'">


### PR DESCRIPTION
This PR fixes the build error from the ShareLink sample project in KeyVault by adding a direct dependency to Azure.Core