### PR TITLE
[KeyVault] Hide KeyAttestation properties' setters

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net8.0.cs
@@ -106,10 +106,10 @@ namespace Azure.Security.KeyVault.Keys
     public partial class KeyAttestation
     {
         public KeyAttestation() { }
-        public System.ReadOnlyMemory<byte> CertificatePemFile { get { throw null; } set { } }
-        public System.ReadOnlyMemory<byte> PrivateKeyAttestation { get { throw null; } set { } }
-        public System.ReadOnlyMemory<byte> PublicKeyAttestation { get { throw null; } set { } }
-        public string Version { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte> CertificatePemFile { get { throw null; } }
+        public System.ReadOnlyMemory<byte> PrivateKeyAttestation { get { throw null; } }
+        public System.ReadOnlyMemory<byte> PublicKeyAttestation { get { throw null; } }
+        public string Version { get { throw null; } }
     }
     public partial class KeyClient
     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
@@ -106,10 +106,10 @@ namespace Azure.Security.KeyVault.Keys
     public partial class KeyAttestation
     {
         public KeyAttestation() { }
-        public System.ReadOnlyMemory<byte> CertificatePemFile { get { throw null; } set { } }
-        public System.ReadOnlyMemory<byte> PrivateKeyAttestation { get { throw null; } set { } }
-        public System.ReadOnlyMemory<byte> PublicKeyAttestation { get { throw null; } set { } }
-        public string Version { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte> CertificatePemFile { get { throw null; } }
+        public System.ReadOnlyMemory<byte> PrivateKeyAttestation { get { throw null; } }
+        public System.ReadOnlyMemory<byte> PublicKeyAttestation { get { throw null; } }
+        public string Version { get { throw null; } }
     }
     public partial class KeyClient
     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttestation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttestation.cs
@@ -18,24 +18,24 @@ namespace Azure.Security.KeyVault.Keys
         }
 
         /// <summary>
-        /// Gets or sets a base64url-encoded string containing certificates in PEM format, used for attestation validation.
+        /// Gets a base64url-encoded string containing certificates in PEM format, used for attestation validation.
         /// </summary>
-        public ReadOnlyMemory<byte> CertificatePemFile { get; set; }
+        public ReadOnlyMemory<byte> CertificatePemFile { get; internal set; }
 
         /// <summary>
-        /// Gets or sets the attestation blob bytes encoded as a base64 URL string corresponding to the private key value.
+        /// Gets the attestation blob bytes encoded as a base64 URL string corresponding to the private key value.
         /// </summary>
-        public ReadOnlyMemory<byte> PrivateKeyAttestation { get; set; }
+        public ReadOnlyMemory<byte> PrivateKeyAttestation { get; internal set; }
 
         /// <summary>
-        /// Gets or sets the attestation blob bytes encoded as a base64 URL string.
+        /// Gets the attestation blob bytes encoded as a base64 URL string.
         /// In the case of an asymmetric key, this corresponds to the public key value.
         /// </summary>
-        public ReadOnlyMemory<byte> PublicKeyAttestation { get; set; }
+        public ReadOnlyMemory<byte> PublicKeyAttestation { get; internal set; }
 
         /// <summary>
-        /// Gets or sets the version of the attestation.
+        /// Gets the version of the attestation.
         /// </summary>
-        public string Version { get; set; }
+        public string Version { get; internal set; }
     }
 }


### PR DESCRIPTION
This PR addresses another comment left on [API View](https://spa.apiview.dev/review/46bf5efced644177abb4c0b630985526?activeApiRevisionId=b1683c9e4e594bd096192d5ce43f1869&diffApiRevisionId=e28b8ebc96dc47ecb5f20dbd61e8d92e&diffStyle=trees).

It hides the setters of the `KeyAttestation` properties by changing them to internal.