### PR TITLE
[Identity] Merge Changelog and Version after patch release from hotfix branch

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -17,11 +17,11 @@
 - `VisualStudioCredential` throws `CredentialUnavailableException` for all failures except for OperationCancelledException due to cancellation being requested for a `CancellationToken`. This ensures that it falls through for most failures when part of a chained credential.
 - Removed `AzureApplicationCredential`. For context, see issue [49781](https://github.com/Azure/azure-sdk-for-net/issues/49781).
 
-## 1.14.1 (2025-07-08)
+## 1.14.1 (2025-06-24)
 
 ###  Bugs Fixed
 
-- Added support in AzurePowerShellCredential for the Az.Accounts 5.0.0+ (Az 14.0.0+) breaking change where Get-AzAccessToken returns PSSecureAccessToken with a SecureString Token property instead of plaintext.Add commentMore actions
+- Added support in `AzurePowerShellCredential` for the `Az.Accounts` 5.0.0+ (Az 14.0.0+) breaking change where `Get-AzAccessToken` returns `PSSecureAccessToken` with a `SecureString` Token property instead of plaintext.
 
 ## 1.14.0 (2025-05-13)
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -5,8 +5,6 @@
 ### Features Added
 - Expanded the set of acceptable values for environment variable `AZURE_TOKEN_CREDENTIALS` to allow for selection of a specific credential in the `DefaultAzureCredential` chain. The valid values now include any of the credential names available in the default chain (`VisualStudioCredential`, `VisualStudioCodeCredential`, `AzureCliCredential`, `AzurePowerShellCredential`, `AzureDeveloperCliCredential`, `EnvironmentCredential`, `WorkloadIdentityCredential`, `ManagedIdentityCredential`, `InteractiveBrowserCredential`, or `BrokerAuthenticationCredential`.) **Note:** `BrokerAuthenticationCredential` requires that the project include a reference to package Azure.Identity.Broker.
 
-- Added support in `AzurePowerShellCredential` for the Az.Accounts 5.0.0+ (Az 14.0.0+) breaking change where `Get-AzAccessToken` returns `PSSecureAccessToken` with a `SecureString` Token property instead of plaintext.
-
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -18,6 +16,12 @@
 
 - `VisualStudioCredential` throws `CredentialUnavailableException` for all failures except for OperationCancelledException due to cancellation being requested for a `CancellationToken`. This ensures that it falls through for most failures when part of a chained credential.
 - Removed `AzureApplicationCredential`. For context, see issue [49781](https://github.com/Azure/azure-sdk-for-net/issues/49781).
+
+## 1.14.1 (2025-07-08)
+
+###  Bugs Fixed
+
+- Added support in AzurePowerShellCredential for the Az.Accounts 5.0.0+ (Az 14.0.0+) breaking change where Get-AzAccessToken returns PSSecureAccessToken with a SecureString Token property instead of plaintext.Add commentMore actions
 
 ## 1.14.0 (2025-05-13)
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## 1.14.1 (2025-06-24)
 
-###  Bugs Fixed
+### Bugs Fixed
 
 - Added support in `AzurePowerShellCredential` for the `Az.Accounts` 5.0.0+ (Az 14.0.0+) breaking change where `Get-AzAccessToken` returns `PSSecureAccessToken` with a `SecureString` Token property instead of plaintext.
 

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Microsoft Azure.Identity Component</AssemblyTitle>
     <Version>1.15.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.14.0</ApiCompatVersion>
+    <ApiCompatVersion>1.14.1</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021;AZC0011</NoWarn>


### PR DESCRIPTION
This PR substitutes https://github.com/Azure/azure-sdk-for-net/pull/50851. Updates the changelog and versions after releasing 1.14.1 from the hotfix branch.

The next version is still `1.15.0-beta.1`, just the latest API Compat version is now `1.14.1`.