### PR TITLE
[EngSys/Docs] Exclude namespaces where EditorBrowsable is Never

### DIFF
--- a/eng/scripts/docs/tests/Toc-Generation.Tests.ps1
+++ b/eng/scripts/docs/tests/Toc-Generation.Tests.ps1
@@ -6,6 +6,8 @@ Invoke-Pester -Output Detailed $PSScriptRoot\Toc-Generation.Tests.ps1
 
 Import-Module Pester
 
+$nugetAvailable = Get-Command nuget -ErrorAction SilentlyContinue
+
 BeforeAll {
     . $PSScriptRoot/../Docs-ToC.ps1
     . $PSScriptRoot/logging.ps1
@@ -21,7 +23,7 @@ AfterAll {
 # 2. Tests on Fetch-NamespacesFromNupkg from public feeds. 
 # 3. Tests on Get-Toc-Children for latest
 # 4. Tests on Get-Toc-Children for preview
-Describe "Fetch-NamespacesFromNupkg-Nuget" -Tag "UnitTest" {
+Describe "Fetch-NamespacesFromNupkg-Nuget" -Tag "UnitTest" -Skip:(!$nugetAvailable) {
     # Passed cases
     It "Fetch namespaces from package downloads from nuget" -TestCases @(
         @{ package = "Azure.Core"; version="1.24.0"; expectNamespaces = @('Azure', 'Azure.Core', 'Azure.Core.Cryptography', 'Azure.Core.Diagnostics', 'Azure.Core.Extensions', 'Azure.Core.GeoJson', 'Azure.Core.Pipeline', 'Azure.Core.Serialization', 'Azure.Messaging') }
@@ -44,7 +46,7 @@ Describe "Fetch-NamespacesFromNupkg-Nuget" -Tag "UnitTest" {
     }
 }
 
-Describe "Fetch-NamespacesFromNupkg-PublicFeeds" -Tag "UnitTest" {
+Describe "Fetch-NamespacesFromNupkg-PublicFeeds" -Tag "UnitTest" -Skip:(!$nugetAvailable) {
     BeforeAll {
         Set-Variable -Name 'PackageSourceOverride' -Value "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" -ErrorAction 'Ignore'
     }


### PR DESCRIPTION
Added `hasEditorBrowsableNever` which reads metadata available in the given DLL and checks specifically for `System.ComponentModel.EditorBrowsableAttribute`. If it's set to `Never` then the namespaces is not included for that type. Another type without that attribute/value combination will result in the namespace being included. 

Metadata reading is needed because the Reflection classes in .NET throw errors when dependencies (like Azure.Core) are not present. 

Example builds. See `Artifacts/packages_PRBatch/PackageInfo/Azure.AI.Langauge.Conversations.json`

* Without change -- https://dev.azure.com/azure-sdk/public/_build/results?buildId=5035673&view=artifacts&pathAsName=false&type=publishedArtifacts 
![image](https://github.com/user-attachments/assets/2ed2ad34-4acf-4d4c-a180-4c52acea6583)

* With change -- https://dev.azure.com/azure-sdk/public/_build/results?buildId=5040486&view=artifacts&pathAsName=false&type=publishedArtifacts
![image](https://github.com/user-attachments/assets/1bffca18-5b00-4448-8060-e24f6e481b0d)

Verification done: 

Ran a check that verified namespaces in docs metadata JSON files ([example](https://github.com/MicrosoftDocs/azure-docs-sdk-dotnet/blob/main/metadata/latest/Azure.Core.json#L38)) match those extracted from the package on Nuget at the same version. There are 7 instances where packages and namespaces did not match. Those fall into two buckets: 

1. Removal of namespaces not currently shown on the docs site (this is probably because the entities are already not documentable) 
2. Some differences in namespaces for packages that are not Track 2 