### PR TITLE
feat: add support for the 2024-02-01 metric ns API

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.Query/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added support for the `2024-02-01` service version to `MetricsQueryClient`.
 
 ## 1.6.0 (2024-12-03)
 

--- a/sdk/monitor/Azure.Monitor.Query/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.Query/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added support for the `2024-02-01` service version to `MetricsQueryClient`.
+- Added support for the `2024-02-01` metric namespaces service version to `MetricsQueryClient`.
 
 ## 1.6.0 (2024-12-03)
 

--- a/sdk/monitor/Azure.Monitor.Query/api/Azure.Monitor.Query.net8.0.cs
+++ b/sdk/monitor/Azure.Monitor.Query/api/Azure.Monitor.Query.net8.0.cs
@@ -141,11 +141,12 @@ namespace Azure.Monitor.Query
     }
     public partial class MetricsQueryClientOptions : Azure.Core.ClientOptions
     {
-        public MetricsQueryClientOptions(Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion version = Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion.V2018_01_01) { }
+        public MetricsQueryClientOptions(Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion version = Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion.V2024_02_01) { }
         public Azure.Monitor.Query.MetricsQueryAudience? Audience { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V2018_01_01 = 1,
+            V2024_02_01 = 2,
         }
     }
     public partial class MetricsQueryOptions

--- a/sdk/monitor/Azure.Monitor.Query/api/Azure.Monitor.Query.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.Query/api/Azure.Monitor.Query.netstandard2.0.cs
@@ -141,11 +141,12 @@ namespace Azure.Monitor.Query
     }
     public partial class MetricsQueryClientOptions : Azure.Core.ClientOptions
     {
-        public MetricsQueryClientOptions(Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion version = Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion.V2018_01_01) { }
+        public MetricsQueryClientOptions(Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion version = Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion.V2024_02_01) { }
         public Azure.Monitor.Query.MetricsQueryAudience? Audience { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V2018_01_01 = 1,
+            V2024_02_01 = 2,
         }
     }
     public partial class MetricsQueryOptions

--- a/sdk/monitor/Azure.Monitor.Query/assets.json
+++ b/sdk/monitor/Azure.Monitor.Query/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/monitor/Azure.Monitor.Query",
-  "Tag": "net/monitor/Azure.Monitor.Query_3bd28d9e3d"
+  "Tag": "net/monitor/Azure.Monitor.Query_8e43bc53d8"
 }

--- a/sdk/monitor/Azure.Monitor.Query/src/Generated/MetricNamespacesRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Generated/MetricNamespacesRestClient.cs
@@ -45,7 +45,7 @@ namespace Azure.Monitor.Query
             uri.AppendPath("/", false);
             uri.AppendPath(resourceUri, false);
             uri.AppendPath("/providers/microsoft.insights/metricNamespaces", false);
-            uri.AppendQuery("api-version", "2017-12-01-preview", true);
+            uri.AppendQuery("api-version", "2024-02-01", true);
             if (startTime != null)
             {
                 uri.AppendQuery("startTime", startTime, true);

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClientOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClientOptions.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.Query
         /// <summary>
         /// The latest service version supported by this client library.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2018_01_01;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2024_02_01;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MetricsQueryClientOptions"/> class.
@@ -35,12 +35,15 @@ namespace Azure.Monitor.Query
         /// </summary>
         public enum ServiceVersion
         {
-#pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
             /// Version 2018-01-01 of the service.
             /// </summary>
             V2018_01_01 = 1,
-#pragma warning restore CA1707 // Identifiers should not contain underscores
+
+            /// <summary>
+            /// Version 2024-02-01 of the service.
+            /// </summary>
+            V2024_02_01 = 2,
         }
 
         /// <summary>

--- a/sdk/monitor/Azure.Monitor.Query/src/autorest.md
+++ b/sdk/monitor/Azure.Monitor.Query/src/autorest.md
@@ -7,7 +7,7 @@ title: MonitorQuery
 input-file:
     - https://github.com/Azure/azure-rest-api-specs/blob/0373f0edc4414fd402603fac51d0df93f1f70507/specification/monitor/resource-manager/Microsoft.Insights/stable/2023-10-01/metricDefinitions_API.json
     - https://github.com/Azure/azure-rest-api-specs/blob/0373f0edc4414fd402603fac51d0df93f1f70507/specification/monitor/resource-manager/Microsoft.Insights/stable/2023-10-01/metrics_API.json
-    - https://github.com/Azure/azure-rest-api-specs/blob/0373f0edc4414fd402603fac51d0df93f1f70507/specification/monitor/resource-manager/Microsoft.Insights/preview/2017-12-01-preview/metricNamespaces_API.json
+    - https://github.com/Azure/azure-rest-api-specs/blob/0b64ca7cbe3af8cd13228dfb783a16b8272b8be2/specification/monitor/resource-manager/Microsoft.Insights/stable/2024-02-01/metricNamespaces_API.json
     - https://github.com/Azure/azure-rest-api-specs/blob/0550754fb421cd3a5859abf6713a542b682f626c/specification/monitor/data-plane/Microsoft.Insights/stable/2023-10-01/metricBatch.json
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/21f5332f2dc7437d1446edf240e9a3d4c90c6431/specification/operationalinsights/data-plane/Microsoft.OperationalInsights/stable/2022-10-27/OperationalInsights.json
 generation1-convenience-client: true

--- a/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientLiveTests.cs
@@ -247,9 +247,9 @@ namespace Azure.Monitor.Query.Tests
                 TestEnvironment.MetricsResource).ToEnumerableAsync();
 
             Assert.True(results.Any(ns =>
-                ns.Name == "microsoft.operationalinsights-workspaces" &&
-                ns.Type == "Microsoft.Insights/metricNamespaces" &&
-                ns.FullyQualifiedName == "microsoft.operationalinsights/workspaces"));
+                ns.Name.Equals("microsoft.operationalinsights-workspaces", StringComparison.OrdinalIgnoreCase) &&
+                ns.Type.Equals("Microsoft.Insights/metricNamespaces", StringComparison.OrdinalIgnoreCase) &&
+                ns.FullyQualifiedName.Equals("microsoft.operationalinsights/workspaces", StringComparison.OrdinalIgnoreCase)));
         }
 
         [RecordedTest]


### PR DESCRIPTION
This PR updates the Metrics Query client with support for the  `2024-02-01` metricNamespaces API service version.

fixes: https://github.com/Azure/azure-sdk-for-net/issues/49484