### PR TITLE
Factor ChatOptions.Instructions into PersistentAgentsChatClient

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -207,7 +207,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.Contains('Azure.AI.Agents.Persistent'))">
-    <PackageReference Update="Microsoft.Extensions.AI.Abstractions" Version="9.6.0"/>
+    <PackageReference Update="Microsoft.Extensions.AI.Abstractions" Version="9.7.0"/>
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.Contains('Azure.Projects'))">

--- a/sdk/ai/Azure.AI.Agents.Persistent/assets.json
+++ b/sdk/ai/Azure.AI.Agents.Persistent/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/ai/Azure.AI.Agents.Persistent",
-  "Tag": "net/ai/Azure.AI.Agents.Persistent_ee70790a0c"
+  "Tag": "net/ai/Azure.AI.Agents.Persistent_566ea3f825"
 }

--- a/sdk/ai/Azure.AI.Agents.Persistent/tests/PersistentAgentsChatClientTests.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/tests/PersistentAgentsChatClientTests.cs
@@ -339,7 +339,7 @@ namespace Azure.AI.Agents.Persistent.Tests
             Pageable<PersistentAgent> agents = client.Administration.GetAgents();
             foreach (PersistentAgent agent in agents)
             {
-                if (agent.Name.StartsWith(AGENT_NAME))
+                if (agent.Name is not null && agent.Name.StartsWith(AGENT_NAME))
                     client.Administration.DeleteAgent(agent.Id);
             }
 


### PR DESCRIPTION
Bumps the minor version of Microsoft.Extensions.AI.Abstractions used by Azure.AI.Agents.Persistent, and factors in the new ChatOptions.Instructions property so that it properly flows through.

cc: @dmytrostruk, @markwallace-microsoft