### PR TITLE
Adjust DataFactoryContext for DataFactoryElement<>

### DIFF
--- a/sdk/core/Azure.Core.Expressions.DataFactory/api/Azure.Core.Expressions.DataFactory.net8.0.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/api/Azure.Core.Expressions.DataFactory.net8.0.cs
@@ -4,7 +4,7 @@ namespace Azure.Core.Expressions.DataFactory
     {
         internal DataFactoryContext() { }
         public static Azure.Core.Expressions.DataFactory.DataFactoryContext Default { get { throw null; } }
-        protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder builder) { throw null; }
+        protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder? builder) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DataFactoryElementKind : System.IEquatable<Azure.Core.Expressions.DataFactory.DataFactoryElementKind>

--- a/sdk/core/Azure.Core.Expressions.DataFactory/api/Azure.Core.Expressions.DataFactory.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/api/Azure.Core.Expressions.DataFactory.netstandard2.0.cs
@@ -4,7 +4,7 @@ namespace Azure.Core.Expressions.DataFactory
     {
         internal DataFactoryContext() { }
         public static Azure.Core.Expressions.DataFactory.DataFactoryContext Default { get { throw null; } }
-        protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder builder) { throw null; }
+        protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder? builder) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DataFactoryElementKind : System.IEquatable<Azure.Core.Expressions.DataFactory.DataFactoryElementKind>

--- a/sdk/core/Azure.Core.Expressions.DataFactory/src/Azure.Core.Expressions.DataFactory.csproj
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/src/Azure.Core.Expressions.DataFactory.csproj
@@ -11,6 +11,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableClientSdkAnalyzers>true</EnableClientSdkAnalyzers>
     <EnableBannedApiAnalyzers>false</EnableBannedApiAnalyzers>
+    <NoWarn>SCM0002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryContext.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryContext.cs
@@ -1,14 +1,82 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.ClientModel.Primitives;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Azure.Core.Expressions.DataFactory
 {
     /// <summary>
     /// Context class used by <see cref="ModelReaderWriter"/> to read and write models in an AOT compatible way.
     /// </summary>
-    public partial class DataFactoryContext : ModelReaderWriterContext
+    public class DataFactoryContext : ModelReaderWriterContext
     {
+        private readonly Dictionary<Type, Func<ModelReaderWriterTypeBuilder>> _typeBuilderFactories = new();
+        private readonly ConcurrentDictionary<Type, ModelReaderWriterTypeBuilder> _typeBuilders = new();
+
+        private static readonly Dictionary<Type, ModelReaderWriterContext> s_referenceContexts = new()
+        {
+            { typeof(AzureCoreContext), AzureCoreContext.Default },
+        };
+
+        private static DataFactoryContext? _dataFactoryContext;
+        /// <summary> Gets the default instance </summary>
+        public static DataFactoryContext Default => _dataFactoryContext ??= new();
+
+        private DataFactoryContext()
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override bool TryGetTypeBuilderCore(Type type, out ModelReaderWriterTypeBuilder? builder)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(DataFactoryElement<>))
+            {
+                builder = GetBuilder(type.GetGenericArguments()[0]);
+                return true;
+            }
+
+            if (_typeBuilders.TryGetValue(type, out builder))
+            {
+                return true;
+            }
+
+            if (_typeBuilderFactories.TryGetValue(type, out var factory))
+            {
+                builder = factory();
+                _typeBuilders.TryAdd(type, builder);
+                return true;
+            }
+
+            foreach (var kvp in s_referenceContexts)
+            {
+                if (kvp.Value.TryGetTypeBuilder(type, out builder))
+                {
+                    _typeBuilders.TryAdd(type, builder);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private ModelReaderWriterTypeBuilder? GetBuilder(Type type)
+        {
+            var genericType = typeof(DataFactoryElementTypeBuilder<>);
+            var constructedType = genericType.MakeGenericType(type);
+            return Activator.CreateInstance(constructedType) as ModelReaderWriterTypeBuilder;
+        }
+
+        private class DataFactoryElementTypeBuilder<T> : ModelReaderWriterTypeBuilder
+        {
+            protected override Type BuilderType => typeof(DataFactoryElement<T>);
+
+            protected override object CreateInstance()
+            {
+                return new DataFactoryElement<T>(default);
+            }
+        }
     }
 }

--- a/sdk/core/Azure.Core.Expressions.DataFactory/tests/DataFactoryElementTests.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/tests/DataFactoryElementTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NUnit.Framework;
@@ -1063,11 +1062,7 @@ namespace Azure.Core.Expressions.DataFactory.Tests
         private string GetSerializedString<T>(DataFactoryElement<T> payload) => ModelReaderWriter.Write(payload).ToString();
 
         private ModelReaderWriterOptions s_options = new ModelReaderWriterOptions("W");
-        private DataFactoryElement<T> Deserialize<T>(string json)
-        {
-            var instance = new DataFactoryElement<T>(default);
-            return ((IJsonModel<DataFactoryElement<T>>)instance).Create(BinaryData.FromString($"{json}"), s_options);
-        }
+        private DataFactoryElement<T> Deserialize<T>(string json) => ModelReaderWriter.Read<DataFactoryElement<T>>(BinaryData.FromString(json), s_options, DataFactoryContext.Default)!;
 
         [Test]
         public void SerializationFromJsonConverterForInt()


### PR DESCRIPTION
In ModelReaderWriterContext
```csharp
protected override bool TryGetTypeBuilderCore(Type type, out ModelReaderWriterTypeBuilder? builder)
```
has the ability to get the actual type of generic type `DataFactoryElement<>`

This PR removes `partial` to disable the generation to be able to add user-defined logic to `TryGetTypeBuilderCore`
The downside of this is, we need to maintain this context manually. It would be better to provide a flexible way to add user-defined logic to `TryGetTypeBuilderCore`.