### PR TITLE
[KeyVault] Update tests recordings for Certificates

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/assets.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/keyvault/Azure.Security.KeyVault.Certificates",
-  "Tag": "net/keyvault/Azure.Security.KeyVault.Certificates_42c799d783"
+  "Tag": "net/keyvault/Azure.Security.KeyVault.Certificates_757a6cce78"
 }


### PR DESCRIPTION
Some test recordings for Certificates were outdated after merging Keys with new service version in main.
This PR fixes the issue found by the [Core pipeline](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5023595&view=ms.vss-test-web.build-test-results-tab) by re-recording the tests.