### PR TITLE
Add latest commit ref to autorest.md

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/src/autorest.md
+++ b/sdk/monitor/Azure.Monitor.Query/src/autorest.md
@@ -9,7 +9,7 @@ input-file:
     - https://github.com/Azure/azure-rest-api-specs/blob/0373f0edc4414fd402603fac51d0df93f1f70507/specification/monitor/resource-manager/Microsoft.Insights/stable/2023-10-01/metrics_API.json
     - https://github.com/Azure/azure-rest-api-specs/blob/0b64ca7cbe3af8cd13228dfb783a16b8272b8be2/specification/monitor/resource-manager/Microsoft.Insights/stable/2024-02-01/metricNamespaces_API.json
     - https://github.com/Azure/azure-rest-api-specs/blob/0550754fb421cd3a5859abf6713a542b682f626c/specification/monitor/data-plane/Microsoft.Insights/stable/2023-10-01/metricBatch.json
-    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/21f5332f2dc7437d1446edf240e9a3d4c90c6431/specification/operationalinsights/data-plane/Microsoft.OperationalInsights/stable/2022-10-27/OperationalInsights.json
+    - https://github.com/Azure/azure-rest-api-specs/blob/72427ef3ff5875bd8409ef112ef5e6f3cf2b8795/specification/operationalinsights/data-plane/Microsoft.OperationalInsights/stable/2022-10-27/OperationalInsights.json
 generation1-convenience-client: true
 modelerfour:
     lenient-model-deduplication: true


### PR DESCRIPTION
This PR updates the commit reference for the OperationalInsights swagger to reference the latest commit from the main branch of the specs repo.