### PR TITLE
Fix error code string comparison

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 - Fixed an issue where `TimeSpan` properties in strongly typed table entities were not being deserialized.
 - Fixed an issue when deserializing strongly typed table entities with enum properties. Enum values that aren't defined in the enum type are now skipped during deserialization of the table entity.
+- Fixed an issue when comparing `TableErrorCode` with null strings using equality operators.
 
 ### Other Changes
 

--- a/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.net8.0.cs
+++ b/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.net8.0.cs
@@ -310,8 +310,12 @@ namespace Azure.Data.Tables.Models
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Azure.Data.Tables.Models.TableErrorCode left, Azure.Data.Tables.Models.TableErrorCode right) { throw null; }
+        public static bool operator ==(Azure.Data.Tables.Models.TableErrorCode code, string value) { throw null; }
+        public static bool operator ==(string value, Azure.Data.Tables.Models.TableErrorCode code) { throw null; }
         public static implicit operator Azure.Data.Tables.Models.TableErrorCode (string value) { throw null; }
         public static bool operator !=(Azure.Data.Tables.Models.TableErrorCode left, Azure.Data.Tables.Models.TableErrorCode right) { throw null; }
+        public static bool operator !=(Azure.Data.Tables.Models.TableErrorCode code, string value) { throw null; }
+        public static bool operator !=(string value, Azure.Data.Tables.Models.TableErrorCode code) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class TableGeoReplicationInfo

--- a/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
+++ b/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
@@ -309,8 +309,12 @@ namespace Azure.Data.Tables.Models
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Azure.Data.Tables.Models.TableErrorCode left, Azure.Data.Tables.Models.TableErrorCode right) { throw null; }
+        public static bool operator ==(Azure.Data.Tables.Models.TableErrorCode code, string value) { throw null; }
+        public static bool operator ==(string value, Azure.Data.Tables.Models.TableErrorCode code) { throw null; }
         public static implicit operator Azure.Data.Tables.Models.TableErrorCode (string value) { throw null; }
         public static bool operator !=(Azure.Data.Tables.Models.TableErrorCode left, Azure.Data.Tables.Models.TableErrorCode right) { throw null; }
+        public static bool operator !=(Azure.Data.Tables.Models.TableErrorCode code, string value) { throw null; }
+        public static bool operator !=(string value, Azure.Data.Tables.Models.TableErrorCode code) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class TableGeoReplicationInfo

--- a/sdk/tables/Azure.Data.Tables/src/TableErrorCode.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableErrorCode.cs
@@ -215,6 +215,19 @@ namespace Azure.Data.Tables.Models
         public static bool operator ==(TableErrorCode left, TableErrorCode right) => left.Equals(right);
         /// <summary> Determines if two <see cref="TableErrorCode"/> values are not the same. </summary>
         public static bool operator !=(TableErrorCode left, TableErrorCode right) => !left.Equals(right);
+
+        /// <summary> Determines if a <see cref="TableErrorCode"/> and a string are equal. </summary>
+        public static bool operator ==(TableErrorCode code, string value) => value != null && code.Equals(value);
+
+        /// <summary> Determines if a <see cref="TableErrorCode"/> and a string are not equal. </summary>
+        public static bool operator !=(TableErrorCode code, string value) => !(code == value);
+
+        /// <summary> Determines if a string and a <see cref="TableErrorCode"/> are equal. </summary>
+        public static bool operator ==(string value, TableErrorCode code) => code == value;
+
+        /// <summary> Determines if a string and a <see cref="TableErrorCode"/> are not equal. </summary>
+        public static bool operator !=(string value, TableErrorCode code) => !(value == code);
+
         /// <summary> Converts a string to a <see cref="TableErrorCode"/>. </summary>
         public static implicit operator TableErrorCode(string value) => new TableErrorCode(value);
 

--- a/sdk/tables/Azure.Data.Tables/tests/TableErrorCodeTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableErrorCodeTests.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Data.Tables.Models;
+using NUnit.Framework;
+
+namespace Azure.Data.Tables.Tests
+{
+    public class TableErrorCodeTests
+    {
+        [Test]
+        public void EqualityOperator_TableErrorCodeToString_ReturnsCorrectResult()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string matchingString = "EntityNotFound";
+            string nonMatchingString = "TableNotFound";
+
+            // Act & Assert
+            Assert.IsTrue(errorCode == matchingString);
+            Assert.IsFalse(errorCode == nonMatchingString);
+        }
+
+        [Test]
+        public void EqualityOperator_TableErrorCodeToNullString_ReturnsFalse()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string nullString = null;
+
+            // Act & Assert
+            Assert.IsFalse(errorCode == nullString);
+        }
+
+        [Test]
+        public void InequalityOperator_TableErrorCodeToString_ReturnsCorrectResult()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string matchingString = "EntityNotFound";
+            string nonMatchingString = "TableNotFound";
+
+            // Act & Assert
+            Assert.IsTrue(errorCode == matchingString);
+            Assert.IsTrue(errorCode != nonMatchingString);
+        }
+
+        [Test]
+        public void InequalityOperator_TableErrorCodeToNullString_ReturnsTrue()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string nullString = null;
+
+            // Act & Assert
+            Assert.IsTrue(errorCode != nullString);
+        }
+
+        [Test]
+        public void EqualityOperator_StringToTableErrorCode_ReturnsCorrectResult()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string matchingString = "EntityNotFound";
+            string nonMatchingString = "TableNotFound";
+
+            // Act & Assert
+            Assert.IsTrue(matchingString == errorCode);
+            Assert.IsFalse(nonMatchingString == errorCode);
+        }
+
+        [Test]
+        public void EqualityOperator_NullStringToTableErrorCode_ReturnsFalse()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string nullString = null;
+
+            // Act & Assert
+            Assert.IsFalse(nullString == errorCode);
+        }
+
+        [Test]
+        public void InequalityOperator_StringToTableErrorCode_ReturnsCorrectResult()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string matchingString = "EntityNotFound";
+            string nonMatchingString = "TableNotFound";
+
+            // Act & Assert
+            Assert.IsTrue(matchingString == errorCode);
+            Assert.IsTrue(nonMatchingString != errorCode);
+        }
+
+        [Test]
+        public void InequalityOperator_NullStringToTableErrorCode_ReturnsTrue()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string nullString = null;
+
+            // Act & Assert
+            Assert.IsTrue(nullString != errorCode);
+        }
+
+        [Test]
+        public void EqualityOperators_WithVariousErrorCodes_WorkCorrectly()
+        {
+            // Arrange & Act & Assert
+            Assert.IsTrue(TableErrorCode.TableAlreadyExists == "TableAlreadyExists");
+            Assert.IsTrue("TableAlreadyExists" == TableErrorCode.TableAlreadyExists);
+            Assert.IsTrue(TableErrorCode.OperationTimedOut == "OperationTimedOut");
+            Assert.IsTrue("OperationTimedOut" == TableErrorCode.OperationTimedOut);
+            Assert.IsTrue(TableErrorCode.Forbidden == "Forbidden");
+            Assert.IsTrue("Forbidden" == TableErrorCode.Forbidden);
+            Assert.IsFalse(TableErrorCode.TableAlreadyExists == "EntityNotFound");
+            Assert.IsFalse("EntityNotFound" == TableErrorCode.TableAlreadyExists);
+        }
+
+        [Test]
+        public void InequalityOperators_WithVariousErrorCodes_WorkCorrectly()
+        {
+            // Arrange & Act & Assert
+            Assert.IsTrue(TableErrorCode.TableAlreadyExists == "TableAlreadyExists");
+            Assert.IsTrue("TableAlreadyExists" == TableErrorCode.TableAlreadyExists);
+            Assert.IsFalse(TableErrorCode.OperationTimedOut != "OperationTimedOut");
+            Assert.IsFalse("OperationTimedOut" != TableErrorCode.OperationTimedOut);
+            Assert.IsTrue(TableErrorCode.TableAlreadyExists != "EntityNotFound");
+            Assert.IsTrue("EntityNotFound" != TableErrorCode.TableAlreadyExists);
+        }
+
+        [Test]
+        public void StringOperators_DoNotThrowOnNullValues()
+        {
+            // Arrange
+            var errorCode = TableErrorCode.EntityNotFound;
+            string nullString = null;
+
+            // Act & Assert - These should not throw exceptions
+            Assert.DoesNotThrow(() =>
+            {
+                var result1 = errorCode == nullString;
+                var result2 = errorCode != nullString;
+                var result3 = nullString == errorCode;
+                var result4 = nullString != errorCode;
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a fix when comparing `TableErrorCode` with a null string.

fixes: https://github.com/Azure/azure-sdk-for-net/issues/48116