### PR TITLE
Fix the get mockable client methods to be private

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -81,11 +81,13 @@ namespace Azure.Generator.Management
                 scopeCandidates[resource.ResourceScope].Add(resource);
             }
 
+            var mockableArmClientResource = new MockableArmClientProvider(typeof(ArmClient), resources);
             var mockableResources = new List<MockableResourceProvider>(scopeCandidates.Count)
             {
                 // add the arm client mockable resource
-                new MockableArmClientProvider(typeof(ArmClient), resources)
+                mockableArmClientResource
             };
+            ManagementClientGenerator.Instance.AddTypeToKeep(mockableArmClientResource.Name);
 
             foreach (var (scope, candidates) in scopeCandidates)
             {
@@ -93,6 +95,7 @@ namespace Azure.Generator.Management
                 {
                     var mockableExtension = new MockableResourceProvider(_scopeToTypes[scope], candidates);
                     mockableResources.Add(mockableExtension);
+                    ManagementClientGenerator.Instance.AddTypeToKeep(mockableExtension.Name);
                 }
             }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ExtensionProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ExtensionProvider.cs
@@ -64,7 +64,7 @@ namespace Azure.Generator.Management.Providers
             var methodSignature = new MethodSignature(
                 $"Get{mockableResource.Name}",
                 null,
-                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                MethodSignatureModifiers.Private | MethodSignatureModifiers.Static,
                 mockableResource.Type,
                 null,
                 [parameter]);

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MgmtTypeSpecExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MgmtTypeSpecExtensions.cs
@@ -20,13 +20,13 @@ namespace MgmtTypeSpec
     public static partial class MgmtTypeSpecExtensions
     {
         /// <param name="client"></param>
-        public static MockableMgmtTypeSpecArmClient GetMockableMgmtTypeSpecArmClient(ArmClient client)
+        private static MockableMgmtTypeSpecArmClient GetMockableMgmtTypeSpecArmClient(ArmClient client)
         {
             return client.GetCachedClient(client0 => new MockableMgmtTypeSpecArmClient(client0, ResourceIdentifier.Root));
         }
 
         /// <param name="resourceGroupResource"></param>
-        public static MockableMgmtTypeSpecResourceGroupResource GetMockableMgmtTypeSpecResourceGroupResource(ResourceGroupResource resourceGroupResource)
+        private static MockableMgmtTypeSpecResourceGroupResource GetMockableMgmtTypeSpecResourceGroupResource(ResourceGroupResource resourceGroupResource)
         {
             return resourceGroupResource.GetCachedClient(client => new MockableMgmtTypeSpecResourceGroupResource(client, resourceGroupResource.Id));
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MockableMgmtTypeSpecResourceGroupResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MockableMgmtTypeSpecResourceGroupResource.cs
@@ -17,7 +17,7 @@ using MgmtTypeSpec;
 namespace MgmtTypeSpec.Mocking
 {
     /// <summary></summary>
-    internal partial class MockableMgmtTypeSpecResourceGroupResource : ArmResource
+    public partial class MockableMgmtTypeSpecResourceGroupResource : ArmResource
     {
         /// <summary> Initializes a new instance of MockableMgmtTypeSpecResourceGroupResource for mocking. </summary>
         protected MockableMgmtTypeSpecResourceGroupResource()

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MockableMgmtTypeSpecResourceGroupResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MockableMgmtTypeSpecResourceGroupResource.cs
@@ -17,7 +17,7 @@ using MgmtTypeSpec;
 namespace MgmtTypeSpec.Mocking
 {
     /// <summary></summary>
-    public partial class MockableMgmtTypeSpecResourceGroupResource : ArmResource
+    internal partial class MockableMgmtTypeSpecResourceGroupResource : ArmResource
     {
         /// <summary> Initializes a new instance of MockableMgmtTypeSpecResourceGroupResource for mocking. </summary>
         protected MockableMgmtTypeSpecResourceGroupResource()


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/50979

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
