### PR TITLE
Refine new project scaffolding.

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
@@ -20,9 +20,6 @@ namespace Azure.Generator.Primitives
         private const string ParentDirectory = "../";
         private const string SharedSourceLinkBase = "Shared/Core";
 
-        private int PathSegmentCount => _pathSegmentCount ??= GetPathSegmentCount();
-        private int? _pathSegmentCount;
-
         /// <inheritdoc/>
         protected override string GetSourceProjectFileContent()
         {
@@ -58,8 +55,7 @@ namespace Azure.Generator.Primitives
             "DiagnosticScopeFactory.cs",
             "DiagnosticScope.cs",
             "HttpMessageSanitizer.cs",
-            "TrimmingAttribute.cs",
-            "NoValueResponseOfT.cs",
+            "TrimmingAttribute.cs"
         ];
 
         private static readonly IReadOnlyList<string> _lroSharedFiles =
@@ -128,7 +124,7 @@ namespace Azure.Generator.Primitives
         /// <returns>A relative path string for the compile include file.</returns>
         protected string GetCompileInclude(string fileName, string relativeSegment = RelativeCoreSegment)
         {
-            return $"{MSBuildThisFileDirectory}{string.Concat(Enumerable.Repeat(ParentDirectory, PathSegmentCount))}{relativeSegment}{fileName}";
+            return $"{MSBuildThisFileDirectory}{string.Concat(Enumerable.Repeat(ParentDirectory, GetPathSegmentCount()))}{relativeSegment}{fileName}";
         }
 
         /// <summary>

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
@@ -37,7 +37,7 @@ namespace Azure.Generator.Primitives
                 builder.PackageReferences.Add(packages);
             }
 
-            foreach (var compileInclude in BuildCompileIncludes())
+            foreach (var compileInclude in CompileIncludes)
             {
                 builder.CompileIncludes.Add(compileInclude);
             }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/BasicTypeSpec.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/BasicTypeSpec.csproj
@@ -18,7 +18,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/api-key/src/Authentication.ApiKey.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/api-key/src/Authentication.ApiKey.csproj
@@ -18,7 +18,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/http/custom/src/Authentication.Http.Custom.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/http/custom/src/Authentication.Http.Custom.csproj
@@ -18,7 +18,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/oauth2/src/Authentication.OAuth2.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/oauth2/src/Authentication.OAuth2.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/union/src/Authentication.Union.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/union/src/Authentication.Union.csproj
@@ -18,7 +18,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/client-generator-core/flatten-property/src/_Specs_.Azure.ClientGenerator.Core.FlattenProperty.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/client-generator-core/flatten-property/src/_Specs_.Azure.ClientGenerator.Core.FlattenProperty.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/client-generator-core/usage/src/_Specs_.Azure.ClientGenerator.Core.Usage.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/client-generator-core/usage/src/_Specs_.Azure.ClientGenerator.Core.Usage.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/core/lro/rpc/src/_Specs_.Azure.Core.Lro.Rpc.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/core/lro/rpc/src/_Specs_.Azure.Core.Lro.Rpc.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/AsyncLockWithValue.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/FixedDelayWithNoJitterStrategy.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpPipelineExtensions.cs" LinkBase="Shared/Core" />

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/core/lro/standard/src/_Specs_.Azure.Core.Lro.Standard.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/core/lro/standard/src/_Specs_.Azure.Core.Lro.Standard.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/AsyncLockWithValue.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/FixedDelayWithNoJitterStrategy.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpPipelineExtensions.cs" LinkBase="Shared/Core" />

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/core/model/src/_Specs_.Azure.Core.Model.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/core/model/src/_Specs_.Azure.Core.Model.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/special-headers/client-request-id/src/Azure.SpecialHeaders.XmsClientRequestId.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/special-headers/client-request-id/src/Azure.SpecialHeaders.XmsClientRequestId.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/default/src/Client.Structure.Service.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/default/src/Client.Structure.Service.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/bytes/src/Encode.Bytes.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/bytes/src/Encode.Bytes.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/datetime/src/Encode.Datetime.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/datetime/src/Encode.Datetime.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/duration/src/Encode.Duration.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/duration/src/Encode.Duration.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/numeric/src/Encode.Numeric.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/numeric/src/Encode.Numeric.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/basic/src/Parameters.Basic.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/basic/src/Parameters.Basic.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/body-optionality/src/Parameters.BodyOptionality.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/body-optionality/src/Parameters.BodyOptionality.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/collection-format/src/Parameters.CollectionFormat.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/collection-format/src/Parameters.CollectionFormat.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/path/src/Parameters.Path.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/path/src/Parameters.Path.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/spread/src/Parameters.Spread.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/spread/src/Parameters.Spread.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/content-negotiation/src/Payload.ContentNegotiation.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/content-negotiation/src/Payload.ContentNegotiation.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/json-merge-patch/src/Payload.JsonMergePatch.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/json-merge-patch/src/Payload.JsonMergePatch.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/media-type/src/Payload.MediaType.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/media-type/src/Payload.MediaType.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/multipart/src/Payload.MultiPart.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/multipart/src/Payload.MultiPart.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/pageable/src/Payload.Pageable.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/pageable/src/Payload.Pageable.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/routes/src/Routes.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/routes/src/Routes.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/serialization/encoded-name/json/src/Serialization.EncodedName.Json.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/serialization/encoded-name/json/src/Serialization.EncodedName.Json.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/endpoint/not-defined/src/Server.Endpoint.NotDefined.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/endpoint/not-defined/src/Server.Endpoint.NotDefined.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/path/multiple/src/Server.Path.Multiple.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/path/multiple/src/Server.Path.Multiple.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/path/single/src/Server.Path.Single.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/path/single/src/Server.Path.Single.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/versions/not-versioned/src/Server.Versions.NotVersioned.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/versions/not-versioned/src/Server.Versions.NotVersioned.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/versions/versioned/src/Server.Versions.Versioned.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/server/versions/versioned/src/Server.Versions.Versioned.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/special-headers/conditional-request/src/SpecialHeaders.ConditionalRequest.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/special-headers/conditional-request/src/SpecialHeaders.ConditionalRequest.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/special-headers/repeatability/src/SpecialHeaders.Repeatability.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/special-headers/repeatability/src/SpecialHeaders.Repeatability.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/special-words/src/SpecialWords.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/special-words/src/SpecialWords.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/streaming/jsonl/src/Streaming.Jsonl.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/streaming/jsonl/src/Streaming.Jsonl.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/array/src/Type.Array.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/array/src/Type.Array.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/dictionary/src/Type.Dictionary.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/dictionary/src/Type.Dictionary.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/enum/extensible/src/Type.Enum.Extensible.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/enum/extensible/src/Type.Enum.Extensible.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/enum/fixed/src/Type.Enum.Fixed.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/enum/fixed/src/Type.Enum.Fixed.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/empty/src/Type.Model.Empty.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/empty/src/Type.Model.Empty.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/enum-discriminator/src/Type.Model.Inheritance.EnumDiscriminator.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/enum-discriminator/src/Type.Model.Inheritance.EnumDiscriminator.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/nested-discriminator/src/Type.Model.Inheritance.NestedDiscriminator.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/nested-discriminator/src/Type.Model.Inheritance.NestedDiscriminator.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/not-discriminated/src/Type.Model.Inheritance.NotDiscriminated.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/not-discriminated/src/Type.Model.Inheritance.NotDiscriminated.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/recursive/src/Type.Model.Inheritance.Recursive.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/recursive/src/Type.Model.Inheritance.Recursive.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/single-discriminator/src/Type.Model.Inheritance.SingleDiscriminator.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/single-discriminator/src/Type.Model.Inheritance.SingleDiscriminator.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/usage/src/Type.Model.Usage.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/usage/src/Type.Model.Usage.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/visibility/src/Type.Model.Visibility.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/visibility/src/Type.Model.Visibility.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/additional-properties/src/Type.Property.AdditionalProperties.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/additional-properties/src/Type.Property.AdditionalProperties.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/nullable/src/Type.Property.Nullable.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/nullable/src/Type.Property.Nullable.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/optionality/src/Type.Property.Optional.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/optionality/src/Type.Property.Optional.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/value-types/src/Type.Property.ValueTypes.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/value-types/src/Type.Property.ValueTypes.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/scalar/src/Type.Scalar.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/scalar/src/Type.Scalar.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/union/src/Type.Union.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/type/union/src/Type.Union.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
-    <Compile Include="$(MSBuildThisFileDirectory)../../../../../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The purpose of this change is to let management generator has the ability to add dedicated compile include files.
