### PR TITLE
[Extensions] DataProtection fixes and release prep

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
+## 1.5.1 (2025-06-23)
 
-### Features Added
+### Acknowledgments
 
-### Breaking Changes
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- Mike Alhayek _([GitHub](https://github.com/MikeAlhayek))_
 
 ### Bugs Fixed
 
-### Other Changes
+- Updated `ConfigureKeyManagementBlobClientOptions` to ensure that its dependencies were resolved in the correct scope to prevent issues due to lifetime drift.  Previously, a new scope was created to resolve `AzureBlobXmlRepository`.  However, `AzureBlobXmlRepository` is registered as a singleton and should be resolved from the same scope in which the options are being configured. Creating a new scope introduced unnecessary overhead and potential for unexpected behavior due to differences in service lifetime management.  _(A community contribution, courtesy of [danielmarbach](https://github.com/MikeAlhayek))_
 
 ## 1.5.0 (2025-02-11)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Blob storage support as key store (https://docs.microsoft.com/aspnet/core/security/data-protection/implementation/key-storage-providers).</Description>
     <PackageTags>aspnetcore;dataprotection;azure;blob;key store</PackageTags>
-    <Version>1.6.0-beta.1</Version>
+    <Version>1.5.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.0</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" VersionOverride="8.0.11" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Azure.Storage.Blobs" />
   </ItemGroup>
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Release History
 
-## 1.7.0-beta.1 (Unreleased)
+## 1.6.1 (2025-06-23)
 
-### Features Added
+### Acknowledgments
 
-### Breaking Changes
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- Mike Alhayek _([GitHub](https://github.com/MikeAlhayek))_
 
 ### Bugs Fixed
 
-### Other Changes
+- Updated `ConfigureKeyManagementKeyVaultEncryptorClientOptions` to ensure that its dependencies were resolved in the correct scope to prevent issues due to lifetime drift.  Previously, a new scope was created to resolve `AzureKeyVaultXmlEncryptor`.  However, `AzureKeyVaultXmlEncryptor` is registered as a singleton and should be resolved from the same scope in which the options are being configured. Creating a new scope introduced unnecessary overhead and potential for unexpected behavior due to differences in service lifetime management.  _(A community contribution, courtesy of [danielmarbach](https://github.com/MikeAlhayek))_
 
 ## 1.6.0 (2025-05-19)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Microsoft Azure Key Vault key encryption support.</Description>
     <PackageTags>aspnetcore;dataprotection;azure;keyvault</PackageTags>
-    <Version>1.7.0-beta.1</Version>
+    <Version>1.6.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.6.0</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" VersionOverride="8.0.11" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
   </ItemGroup>
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/ConfigureKeyManagementKeyVaultEncryptorClientOptions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/ConfigureKeyManagementKeyVaultEncryptorClientOptions.cs
@@ -2,27 +2,22 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Azure.Extensions.AspNetCore.DataProtection.Keys
 {
     internal sealed class ConfigureKeyManagementKeyVaultEncryptorClientOptions : IConfigureOptions<KeyManagementOptions>
     {
-        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly AzureKeyVaultXmlEncryptor _azureKeyVaultXmlEncryptor;
 
-        public ConfigureKeyManagementKeyVaultEncryptorClientOptions(IServiceScopeFactory serviceScopeFactory)
+        public ConfigureKeyManagementKeyVaultEncryptorClientOptions(AzureKeyVaultXmlEncryptor azureKeyVaultXmlEncryptor)
         {
-            _serviceScopeFactory = serviceScopeFactory;
+            _azureKeyVaultXmlEncryptor = azureKeyVaultXmlEncryptor;
         }
 
         public void Configure(KeyManagementOptions options)
         {
-            using var scope = _serviceScopeFactory.CreateScope();
-
-            var provider = scope.ServiceProvider;
-
-            options.XmlEncryptor = provider.GetRequiredService<AzureKeyVaultXmlEncryptor>();
+            options.XmlEncryptor = _azureKeyVaultXmlEncryptor;
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a DI scope lifetime bug in the DataProtection.Keys package to mirror a fix made in the DataProtection.Blobs package and prepare both packages for release.

## References and resources

- [Don't create new service-scope in ConfigureKeyManagementBlobClientOptions (#50748)](https://github.com/Azure/azure-sdk-for-net/pull/50748)