### PR TITLE
Don't generate builder extensions for internal clients

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureOutputLibrary.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureOutputLibrary.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Azure.Generator.Providers;
 using Microsoft.TypeSpec.Generator.ClientModel;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 
 namespace Azure.Generator
@@ -17,12 +18,13 @@ namespace Azure.Generator
         protected override TypeProvider[] BuildTypeProviders()
         {
             var types = base.BuildTypeProviders();
-            var clients = types.OfType<ClientProvider>().ToList();
+            var publicClients = types.OfType<ClientProvider>().Where(
+                client => client.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public)).ToList();
             return
             [
                 .. types,
                 new RequestContextExtensionsDefinition(),
-                .. clients.Count > 0 ? [new ClientBuilderExtensionsDefinition(clients)] : Array.Empty<TypeProvider>()
+                .. publicClients.Count > 0 ? [new ClientBuilderExtensionsDefinition(publicClients)] : Array.Empty<TypeProvider>()
             ];
         }
     }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/ClientBuilderExtensionsDefinition.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/ClientBuilderExtensionsDefinition.cs
@@ -23,12 +23,12 @@ namespace Azure.Generator.Providers
     /// </summary>
     internal class ClientBuilderExtensionsDefinition : TypeProvider
     {
-        private readonly IEnumerable<ClientProvider> _clients;
+        private readonly IEnumerable<ClientProvider> _publicClients;
         private readonly string _resourceProviderName;
 
-        public ClientBuilderExtensionsDefinition(IEnumerable<ClientProvider> clients)
+        public ClientBuilderExtensionsDefinition(IEnumerable<ClientProvider> publicClients)
         {
-            _clients = clients;
+            _publicClients = publicClients;
             _resourceProviderName = TypeNameUtilities.GetResourceProviderName();
             AzureClientGenerator.Instance.AddTypeToKeep(this);
         }
@@ -47,7 +47,7 @@ namespace Azure.Generator.Providers
         protected override MethodProvider[] BuildMethods()
         {
             var methods = new List<MethodProvider>();
-            foreach (var client in _clients)
+            foreach (var client in _publicClients)
             {
                 if (client.ClientOptionsParameter == null)
                 {

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/ClientBuilderExtensionsDefinitions/ClientBuilderExtensionsTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/ClientBuilderExtensionsDefinitions/ClientBuilderExtensionsTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Azure.Generator.Providers;
 using Azure.Generator.Tests.Common;
 using Azure.Generator.Tests.TestHelpers;
+using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using NUnit.Framework;
@@ -83,6 +84,57 @@ namespace Azure.Generator.Tests.Providers.ClientBuilderExtensionsDefinitions
             var writer = new TypeProviderWriter(builderExtensions!);
             var file = writer.Write();
             Assert.AreEqual(Helpers.GetExpectedFromFile(), file.Content);
+        }
+
+        [Test]
+        public void DoesNotAddExtensionMethodsClassIfOnlyInternalClients()
+        {
+            var client = InputFactory.Client("TestClient", "Samples", "");
+            var plugin = MockHelpers.LoadMockPlugin(
+                apiKeyAuth: () => new InputApiKeyAuth("mock", null),
+                oauth2Auth: ()=> new InputOAuth2Auth(["mock"]),
+                clients: () => [client],
+                createClientCore: inputClient =>
+                {
+                    var provider =  new ClientProvider(inputClient);
+                    provider.Update(modifiers: TypeSignatureModifiers.Internal | TypeSignatureModifiers.Class);
+                    return provider;
+                });
+
+            var builderExtensions = plugin.Object.OutputLibrary.TypeProviders
+                .OfType<ClientBuilderExtensionsDefinition>().SingleOrDefault();
+
+            Assert.IsNull(builderExtensions);
+        }
+
+        [Test]
+        public void DoesNotAddExtensionMethodsForInternalClients()
+        {
+            var client1 = InputFactory.Client("TestClient1", "Samples", "");
+            var client2 = InputFactory.Client("TestClient2", "Samples", "");
+            var plugin = MockHelpers.LoadMockPlugin(
+                apiKeyAuth: () => new InputApiKeyAuth("mock", null),
+                oauth2Auth: ()=> new InputOAuth2Auth(["mock"]),
+                clients: () => [client1, client2],
+                createClientCore: inputClient =>
+                {
+                    var provider =  new ClientProvider(inputClient);
+                    if (inputClient.Name == "TestClient1")
+                    {
+                        provider.Update(modifiers: TypeSignatureModifiers.Internal | TypeSignatureModifiers.Class);
+                    }
+                    return provider;
+                });
+
+            var builderExtensions = plugin.Object.OutputLibrary.TypeProviders
+                .OfType<ClientBuilderExtensionsDefinition>().SingleOrDefault();
+
+            Assert.IsNotNull(builderExtensions);
+            Assert.AreEqual(3, builderExtensions!.Methods.Count);
+            foreach (var method in builderExtensions.Methods)
+            {
+                Assert.IsTrue(method.Signature.Name.EndsWith("TestClient2", StringComparison.Ordinal));
+            }
         }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/TestHelpers/MockHelpers.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/TestHelpers/MockHelpers.cs
@@ -32,6 +32,7 @@ namespace Azure.Generator.Tests.TestHelpers
             Func<IReadOnlyList<InputEnumType>>? inputEnums = null,
             Func<IReadOnlyList<InputModelType>>? inputModels = null,
             Func<IReadOnlyList<InputClient>>? clients = null,
+            Func<InputClient, ClientProvider?>? createClientCore = null,
             ClientResponseApi? clientResponseApi = null,
             ClientPipelineApi? clientPipelineApi = null,
             HttpMessageApi? httpMessageApi = null,
@@ -60,6 +61,12 @@ namespace Azure.Generator.Tests.TestHelpers
             {
                 mockTypeFactory = new Mock<AzureTypeFactory>() { CallBase = true };
                 mockTypeFactory.Protected().Setup<CSharpType>("CreateCSharpTypeCore", ItExpr.IsAny<InputType>()).Returns(createCSharpTypeCore);
+            }
+
+            if (createClientCore is not null)
+            {
+                mockTypeFactory ??= new Mock<AzureTypeFactory>() { CallBase = true };
+                mockTypeFactory.Protected().Setup<ClientProvider?>("CreateClientCore", ItExpr.IsAny<InputClient>()).Returns(createClientCore);
             }
 
             // initialize the mock singleton instance of the plugin


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/50789