### PR TITLE
Wait for 2 secs before scaling out for SB ScaleMonitor 

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Wait for 2 secs before scaling out for ScaleMonitor to avoid aggressive scaling (matches with ScaleControlelr V2) - AB#32302750
+
 ### Other Changes
 
 ## 5.17.0 (2025-06-20)

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusScaleMonitor.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusScaleMonitor.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         private readonly ILogger<ServiceBusScaleMonitor> _logger;
         private readonly ServiceBusMetricsProvider _serviceBusMetricsProvider;
 
-        // to avoid frequent scaling out when queue time is increasing, we wait for atleast 2s before scaling out (backward compatibility with SCV2).
-        public static double MinimumLastQueueMessageInSecondsThreshold = 2.0;
+        // to avoid frequent scaling out when queue time is increasing, we wait for at least 2s before scaling out (backward compatibility with SCV2).
+        public static TimeSpan MinimumLastQueueMessageInSecondsThreshold = TimeSpan.FromSeconds(2.0);
 
         public ServiceBusScaleMonitor(
             string functionId,
@@ -151,8 +151,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                         (prev, next) => prev.QueueTime <= next.QueueTime);
                 if (queueTimeIncreasing)
                 {
-                    // to avoid frequent scaling out when queue time is increasing, we wait for atleast 2s (backward compatibility with SCV2).
-                    if (lastSampleQueueTime >= TimeSpan.FromSeconds(MinimumLastQueueMessageInSecondsThreshold))
+                    // to avoid frequent scaling out when queue time is increasing, we wait for at least 2s (backward compatibility with SCV2).
+                    if (lastSampleQueueTime >= MinimumLastQueueMessageInSecondsThreshold)
                     {
                         status.Vote = ScaleVote.ScaleOut;
                         _logger.LogInformation($"Queue time is increasing for '{_entityPath}'.");
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                     else
                     {
                         status.Vote = ScaleVote.None;
-                        _logger.LogInformation($"Queue time is increasing for '{_entityPath}' but we do not scale out unless queue latency is greater than {MinimumLastQueueMessageInSecondsThreshold}s. Current queue latency is {lastSampleQueueTime.TotalSeconds}s.");
+                        _logger.LogInformation($"Queue time is increasing for '{_entityPath}' but we do not scale out unless queue latency is greater than {MinimumLastQueueMessageInSecondsThreshold.TotalSeconds}s. Current queue latency is {lastSampleQueueTime.TotalSeconds}s.");
                         return status;
                     }
                 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusScaleMonitor.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusScaleMonitor.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         private readonly ILogger<ServiceBusScaleMonitor> _logger;
         private readonly ServiceBusMetricsProvider _serviceBusMetricsProvider;
 
+        // to avoid frequent scaling out when queue time is increasing, we wait for atleast 2s before scaling out (backward compatibility with SCV2).
+        public static double MinimumLastQueueMessageInSecondsThreshold = 2.0;
+
         public ServiceBusScaleMonitor(
             string functionId,
             string entityPath,
@@ -137,7 +140,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 }
             }
 
-            if (metrics[0].QueueTime > TimeSpan.Zero && metrics[0].QueueTime < metrics[NumberOfSamplesToConsider - 1].QueueTime)
+            var lastSampleQueueTime = metrics[NumberOfSamplesToConsider - 1].QueueTime;
+
+            if (metrics[0].QueueTime > TimeSpan.Zero && metrics[0].QueueTime < lastSampleQueueTime)
             {
                 bool queueTimeIncreasing =
                     IsTrueForLastN(
@@ -146,9 +151,19 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                         (prev, next) => prev.QueueTime <= next.QueueTime);
                 if (queueTimeIncreasing)
                 {
-                    status.Vote = ScaleVote.ScaleOut;
-                    _logger.LogInformation($"Queue time is increasing for '{_entityPath}'.");
-                    return status;
+                    // to avoid frequent scaling out when queue time is increasing, we wait for atleast 2s (backward compatibility with SCV2).
+                    if (lastSampleQueueTime >= TimeSpan.FromSeconds(MinimumLastQueueMessageInSecondsThreshold))
+                    {
+                        status.Vote = ScaleVote.ScaleOut;
+                        _logger.LogInformation($"Queue time is increasing for '{_entityPath}'.");
+                        return status;
+                    }
+                    else
+                    {
+                        status.Vote = ScaleVote.None;
+                        _logger.LogInformation($"Queue time is increasing for '{_entityPath}' but we do not scale out unless queue latency is greater than {MinimumLastQueueMessageInSecondsThreshold}s. Current queue latency is {lastSampleQueueTime.TotalSeconds}s.");
+                        return status;
+                    }
                 }
             }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -698,6 +698,33 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         }
 
         [Test]
+        public void GetScaleStatus_QueueTimeIncreasingLessThanMinimumWaitTime_ReturnsScaleVoteNone()
+        {
+            var context = new ScaleStatusContext<ServiceBusTriggerMetrics>
+            {
+                WorkerCount = 1
+            };
+            var timestamp = DateTime.UtcNow;
+            var lastQueueTime = 0.5;
+            context.Metrics = new List<ServiceBusTriggerMetrics>
+                {
+                    new ServiceBusTriggerMetrics { MessageCount = 100, PartitionCount = 0, QueueTime = TimeSpan.FromSeconds(0.1), Timestamp = timestamp.AddSeconds(15) },
+                    new ServiceBusTriggerMetrics { MessageCount = 100, PartitionCount = 0, QueueTime = TimeSpan.FromSeconds(0.2), Timestamp = timestamp.AddSeconds(15) },
+                    new ServiceBusTriggerMetrics { MessageCount = 100, PartitionCount = 0, QueueTime = TimeSpan.FromSeconds(0.3), Timestamp = timestamp.AddSeconds(15) },
+                    new ServiceBusTriggerMetrics { MessageCount = 100, PartitionCount = 0, QueueTime = TimeSpan.FromSeconds(0.4), Timestamp = timestamp.AddSeconds(15) },
+                    new ServiceBusTriggerMetrics { MessageCount = 100, PartitionCount = 0, QueueTime = TimeSpan.FromSeconds(lastQueueTime), Timestamp = timestamp.AddSeconds(15) },
+                };
+
+            var status = _scaleMonitor.GetScaleStatus(context);
+            Assert.AreEqual(ScaleVote.None, status.Vote);
+
+            var logs = _loggerProvider.GetAllLogMessages().ToArray();
+            var log = logs[0];
+            Assert.AreEqual(LogLevel.Information, log.Level);
+            Assert.AreEqual($"Queue time is increasing for '{_entityPath}' but we do not scale out unless queue latency is greater than {ServiceBusScaleMonitor.MinimumLastQueueMessageInSecondsThreshold}s. Current queue latency is {lastQueueTime}s.", log.FormattedMessage);
+        }
+
+        [Test]
         public void GetScaleStatus_QueueLengthDecreasing_ReturnsVote_ScaleIn()
         {
             var context = new ScaleStatusContext<ServiceBusTriggerMetrics>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -721,7 +721,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             var logs = _loggerProvider.GetAllLogMessages().ToArray();
             var log = logs[0];
             Assert.AreEqual(LogLevel.Information, log.Level);
-            Assert.AreEqual($"Queue time is increasing for '{_entityPath}' but we do not scale out unless queue latency is greater than {ServiceBusScaleMonitor.MinimumLastQueueMessageInSecondsThreshold}s. Current queue latency is {lastQueueTime}s.", log.FormattedMessage);
+            Assert.AreEqual($"Queue time is increasing for '{_entityPath}' but we do not scale out unless queue latency is greater than {ServiceBusScaleMonitor.MinimumLastQueueMessageInSecondsThreshold.TotalSeconds}s. Current queue latency is {lastQueueTime}s.", log.FormattedMessage);
         }
 
         [Test]


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

This PR addresses a wait for taking the scaling decision for ServiceBus extension. To avoid aggressive scaleouts, we only vote to scale out if the last message that was added to the ServiceBus was more than 2secs apart. 
(This was a repair item to make this scaling behavior consistent with how ScaleController V2 was doing it). 
AB#32302750
