### PR TITLE
replace Get*Client() with properties

### DIFF
--- a/sdk/ai/Azure.AI.Projects/CHANGELOG.md
+++ b/sdk/ai/Azure.AI.Projects/CHANGELOG.md
@@ -7,9 +7,8 @@
 ### Breaking Changes
 * Method argument name changes:
   * In Datasets methods `PendingUpload` and `PendingUploadAsync`, argument `body` was replaced with `pendingUploadRequest`
-
-
 * Removing `GetChatCompletionsClient`, `GetEmbeddingsClient`, and `GetImageEmbeddingsClient` methods from `AIProjectClient`. The Inference client should be used directly instead.
+* Replacing `GetConnectionsClient`, `GetDatasetsClient`, `GetDeploymentsClient`, and`GetIndexesClient` with `Connections`, `Datasets`, `Deployments`, and `Indexes` properties.
 
 ### Bugs Fixed
 

--- a/sdk/ai/Azure.AI.Projects/README.md
+++ b/sdk/ai/Azure.AI.Projects/README.md
@@ -211,22 +211,21 @@ var endpoint = System.Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
 var modelDeploymentName = System.Environment.GetEnvironmentVariable("MODEL_DEPLOYMENT_NAME");
 var modelPublisher = System.Environment.GetEnvironmentVariable("MODEL_PUBLISHER");
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Deployments deployments = projectClient.GetDeploymentsClient();
 
 Console.WriteLine("List all deployments:");
-foreach (var deployment in deployments.GetDeployments())
+foreach (Deployment deployment in projectClient.Deployments.GetDeployments())
 {
     Console.WriteLine(deployment);
 }
 
 Console.WriteLine($"List all deployments by the model publisher `{modelPublisher}`:");
-foreach (var deployment in deployments.GetDeployments(modelPublisher: modelPublisher))
+foreach (Deployment deployment in projectClient.Deployments.GetDeployments(modelPublisher: modelPublisher))
 {
     Console.WriteLine(deployment);
 }
 
 Console.WriteLine($"Get a single deployment named `{modelDeploymentName}`:");
-var deploymentDetails = deployments.GetDeployment(modelDeploymentName);
+Deployment deploymentDetails = projectClient.Deployments.GetDeployment(modelDeploymentName);
 Console.WriteLine(deploymentDetails);
 ```
 
@@ -238,35 +237,34 @@ The code below shows some Connection operations, which allow you to enumerate th
 var endpoint = Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
 var connectionName = Environment.GetEnvironmentVariable("CONNECTION_NAME");
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Connections connectionsClient = projectClient.GetConnectionsClient();
 
 Console.WriteLine("List the properties of all connections:");
-foreach (var connection in connectionsClient.GetConnections())
+foreach (Connection connection in projectClient.Connections.GetConnections())
 {
     Console.WriteLine(connection);
     Console.Write(connection.Name);
 }
 
 Console.WriteLine("List the properties of all connections of a particular type (e.g., Azure OpenAI connections):");
-foreach (var connection in connectionsClient.GetConnections(connectionType: ConnectionType.AzureOpenAI))
+foreach (Connection connection in projectClient.Connections.GetConnections(connectionType: ConnectionType.AzureOpenAI))
 {
     Console.WriteLine(connection);
 }
 
 Console.WriteLine($"Get the properties of a connection named `{connectionName}`:");
-var specificConnection = connectionsClient.Get(connectionName, includeCredentials: false);
+Connection specificConnection = projectClient.Connections.Get(connectionName, includeCredentials: false);
 Console.WriteLine(specificConnection);
 
 Console.WriteLine("Get the properties of a connection with credentials:");
-var specificConnectionCredentials = connectionsClient.Get(connectionName, includeCredentials: true);
+Connection specificConnectionCredentials = projectClient.Connections.Get(connectionName, includeCredentials: true);
 Console.WriteLine(specificConnectionCredentials);
 
 Console.WriteLine($"Get the properties of the default connection:");
-var defaultConnection = connectionsClient.GetDefault(includeCredentials: false);
+Connection defaultConnection = projectClient.Connections.GetDefault(includeCredentials: false);
 Console.WriteLine(defaultConnection);
 
 Console.WriteLine($"Get the properties of the default connection with credentials:");
-var defaultConnectionCredentials = connectionsClient.GetDefault(includeCredentials: true);
+Connection defaultConnectionCredentials = projectClient.Connections.GetDefault(includeCredentials: true);
 Console.WriteLine(defaultConnectionCredentials);
 ```
 
@@ -283,10 +281,9 @@ var datasetVersion2 = System.Environment.GetEnvironmentVariable("DATASET_VERSION
 var filePath = System.Environment.GetEnvironmentVariable("SAMPLE_FILE_PATH") ?? "sample_folder/sample_file1.txt";
 var folderPath = System.Environment.GetEnvironmentVariable("SAMPLE_FOLDER_PATH") ?? "sample_folder";
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Datasets datasets = projectClient.GetDatasetsClient();
 
 Console.WriteLine($"Uploading a single file to create Dataset version {datasetVersion1}:");
-DatasetVersion dataset = datasets.UploadFile(
+DatasetVersion dataset = projectClient.Datasets.UploadFile(
     name: datasetName,
     version: datasetVersion1,
     filePath: filePath,
@@ -295,7 +292,7 @@ DatasetVersion dataset = datasets.UploadFile(
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Uploading folder to create Dataset version {datasetVersion2}:");
-dataset = datasets.UploadFolder(
+dataset = projectClient.Datasets.UploadFolder(
     name: datasetName,
     version: datasetVersion2,
     folderPath: folderPath,
@@ -305,29 +302,29 @@ dataset = datasets.UploadFolder(
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Retrieving Dataset version {datasetVersion1}:");
-dataset = datasets.GetDataset(datasetName, datasetVersion1);
+dataset = projectClient.Datasets.GetDataset(datasetName, datasetVersion1);
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Retrieving credentials of Dataset {datasetName} version {datasetVersion1}:");
-AssetCredentialResponse credentials = datasets.GetCredentials(datasetName, datasetVersion1);
+AssetCredentialResponse credentials = projectClient.Datasets.GetCredentials(datasetName, datasetVersion1);
 Console.WriteLine(credentials);
 
 Console.WriteLine($"Listing all versions for Dataset '{datasetName}':");
-foreach (var ds in datasets.GetVersions(datasetName))
+foreach (DatasetVersion ds in projectClient.Datasets.GetVersions(datasetName))
 {
     Console.WriteLine(ds);
     Console.WriteLine(ds.Version);
 }
 
 Console.WriteLine($"Listing latest versions for all datasets:");
-foreach (var ds in datasets.GetDatasetVersions())
+foreach (DatasetVersion ds in projectClient.Datasets.GetDatasetVersions())
 {
     Console.WriteLine(ds);
 }
 
 Console.WriteLine($"Deleting Dataset versions {datasetVersion1} and {datasetVersion2}:");
-datasets.Delete(datasetName, datasetVersion1);
-datasets.Delete(datasetName, datasetVersion2);
+projectClient.Datasets.Delete(datasetName, datasetVersion1);
+projectClient.Datasets.Delete(datasetName, datasetVersion2);
 ```
 
 ### Indexes operations
@@ -341,7 +338,6 @@ var indexVersion = Environment.GetEnvironmentVariable("INDEX_VERSION") ?? "1.0";
 var aiSearchConnectionName = Environment.GetEnvironmentVariable("AI_SEARCH_CONNECTION_NAME") ?? "my-ai-search-connection-name";
 var aiSearchIndexName = Environment.GetEnvironmentVariable("AI_SEARCH_INDEX_NAME") ?? "my-ai-search-index-name";
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Indexes indexesClient = projectClient.GetIndexesClient();
 
 RequestContent content = RequestContent.Create(new
 {
@@ -354,7 +350,7 @@ RequestContent content = RequestContent.Create(new
 });
 
 Console.WriteLine($"Create an Index named `{indexName}` referencing an existing AI Search resource:");
-var index = indexesClient.CreateOrUpdate(
+var index = projectClient.Indexes.CreateOrUpdate(
     name: indexName,
     version: indexVersion,
     content: content
@@ -362,23 +358,23 @@ var index = indexesClient.CreateOrUpdate(
 Console.WriteLine(index);
 
 Console.WriteLine($"Get an existing Index named `{indexName}`, version `{indexVersion}`:");
-var retrievedIndex = indexesClient.GetIndex(name: indexName, version: indexVersion);
+Index retrievedIndex = projectClient.Indexes.GetIndex(name: indexName, version: indexVersion);
 Console.WriteLine(retrievedIndex);
 
 Console.WriteLine($"Listing all versions of the Index named `{indexName}`:");
-foreach (var version in indexesClient.GetVersions(name: indexName))
+foreach (Index version in projectClient.Indexes.GetVersions(name: indexName))
 {
     Console.WriteLine(version);
 }
 
 Console.WriteLine($"Listing all Indices:");
-foreach (var version in indexesClient.GetIndices())
+foreach (Index version in projectClient.Indexes.GetIndices())
 {
     Console.WriteLine(version);
 }
 
 Console.WriteLine("Delete the Index version created above:");
-indexesClient.Delete(name: indexName, version: indexVersion);
+projectClient.Indexes.Delete(name: indexName, version: indexVersion);
 ```
 
 ## Troubleshooting

--- a/sdk/ai/Azure.AI.Projects/api/Azure.AI.Projects.net8.0.cs
+++ b/sdk/ai/Azure.AI.Projects/api/Azure.AI.Projects.net8.0.cs
@@ -79,6 +79,10 @@ namespace Azure.AI.Projects
         protected AIProjectClient() : base (default(int)) { }
         public AIProjectClient(System.Uri endpoint, Azure.Core.TokenCredential credential = null) : base (default(int)) { }
         public AIProjectClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.AI.Projects.AIProjectClientOptions options) : base (default(int)) { }
+        public Azure.AI.Projects.Connections Connections { get { throw null; } }
+        public Azure.AI.Projects.Datasets Datasets { get { throw null; } }
+        public Azure.AI.Projects.Deployments Deployments { get { throw null; } }
+        public Azure.AI.Projects.Indexes Indexes { get { throw null; } }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public Azure.AI.Projects.Telemetry Telemetry { get { throw null; } }
         public override System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> GetAllConnections() { throw null; }

--- a/sdk/ai/Azure.AI.Projects/api/Azure.AI.Projects.netstandard2.0.cs
+++ b/sdk/ai/Azure.AI.Projects/api/Azure.AI.Projects.netstandard2.0.cs
@@ -79,6 +79,10 @@ namespace Azure.AI.Projects
         protected AIProjectClient() : base (default(int)) { }
         public AIProjectClient(System.Uri endpoint, Azure.Core.TokenCredential credential = null) : base (default(int)) { }
         public AIProjectClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.AI.Projects.AIProjectClientOptions options) : base (default(int)) { }
+        public Azure.AI.Projects.Connections Connections { get { throw null; } }
+        public Azure.AI.Projects.Datasets Datasets { get { throw null; } }
+        public Azure.AI.Projects.Deployments Deployments { get { throw null; } }
+        public Azure.AI.Projects.Indexes Indexes { get { throw null; } }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public Azure.AI.Projects.Telemetry Telemetry { get { throw null; } }
         public override System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> GetAllConnections() { throw null; }

--- a/sdk/ai/Azure.AI.Projects/samples/Sample1_Datasets.md
+++ b/sdk/ai/Azure.AI.Projects/samples/Sample1_Datasets.md
@@ -24,10 +24,9 @@ var datasetVersion2 = System.Environment.GetEnvironmentVariable("DATASET_VERSION
 var filePath = System.Environment.GetEnvironmentVariable("SAMPLE_FILE_PATH") ?? "sample_folder/sample_file1.txt";
 var folderPath = System.Environment.GetEnvironmentVariable("SAMPLE_FOLDER_PATH") ?? "sample_folder";
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Datasets datasets = projectClient.GetDatasetsClient();
 
 Console.WriteLine($"Uploading a single file to create Dataset version {datasetVersion1}:");
-DatasetVersion dataset = datasets.UploadFile(
+DatasetVersion dataset = projectClient.Datasets.UploadFile(
     name: datasetName,
     version: datasetVersion1,
     filePath: filePath,
@@ -36,7 +35,7 @@ DatasetVersion dataset = datasets.UploadFile(
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Uploading folder to create Dataset version {datasetVersion2}:");
-dataset = datasets.UploadFolder(
+dataset = projectClient.Datasets.UploadFolder(
     name: datasetName,
     version: datasetVersion2,
     folderPath: folderPath,
@@ -46,29 +45,29 @@ dataset = datasets.UploadFolder(
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Retrieving Dataset version {datasetVersion1}:");
-dataset = datasets.GetDataset(datasetName, datasetVersion1);
+dataset = projectClient.Datasets.GetDataset(datasetName, datasetVersion1);
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Retrieving credentials of Dataset {datasetName} version {datasetVersion1}:");
-AssetCredentialResponse credentials = datasets.GetCredentials(datasetName, datasetVersion1);
+AssetCredentialResponse credentials = projectClient.Datasets.GetCredentials(datasetName, datasetVersion1);
 Console.WriteLine(credentials);
 
 Console.WriteLine($"Listing all versions for Dataset '{datasetName}':");
-foreach (var ds in datasets.GetVersions(datasetName))
+foreach (DatasetVersion ds in projectClient.Datasets.GetVersions(datasetName))
 {
     Console.WriteLine(ds);
     Console.WriteLine(ds.Version);
 }
 
 Console.WriteLine($"Listing latest versions for all datasets:");
-foreach (var ds in datasets.GetDatasetVersions())
+foreach (DatasetVersion ds in projectClient.Datasets.GetDatasetVersions())
 {
     Console.WriteLine(ds);
 }
 
 Console.WriteLine($"Deleting Dataset versions {datasetVersion1} and {datasetVersion2}:");
-datasets.Delete(datasetName, datasetVersion1);
-datasets.Delete(datasetName, datasetVersion2);
+projectClient.Datasets.Delete(datasetName, datasetVersion1);
+projectClient.Datasets.Delete(datasetName, datasetVersion2);
 ```
 
 
@@ -82,10 +81,9 @@ var datasetVersion2 = System.Environment.GetEnvironmentVariable("DATASET_VERSION
 var filePath = System.Environment.GetEnvironmentVariable("SAMPLE_FILE_PATH") ?? "sample_folder/sample_file1.txt";
 var folderPath = System.Environment.GetEnvironmentVariable("SAMPLE_FOLDER_PATH") ?? "sample_folder";
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Datasets datasets = projectClient.GetDatasetsClient();
 
 Console.WriteLine($"Uploading a single file to create Dataset version {datasetVersion1}...");
-DatasetVersion dataset = await datasets.UploadFileAsync(
+DatasetVersion dataset = await projectClient.Datasets.UploadFileAsync(
     name: datasetName,
     version: datasetVersion1,
     filePath: filePath,
@@ -94,7 +92,7 @@ DatasetVersion dataset = await datasets.UploadFileAsync(
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Uploading folder to create Dataset version {datasetVersion2}...");
-dataset = await datasets.UploadFolderAsync(
+dataset = await projectClient.Datasets.UploadFolderAsync(
     name: datasetName,
     version: datasetVersion2,
     folderPath: folderPath,
@@ -104,26 +102,26 @@ dataset = await datasets.UploadFolderAsync(
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Retrieving Dataset version {datasetVersion1}...");
-dataset = await datasets.GetDatasetAsync(datasetName, datasetVersion1);
+dataset = await projectClient.Datasets.GetDatasetAsync(datasetName, datasetVersion1);
 Console.WriteLine(dataset);
 
 Console.WriteLine($"Retrieving credentials of Dataset {datasetName} version {datasetVersion1}:");
-AssetCredentialResponse credentials = await datasets.GetCredentialsAsync(datasetName, datasetVersion1);
+AssetCredentialResponse credentials = await projectClient.Datasets.GetCredentialsAsync(datasetName, datasetVersion1);
 Console.WriteLine(credentials);
 
 Console.WriteLine($"Listing all versions for Dataset '{datasetName}':");
-await foreach (var ds in datasets.GetVersionsAsync(datasetName))
+await foreach (DatasetVersion ds in projectClient.Datasets.GetVersionsAsync(datasetName))
 {
     Console.WriteLine(ds.Version);
 }
 
 Console.WriteLine($"Listing latest versions for all datasets:");
-await foreach (var ds in datasets.GetDatasetVersionsAsync())
+await foreach (DatasetVersion ds in projectClient.Datasets.GetDatasetVersionsAsync())
 {
     Console.WriteLine(ds);
 }
 
 Console.WriteLine($"Deleting Dataset versions {datasetVersion1} and {datasetVersion2}...");
-await datasets.DeleteAsync(datasetName, datasetVersion1);
-await datasets.DeleteAsync(datasetName, datasetVersion2);
+await projectClient.Datasets.DeleteAsync(datasetName, datasetVersion1);
+await projectClient.Datasets.DeleteAsync(datasetName, datasetVersion2);
 ```

--- a/sdk/ai/Azure.AI.Projects/samples/Sample2_Deployments.md
+++ b/sdk/ai/Azure.AI.Projects/samples/Sample2_Deployments.md
@@ -17,22 +17,21 @@ var endpoint = System.Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
 var modelDeploymentName = System.Environment.GetEnvironmentVariable("MODEL_DEPLOYMENT_NAME");
 var modelPublisher = System.Environment.GetEnvironmentVariable("MODEL_PUBLISHER");
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Deployments deployments = projectClient.GetDeploymentsClient();
 
 Console.WriteLine("List all deployments:");
-foreach (var deployment in deployments.GetDeployments())
+foreach (Deployment deployment in projectClient.Deployments.GetDeployments())
 {
     Console.WriteLine(deployment);
 }
 
 Console.WriteLine($"List all deployments by the model publisher `{modelPublisher}`:");
-foreach (var deployment in deployments.GetDeployments(modelPublisher: modelPublisher))
+foreach (Deployment deployment in projectClient.Deployments.GetDeployments(modelPublisher: modelPublisher))
 {
     Console.WriteLine(deployment);
 }
 
 Console.WriteLine($"Get a single deployment named `{modelDeploymentName}`:");
-var deploymentDetails = deployments.GetDeployment(modelDeploymentName);
+Deployment deploymentDetails = projectClient.Deployments.GetDeployment(modelDeploymentName);
 Console.WriteLine(deploymentDetails);
 ```
 
@@ -43,21 +42,20 @@ var endpoint = System.Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
 var modelDeploymentName = System.Environment.GetEnvironmentVariable("DEPLOYMENT_NAME");
 var modelPublisher = System.Environment.GetEnvironmentVariable("MODEL_PUBLISHER");
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Deployments deployments = projectClient.GetDeploymentsClient();
 
 Console.WriteLine("List all deployments:");
-await foreach (var deployment in deployments.GetDeploymentsAsync())
+await foreach (Deployment deployment in projectClient.Deployments.GetDeploymentsAsync())
 {
     Console.WriteLine(deployment);
 }
 
 Console.WriteLine($"List all deployments by the model publisher `{modelPublisher}`:");
-await foreach (var deployment in deployments.GetDeploymentsAsync(modelPublisher: modelPublisher))
+await foreach (Deployment deployment in projectClient.Deployments.GetDeploymentsAsync(modelPublisher: modelPublisher))
 {
     Console.WriteLine(deployment);
 }
 
 Console.WriteLine($"Get a single deployment named `{modelDeploymentName}`:");
-var deploymentDetails = deployments.GetDeploymentAsync(modelDeploymentName);
+Deployment deploymentDetails = await projectClient.Deployments.GetDeploymentAsync(modelDeploymentName);
 Console.WriteLine(deploymentDetails);
 ```

--- a/sdk/ai/Azure.AI.Projects/samples/Sample3_Connections.md
+++ b/sdk/ai/Azure.AI.Projects/samples/Sample3_Connections.md
@@ -14,35 +14,34 @@ In this example, we will demonstrate listing and retrieving connections using th
 var endpoint = Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
 var connectionName = Environment.GetEnvironmentVariable("CONNECTION_NAME");
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Connections connectionsClient = projectClient.GetConnectionsClient();
 
 Console.WriteLine("List the properties of all connections:");
-foreach (var connection in connectionsClient.GetConnections())
+foreach (Connection connection in projectClient.Connections.GetConnections())
 {
     Console.WriteLine(connection);
     Console.Write(connection.Name);
 }
 
 Console.WriteLine("List the properties of all connections of a particular type (e.g., Azure OpenAI connections):");
-foreach (var connection in connectionsClient.GetConnections(connectionType: ConnectionType.AzureOpenAI))
+foreach (Connection connection in projectClient.Connections.GetConnections(connectionType: ConnectionType.AzureOpenAI))
 {
     Console.WriteLine(connection);
 }
 
 Console.WriteLine($"Get the properties of a connection named `{connectionName}`:");
-var specificConnection = connectionsClient.Get(connectionName, includeCredentials: false);
+Connection specificConnection = projectClient.Connections.Get(connectionName, includeCredentials: false);
 Console.WriteLine(specificConnection);
 
 Console.WriteLine("Get the properties of a connection with credentials:");
-var specificConnectionCredentials = connectionsClient.Get(connectionName, includeCredentials: true);
+Connection specificConnectionCredentials = projectClient.Connections.Get(connectionName, includeCredentials: true);
 Console.WriteLine(specificConnectionCredentials);
 
 Console.WriteLine($"Get the properties of the default connection:");
-var defaultConnection = connectionsClient.GetDefault(includeCredentials: false);
+Connection defaultConnection = projectClient.Connections.GetDefault(includeCredentials: false);
 Console.WriteLine(defaultConnection);
 
 Console.WriteLine($"Get the properties of the default connection with credentials:");
-var defaultConnectionCredentials = connectionsClient.GetDefault(includeCredentials: true);
+Connection defaultConnectionCredentials = projectClient.Connections.GetDefault(includeCredentials: true);
 Console.WriteLine(defaultConnectionCredentials);
 ```
 
@@ -51,34 +50,33 @@ Console.WriteLine(defaultConnectionCredentials);
 var endpoint = Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
 var connectionName = Environment.GetEnvironmentVariable("CONNECTION_NAME");
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Connections connectionsClient = projectClient.GetConnectionsClient();
 
 Console.WriteLine("List the properties of all connections:");
-await foreach (var connection in connectionsClient.GetConnectionsAsync())
+await foreach (Connection connection in projectClient.Connections.GetConnectionsAsync())
 {
     Console.WriteLine(connection);
     Console.Write(connection.Name);
 }
 
 Console.WriteLine("List the properties of all connections of a particular type (e.g., Azure OpenAI connections):");
-await foreach (var connection in connectionsClient.GetConnectionsAsync(connectionType: ConnectionType.AzureOpenAI))
+await foreach (Connection connection in projectClient.Connections.GetConnectionsAsync(connectionType: ConnectionType.AzureOpenAI))
 {
     Console.WriteLine(connection);
 }
 
 Console.WriteLine($"Get the properties of a connection named `{connectionName}`:");
-var specificConnection = await connectionsClient.GetAsync(connectionName, includeCredentials: false);
+Connection specificConnection = await projectClient.Connections.GetAsync(connectionName, includeCredentials: false);
 Console.WriteLine(specificConnection);
 
 Console.WriteLine("Get the properties of a connection with credentials:");
-var specificConnectionCredentials = await connectionsClient.GetAsync(connectionName, includeCredentials: true);
+Connection specificConnectionCredentials = await projectClient.Connections.GetAsync(connectionName, includeCredentials: true);
 Console.WriteLine(specificConnectionCredentials);
 
 Console.WriteLine($"Get the properties of the default connection:");
-var defaultConnection = await connectionsClient.GetDefaultAsync(includeCredentials: false);
+Connection defaultConnection = await projectClient.Connections.GetDefaultAsync(includeCredentials: false);
 Console.WriteLine(defaultConnection);
 
 Console.WriteLine($"Get the properties of the default connection with credentials:");
-var defaultConnectionCredentials = await connectionsClient.GetDefaultAsync(includeCredentials: true);
+Connection defaultConnectionCredentials = await projectClient.Connections.GetDefaultAsync(includeCredentials: true);
 Console.WriteLine(defaultConnectionCredentials);
 ```

--- a/sdk/ai/Azure.AI.Projects/samples/Sample4_Indexes.md
+++ b/sdk/ai/Azure.AI.Projects/samples/Sample4_Indexes.md
@@ -21,7 +21,6 @@ var indexVersion = Environment.GetEnvironmentVariable("INDEX_VERSION") ?? "1.0";
 var aiSearchConnectionName = Environment.GetEnvironmentVariable("AI_SEARCH_CONNECTION_NAME") ?? "my-ai-search-connection-name";
 var aiSearchIndexName = Environment.GetEnvironmentVariable("AI_SEARCH_INDEX_NAME") ?? "my-ai-search-index-name";
 AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-Indexes indexesClient = projectClient.GetIndexesClient();
 
 RequestContent content = RequestContent.Create(new
 {
@@ -34,7 +33,7 @@ RequestContent content = RequestContent.Create(new
 });
 
 Console.WriteLine($"Create an Index named `{indexName}` referencing an existing AI Search resource:");
-var index = indexesClient.CreateOrUpdate(
+var index = projectClient.Indexes.CreateOrUpdate(
     name: indexName,
     version: indexVersion,
     content: content
@@ -42,21 +41,21 @@ var index = indexesClient.CreateOrUpdate(
 Console.WriteLine(index);
 
 Console.WriteLine($"Get an existing Index named `{indexName}`, version `{indexVersion}`:");
-var retrievedIndex = indexesClient.GetIndex(name: indexName, version: indexVersion);
+Index retrievedIndex = projectClient.Indexes.GetIndex(name: indexName, version: indexVersion);
 Console.WriteLine(retrievedIndex);
 
 Console.WriteLine($"Listing all versions of the Index named `{indexName}`:");
-foreach (var version in indexesClient.GetVersions(name: indexName))
+foreach (Index version in projectClient.Indexes.GetVersions(name: indexName))
 {
     Console.WriteLine(version);
 }
 
 Console.WriteLine($"Listing all Indices:");
-foreach (var version in indexesClient.GetIndices())
+foreach (Index version in projectClient.Indexes.GetIndices())
 {
     Console.WriteLine(version);
 }
 
 Console.WriteLine("Delete the Index version created above:");
-indexesClient.Delete(name: indexName, version: indexVersion);
+projectClient.Indexes.Delete(name: indexName, version: indexVersion);
 ```

--- a/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
@@ -82,5 +82,11 @@ namespace Azure.AI.Projects
                 ? new ManagedIdentityCredential(clientId)
                 : new ChainedTokenCredential(new AzureCliCredential(), new AzureDeveloperCliCredential());
         }
+
+        public Connections Connections { get => this.GetConnectionsClient(); }
+        public Datasets Datasets { get => this.GetDatasetsClient(); }
+        public Deployments Deployments { get => this.GetDeploymentsClient(); }
+        public Indexes Indexes { get => this.GetIndexesClient(); }
+        public Telemetry Telemetry { get => new Telemetry(this); }
     }
 }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/Telemetry/Telemetry.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/Telemetry/Telemetry.cs
@@ -12,11 +12,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.Projects
 {
-    public partial class AIProjectClient
-    {
-        private Telemetry _telemetry;
-        public Telemetry Telemetry => _telemetry ??= new Telemetry(this);
-    }
     /// <summary>
     /// Provides telemetry-related operations for the project.
     /// </summary>

--- a/sdk/ai/Azure.AI.Projects/tests/Samples/Connections/Sample_Connections.cs
+++ b/sdk/ai/Azure.AI.Projects/tests/Samples/Connections/Sample_Connections.cs
@@ -25,35 +25,34 @@ namespace Azure.AI.Projects.Tests
             var connectionName = TestEnvironment.CONNECTIONNAME;
 #endif
             AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-            Connections connectionsClient = projectClient.GetConnectionsClient();
 
             Console.WriteLine("List the properties of all connections:");
-            foreach (var connection in connectionsClient.GetConnections())
+            foreach (Connection connection in projectClient.Connections.GetConnections())
             {
                 Console.WriteLine(connection);
                 Console.Write(connection.Name);
             }
 
             Console.WriteLine("List the properties of all connections of a particular type (e.g., Azure OpenAI connections):");
-            foreach (var connection in connectionsClient.GetConnections(connectionType: ConnectionType.AzureOpenAI))
+            foreach (Connection connection in projectClient.Connections.GetConnections(connectionType: ConnectionType.AzureOpenAI))
             {
                 Console.WriteLine(connection);
             }
 
             Console.WriteLine($"Get the properties of a connection named `{connectionName}`:");
-            var specificConnection = connectionsClient.Get(connectionName, includeCredentials: false);
+            Connection specificConnection = projectClient.Connections.Get(connectionName, includeCredentials: false);
             Console.WriteLine(specificConnection);
 
             Console.WriteLine("Get the properties of a connection with credentials:");
-            var specificConnectionCredentials = connectionsClient.Get(connectionName, includeCredentials: true);
+            Connection specificConnectionCredentials = projectClient.Connections.Get(connectionName, includeCredentials: true);
             Console.WriteLine(specificConnectionCredentials);
 
             Console.WriteLine($"Get the properties of the default connection:");
-            var defaultConnection = connectionsClient.GetDefault(includeCredentials: false);
+            Connection defaultConnection = projectClient.Connections.GetDefault(includeCredentials: false);
             Console.WriteLine(defaultConnection);
 
             Console.WriteLine($"Get the properties of the default connection with credentials:");
-            var defaultConnectionCredentials = connectionsClient.GetDefault(includeCredentials: true);
+            Connection defaultConnectionCredentials = projectClient.Connections.GetDefault(includeCredentials: true);
             Console.WriteLine(defaultConnectionCredentials);
             #endregion
         }
@@ -71,35 +70,34 @@ namespace Azure.AI.Projects.Tests
             var connectionName = TestEnvironment.CONNECTIONNAME;
 #endif
             AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-            Connections connectionsClient = projectClient.GetConnectionsClient();
 
             Console.WriteLine("List the properties of all connections:");
-            await foreach (var connection in connectionsClient.GetConnectionsAsync())
+            await foreach (Connection connection in projectClient.Connections.GetConnectionsAsync())
             {
                 Console.WriteLine(connection);
                 Console.Write(connection.Name);
             }
 
             Console.WriteLine("List the properties of all connections of a particular type (e.g., Azure OpenAI connections):");
-            await foreach (var connection in connectionsClient.GetConnectionsAsync(connectionType: ConnectionType.AzureOpenAI))
+            await foreach (Connection connection in projectClient.Connections.GetConnectionsAsync(connectionType: ConnectionType.AzureOpenAI))
             {
                 Console.WriteLine(connection);
             }
 
             Console.WriteLine($"Get the properties of a connection named `{connectionName}`:");
-            var specificConnection = await connectionsClient.GetAsync(connectionName, includeCredentials: false);
+            Connection specificConnection = await projectClient.Connections.GetAsync(connectionName, includeCredentials: false);
             Console.WriteLine(specificConnection);
 
             Console.WriteLine("Get the properties of a connection with credentials:");
-            var specificConnectionCredentials = await connectionsClient.GetAsync(connectionName, includeCredentials: true);
+            Connection specificConnectionCredentials = await projectClient.Connections.GetAsync(connectionName, includeCredentials: true);
             Console.WriteLine(specificConnectionCredentials);
 
             Console.WriteLine($"Get the properties of the default connection:");
-            var defaultConnection = await connectionsClient.GetDefaultAsync(includeCredentials: false);
+            Connection defaultConnection = await projectClient.Connections.GetDefaultAsync(includeCredentials: false);
             Console.WriteLine(defaultConnection);
 
             Console.WriteLine($"Get the properties of the default connection with credentials:");
-            var defaultConnectionCredentials = await connectionsClient.GetDefaultAsync(includeCredentials: true);
+            Connection defaultConnectionCredentials = await projectClient.Connections.GetDefaultAsync(includeCredentials: true);
             Console.WriteLine(defaultConnectionCredentials);
             #endregion
         }

--- a/sdk/ai/Azure.AI.Projects/tests/Samples/Datasets/Sample_Datasets.cs
+++ b/sdk/ai/Azure.AI.Projects/tests/Samples/Datasets/Sample_Datasets.cs
@@ -46,10 +46,9 @@ namespace Azure.AI.Projects.Tests
             }
 #endif
             AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-            Datasets datasets = projectClient.GetDatasetsClient();
 
             Console.WriteLine($"Uploading a single file to create Dataset version {datasetVersion1}:");
-            DatasetVersion dataset = datasets.UploadFile(
+            DatasetVersion dataset = projectClient.Datasets.UploadFile(
                 name: datasetName,
                 version: datasetVersion1,
                 filePath: filePath,
@@ -58,7 +57,7 @@ namespace Azure.AI.Projects.Tests
             Console.WriteLine(dataset);
 
             Console.WriteLine($"Uploading folder to create Dataset version {datasetVersion2}:");
-            dataset = datasets.UploadFolder(
+            dataset = projectClient.Datasets.UploadFolder(
                 name: datasetName,
                 version: datasetVersion2,
                 folderPath: folderPath,
@@ -68,29 +67,29 @@ namespace Azure.AI.Projects.Tests
             Console.WriteLine(dataset);
 
             Console.WriteLine($"Retrieving Dataset version {datasetVersion1}:");
-            dataset = datasets.GetDataset(datasetName, datasetVersion1);
+            dataset = projectClient.Datasets.GetDataset(datasetName, datasetVersion1);
             Console.WriteLine(dataset);
 
             Console.WriteLine($"Retrieving credentials of Dataset {datasetName} version {datasetVersion1}:");
-            AssetCredentialResponse credentials = datasets.GetCredentials(datasetName, datasetVersion1);
+            AssetCredentialResponse credentials = projectClient.Datasets.GetCredentials(datasetName, datasetVersion1);
             Console.WriteLine(credentials);
 
             Console.WriteLine($"Listing all versions for Dataset '{datasetName}':");
-            foreach (var ds in datasets.GetVersions(datasetName))
+            foreach (DatasetVersion ds in projectClient.Datasets.GetVersions(datasetName))
             {
                 Console.WriteLine(ds);
                 Console.WriteLine(ds.Version);
             }
 
             Console.WriteLine($"Listing latest versions for all datasets:");
-            foreach (var ds in datasets.GetDatasetVersions())
+            foreach (DatasetVersion ds in projectClient.Datasets.GetDatasetVersions())
             {
                 Console.WriteLine(ds);
             }
 
             Console.WriteLine($"Deleting Dataset versions {datasetVersion1} and {datasetVersion2}:");
-            datasets.Delete(datasetName, datasetVersion1);
-            datasets.Delete(datasetName, datasetVersion2);
+            projectClient.Datasets.Delete(datasetName, datasetVersion1);
+            projectClient.Datasets.Delete(datasetName, datasetVersion2);
             #endregion
         }
 
@@ -127,10 +126,9 @@ namespace Azure.AI.Projects.Tests
             }
 #endif
             AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-            Datasets datasets = projectClient.GetDatasetsClient();
 
             Console.WriteLine($"Uploading a single file to create Dataset version {datasetVersion1}...");
-            DatasetVersion dataset = await datasets.UploadFileAsync(
+            DatasetVersion dataset = await projectClient.Datasets.UploadFileAsync(
                 name: datasetName,
                 version: datasetVersion1,
                 filePath: filePath,
@@ -139,7 +137,7 @@ namespace Azure.AI.Projects.Tests
             Console.WriteLine(dataset);
 
             Console.WriteLine($"Uploading folder to create Dataset version {datasetVersion2}...");
-            dataset = await datasets.UploadFolderAsync(
+            dataset = await projectClient.Datasets.UploadFolderAsync(
                 name: datasetName,
                 version: datasetVersion2,
                 folderPath: folderPath,
@@ -149,28 +147,28 @@ namespace Azure.AI.Projects.Tests
             Console.WriteLine(dataset);
 
             Console.WriteLine($"Retrieving Dataset version {datasetVersion1}...");
-            dataset = await datasets.GetDatasetAsync(datasetName, datasetVersion1);
+            dataset = await projectClient.Datasets.GetDatasetAsync(datasetName, datasetVersion1);
             Console.WriteLine(dataset);
 
             Console.WriteLine($"Retrieving credentials of Dataset {datasetName} version {datasetVersion1}:");
-            AssetCredentialResponse credentials = await datasets.GetCredentialsAsync(datasetName, datasetVersion1);
+            AssetCredentialResponse credentials = await projectClient.Datasets.GetCredentialsAsync(datasetName, datasetVersion1);
             Console.WriteLine(credentials);
 
             Console.WriteLine($"Listing all versions for Dataset '{datasetName}':");
-            await foreach (var ds in datasets.GetVersionsAsync(datasetName))
+            await foreach (DatasetVersion ds in projectClient.Datasets.GetVersionsAsync(datasetName))
             {
                 Console.WriteLine(ds.Version);
             }
 
             Console.WriteLine($"Listing latest versions for all datasets:");
-            await foreach (var ds in datasets.GetDatasetVersionsAsync())
+            await foreach (DatasetVersion ds in projectClient.Datasets.GetDatasetVersionsAsync())
             {
                 Console.WriteLine(ds);
             }
 
             Console.WriteLine($"Deleting Dataset versions {datasetVersion1} and {datasetVersion2}...");
-            await datasets.DeleteAsync(datasetName, datasetVersion1);
-            await datasets.DeleteAsync(datasetName, datasetVersion2);
+            await projectClient.Datasets.DeleteAsync(datasetName, datasetVersion1);
+            await projectClient.Datasets.DeleteAsync(datasetName, datasetVersion2);
             #endregion
         }
     }

--- a/sdk/ai/Azure.AI.Projects/tests/Samples/Deployment/Sample_Deployment.cs
+++ b/sdk/ai/Azure.AI.Projects/tests/Samples/Deployment/Sample_Deployment.cs
@@ -27,22 +27,21 @@ public class Sample_Deployment : SamplesBase<AIProjectsTestEnvironment>
         var modelPublisher = TestEnvironment.MODELPUBLISHER;
 #endif
         AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-        Deployments deployments = projectClient.GetDeploymentsClient();
 
         Console.WriteLine("List all deployments:");
-        foreach (var deployment in deployments.GetDeployments())
+        foreach (Deployment deployment in projectClient.Deployments.GetDeployments())
         {
             Console.WriteLine(deployment);
         }
 
         Console.WriteLine($"List all deployments by the model publisher `{modelPublisher}`:");
-        foreach (var deployment in deployments.GetDeployments(modelPublisher: modelPublisher))
+        foreach (Deployment deployment in projectClient.Deployments.GetDeployments(modelPublisher: modelPublisher))
         {
             Console.WriteLine(deployment);
         }
 
         Console.WriteLine($"Get a single deployment named `{modelDeploymentName}`:");
-        var deploymentDetails = deployments.GetDeployment(modelDeploymentName);
+        Deployment deploymentDetails = projectClient.Deployments.GetDeployment(modelDeploymentName);
         Console.WriteLine(deploymentDetails);
         #endregion
     }
@@ -62,22 +61,21 @@ public class Sample_Deployment : SamplesBase<AIProjectsTestEnvironment>
         var modelPublisher = TestEnvironment.MODELPUBLISHER;
 #endif
         AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-        Deployments deployments = projectClient.GetDeploymentsClient();
 
         Console.WriteLine("List all deployments:");
-        await foreach (var deployment in deployments.GetDeploymentsAsync())
+        await foreach (Deployment deployment in projectClient.Deployments.GetDeploymentsAsync())
         {
             Console.WriteLine(deployment);
         }
 
         Console.WriteLine($"List all deployments by the model publisher `{modelPublisher}`:");
-        await foreach (var deployment in deployments.GetDeploymentsAsync(modelPublisher: modelPublisher))
+        await foreach (Deployment deployment in projectClient.Deployments.GetDeploymentsAsync(modelPublisher: modelPublisher))
         {
             Console.WriteLine(deployment);
         }
 
         Console.WriteLine($"Get a single deployment named `{modelDeploymentName}`:");
-        var deploymentDetails = deployments.GetDeploymentAsync(modelDeploymentName);
+        Deployment deploymentDetails = await projectClient.Deployments.GetDeploymentAsync(modelDeploymentName);
         Console.WriteLine(deploymentDetails);
         #endregion
     }

--- a/sdk/ai/Azure.AI.Projects/tests/Samples/Indexes/Sample_Indexes.cs
+++ b/sdk/ai/Azure.AI.Projects/tests/Samples/Indexes/Sample_Indexes.cs
@@ -32,7 +32,6 @@ namespace Azure.AI.Projects.Tests
             var aiSearchIndexName = TestEnvironment.AISEARCHINDEXNAME ?? "my-ai-search-index-name";
 #endif
             AIProjectClient projectClient = new(new Uri(endpoint), new DefaultAzureCredential());
-            Indexes indexesClient = projectClient.GetIndexesClient();
 
             RequestContent content = RequestContent.Create(new
             {
@@ -45,7 +44,7 @@ namespace Azure.AI.Projects.Tests
             });
 
             Console.WriteLine($"Create an Index named `{indexName}` referencing an existing AI Search resource:");
-            var index = indexesClient.CreateOrUpdate(
+            var index = projectClient.Indexes.CreateOrUpdate(
                 name: indexName,
                 version: indexVersion,
                 content: content
@@ -53,23 +52,23 @@ namespace Azure.AI.Projects.Tests
             Console.WriteLine(index);
 
             Console.WriteLine($"Get an existing Index named `{indexName}`, version `{indexVersion}`:");
-            var retrievedIndex = indexesClient.GetIndex(name: indexName, version: indexVersion);
+            Index retrievedIndex = projectClient.Indexes.GetIndex(name: indexName, version: indexVersion);
             Console.WriteLine(retrievedIndex);
 
             Console.WriteLine($"Listing all versions of the Index named `{indexName}`:");
-            foreach (var version in indexesClient.GetVersions(name: indexName))
+            foreach (Index version in projectClient.Indexes.GetVersions(name: indexName))
             {
                 Console.WriteLine(version);
             }
 
             Console.WriteLine($"Listing all Indices:");
-            foreach (var version in indexesClient.GetIndices())
+            foreach (Index version in projectClient.Indexes.GetIndices())
             {
                 Console.WriteLine(version);
             }
 
             Console.WriteLine("Delete the Index version created above:");
-            indexesClient.Delete(name: indexName, version: indexVersion);
+            projectClient.Indexes.Delete(name: indexName, version: indexVersion);
             #endregion
         }
     }


### PR DESCRIPTION
* add functionality to use `Connections`, `Datasets`, `Deployments`, and `Indexes` properties instead of `GetConnectionsClient()`, `GetDatasetsClient()`, `GetDeploymentsClient()`, and `GetIndexesClient()`
* update changelog, samples, and api
* still left to do: mark `GetConnectionsClient()`, `GetDatasetsClient()`, `GetDeploymentsClient()`, and `GetIndexesClient()` as internal