### PR TITLE
Fix image demands

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -11,7 +11,7 @@ pr:
 
 pool:
   name: $(WINDOWSPOOL)
-  demands: $(WindowsImageDemand)
+  demands: ImageOverride -equals $(WINDOWSVMIMAGE)
 
 variables:
   - template: templates/variables/globals.yml

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -34,7 +34,7 @@ jobs:
   - job: UpdateDocsMsBuildConfig
     pool:
       name: $(LINUXPOOL)
-      demands: $(LinuxImageDemand)
+      demands: ImageOverride -equals $(LINUXVMIMAGE)
 
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -22,8 +22,3 @@ variables:
     value: windows
   - name: MACOS
     value: macOS
-
-  - name: LinuxImageDemand
-    value: ImageOverride -equals $(LINUXVMIMAGE)
-  - name: WindowsImageDemand
-    value: ImageOverride -equals $(WINDOWSVMIMAGE)


### PR DESCRIPTION
Image demands appear to look for the raw string `ImageOverride` or they get ignored. We can still use the variable but it must have `ImageOverride` hard-coded in the demand statement. 