### PR TITLE
[KeyVault] Addresses API View comments and prepare release for Keys

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -15,8 +15,6 @@ Thank you to our developer community members who helped to make the Key Vault cl
 - Added Attestation property for Keys in Managed HSM Key Vaults.
 - Adde new `GetKeyAttestation` operation to get the public part of a stored key along with its attestation blob.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Removed additional forward slash in `RestoreKeyBackup` and `RestoreKeyBackupAsync`.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.0-beta.2 (Unreleased)
+## 4.8.0 (2025-06-27)
 
 ### Acknowledgments
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net8.0.cs
@@ -106,9 +106,9 @@ namespace Azure.Security.KeyVault.Keys
     public partial class KeyAttestation
     {
         public KeyAttestation() { }
-        public byte[] CertificatePemFile { get { throw null; } set { } }
-        public byte[] PrivateKeyAttestation { get { throw null; } set { } }
-        public byte[] PublicKeyAttestation { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte> CertificatePemFile { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte> PrivateKeyAttestation { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte> PublicKeyAttestation { get { throw null; } set { } }
         public string Version { get { throw null; } set { } }
     }
     public partial class KeyClient

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
@@ -106,9 +106,9 @@ namespace Azure.Security.KeyVault.Keys
     public partial class KeyAttestation
     {
         public KeyAttestation() { }
-        public byte[] CertificatePemFile { get { throw null; } set { } }
-        public byte[] PrivateKeyAttestation { get { throw null; } set { } }
-        public byte[] PublicKeyAttestation { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte> CertificatePemFile { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte> PrivateKeyAttestation { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte> PublicKeyAttestation { get { throw null; } set { } }
         public string Version { get { throw null; } set { } }
     }
     public partial class KeyClient

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Keys client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Keys client library</AssemblyTitle>
-    <Version>4.8.0-beta.2</Version>
+    <Version>4.8.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.7.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Keys;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttestation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttestation.cs
@@ -20,18 +20,18 @@ namespace Azure.Security.KeyVault.Keys
         /// <summary>
         /// Gets or sets a base64url-encoded string containing certificates in PEM format, used for attestation validation.
         /// </summary>
-        public byte[] CertificatePemFile { get; set; }
+        public ReadOnlyMemory<byte> CertificatePemFile { get; set; }
 
         /// <summary>
         /// Gets or sets the attestation blob bytes encoded as a base64 URL string corresponding to the private key value.
         /// </summary>
-        public byte[] PrivateKeyAttestation { get; set; }
+        public ReadOnlyMemory<byte> PrivateKeyAttestation { get; set; }
 
         /// <summary>
         /// Gets or sets the attestation blob bytes encoded as a base64 URL string.
         /// In the case of an asymmetric key, this corresponds to the public key value.
         /// </summary>
-        public byte[] PublicKeyAttestation { get; set; }
+        public ReadOnlyMemory<byte> PublicKeyAttestation { get; set; }
 
         /// <summary>
         /// Gets or sets the version of the attestation.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
@@ -143,17 +143,17 @@ namespace Azure.Security.KeyVault.Keys
             if (Attestation != null)
             {
                 json.WriteStartObject(s_keyAttestationPropertyNameBytes);
-                if (Attestation.CertificatePemFile != null)
+                if (!Attestation.CertificatePemFile.IsEmpty)
                 {
-                    json.WriteString("certificatePemFile", Convert.ToBase64String(Attestation.CertificatePemFile));
+                    json.WriteString("certificatePemFile", Convert.ToBase64String(Attestation.CertificatePemFile.ToArray()));
                 }
-                if (Attestation.PrivateKeyAttestation != null)
+                if (!Attestation.PrivateKeyAttestation.IsEmpty)
                 {
-                    json.WriteString("privateKeyAttestation", Convert.ToBase64String(Attestation.PrivateKeyAttestation));
+                    json.WriteString("privateKeyAttestation", Convert.ToBase64String(Attestation.PrivateKeyAttestation.ToArray()));
                 }
-                if (Attestation.PublicKeyAttestation != null)
+                if (!Attestation.PublicKeyAttestation.IsEmpty)
                 {
-                    json.WriteString("publicKeyAttestation", Convert.ToBase64String(Attestation.PublicKeyAttestation));
+                    json.WriteString("publicKeyAttestation", Convert.ToBase64String(Attestation.PublicKeyAttestation.ToArray()));
                 }
                 if (Attestation.Version != null)
                 {


### PR DESCRIPTION
This PR addresses the comments on this [API View](https://spa.apiview.dev/review/46bf5efced644177abb4c0b630985526?activeApiRevisionId=faaf415be21849f3a295785479ab70f4&diffApiRevisionId=e28b8ebc96dc47ecb5f20dbd61e8d92e&diffStyle=trees) revision by changing the `KeyAttestation` properties to `System.ReadOnlyMemory<byte>`

Also, this PR prepares the upcoming `4.8.0` release for Keys.