### PR TITLE
[Elastic] Fix for issue #50974

### DIFF
--- a/sdk/elastic/Azure.ResourceManager.Elastic/CHANGELOG.md
+++ b/sdk/elastic/Azure.ResourceManager.Elastic/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed serialization issue in `ElasticCloudDeployment` where `ElasticsearchServiceUri`, `KibanaServiceUri`, and `KibanaSsoUri` properties would throw `InvalidOperationException` when containing relative URIs. Added custom serialization hooks to handle both absolute and relative URIs by using `OriginalString` for relative URIs instead of `AbsoluteUri`. This resolves issue #50974.
+
 ### Other Changes
 
 ## 1.0.0 (2024-12-26)

--- a/sdk/elastic/Azure.ResourceManager.Elastic/src/Custom/ElasticCloudDeployment.cs
+++ b/sdk/elastic/Azure.ResourceManager.Elastic/src/Custom/ElasticCloudDeployment.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.ResourceManager.Elastic.Models
+{
+    // This is the fix for issue #50974
+    [CodeGenSerialization(nameof(ElasticsearchServiceUri), SerializationValueHook = nameof(WriteElasticsearchServiceUri), DeserializationValueHook = nameof(DeserializeElasticsearchServiceUri))]
+    [CodeGenSerialization(nameof(KibanaServiceUri), SerializationValueHook = nameof(WriteKibanaServiceUri), DeserializationValueHook = nameof(DeserializeKibanaServiceUri))]
+    [CodeGenSerialization(nameof(KibanaSsoUri), SerializationValueHook = nameof(WriteKibanaSsoUri), DeserializationValueHook = nameof(DeserializeKibanaSsoUri))]
+    public partial class ElasticCloudDeployment
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void WriteElasticsearchServiceUri(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            if (ElasticsearchServiceUri.IsAbsoluteUri)
+                writer.WriteStringValue(ElasticsearchServiceUri.AbsoluteUri);
+            else
+                writer.WriteStringValue(ElasticsearchServiceUri.OriginalString);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DeserializeElasticsearchServiceUri(JsonProperty property, ref Uri elasticsearchServiceUrl)
+        {
+            if (property.Value.ValueKind != JsonValueKind.Null)
+            {
+                if (Uri.TryCreate(property.Value.GetString(), UriKind.Absolute, out elasticsearchServiceUrl))
+                {
+                    elasticsearchServiceUrl = new Uri(property.Value.GetString(), UriKind.Absolute);
+                }
+                else
+                {
+                    elasticsearchServiceUrl = new Uri(property.Value.GetString(), UriKind.Relative);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void WriteKibanaServiceUri(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            if (KibanaServiceUri.IsAbsoluteUri)
+                writer.WriteStringValue(KibanaServiceUri.AbsoluteUri);
+            else
+                writer.WriteStringValue(KibanaServiceUri.OriginalString);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DeserializeKibanaServiceUri(JsonProperty property, ref Uri kibanaServiceUrl)
+        {
+            if (property.Value.ValueKind != JsonValueKind.Null)
+            {
+                if (Uri.TryCreate(property.Value.GetString(), UriKind.Absolute, out kibanaServiceUrl))
+                {
+                    kibanaServiceUrl = new Uri(property.Value.GetString(), UriKind.Absolute);
+                }
+                else
+                {
+                    kibanaServiceUrl = new Uri(property.Value.GetString(), UriKind.Relative);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void WriteKibanaSsoUri(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            if (KibanaSsoUri.IsAbsoluteUri)
+                writer.WriteStringValue(KibanaSsoUri.AbsoluteUri);
+            else
+                writer.WriteStringValue(KibanaSsoUri.OriginalString);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DeserializeKibanaSsoUri(JsonProperty property, ref Uri kibanaSsoUrl)
+        {
+            if (property.Value.ValueKind != JsonValueKind.Null)
+            {
+                if (Uri.TryCreate(property.Value.GetString(), UriKind.Absolute, out kibanaSsoUrl))
+                {
+                    kibanaSsoUrl = new Uri(property.Value.GetString(), UriKind.Absolute);
+                }
+                else
+                {
+                    kibanaSsoUrl = new Uri(property.Value.GetString(), UriKind.Relative);
+                }
+            }
+        }
+    }
+}

--- a/sdk/elastic/Azure.ResourceManager.Elastic/src/Custom/ElasticCloudDeployment.cs
+++ b/sdk/elastic/Azure.ResourceManager.Elastic/src/Custom/ElasticCloudDeployment.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Azure.Core;
@@ -21,75 +20,54 @@ namespace Azure.ResourceManager.Elastic.Models
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void WriteElasticsearchServiceUri(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
-            if (ElasticsearchServiceUri.IsAbsoluteUri)
-                writer.WriteStringValue(ElasticsearchServiceUri.AbsoluteUri);
-            else
-                writer.WriteStringValue(ElasticsearchServiceUri.OriginalString);
+            WriteUri(writer, ElasticsearchServiceUri);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void DeserializeElasticsearchServiceUri(JsonProperty property, ref Uri elasticsearchServiceUrl)
         {
-            if (property.Value.ValueKind != JsonValueKind.Null)
-            {
-                if (Uri.TryCreate(property.Value.GetString(), UriKind.Absolute, out elasticsearchServiceUrl))
-                {
-                    elasticsearchServiceUrl = new Uri(property.Value.GetString(), UriKind.Absolute);
-                }
-                else
-                {
-                    elasticsearchServiceUrl = new Uri(property.Value.GetString(), UriKind.Relative);
-                }
-            }
+            DeserializeUri(property, ref elasticsearchServiceUrl);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void WriteKibanaServiceUri(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
-            if (KibanaServiceUri.IsAbsoluteUri)
-                writer.WriteStringValue(KibanaServiceUri.AbsoluteUri);
-            else
-                writer.WriteStringValue(KibanaServiceUri.OriginalString);
+            WriteUri(writer, KibanaServiceUri);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void DeserializeKibanaServiceUri(JsonProperty property, ref Uri kibanaServiceUrl)
         {
-            if (property.Value.ValueKind != JsonValueKind.Null)
-            {
-                if (Uri.TryCreate(property.Value.GetString(), UriKind.Absolute, out kibanaServiceUrl))
-                {
-                    kibanaServiceUrl = new Uri(property.Value.GetString(), UriKind.Absolute);
-                }
-                else
-                {
-                    kibanaServiceUrl = new Uri(property.Value.GetString(), UriKind.Relative);
-                }
-            }
+            DeserializeUri(property, ref kibanaServiceUrl);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void WriteKibanaSsoUri(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
-            if (KibanaSsoUri.IsAbsoluteUri)
-                writer.WriteStringValue(KibanaSsoUri.AbsoluteUri);
-            else
-                writer.WriteStringValue(KibanaSsoUri.OriginalString);
+            WriteUri(writer, KibanaSsoUri);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void DeserializeKibanaSsoUri(JsonProperty property, ref Uri kibanaSsoUrl)
         {
+            DeserializeUri(property, ref kibanaSsoUrl);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WriteUri(Utf8JsonWriter writer, Uri uri)
+        {
+            writer.WriteStringValue(uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.OriginalString);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DeserializeUri(JsonProperty property, ref Uri uri)
+        {
             if (property.Value.ValueKind != JsonValueKind.Null)
             {
-                if (Uri.TryCreate(property.Value.GetString(), UriKind.Absolute, out kibanaSsoUrl))
-                {
-                    kibanaSsoUrl = new Uri(property.Value.GetString(), UriKind.Absolute);
-                }
-                else
-                {
-                    kibanaSsoUrl = new Uri(property.Value.GetString(), UriKind.Relative);
-                }
+                var uriString = property.Value.GetString();
+                uri = Uri.TryCreate(uriString, UriKind.Absolute, out var absoluteUri)
+                    ? absoluteUri
+                    : new Uri(uriString, UriKind.Relative);
             }
         }
     }

--- a/sdk/elastic/Azure.ResourceManager.Elastic/src/Generated/Models/ElasticCloudDeployment.Serialization.cs
+++ b/sdk/elastic/Azure.ResourceManager.Elastic/src/Generated/Models/ElasticCloudDeployment.Serialization.cs
@@ -57,17 +57,17 @@ namespace Azure.ResourceManager.Elastic.Models
             if (options.Format != "W" && Optional.IsDefined(ElasticsearchServiceUri))
             {
                 writer.WritePropertyName("elasticsearchServiceUrl"u8);
-                writer.WriteStringValue(ElasticsearchServiceUri.AbsoluteUri);
+                WriteElasticsearchServiceUri(writer, options);
             }
             if (options.Format != "W" && Optional.IsDefined(KibanaServiceUri))
             {
                 writer.WritePropertyName("kibanaServiceUrl"u8);
-                writer.WriteStringValue(KibanaServiceUri.AbsoluteUri);
+                WriteKibanaServiceUri(writer, options);
             }
             if (options.Format != "W" && Optional.IsDefined(KibanaSsoUri))
             {
                 writer.WritePropertyName("kibanaSsoUrl"u8);
-                writer.WriteStringValue(KibanaSsoUri.AbsoluteUri);
+                WriteKibanaSsoUri(writer, options);
             }
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
@@ -139,29 +139,17 @@ namespace Azure.ResourceManager.Elastic.Models
                 }
                 if (property.NameEquals("elasticsearchServiceUrl"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
-                    elasticsearchServiceUrl = new Uri(property.Value.GetString());
+                    DeserializeElasticsearchServiceUri(property, ref elasticsearchServiceUrl);
                     continue;
                 }
                 if (property.NameEquals("kibanaServiceUrl"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
-                    kibanaServiceUrl = new Uri(property.Value.GetString());
+                    DeserializeKibanaServiceUri(property, ref kibanaServiceUrl);
                     continue;
                 }
                 if (property.NameEquals("kibanaSsoUrl"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
-                    kibanaSsoUrl = new Uri(property.Value.GetString());
+                    DeserializeKibanaSsoUri(property, ref kibanaSsoUrl);
                     continue;
                 }
                 if (options.Format != "W")

--- a/sdk/elastic/Azure.ResourceManager.Elastic/tests/Tests/ElasticCloudDeploymentRegressionTests.cs
+++ b/sdk/elastic/Azure.ResourceManager.Elastic/tests/Tests/ElasticCloudDeploymentRegressionTests.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Text.Json;
 using Azure.ResourceManager.Elastic.Models;
 using NUnit.Framework;
-using System.ClientModel.Primitives;
-using Azure.Core;
-using System.Text.Json;
 
 namespace Azure.ResourceManager.Elastic.Tests
 {

--- a/sdk/elastic/Azure.ResourceManager.Elastic/tests/Tests/ElasticCloudDeploymentRegressionTests.cs
+++ b/sdk/elastic/Azure.ResourceManager.Elastic/tests/Tests/ElasticCloudDeploymentRegressionTests.cs
@@ -75,10 +75,10 @@ namespace Azure.ResourceManager.Elastic.Tests
         [Test]
         public void SerializeAndDeserialize_AllUriProperties_WithRelativeUris()
         {
-            // Arrange
-            var elasticsearchServiceUri = new Uri("/elasticsearch", UriKind.Relative);
-            var kibanaServiceUri = new Uri("/kibana", UriKind.Relative);
-            var kibanaSsoUri = new Uri("/kibana/sso", UriKind.Relative);
+            // Arrange - Use relative paths that don't start with "/" to avoid platform-specific interpretation
+            var elasticsearchServiceUri = new Uri("elasticsearch", UriKind.Relative);
+            var kibanaServiceUri = new Uri("kibana", UriKind.Relative);
+            var kibanaSsoUri = new Uri("kibana/sso", UriKind.Relative);
 
             var deployment = new ElasticCloudDeployment(
                 name: "test-deployment",
@@ -102,15 +102,15 @@ namespace Azure.ResourceManager.Elastic.Tests
 
             if (root.TryGetProperty("elasticsearchServiceUrl", out var esElement))
             {
-                Assert.AreEqual("/elasticsearch", esElement.GetString());
+                Assert.AreEqual("elasticsearch", esElement.GetString());
             }
             if (root.TryGetProperty("kibanaServiceUrl", out var kibanaElement))
             {
-                Assert.AreEqual("/kibana", kibanaElement.GetString());
+                Assert.AreEqual("kibana", kibanaElement.GetString());
             }
             if (root.TryGetProperty("kibanaSsoUrl", out var kibanaSsoElement))
             {
-                Assert.AreEqual("/kibana/sso", kibanaSsoElement.GetString());
+                Assert.AreEqual("kibana/sso", kibanaSsoElement.GetString());
             }
 
             // Act - Deserialize
@@ -128,9 +128,9 @@ namespace Azure.ResourceManager.Elastic.Tests
             Assert.IsFalse(deserialized.KibanaSsoUri.IsAbsoluteUri);
 
             // Verify original strings are preserved
-            Assert.AreEqual("/elasticsearch", deserialized.ElasticsearchServiceUri.OriginalString);
-            Assert.AreEqual("/kibana", deserialized.KibanaServiceUri.OriginalString);
-            Assert.AreEqual("/kibana/sso", deserialized.KibanaSsoUri.OriginalString);
+            Assert.AreEqual("elasticsearch", deserialized.ElasticsearchServiceUri.OriginalString);
+            Assert.AreEqual("kibana", deserialized.KibanaServiceUri.OriginalString);
+            Assert.AreEqual("kibana/sso", deserialized.KibanaSsoUri.OriginalString);
         }
     }
 }

--- a/sdk/elastic/Azure.ResourceManager.Elastic/tests/Tests/ElasticCloudDeploymentRegressionTests.cs
+++ b/sdk/elastic/Azure.ResourceManager.Elastic/tests/Tests/ElasticCloudDeploymentRegressionTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.ResourceManager.Elastic.Models;
+using NUnit.Framework;
+using System.ClientModel.Primitives;
+using Azure.Core;
+using System.Text.Json;
+
+namespace Azure.ResourceManager.Elastic.Tests
+{
+    /// <summary>
+    /// Regression tests for ElasticCloudDeployment custom serialization fixes for issue #50974
+    /// </summary>
+    public class ElasticCloudDeploymentRegressionTests
+    {
+        [Test]
+        public void SerializeAndDeserialize_AllUriProperties_WithAbsoluteUris()
+        {
+            // Arrange
+            var elasticsearchServiceUri = new Uri("https://elasticsearch.example.com:9200");
+            var kibanaServiceUri = new Uri("https://kibana.example.com:5601");
+            var kibanaSsoUri = new Uri("https://kibana.example.com:5601/sso");
+
+            var deployment = new ElasticCloudDeployment(
+                name: "test-deployment",
+                deploymentId: "dep-123",
+                azureSubscriptionId: "sub-456",
+                elasticsearchRegion: "eastus",
+                elasticsearchServiceUri: elasticsearchServiceUri,
+                kibanaServiceUri: kibanaServiceUri,
+                kibanaSsoUri: kibanaSsoUri,
+                serializedAdditionalRawData: new Dictionary<string, BinaryData>()
+            );
+
+            // Act - Serialize
+            var model = deployment as IPersistableModel<ElasticCloudDeployment>;
+            var wire = ModelReaderWriter.Write(model);
+            var jsonString = wire.ToString();
+
+            // Verify serialized JSON contains absolute URIs
+            var jsonDoc = JsonDocument.Parse(jsonString);
+            var root = jsonDoc.RootElement;
+
+            if (root.TryGetProperty("elasticsearchServiceUrl", out var esElement))
+            {
+                Assert.AreEqual("https://elasticsearch.example.com:9200/", esElement.GetString());
+            }
+            if (root.TryGetProperty("kibanaServiceUrl", out var kibanaElement))
+            {
+                Assert.AreEqual("https://kibana.example.com:5601/", kibanaElement.GetString());
+            }
+            if (root.TryGetProperty("kibanaSsoUrl", out var kibanaSsoElement))
+            {
+                Assert.AreEqual("https://kibana.example.com:5601/sso", kibanaSsoElement.GetString());
+            }
+
+            // Act - Deserialize
+            var deserialized = ModelReaderWriter.Read<ElasticCloudDeployment>(wire);
+
+            // Assert
+            Assert.NotNull(deserialized);
+            Assert.AreEqual(elasticsearchServiceUri, deserialized.ElasticsearchServiceUri);
+            Assert.AreEqual(kibanaServiceUri, deserialized.KibanaServiceUri);
+            Assert.AreEqual(kibanaSsoUri, deserialized.KibanaSsoUri);
+
+            // Verify all URIs are absolute
+            Assert.IsTrue(deserialized.ElasticsearchServiceUri.IsAbsoluteUri);
+            Assert.IsTrue(deserialized.KibanaServiceUri.IsAbsoluteUri);
+            Assert.IsTrue(deserialized.KibanaSsoUri.IsAbsoluteUri);
+        }
+
+        [Test]
+        public void SerializeAndDeserialize_AllUriProperties_WithRelativeUris()
+        {
+            // Arrange
+            var elasticsearchServiceUri = new Uri("/elasticsearch", UriKind.Relative);
+            var kibanaServiceUri = new Uri("/kibana", UriKind.Relative);
+            var kibanaSsoUri = new Uri("/kibana/sso", UriKind.Relative);
+
+            var deployment = new ElasticCloudDeployment(
+                name: "test-deployment",
+                deploymentId: "dep-123",
+                azureSubscriptionId: "sub-456",
+                elasticsearchRegion: "eastus",
+                elasticsearchServiceUri: elasticsearchServiceUri,
+                kibanaServiceUri: kibanaServiceUri,
+                kibanaSsoUri: kibanaSsoUri,
+                serializedAdditionalRawData: new Dictionary<string, BinaryData>()
+            );
+
+            // Act - Serialize
+            var model = deployment as IPersistableModel<ElasticCloudDeployment>;
+            var wire = ModelReaderWriter.Write(model);
+            var jsonString = wire.ToString();
+
+            // Verify serialized JSON contains relative URIs as original strings
+            var jsonDoc = JsonDocument.Parse(jsonString);
+            var root = jsonDoc.RootElement;
+
+            if (root.TryGetProperty("elasticsearchServiceUrl", out var esElement))
+            {
+                Assert.AreEqual("/elasticsearch", esElement.GetString());
+            }
+            if (root.TryGetProperty("kibanaServiceUrl", out var kibanaElement))
+            {
+                Assert.AreEqual("/kibana", kibanaElement.GetString());
+            }
+            if (root.TryGetProperty("kibanaSsoUrl", out var kibanaSsoElement))
+            {
+                Assert.AreEqual("/kibana/sso", kibanaSsoElement.GetString());
+            }
+
+            // Act - Deserialize
+            var deserialized = ModelReaderWriter.Read<ElasticCloudDeployment>(wire);
+
+            // Assert
+            Assert.NotNull(deserialized);
+            Assert.AreEqual(elasticsearchServiceUri, deserialized.ElasticsearchServiceUri);
+            Assert.AreEqual(kibanaServiceUri, deserialized.KibanaServiceUri);
+            Assert.AreEqual(kibanaSsoUri, deserialized.KibanaSsoUri);
+
+            // Verify all URIs are relative
+            Assert.IsFalse(deserialized.ElasticsearchServiceUri.IsAbsoluteUri);
+            Assert.IsFalse(deserialized.KibanaServiceUri.IsAbsoluteUri);
+            Assert.IsFalse(deserialized.KibanaSsoUri.IsAbsoluteUri);
+
+            // Verify original strings are preserved
+            Assert.AreEqual("/elasticsearch", deserialized.ElasticsearchServiceUri.OriginalString);
+            Assert.AreEqual("/kibana", deserialized.KibanaServiceUri.OriginalString);
+            Assert.AreEqual("/kibana/sso", deserialized.KibanaSsoUri.OriginalString);
+        }
+    }
+}


### PR DESCRIPTION
This is a fix for issue #50974 .
Fixed serialization issue in `ElasticCloudDeployment` where `ElasticsearchServiceUri`, `KibanaServiceUri`, and `KibanaSsoUri` properties would throw `InvalidOperationException` when containing relative URIs. Added custom serialization hooks to handle both absolute and relative URIs by using `OriginalString` for relative URIs instead of `AbsoluteUri`. 

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
