### PR TITLE
Relax JSON encoding in System.ClientModel

### DIFF
--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonCollectionWriter.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonCollectionWriter.cs
@@ -3,6 +3,7 @@
 
 using System.ClientModel.Internal;
 using System.Collections;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 
 namespace System.ClientModel.Primitives;
@@ -12,7 +13,7 @@ internal class JsonCollectionWriter : CollectionWriter
     internal override BinaryData Write(IEnumerable enumerable, ModelReaderWriterOptions options)
     {
         using UnsafeBufferSequence sequenceWriter = new();
-        using Utf8JsonWriter writer = new(sequenceWriter);
+        using Utf8JsonWriter writer = new(sequenceWriter, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
         WriteEnumerable(enumerable, writer, options);
         writer.Flush();
         return sequenceWriter.ExtractReader().ToBinaryData();

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelWriterOfT.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelWriterOfT.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ClientModel.Primitives;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 
 namespace System.ClientModel.Internal;
@@ -29,7 +30,7 @@ internal partial class ModelWriter<T>
     public UnsafeBufferSequence.Reader ExtractReader()
     {
         using UnsafeBufferSequence sequenceWriter = new UnsafeBufferSequence();
-        using var jsonWriter = new Utf8JsonWriter(sequenceWriter);
+        using var jsonWriter = new Utf8JsonWriter(sequenceWriter, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
         _model.Write(jsonWriter, _options);
         jsonWriter.Flush();
         return sequenceWriter.ExtractReader();


### PR DESCRIPTION
The default encoding rules used by Utf8JsonWriter are very strict, more than what's needed just for JSON, under the assumption that the resulting JSON might be embedded in an HTML page / script element. That strictness is not necessary or desirable when JSON is just being sent as part of an application/json payload, as it is with API inputs/outputs. The stricter encoding rules can have measurable impact, especially with the kinds of payloads commonly used in these APIs, e.g. base64 includes '+' in its alphabet, and '+' is a character that's encoded in the strict mode and not in the relaxed mode.

This PR relaxes the encoding rules used.

@grabyourpitchforks
