### PR TITLE
[CODEOWNERS] Removing invalid owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -452,8 +452,8 @@
 # ServiceLabel: %Data Lake
 # ServiceOwners:                                                   @seanmcc-msft
 
-# ServiceLabel: %Data Lake Storage Gen2
-# ServiceOwners:                                                   @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft @nickliu-msft
+# ServiceLabel: %Data Lake Storage Gen
+# ServiceOwners:                                                   @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft
 
 # ServiceLabel: %Data Lake Analytics
 # ServiceOwners:                                                   @idear1203
@@ -865,16 +865,16 @@
 # ServiceOwners:                                                   @azureSQLGitHub
 
 # PRLabel: %Storage
-/sdk/storage*/                                                     @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft @nickliu-msft
+/sdk/storage*/                                                     @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft
 
 # PRLabel: %Storage
-/sdk/storage/Azure.Storage.*/                                      @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft @nickliu-msft
+/sdk/storage/Azure.Storage.*/                                      @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft
 
 # PRLabel: %Storage
-/sdk/storage/Microsoft.Azure.WebJobs.*/                            @seanmcc-msft @amnguye @jaschrep-msft @tg-msft @fabiocav @mathewc @jalauzon-msft @nickliu-msft
+/sdk/storage/Microsoft.Azure.WebJobs.*/                            @seanmcc-msft @amnguye @jaschrep-msft @tg-msft @fabiocav @mathewc @jalauzon-msft
 
 # ServiceLabel: %Storage
-# ServiceOwners:                                                   @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft @nickliu-msft
+# ServiceOwners:                                                   @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft
 
 # PRLabel: %Storage
 /sdk/storagesync/                                                  @ankushbindlish2 @anpint
@@ -981,10 +981,10 @@
 # ServiceOwners:                                                   @sahilarora92 @rahuls-microsoft
 
 # PRLael: %Container Orchestrator Runtime
-/sdk/containerorchestratorruntime/Azure.ResourceManager.*/         @ddadaal
+/sdk/containerorchestratorruntime/Azure.ResourceManager.*/         @ArthurMa1978
 
 # ServiceLabel: %Container Orchestrator Runtime
-# ServiceOwners:                                                   @ddadaal
+# ServiceOwners:                                                   @ArthurMa1978
 
 # PRLabel: %Database Watcher
 /sdk/databasewatcher/Azure.ResourceManager.*/                      @Renyx1219

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -452,7 +452,7 @@
 # ServiceLabel: %Data Lake
 # ServiceOwners:                                                   @seanmcc-msft
 
-# ServiceLabel: %Data Lake Storage Gen
+# ServiceLabel: %Data Lake Storage Gen2
 # ServiceOwners:                                                   @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft
 
 # ServiceLabel: %Data Lake Analytics


### PR DESCRIPTION
# Summary

The focus of these changes is to remove another batch of code owners who were recently flagged by the linter as invalid.  

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5051634&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_