### PR TITLE
Fix syntax in example

### DIFF
--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -256,7 +256,7 @@ Another approach would be to filter out generic HTTP client activities:
 .WithTracing(tracerProviderBuilder => tracerProviderBuilder
     .AddSource("Azure.*")
     .AddHttpClientInstrumentation(o => {
-        o => o.FilterHttpRequestMessage = (_) => Activity.Current?.Parent?.Source?.Name != "Azure.Core.Http";
+        o.FilterHttpRequestMessage = (_) => Activity.Current?.Parent?.Source?.Name != "Azure.Core.Http";
     })
     ...)
 ```


### PR DESCRIPTION
Fixed broken example code.

Did not convert to use `Snippet:XYZ` under the assumption that there is a reason these are not already code-backed snippets. To back them with code would require adding a dependency on OpenTelemetry.Extensions.Hosting to the Test project