### PR TITLE
[CODEOWNERS] Fix linter errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -877,7 +877,7 @@
 # ServiceOwners:                                                   @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft @nickliu-msft
 
 # PRLabel: %Storage
-/sdk/storagesync/                                                  @ankushbindlish2 @anpint @jlindamood
+/sdk/storagesync/                                                  @ankushbindlish2 @anpint
 
 # ServiceLabel: %Storsimple
 # ServiceOwners:                                                   @anoobbacker @ganzee @manuaery


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner who no longer meets the criteria due to changes in their account.