### PR TITLE
Don't change the namespace for customized models

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/NamespaceVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/NamespaceVisitor.cs
@@ -54,9 +54,13 @@ namespace Azure.Generator.Visitors
         {
             if (AzureClientGenerator.Instance.Configuration.UseModelNamespace())
             {
-                type.Update(
-                    @namespace: AzureClientGenerator.Instance.TypeFactory.GetCleanNameSpace(
-                        $"{AzureClientGenerator.Instance.TypeFactory.PrimaryNamespace}.Models"));
+                if (type.CustomCodeView == null)
+                {
+                    // If the type is customized, then we don't want to override the namespace.
+                    type.Update(
+                        @namespace: AzureClientGenerator.Instance.TypeFactory.GetCleanNameSpace(
+                            $"{AzureClientGenerator.Instance.TypeFactory.PrimaryNamespace}.Models"));
+                }
             }
             else
             {

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/NamespaceVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/NamespaceVisitor.cs
@@ -54,9 +54,9 @@ namespace Azure.Generator.Visitors
         {
             if (AzureClientGenerator.Instance.Configuration.UseModelNamespace())
             {
+                // If the type is customized, then we don't want to override the namespace.
                 if (type.CustomCodeView == null)
                 {
-                    // If the type is customized, then we don't want to override the namespace.
                     type.Update(
                         @namespace: AzureClientGenerator.Instance.TypeFactory.GetCleanNameSpace(
                             $"{AzureClientGenerator.Instance.TypeFactory.PrimaryNamespace}.Models"));

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/TestHelpers/MockHelpers.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/TestHelpers/MockHelpers.cs
@@ -91,5 +91,13 @@ namespace Azure.Generator.Tests.TestHelpers
             configureMethod!.Invoke(mockPluginInstance.Object, null);
             return mockPluginInstance;
         }
+
+        public static void SetCustomCodeView(ModelProvider modelProvider, TypeProvider customCodeTypeProvider)
+        {
+            modelProvider.GetType().BaseType!.GetField(
+                    "_customCodeView",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
+                .SetValue(modelProvider, new Lazy<TypeProvider>(() => customCodeTypeProvider));
+        }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/NamespaceVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/NamespaceVisitorTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Azure.Generator.Tests.Common;
 using Azure.Generator.Tests.TestHelpers;
 using Azure.Generator.Visitors;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/NamespaceVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/NamespaceVisitorTests.cs
@@ -48,10 +48,7 @@ namespace Azure.Generator.Tests.Visitors
             var model = new ModelProvider(inputType);
 
             // simulate a customized model
-            model.GetType().BaseType!.GetField(
-                "_customCodeView",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
-                .SetValue(model, new Lazy<TypeProvider>(() => new TestTypeProvider()));
+            MockHelpers.SetCustomCodeView(model, new TestTypeProvider());
             var updatedModel = visitor.InvokePreVisitModel(inputType, model);
 
             Assert.IsNotNull(updatedModel);


### PR DESCRIPTION
Found while working on https://github.com/Azure/azure-sdk-for-net/pull/50564