### PR TITLE
[KeyVault] Admin: Update TSP commit

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tsp-location.yaml
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/keyvault/Security.KeyVault.Administration
-commit: 4b61462dbf0a0cc3bf0513d1c6358dd7bc889276
+commit: bc16bd3359c80260f1d1d523679fbe6806ce0813
 repo: Azure/azure-rest-api-specs
 
 additionalDirectories:


### PR DESCRIPTION
The Admin TSP commit was not the one in main, as pointed out by this [pipeline run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4985100&view=logs&j=2b01de42-9ade-58f6-0333-0dde881ddd0e&t=02862d12-ad9c-597f-799b-3e2c8253f7d6&l=18). This PR updates the commit to the correct one: [Key Vault version 7.6](https://github.com/Azure/azure-rest-api-specs/commit/bc16bd3359c80260f1d1d523679fbe6806ce0813).

There were no changes to the code after re-generating with this new commit