### PR TITLE
Don't create new service-scope in ConfigureKeyManagementBlobClientOptions

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/ConfigureKeyManagementBlobClientOptions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/ConfigureKeyManagementBlobClientOptions.cs
@@ -9,20 +9,16 @@ namespace Azure.Extensions.AspNetCore.DataProtection.Blobs
 {
     internal sealed class ConfigureKeyManagementBlobClientOptions : IConfigureOptions<KeyManagementOptions>
     {
-        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly AzureBlobXmlRepository _azureBlobXmlRepository;
 
-        public ConfigureKeyManagementBlobClientOptions(IServiceScopeFactory serviceScopeFactory)
+        public ConfigureKeyManagementBlobClientOptions(AzureBlobXmlRepository azureBlobXmlRepository)
         {
-            _serviceScopeFactory = serviceScopeFactory;
+            _azureBlobXmlRepository = azureBlobXmlRepository;
         }
 
         public void Configure(KeyManagementOptions options)
         {
-            using var scope = _serviceScopeFactory.CreateScope();
-
-            var provider = scope.ServiceProvider;
-
-            options.XmlRepository = provider.GetRequiredService<AzureBlobXmlRepository>();
+            options.XmlRepository = _azureBlobXmlRepository;
         }
     }
 }


### PR DESCRIPTION
### Summary

This PR improves how the `ConfigureKeyManagementBlobClientOptions` class resolves dependencies by removing the unnecessary creation of a new service scope during configuration.

### Problem

Currently, the `ConfigureKeyManagementBlobClientOptions` class creates a new `IServiceScope` to resolve the required `AzureBlobXmlRepository` instance. However, `AzureBlobXmlRepository` is registered as a singleton and should be resolved from the same scope in which the options are being configured. Creating a new scope introduces unnecessary overhead and may lead to unexpected behavior due to differences in service lifetime management.

This issue is visible here:
[[Azure.Extensions.AspNetCore.DataProtection.Blobs/blob/0cae1c4...#L221](https://github.com/Azure/azure-sdk-for-net/blob/0cae1c46428963356dada45d22c2179dd6bbd397/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/AzureStorageBlobDataProtectionBuilderExtensions.cs#L221C28-L221C50)](https://github.com/Azure/azure-sdk-for-net/blob/0cae1c46428963356dada45d22c2179dd6bbd397/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/AzureStorageBlobDataProtectionBuilderExtensions.cs#L221C28-L221C50)

### Solution

Instead of creating a new scope, this change injects the already-registered singleton instance of `AzureBlobXmlRepository` directly into the constructor of `ConfigureKeyManagementBlobClientOptions` and uses it to configure the `XmlRepository`. This ensures consistent lifetime and configuration behavior.

### Background / Related Context

A similar multi-tenant configuration pattern is used in [[Orchard Core](https://github.com/OrchardCMS/OrchardCore)](https://github.com/OrchardCMS/OrchardCore), where service scopes are carefully managed per tenant. For example:

* A service scope is created per tenant:
  [[ShellContextFactory.cs#L80](https://github.com/OrchardCMS/OrchardCore/blob/4b059f06e9790b81fa0d1fe0025530f301c1e4b8/src/OrchardCore/OrchardCore/Shell/Builders/ShellContextFactory.cs#L80)](https://github.com/OrchardCMS/OrchardCore/blob/4b059f06e9790b81fa0d1fe0025530f301c1e4b8/src/OrchardCore/OrchardCore/Shell/Builders/ShellContextFactory.cs#L80)
* Configuration for blob-based data protection options is done during tenant startup:
  [[ShellContextFactory.cs#L82-L92](https://github.com/OrchardCMS/OrchardCore/blob/4b059f06e9790b81fa0d1fe0025530f301c1e4b8/src/OrchardCore/OrchardCore/Shell/Builders/ShellContextFactory.cs#L82-L92)](https://github.com/OrchardCMS/OrchardCore/blob/4b059f06e9790b81fa0d1fe0025530f301c1e4b8/src/OrchardCore/OrchardCore/Shell/Builders/ShellContextFactory.cs#L82-L92)

In that setup:

* The `BlobOptions` class is registered as a singleton:
  [[BlobOptions.cs](https://github.com/OrchardCMS/OrchardCore/blob/4b059f06e9790b81fa0d1fe0025530f301c1e4b8/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/BlobOptions.cs#L3-L12)](https://github.com/OrchardCMS/OrchardCore/blob/4b059f06e9790b81fa0d1fe0025530f301c1e4b8/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/BlobOptions.cs#L3-L12)
* The options are configured via `BlobOptionsSetup`, which relies on the default scope:
  [[BlobOptionsSetup.cs#L33-L38](https://github.com/OrchardCMS/OrchardCore/blob/5f8f50b5f65987d7ebb3305392bcd54ab5750e17/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/BlobOptionsSetup.cs#L33-L38)](https://github.com/OrchardCMS/OrchardCore/blob/5f8f50b5f65987d7ebb3305392bcd54ab5750e17/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/BlobOptionsSetup.cs#L33-L38)

If a new scope is created during configuration (as is done in the current implementation of `ConfigureKeyManagementBlobClientOptions`), the singleton `BlobOptions` instance may not have been configured yet, causing issues such as `BlobName` being null.

### Benefits

* Ensures correct and consistent configuration behavior.
* Avoids potential race conditions or null configuration values.
* Aligns with best practices for singleton service resolution.