### PR TITLE
Fix usage data missing in streaming response

### DIFF
--- a/sdk/ai/Azure.AI.Inference/src/Customized/ChatCompletionsOptions.Serialization.cs
+++ b/sdk/ai/Azure.AI.Inference/src/Customized/ChatCompletionsOptions.Serialization.cs
@@ -70,6 +70,14 @@ namespace Azure.AI.Inference
             {
                 writer.WritePropertyName("stream"u8);
                 writer.WriteBooleanValue(InternalShouldStreamResponse.Value);
+                if (InternalShouldStreamResponse.Value)
+                {
+                    writer.WritePropertyName("stream_options"u8);
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("include_usage"u8);
+                    writer.WriteBooleanValue(true);
+                    writer.WriteEndObject();
+                }
             }
             if (Optional.IsDefined(Seed))
             {


### PR DESCRIPTION
The current version of SDK is missing the usage data in streaming mode.
This PR adds the missing `stream_options` when `InternalShouldStreamResponse` is set to true so that the token usage data will be properly sent from the service and should be able to fix: #50719 


