### PR TITLE
[CODEOWNERS] Fix linter errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -987,10 +987,10 @@
 # ServiceOwners:                                                   @ArthurMa1978
 
 # PRLabel: %Database Watcher
-/sdk/databasewatcher/Azure.ResourceManager.*/                      @Renyx1219
+/sdk/databasewatcher/Azure.ResourceManager.*/                      @ArthurMa1978
 
 # ServiceLabel: %Database Watcher %Mgmt
-# ServiceOwners:                                                   @Renyx1219
+# ServiceOwners:                                                   @ArthurMa1978
 
 # PRLabel: %Device Registry
 /sdk/deviceregistry/Azure.ResourceManager.DeviceRegistry/          @davidemontanari @atastrophic @marcodalessandro @rohankhandelwal @riteshrao
@@ -1053,7 +1053,7 @@
 # ServiceOwners:                                                   @alluri02
 
 # PRLabel: %Network - CDN
-/sdk/cdn/Azure.ResourceManager.*/                                  @ArcturusZhang @ArthurMa1978 @Ptnan7
+/sdk/cdn/Azure.ResourceManager.*/                                  @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %Network - DNS Private Resolver
 /sdk/dnsresolver/Azure.ResourceManager.*/                          @jamesvoongms @jotrivet
@@ -1062,10 +1062,10 @@
 # ServiceOwners:                                                   @jamesvoongms @jotrivet
 
 # PRLabel: %Network - Front Door
-/sdk/frontdoor/Azure.ResourceManager.*/                            @ArcturusZhang @ArthurMa1978 @Ptnan7
+/sdk/frontdoor/Azure.ResourceManager.*/                            @ArcturusZhang @ArthurMa1978
 
 # ServiceLabel:  %Network - Front Door %Mgmt
-# ServiceOwners:                                                   @Ptnan7
+# ServiceOwners:                                                   @ArthurMa1978
 
 # PRLabel: %Network - Mobile
 /sdk/mobilenetwork/Azure.ResourceManager.*/                        @ArcturusZhang @ArthurMa1978


### PR DESCRIPTION
# Summary

The focus of these changes is to fix some linter errors for owners who are no longer eligible.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5060694&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_