### PR TITLE
[Storage][DataMovement] Fix bugs associated with encoding special characters

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares_3cdf992080"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares_430413f807"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/tests/StartTransferCopyFromShareDirectoryTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/tests/StartTransferCopyFromShareDirectoryTestBase.cs
@@ -102,22 +102,25 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             }
         }
 
+        protected override async Task<IDisposingContainer<BlobContainerClient>> GetDestinationDisposingContainerOauthAsync(
+            string containerName = default,
+            CancellationToken cancellationToken = default)
+        {
+            BlobServiceClient oauthService = DestinationClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential);
+            return await DestinationClientBuilder.GetTestContainerAsync(oauthService, containerName);
+        }
+
         protected override async Task<IDisposingContainer<BlobContainerClient>> GetDestinationDisposingContainerAsync(BlobServiceClient service = null, string containerName = null, CancellationToken cancellationToken = default)
             => await DestinationClientBuilder.GetTestContainerAsync(service, containerName);
 
-        protected override BlobContainerClient GetOAuthDestinationContainerClient(string containerName)
-        {
-            BlobClientOptions options = DestinationClientBuilder.GetOptions();
-            BlobServiceClient oauthService = DestinationClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
-            return oauthService.GetBlobContainerClient(containerName);
-        }
-
-        protected override ShareClient GetOAuthSourceContainerClient(string containerName)
+        protected override async Task<IDisposingContainer<ShareClient>> GetSourceDisposingContainerOauthAsync(
+            string containerName = default,
+            CancellationToken cancellationToken = default)
         {
             ShareClientOptions options = SourceClientBuilder.GetOptions();
             options.ShareTokenIntent = ShareTokenIntent.Backup;
             ShareServiceClient oauthService = SourceClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
-            return oauthService.GetShareClient(containerName);
+            return await SourceClientBuilder.GetTestShareAsync(oauthService, containerName);
         }
 
         protected override async Task<IDisposingContainer<ShareClient>> GetSourceDisposingContainerAsync(

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/tests/StartTransferCopyToShareDirectoryTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/tests/StartTransferCopyToShareDirectoryTestBase.cs
@@ -94,6 +94,16 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             }
         }
 
+        protected override async Task<IDisposingContainer<ShareClient>> GetDestinationDisposingContainerOauthAsync(
+            string containerName = default,
+            CancellationToken cancellationToken = default)
+        {
+            ShareClientOptions options = DestinationClientBuilder.GetOptions();
+            options.ShareTokenIntent = ShareTokenIntent.Backup;
+            ShareServiceClient oauthService = DestinationClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
+            return await DestinationClientBuilder.GetTestShareAsync(oauthService, containerName);
+        }
+
         protected override async Task<IDisposingContainer<ShareClient>> GetDestinationDisposingContainerAsync(ShareServiceClient service = null, string containerName = null, CancellationToken cancellationToken = default)
             => await DestinationClientBuilder.GetTestShareAsync(service, containerName);
 
@@ -176,19 +186,12 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             return InstrumentClientOptions(options);
         }
 
-        protected override ShareClient GetOAuthDestinationContainerClient(string containerName)
+        protected override async Task<IDisposingContainer<BlobContainerClient>> GetSourceDisposingContainerOauthAsync(
+            string containerName = default,
+            CancellationToken cancellationToken = default)
         {
-            ShareClientOptions options = DestinationClientBuilder.GetOptions();
-            options.ShareTokenIntent = ShareTokenIntent.Backup;
-            ShareServiceClient oauthService = DestinationClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
-            return oauthService.GetShareClient(containerName);
-        }
-
-        protected override BlobContainerClient GetOAuthSourceContainerClient(string containerName)
-        {
-            BlobClientOptions options = SourceClientBuilder.GetOptions();
-            BlobServiceClient oauthService = SourceClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
-            return oauthService.GetBlobContainerClient(containerName);
+            BlobServiceClient oauthService = SourceClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential);
+            return await SourceClientBuilder.GetTestContainerAsync(oauthService, containerName);
         }
 
         // Blob to File always needs OAuth source container

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 - Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
-- Fixed an issue with Upload transfers where file names containg certain URL-encoded characters could cause the trasnfer to fail.
+- Fixed an issue with Upload transfers where file names containing certain URL-encoded characters could cause the transfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
-- Fixed an issue with Upload transfers where file names containing certain URL-encoded characters could cause the transfer to fail.
+- Fixed an issue with Copy transfers where if the source file/directory name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
+- Fixed an issue with Upload transfers where file/directory names containing certain URL-encoded characters could cause the transfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
+- Fixed an issue with Upload transfers where file names containg certain URL-encoded characters could cause the trasnfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_5f8193db17"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_1ebb672122"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/StartTransferBlobDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/StartTransferBlobDirectoryCopyTestBase.cs
@@ -234,24 +234,27 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             }
         }
 
+        protected override async Task<IDisposingContainer<BlobContainerClient>> GetDestinationDisposingContainerOauthAsync(
+            string containerName = default,
+            CancellationToken cancellationToken = default)
+        {
+            BlobServiceClient oauthService = DestinationClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential);
+            return await DestinationClientBuilder.GetTestContainerAsync(oauthService, containerName);
+        }
+
         protected override async Task<IDisposingContainer<BlobContainerClient>> GetDestinationDisposingContainerAsync(
             BlobServiceClient service = null,
             string containerName = null,
             CancellationToken cancellationToken = default)
             => await DestinationClientBuilder.GetTestContainerAsync(service, containerName);
 
-        private BlobContainerClient GetOAuthContainerClient(string containerName)
+        protected override async Task<IDisposingContainer<BlobContainerClient>> GetSourceDisposingContainerOauthAsync(
+            string containerName = default,
+            CancellationToken cancellationToken = default)
         {
-            BlobClientOptions options = SourceClientBuilder.GetOptions();
-            BlobServiceClient oauthService = SourceClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
-            return oauthService.GetBlobContainerClient(containerName);
+            BlobServiceClient oauthService = SourceClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential);
+            return await SourceClientBuilder.GetTestContainerAsync(oauthService, containerName);
         }
-
-        protected override BlobContainerClient GetOAuthDestinationContainerClient(string containerName)
-            => GetOAuthContainerClient(containerName);
-
-        protected override BlobContainerClient GetOAuthSourceContainerClient(string containerName)
-            => GetOAuthContainerClient(containerName);
 
         protected override async Task<IDisposingContainer<BlobContainerClient>> GetSourceDisposingContainerAsync(BlobServiceClient service = null, string containerName = null, CancellationToken cancellationToken = default)
         {

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 - Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
-- Fixed an issue with Upload transfers where file names containg certain URL-encoded characters could cause the trasnfer to fail.
+- Fixed an issue with Upload transfers where file names containing certain URL-encoded characters could cause the transfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
-- Fixed an issue with Upload transfers where file names containing certain URL-encoded characters could cause the transfer to fail.
+- Fixed an issue with Copy transfers where if the source file/directory name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
+- Fixed an issue with Upload transfers where file/directory names containing certain URL-encoded characters could cause the transfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
+- Fixed an issue with Upload transfers where file names containg certain URL-encoded characters could cause the trasnfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_f6f89a43f9"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_90fc7c3256"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferCopyTests.cs
@@ -88,26 +88,30 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             CancellationToken cancellationToken = default)
             => await DestinationClientBuilder.GetTestShareAsync(service, containerName, cancellationToken: cancellationToken);
 
+        protected override async Task<IDisposingContainer<ShareClient>> GetDestinationDisposingContainerOauthAsync(
+            string containerName = default,
+            CancellationToken cancellationToken = default)
+        {
+            ShareClientOptions options = DestinationClientBuilder.GetOptions();
+            options.ShareTokenIntent = ShareTokenIntent.Backup;
+            ShareServiceClient oauthService = DestinationClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
+            return await DestinationClientBuilder.GetTestShareAsync(oauthService, containerName, cancellationToken: cancellationToken);
+        }
+
         protected override StorageResourceContainer GetDestinationStorageResourceContainer(
             ShareClient containerClient,
             string prefix,
             TransferPropertiesTestType propertiesTestType = default)
             => new ShareDirectoryStorageResourceContainer(containerClient.GetDirectoryClient(prefix), GetShareFileStorageResourceOptions(propertiesTestType));
 
-        protected override ShareClient GetOAuthSourceContainerClient(string containerName)
+        protected override async Task<IDisposingContainer<ShareClient>> GetSourceDisposingContainerOauthAsync(
+            string containerName = default,
+            CancellationToken cancellationToken = default)
         {
             ShareClientOptions options = SourceClientBuilder.GetOptions();
             options.ShareTokenIntent = ShareTokenIntent.Backup;
             ShareServiceClient oauthService = SourceClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
-            return oauthService.GetShareClient(containerName);
-        }
-
-        protected override ShareClient GetOAuthDestinationContainerClient(string containerName)
-        {
-            ShareClientOptions options = DestinationClientBuilder.GetOptions();
-            options.ShareTokenIntent = ShareTokenIntent.Backup;
-            ShareServiceClient oauthService = DestinationClientBuilder.GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, TestEnvironment.Credential, options);
-            return oauthService.GetShareClient(containerName);
+            return await SourceClientBuilder.GetTestShareAsync(oauthService, containerName, cancellationToken: cancellationToken);
         }
 
         protected override async Task<IDisposingContainer<ShareClient>> GetSourceDisposingContainerAsync(ShareServiceClient service = null, string containerName = null, CancellationToken cancellationToken = default)

--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 - Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
-- Fixed an issue with Upload transfers where file names containg certain URL-encoded characters could cause the trasnfer to fail.
+- Fixed an issue with Upload transfers where file names containing certain URL-encoded characters could cause the transfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
-- Fixed an issue with Upload transfers where file names containing certain URL-encoded characters could cause the transfer to fail.
+- Fixed an issue with Copy transfers where if the source file/directory name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
+- Fixed an issue with Upload transfers where file/directory names containing certain URL-encoded characters could cause the transfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue with Copy transfers where if the source file name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
+- Fixed an issue with Upload transfers where file names containg certain URL-encoded characters could cause the trasnfer to fail.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement",
-  "Tag": "net/storage/Azure.Storage.DataMovement_80d90a8906"
+  "Tag": "net/storage/Azure.Storage.DataMovement_2dbe8c115b"
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalDirectoryStorageResourceContainer.cs
@@ -29,13 +29,7 @@ namespace Azure.Storage.DataMovement
         public LocalDirectoryStorageResourceContainer(string path)
         {
             Argument.AssertNotNullOrWhiteSpace(path, nameof(path));
-            UriBuilder uriBuilder= new UriBuilder()
-            {
-                Scheme = Uri.UriSchemeFile,
-                Host = "",
-                Path = path,
-            };
-            _uri = uriBuilder.Uri;
+            _uri = PathScanner.GetEncodedUriFromPath(path);
         }
 
         /// <summary>
@@ -107,9 +101,8 @@ namespace Azure.Storage.DataMovement
 
         protected internal override StorageResourceContainer GetChildStorageResourceContainer(string path)
         {
-            UriBuilder uri = new UriBuilder(_uri);
-            uri.Path = Path.Combine(uri.Path, path);
-            return new LocalDirectoryStorageResourceContainer(uri.Uri);
+            Uri concatPath = _uri.AppendToPath(path);
+            return new LocalDirectoryStorageResourceContainer(concatPath);
         }
 
         protected internal override Task<StorageResourceContainerProperties> GetPropertiesAsync(CancellationToken cancellationToken = default)

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
@@ -40,13 +40,7 @@ namespace Azure.Storage.DataMovement
         public LocalFileStorageResource(string path)
         {
             Argument.AssertNotNullOrWhiteSpace(path, nameof(path));
-            UriBuilder uriBuilder = new UriBuilder()
-            {
-                Scheme = Uri.UriSchemeFile,
-                Host = "",
-                Path = path,
-            };
-            _uri = uriBuilder.Uri;
+            _uri = PathScanner.GetEncodedUriFromPath(path);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/PathScanner.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/PathScanner.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using System.Threading.Tasks;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Azure.Storage.DataMovement
 {
@@ -86,6 +86,42 @@ namespace Azure.Storage.DataMovement
                     yield return new FileInfo(file);
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets a file Uri that is fully encoded even if the path contains already
+        /// encoded characters (double encoded in this case). <see cref="Uri.LocalPath"/>
+        /// can be used to get decoded version for use with File IO.
+        /// </summary>
+        public static Uri GetEncodedUriFromPath(string path)
+        {
+            // The Uri class will normalize slashes but for Windows, do it
+            // ahead of time to make the remainning logic common. Only do
+            // this for Windows as \ can be a valid character for Linux/Mac.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                path = path.Replace("\\", "/");
+            }
+
+            // Encode each part of the path (except the first one) separately
+            // and then reassemble into a Uri. This is done as Uri can be inconsistent
+            // whether it encodes or not and we want to be sure to preserve any encoding
+            // on disk.
+            string[] pathParts = path.Split('/');
+            List<string> encodedParts = [pathParts.First()];
+            foreach (string part in pathParts.Skip(1))
+            {
+                encodedParts.Add(Uri.EscapeDataString(part));
+            }
+            string encodedPath = string.Join("/", encodedParts);
+
+            UriBuilder uriBuilder = new()
+            {
+                Scheme = Uri.UriSchemeFile,
+                Host = "",
+                Path = encodedPath,
+            };
+            return uriBuilder.Uri;
         }
 
         private static IEnumerable<string> EnumerateDirectories(string path)

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/PathScanner.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/PathScanner.cs
@@ -109,10 +109,7 @@ namespace Azure.Storage.DataMovement
             // on disk.
             string[] pathParts = path.Split('/');
             List<string> encodedParts = [pathParts.First()];
-            foreach (string part in pathParts.Skip(1))
-            {
-                encodedParts.Add(Uri.EscapeDataString(part));
-            }
+            encodedParts.AddRange(pathParts.Skip(1).Select(Uri.EscapeDataString));
             string encodedPath = string.Join("/", encodedParts);
 
             UriBuilder uriBuilder = new()

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -334,7 +334,7 @@ namespace Azure.Storage.DataMovement
                     string subContainerPath = string.IsNullOrEmpty(containerUriPath)
                         ? current.Uri.GetPath()
                         : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
-                    // Decode the container name as it was pulled from encoded URL and will be re-encoded on destination.
+                    // Decode the container name as it was pulled from encoded Uri and will be re-encoded on destination.
                     subContainerPath = WebUtility.UrlDecode(subContainerPath);
                     StorageResourceContainer subContainer =
                         _destinationResourceContainer.GetChildStorageResourceContainer(subContainerPath);
@@ -371,7 +371,7 @@ namespace Azure.Storage.DataMovement
                             {
                                 string containerUriPath = _sourceResourceContainer.Uri.GetPath();
                                 sourceName = current.Uri.GetPath().Substring(containerUriPath.Length + 1);
-                                // Decode the resource name as it was pulled from encoded URL and will be re-encoded on destination.
+                                // Decode the resource name as it was pulled from encoded Uri and will be re-encoded on destination.
                                 sourceName = WebUtility.UrlDecode(sourceName);
                             }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -333,6 +334,8 @@ namespace Azure.Storage.DataMovement
                     string subContainerPath = string.IsNullOrEmpty(containerUriPath)
                         ? current.Uri.GetPath()
                         : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
+                    // Decode the container name as it was pulled from encoded URL and will be re-encoded on destination.
+                    subContainerPath = WebUtility.UrlDecode(subContainerPath);
                     StorageResourceContainer subContainer =
                         _destinationResourceContainer.GetChildStorageResourceContainer(subContainerPath);
 
@@ -368,6 +371,8 @@ namespace Azure.Storage.DataMovement
                             {
                                 string containerUriPath = _sourceResourceContainer.Uri.GetPath();
                                 sourceName = current.Uri.GetPath().Substring(containerUriPath.Length + 1);
+                                // Decode the resource name as it was pulled from encoded URL and will be re-encoded on destination.
+                                sourceName = WebUtility.UrlDecode(sourceName);
                             }
 
                             StorageResourceItem sourceItem = (StorageResourceItem)current;

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Core.TestFramework;
 using NUnit.Framework;
 
 namespace Azure.Storage.DataMovement.Tests
@@ -38,12 +39,24 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [TestCase("/test/path=true@&#%", "/test/path%3Dtrue%40%26%23%25")]
-        [TestCase("/test/path%3Dtest%26", "/test/path%253Dtest%2526")]
+        [RunOnlyOnPlatforms(Windows = true)]
         [TestCase("C:\\test\\path=true@&#%", "C:/test/path%3Dtrue%40%26%23%25")]
         [TestCase("C:\\test\\path%3Dtest%26", "C:/test/path%253Dtest%2526")]
         [TestCase("C:\\test\\folder with spaces", "C:/test/folder%20with%20spaces")]
-        public void Ctor_String_Encoding(string path, string absolutePath)
+        public void Ctor_String_Encoding_Windows(string path, string absolutePath)
+        {
+            LocalDirectoryStorageResourceContainer storageResource = new(path);
+            Assert.That(storageResource.Uri.AbsolutePath, Is.EqualTo(absolutePath));
+            // LocalPath should equal original path
+            Assert.That(storageResource.Uri.LocalPath, Is.EqualTo(path));
+        }
+
+        [Test]
+        [RunOnlyOnPlatforms(Linux = true, OSX = true)]
+        [TestCase("/test/path=true@&#%", "/test/path%3Dtrue%40%26%23%25")]
+        [TestCase("/test/path%3Dtest%26", "/test/path%253Dtest%2526")]
+        [TestCase("/test/folder with spaces", "/test/folder%20with%20spaces")]
+        public void Ctor_String_Encoding_Unix(string path, string absolutePath)
         {
             LocalDirectoryStorageResourceContainer storageResource = new(path);
             Assert.That(storageResource.Uri.AbsolutePath, Is.EqualTo(absolutePath));
@@ -155,27 +168,33 @@ namespace Azure.Storage.DataMovement.Tests
         {
             List<(string Start, string Append)> tests =
             [
-                ("C:\\Users\\user1\\Documents\\directory", "path=true@&#%"),
-                ("C:\\Users\\user1\\Documents\\directory", "path%3Dtest%26"),
-                ("C:\\Users\\user1\\Documents\\directory", "with space"),
-                ("C:\\Users\\user1\\Documents\\directory=true@%", "path=true@&#%"),
-                ("C:\\Users\\user1\\Documents\\directory=true@%", "path%3Dtest%26"),
-                ("C:\\Users\\user1\\Documents\\directory=true@%", "with space"),
-                ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "path=true@&#%"),
-                ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "path%3Dtest%26"),
-                ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "with space"),
                 ("/home/user1/directory", "path=true@&#%"),
                 ("/home/user1/directory", "path%3Dtest%26"),
                 ("/home/user1/directory", "with space"),
             ];
+            // Windows paths only supported on Windows
+            if (Azure.Core.TestFramework.TestEnvironment.IsWindows)
+            {
+                tests.AddRange([
+                    ("C:\\Users\\user1\\Documents\\directory", "path=true@&#%"),
+                    ("C:\\Users\\user1\\Documents\\directory", "path%3Dtest%26"),
+                    ("C:\\Users\\user1\\Documents\\directory", "with space"),
+                    ("C:\\Users\\user1\\Documents\\directory=true@%", "path=true@&#%"),
+                    ("C:\\Users\\user1\\Documents\\directory=true@%", "path%3Dtest%26"),
+                    ("C:\\Users\\user1\\Documents\\directory=true@%", "with space"),
+                    ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "path=true@&#%"),
+                    ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "path%3Dtest%26"),
+                    ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "with space"),
+                ]);
+            }
 
             foreach ((string Start, string Append) test in tests)
             {
                 StorageResourceContainer containerResource = new LocalDirectoryStorageResourceContainer(test.Start);
                 StorageResourceItem resource = containerResource.GetStorageResourceReference(test.Append, default);
 
-                char seperator = test.Start[0] == '/' ? '/' : '\\';
-                string combined = test.Start + seperator + test.Append;
+                char separator = test.Start[0] == '/' ? '/' : '\\';
+                string combined = test.Start + separator + test.Append;
                 Assert.That(resource.Uri.LocalPath, Is.EqualTo(combined));
             }
         }
@@ -200,19 +219,25 @@ namespace Azure.Storage.DataMovement.Tests
         {
             List<(string Start, string Append)> tests =
             [
-                ("C:\\Users\\user1\\Documents\\directory", "path=true@&#%"),
-                ("C:\\Users\\user1\\Documents\\directory", "path%3Dtest%26"),
-                ("C:\\Users\\user1\\Documents\\directory", "with space"),
-                ("C:\\Users\\user1\\Documents\\directory=true@%", "path=true@&#%"),
-                ("C:\\Users\\user1\\Documents\\directory=true@%", "path%3Dtest%26"),
-                ("C:\\Users\\user1\\Documents\\directory=true@%", "with space"),
-                ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "path=true@&#%"),
-                ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "path%3Dtest%26"),
-                ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "with space"),
                 ("/home/user1/directory", "path=true@&#%"),
                 ("/home/user1/directory", "path%3Dtest%26"),
                 ("/home/user1/directory", "with space"),
             ];
+            // Windows paths only supported on Windows
+            if (Azure.Core.TestFramework.TestEnvironment.IsWindows)
+            {
+                tests.AddRange([
+                    ("C:\\Users\\user1\\Documents\\directory", "path=true@&#%"),
+                    ("C:\\Users\\user1\\Documents\\directory", "path%3Dtest%26"),
+                    ("C:\\Users\\user1\\Documents\\directory", "with space"),
+                    ("C:\\Users\\user1\\Documents\\directory=true@%", "path=true@&#%"),
+                    ("C:\\Users\\user1\\Documents\\directory=true@%", "path%3Dtest%26"),
+                    ("C:\\Users\\user1\\Documents\\directory=true@%", "with space"),
+                    ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "path=true@&#%"),
+                    ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "path%3Dtest%26"),
+                    ("C:\\Users\\user1\\Documents\\directory%3Dtrue%26", "with space"),
+                ]);
+            }
 
             foreach ((string Start, string Append) test in tests)
             {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalFileStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalFileStorageResourceTests.cs
@@ -74,6 +74,20 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        [TestCase("/test/path=true@&#%", "/test/path%3Dtrue%40%26%23%25")]
+        [TestCase("/test/path%3Dtest%26", "/test/path%253Dtest%2526")]
+        [TestCase("C:\\test\\path=true@&#%", "C:/test/path%3Dtrue%40%26%23%25")]
+        [TestCase("C:\\test\\path%3Dtest%26", "C:/test/path%253Dtest%2526")]
+        [TestCase("C:\\test\\file with spaces", "C:/test/file%20with%20spaces")]
+        public void Ctor_String_Encoding(string path, string absolutePath)
+        {
+            LocalFileStorageResource storageResource = new(path);
+            Assert.That(storageResource.Uri.AbsolutePath, Is.EqualTo(absolutePath));
+            // LocalPath should equal original path
+            Assert.That(storageResource.Uri.LocalPath, Is.EqualTo(path));
+        }
+
+        [Test]
         public void Ctor_Error()
         {
             Assert.Catch<ArgumentException>(() =>

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalFileStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalFileStorageResourceTests.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Threading.Tasks;
+using Azure.Core.TestFramework;
 using Azure.Storage.Test;
 using Mono.Unix.Native;
 using NUnit.Framework;
@@ -74,11 +75,31 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        [TestCase("/test/path=true@&#%", "/test/path%3Dtrue%40%26%23%25")]
-        [TestCase("/test/path%3Dtest%26", "/test/path%253Dtest%2526")]
+        [RunOnlyOnPlatforms(Windows = true)]
         [TestCase("C:\\test\\path=true@&#%", "C:/test/path%3Dtrue%40%26%23%25")]
         [TestCase("C:\\test\\path%3Dtest%26", "C:/test/path%253Dtest%2526")]
         [TestCase("C:\\test\\file with spaces", "C:/test/file%20with%20spaces")]
+        public void Ctor_String_Encoding_Windows(string path, string absolutePath)
+        {
+            LocalFileStorageResource storageResource = new(path);
+            Assert.That(storageResource.Uri.AbsolutePath, Is.EqualTo(absolutePath));
+            // LocalPath should equal original path
+            Assert.That(storageResource.Uri.LocalPath, Is.EqualTo(path));
+        }
+
+        [Test]
+        [RunOnlyOnPlatforms(Linux = true, OSX = true)]
+        [TestCase("/test/path=true@&#%", "/test/path%3Dtrue%40%26%23%25")]
+        [TestCase("/test/path%3Dtest%26", "/test/path%253Dtest%2526")]
+        [TestCase("/test/file with spaces", "/test/file%20with%20spaces")]
+        public void Ctor_String_Encoding_Unix(string path, string absolutePath)
+        {
+            LocalFileStorageResource storageResource = new(path);
+            Assert.That(storageResource.Uri.AbsolutePath, Is.EqualTo(absolutePath));
+            // LocalPath should equal original path
+            Assert.That(storageResource.Uri.LocalPath, Is.EqualTo(path));
+        }
+
         public void Ctor_String_Encoding(string path, string absolutePath)
         {
             LocalFileStorageResource storageResource = new(path);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferUploadDirectoryTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferUploadDirectoryTestBase.cs
@@ -491,5 +491,37 @@ namespace Azure.Storage.DataMovement.Tests
                 expectedTransfers: 1,
                 cancellationToken: cancellationToken);
         }
+
+        [RecordedTest]
+        [TestCase("source=path@#%")]
+        [TestCase("source%21path%40%23%25")]
+        public async Task Upload_SpecialChars(string prefix)
+        {
+            // Arrange
+            string directoryName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), prefix);
+            using DisposingLocalDirectory disposingLocalDirectory = DisposingLocalDirectory.GetTestDirectory(directoryName);
+            await using IDisposingContainer<TContainerClient> test = await GetDisposingContainerAsync();
+
+            List<string> files =
+            [
+                string.Join("/", "file=test!@#$%"),
+                string.Join("/", "file%3Dtest%26"),  // Already encoded
+                string.Join("/", "folder=bar", "subfile=test!@#$%"),
+                string.Join("/", "folder=bar", "subfile%3Dtest%26"),
+                string.Join("/", "folder%40bar", "different!file"),
+                string.Join("/", "space folder", "space file"),
+            ];
+
+            CancellationToken cancellationToken = TestHelper.GetTimeoutToken(30);
+            await SetupDirectoryAsync(
+                disposingLocalDirectory.DirectoryPath,
+                files.Select(path => (path, (long)Constants.KB)).ToList(),
+                cancellationToken);
+            await UploadDirectoryAndVerifyAsync(
+                disposingLocalDirectory.DirectoryPath,
+                test.Container,
+                expectedTransfers: files.Count,
+                cancellationToken: cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
This change addresses issues with encoding of special characters in file names during transfers:

- Fixed an issue with Copy transfers where if the source file/directory name contained certain special characters, the destination file name would incorrectly contain the encoded version of these characters.
- Fixed an issue with Upload transfers where file/directory names containing certain URL-encoded characters could cause the transfer to fail.

The copy issue was caused by us parsing the source resource name from the source Uri, which was encoded, which then got double encoded when passed to the destination resource. The fix was to decode the source resource name before creating the destination resource.

The Upload issue was caused by how we were constructing the Uri object for local resources. Basically, there are some inconsistencies with `Uri` and `UriBuilder` when it comes to encoding where sometimes things would be encoded and sometimes not. If the file name included already encoded characters, they would not be double encoded so when we used `LocalPath` (which decodes) the file name would no longer be correct. The fix was to manually do the encoding ourselves ahead of time. Unfortunately, this had to be done by splitting the path and encoding each piece.

This change includes some new tests to hopefully cover all the scenarios.