### PR TITLE
[Packages] Bump System.ClientModel

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -86,7 +86,7 @@
 
     <!-- BCL packages -->
     <PackageReference Update="System.Buffers" Version="4.5.1" />
-    <PackageReference Update="System.ClientModel" Version="1.4.2" />
+    <PackageReference Update="System.ClientModel" Version="1.5.0" />
     <PackageReference Update="System.IO.Hashing" Version="8.0.0" />
     <PackageReference Update="System.Memory" Version="4.5.5" />
     <PackageReference Update="System.Memory.Data" Version="8.0.1" />
@@ -426,7 +426,7 @@
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />
-    <PackageReference Update="System.ClientModel" Version="1.4.2" />
+    <PackageReference Update="System.ClientModel" Version="1.5.0" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the central version of the `System.ClientModel` package to the latest release.