### PR TITLE
build: enable plugin & visitors CI pipeline

### DIFF
--- a/eng/packages/plugins/client/Client.Plugin/eng/pipeline/ci.yaml
+++ b/eng/packages/plugins/client/Client.Plugin/eng/pipeline/ci.yaml
@@ -1,0 +1,41 @@
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - eng/packages/plugins/client/Client.Plugin
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+      - release/*
+  paths:
+    include:
+      - eng/packages/plugins/client/Client.Plugin
+
+variables:
+  - template: /eng/pipelines/templates/variables/image.yml
+  - template: /eng/pipelines/templates/variables/globals.yml
+
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+    - stage: Build
+      displayName: 'Build'
+      pool:
+        name: $(LINUXPOOL)
+        image: $(LINUXVMIMAGE)
+        os: linux
+      jobs:
+      - job: Build
+        steps:
+        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        - template: /eng/pipelines/templates/steps/install-dotnet.yml
+        - pwsh: |
+            dotnet build .
+          displayName: 'Build client plugin'
+          workingDirectory: eng/packages/plugins/client/Client.Plugin

--- a/eng/packages/visitors/Visitors/eng/pipeline/ci.yaml
+++ b/eng/packages/visitors/Visitors/eng/pipeline/ci.yaml
@@ -1,0 +1,46 @@
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - eng/packages/plugins/visitors
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+      - release/*
+  paths:
+    include:
+      - eng/packages/plugins/visitors
+
+variables:
+  - template: /eng/pipelines/templates/variables/image.yml
+  - template: /eng/pipelines/templates/variables/globals.yml
+
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+    - stage: BuildAndTest
+      displayName: 'Build and Test'
+      pool:
+        name: $(LINUXPOOL)
+        image: $(LINUXVMIMAGE)
+        os: linux
+      jobs:
+      - job: BuildAndTest
+        displayName: 'Build and Test'
+        steps:
+        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        - template: /eng/pipelines/templates/steps/install-dotnet.yml
+        - pwsh: |
+            dotnet build .
+          displayName: 'Build visitors'
+          workingDirectory: eng/packages/visitors/Visitors
+        - pwsh: |
+            dotnet test .
+          displayName: 'Run visitors tests'
+          workingDirectory: eng/packages/visitors/Visitors

--- a/eng/packages/visitors/Visitors/test/Visitors.Tests.Common/Visitors.Tests.Common.csproj
+++ b/eng/packages/visitors/Visitors/test/Visitors.Tests.Common/Visitors.Tests.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestSupportProject>true</IsTestSupportProject>


### PR DESCRIPTION
This PR enables the CI pipeline for the typespec generator's plugin & visitors. This pipeline will build and run any unit tests in the projects.

Visitor pipeline: [link](https://dev.azure.com/azure-sdk/public/_build?definitionId=7818)
Plugin pipeline: [link](https://dev.azure.com/azure-sdk/public/_build?definitionId=7817)

contributes to : https://github.com/Azure/azure-sdk-for-net/issues/50988