### PR TITLE
Remove unexpected methods from ModelFactory for management

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementClientGenerator.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementClientGenerator.cs
@@ -58,6 +58,7 @@ namespace Azure.Generator.Management
             AddVisitor(new SerializationVisitor());
             AddVisitor(new PaginationVisitor());
             AddVisitor(new SafeFlattenVisitor());
+            AddVisitor(new ModelFactoryVisitor());
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -18,7 +18,8 @@ namespace Azure.Generator.Management
 {
     /// <inheritdoc/>
     public class ManagementOutputLibrary : AzureOutputLibrary
-    {   private ManagementLongRunningOperationProvider? _armOperation;
+    {
+        private ManagementLongRunningOperationProvider? _armOperation;
         internal ManagementLongRunningOperationProvider ArmOperation => _armOperation ??= new ManagementLongRunningOperationProvider(false);
 
         private ManagementLongRunningOperationProvider? _genericArmOperation;
@@ -27,6 +28,25 @@ namespace Azure.Generator.Management
         // TODO: replace this with CSharpType to TypeProvider mapping
         private HashSet<CSharpType>? _resourceTypes;
         private HashSet<CSharpType> ResourceTypes => _resourceTypes ??= BuildResourceModels();
+
+        // TODO: replace this with CSharpType to TypeProvider mapping
+        private HashSet<CSharpType>? _modelFactoryModels;
+        private HashSet<CSharpType> ModelFactoryModels => _modelFactoryModels ??= BuildModelFactoryModels();
+        internal HashSet<CSharpType> BuildModelFactoryModels()
+        {
+            var result = new HashSet<CSharpType>();
+            foreach (var inputModel in ManagementClientGenerator.Instance.InputLibrary.InputNamespace.Models)
+            {
+                var model = ManagementClientGenerator.Instance.TypeFactory.CreateModel(inputModel);
+                if (model is not null && model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public) && model.Properties.Any(prop => !prop.Body.HasSetter))
+                {
+                    result.Add(model.Type);
+                }
+            }
+            return result;
+        }
+
+        internal bool IsModelFactoryModelType(CSharpType type) => ModelFactoryModels.Contains(type);
 
         private HashSet<CSharpType> BuildResourceModels()
         {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -48,14 +48,18 @@ namespace Azure.Generator.Management
 
         private static bool IsModelFactoryModel(ModelProvider model)
         {
-            return model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public) && EnumerateAllProperties(model).Any(prop => !prop.Body.HasSetter);
+            // A model is a model factory model if it is public and it has at least one public property without a setter.
+            return model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public) && EnumerateAllPublicProperties(model).Any(prop => !prop.Body.HasSetter);
 
-            IEnumerable<PropertyProvider> EnumerateAllProperties(ModelProvider current)
+            IEnumerable<PropertyProvider> EnumerateAllPublicProperties(ModelProvider current)
             {
                 var currentModel = current;
                 foreach (var property in currentModel.Properties)
                 {
-                    yield return property;
+                    if (property.Modifiers.HasFlag(MethodSignatureModifiers.Public))
+                    {
+                        yield return property;
+                    }
                 }
 
                 while (currentModel.BaseModelProvider is not null)
@@ -63,7 +67,10 @@ namespace Azure.Generator.Management
                     currentModel = currentModel.BaseModelProvider;
                     foreach (var property in currentModel.Properties)
                     {
-                        yield return property;
+                        if (property.Modifiers.HasFlag(MethodSignatureModifiers.Public))
+                        {
+                            yield return property;
+                        }
                     }
                 }
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.ClientModel;
+using Microsoft.TypeSpec.Generator.Providers;
+using System.Collections.Generic;
+
+namespace Azure.Generator.Management.Visitors
+{
+    internal class ModelFactoryVisitor : ScmLibraryVisitor
+    {
+        protected override TypeProvider? VisitType(TypeProvider type)
+        {
+            if (type is ModelFactoryProvider modelFactory)
+            {
+                var updatedMethods = new List<MethodProvider>();
+                foreach (var method in modelFactory.Methods)
+                {
+                    var returnType = method.Signature.ReturnType;
+                    if (returnType is not null && ManagementClientGenerator.Instance.OutputLibrary.IsModelFactoryModelType(returnType))
+                    {
+                        updatedMethods.Add(method);
+                    }
+                }
+                modelFactory.Update(methods: updatedMethods);
+                return modelFactory;
+            }
+            return base.VisitType(type);
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SafeFlattenVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SafeFlattenVisitor.cs
@@ -16,7 +16,6 @@ namespace Azure.Generator.Management.Visitors
     internal class SafeFlattenVisitor : ScmLibraryVisitor
     {
         private Dictionary<ModelProvider, (HashSet<PropertyProvider> FlattenedProperties, HashSet<PropertyProvider> InternalizedProperties)> _flattenedModels = new();
-        private HashSet<CSharpType> _flattenedTypes = new();
 
         // TODO: we can't check property count of property types in VisitType since we don't have TypeProvider from CSharpType.
         // Once we have CSharpType to TypeProvider mapping, we can remove this and have this logic in VisitType instead
@@ -43,7 +42,6 @@ namespace Azure.Generator.Management.Visitors
                         // make the current property internal
                         var internalSingleProperty = type!.Properties.Single(p => p.Type.AreNamesEqual(propertyTypeProvider.Type)); // type equal not working here, so we use AreNamesEqual
                         internalizedProperties.Add(internalSingleProperty);
-                        _flattenedTypes.Add(propertyTypeProvider.Type!);
 
                         // flatten the single property to public and associate it with the internal property
                         var flattenPropertyName = $"{singleProperty.Name}"; // TODO: handle name conflicts
@@ -83,11 +81,6 @@ namespace Azure.Generator.Management.Visitors
                 }
             }
 
-            // Since we make the properties with flattend types internal, the flattened types will be internalized during post processing, We need to keep the flattened types public
-            if (_flattenedTypes.Any(x => x.AreNamesEqual(type.Type)))
-            {
-                ManagementClientGenerator.Instance.AddTypeToKeep(type);
-            }
             return base.VisitType(type);
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SafeFlattenVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SafeFlattenVisitor.cs
@@ -125,10 +125,13 @@ namespace Azure.Generator.Management.Visitors
             if (updated)
             {
                 method.Signature.Update(parameters: updatedParameters);
+
+                // The model factory method return a new instance of the model type, update the constructor arguments with the flattened properties of internalized properties.
                 var instanceExpression = (method.BodyStatements?.OfType<ExpressionStatement>().Single()?.Expression as KeywordExpression)?.Expression as NewInstanceExpression;
                 var updatedInstanceParamters = new List<ValueExpression>(instanceExpression!.Parameters.Count);
                 foreach (var instanceParemter in instanceExpression!.Parameters)
                 {
+                    // If the instance parameter is a variable expression, we can check if it is a flattened property and update it accordingly.
                     if (instanceParemter is VariableExpression variable && propertyMap.TryGetValue(variable.Type, out var flattenedProperty))
                     {
                         updatedInstanceParamters.Add(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SafeFlattenVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SafeFlattenVisitor.cs
@@ -7,6 +7,7 @@ using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Statements;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
@@ -15,7 +16,8 @@ namespace Azure.Generator.Management.Visitors
 {
     internal class SafeFlattenVisitor : ScmLibraryVisitor
     {
-        private Dictionary<ModelProvider, (HashSet<PropertyProvider> FlattenedProperties, HashSet<PropertyProvider> InternalizedProperties)> _flattenedModels = new();
+        private readonly Dictionary<ModelProvider, (HashSet<PropertyProvider> FlattenedProperties, HashSet<PropertyProvider> InternalizedProperties)> _flattenedModels = new();
+        private readonly Dictionary<CSharpType, Dictionary<CSharpType, PropertyProvider>> _flattenedModelTypes = new();
 
         // TODO: we can't check property count of property types in VisitType since we don't have TypeProvider from CSharpType.
         // Once we have CSharpType to TypeProvider mapping, we can remove this and have this logic in VisitType instead
@@ -26,6 +28,7 @@ namespace Azure.Generator.Management.Visitors
                 return null;
             }
 
+            var flattenedPropertyMap = new Dictionary<CSharpType, PropertyProvider>();
             var flattenedProperties = new HashSet<PropertyProvider>();
             var internalizedProperties = new HashSet<PropertyProvider>();
             foreach (var property in model.Properties)
@@ -58,19 +61,96 @@ namespace Azure.Generator.Management.Visitors
                             });
                         var flattenedProperty = new PropertyProvider(singleProperty.Description, singleProperty.Modifiers, singleProperty.Type, flattenPropertyName, flattenPropertyBody, type, singleProperty.ExplicitInterface, singleProperty.WireInfo, singleProperty.Attributes);
                         flattenedProperties.Add(flattenedProperty);
+                        flattenedPropertyMap.Add(internalSingleProperty.Type, flattenedProperty);
                     }
                 }
             }
             if (flattenedProperties.Count > 0)
             {
                 _flattenedModels[type!] = (flattenedProperties, internalizedProperties);
+                _flattenedModelTypes.Add(type.Type, flattenedPropertyMap);
             }
             return base.PreVisitModel(model, type);
         }
 
         protected override TypeProvider? VisitType(TypeProvider type)
         {
-            if (type is ModelProvider model && _flattenedModels.TryGetValue(model, out var value))
+            if (type is ModelProvider model)
+            {
+                UpdateModel(type, model);
+            }
+
+            if (type is ModelFactoryProvider modelFactory)
+            {
+                // If this is a model factory, we need to ensure that the flattened properties are also included in the factory methods.
+                UpdateModelFactory(modelFactory);
+            }
+
+            return base.VisitType(type);
+        }
+
+        private void UpdateModelFactory(ModelFactoryProvider modelFactory)
+        {
+            foreach (var method in modelFactory.Methods)
+            {
+                var returnType = method.Signature.ReturnType;
+                if (returnType is not null && _flattenedModelTypes.TryGetValue(returnType, out var value))
+                {
+                    UpdateModelFactoryMethod(method, returnType, value);
+                }
+            }
+        }
+
+        private void UpdateModelFactoryMethod(MethodProvider method, CSharpType returnType, Dictionary<CSharpType, PropertyProvider> propertyMap)
+        {
+            var updatedParameters = new List<ParameterProvider>(method.Signature.Parameters.Count);
+            var updated = false;
+            foreach (var parameter in method.Signature.Parameters)
+            {
+                if (propertyMap.TryGetValue(parameter.Type, out var flattenedProperty))
+                {
+                    updated = true;
+                    var updatedParameter = flattenedProperty.AsParameter;
+                    if (flattenedProperty.Type.IsNullable)
+                    {
+                        updatedParameter.DefaultValue = Default; // Ensure that the default value is set to null for nullable types
+                    }
+                    updatedParameters.Add(updatedParameter);
+                }
+                else
+                {
+                    updatedParameters.Add(parameter);
+                }
+            }
+            if (updated)
+            {
+                method.Signature.Update(parameters: updatedParameters);
+                var instanceExpression = (method.BodyStatements?.OfType<ExpressionStatement>().Single()?.Expression as KeywordExpression)?.Expression as NewInstanceExpression;
+                var updatedInstanceParamters = new List<ValueExpression>(instanceExpression!.Parameters.Count);
+                foreach (var instanceParemter in instanceExpression!.Parameters)
+                {
+                    if (instanceParemter is VariableExpression variable && propertyMap.TryGetValue(variable.Type, out var flattenedProperty))
+                    {
+                        updatedInstanceParamters.Add(
+                            new TernaryConditionalExpression(
+                                flattenedProperty.AsParameter.Is(Null),
+                                Default,
+                                New.Instance(
+                                    variable.Type,
+                                    [flattenedProperty.AsParameter, New.Instance(new CSharpType(typeof(Dictionary<,>), typeof(string), typeof(BinaryData)))]))); // TODO: handle additional parameters properly or should it be nullable?
+                    }
+                    else
+                    {
+                        updatedInstanceParamters.Add(instanceParemter);
+                    }
+                }
+                method.Update(signature: method.Signature, bodyStatements: Return(New.Instance(instanceExpression.Type!, updatedInstanceParamters)));
+            }
+        }
+
+        private void UpdateModel(TypeProvider type, ModelProvider model)
+        {
+            if (_flattenedModels.TryGetValue(model, out var value))
             {
                 var (flattenedProperties, internalizedProperties) = value;
                 type.Update(properties: [.. type.Properties, .. flattenedProperties]);
@@ -80,8 +160,6 @@ namespace Azure.Generator.Management.Visitors
                     internalProperty.Update(modifiers: internalProperty.Modifiers & ~MethodSignatureModifiers.Public | MethodSignatureModifiers.Internal);
                 }
             }
-
-            return base.VisitType(type);
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecModelFactory.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Azure.Core;
 using Azure.ResourceManager.Models;
-using Azure.ResourceManager.Resources.Models;
 using MgmtTypeSpec;
 
 namespace MgmtTypeSpec.Models
@@ -19,68 +18,6 @@ namespace MgmtTypeSpec.Models
     public static partial class MgmtTypeSpecModelFactory
     {
 
-        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
-        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
-        /// <param name="name"> The name of the resource. </param>
-        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
-        /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
-        /// <param name="tags"> Resource tags. </param>
-        /// <param name="location"> The geo-location where the resource lives. </param>
-        /// <param name="properties"> The resource-specific properties for this resource. </param>
-        /// <param name="extendedLocation"></param>
-        /// <returns> A new <see cref="MgmtTypeSpec.FooData"/> instance for mocking. </returns>
-        public static FooData FooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, string location = default, FooProperties properties = default, ExtendedLocation extendedLocation = default)
-        {
-            tags ??= new ChangeTrackingDictionary<string, string>();
-
-            return new FooData(
-                id,
-                name,
-                resourceType,
-                systemData,
-                additionalBinaryDataProperties: null,
-                tags,
-                location,
-                properties,
-                extendedLocation);
-        }
-
-        /// <summary> The FooProperties. </summary>
-        /// <param name="serviceUri"> the service url. </param>
-        /// <param name="something"> something. </param>
-        /// <param name="boolValue"> boolean value. </param>
-        /// <param name="floatValue"> float value. </param>
-        /// <param name="doubleValue"> double value. </param>
-        /// <returns> A new <see cref="Models.FooProperties"/> instance for mocking. </returns>
-        public static FooProperties FooProperties(Uri serviceUri = default, string something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default)
-        {
-            return new FooProperties(
-                serviceUri,
-                something,
-                boolValue,
-                floatValue,
-                doubleValue,
-                additionalBinaryDataProperties: null);
-        }
-
-        /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
-        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
-        /// <param name="name"> The name of the resource. </param>
-        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
-        /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
-        /// <param name="properties"> The resource-specific properties for this resource. </param>
-        /// <returns> A new <see cref="MgmtTypeSpec.FooSettingsData"/> instance for mocking. </returns>
-        public static FooSettingsData FooSettingsData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, FooSettingsProperties properties = default)
-        {
-            return new FooSettingsData(
-                id,
-                name,
-                resourceType,
-                systemData,
-                additionalBinaryDataProperties: null,
-                properties);
-        }
-
         /// <summary> The FooSettingsProperties. </summary>
         /// <param name="accessControlEnabled"></param>
         /// <param name="provisioningState"></param>
@@ -88,90 +25,6 @@ namespace MgmtTypeSpec.Models
         public static FooSettingsProperties FooSettingsProperties(bool accessControlEnabled = default, ResourceProvisioningState? provisioningState = default)
         {
             return new FooSettingsProperties(accessControlEnabled, provisioningState, additionalBinaryDataProperties: null);
-        }
-
-        /// <summary> The type used for update operations of the FooSettings. </summary>
-        /// <param name="properties"> The resource-specific properties for this resource. </param>
-        /// <returns> A new <see cref="Models.FooSettingsPatch"/> instance for mocking. </returns>
-        public static FooSettingsPatch FooSettingsPatch(FooSettingsUpdateProperties properties = default)
-        {
-            return new FooSettingsPatch(properties, additionalBinaryDataProperties: null);
-        }
-
-        /// <summary> The updatable properties of the FooSettings. </summary>
-        /// <param name="accessControlEnabled"></param>
-        /// <returns> A new <see cref="Models.FooSettingsUpdateProperties"/> instance for mocking. </returns>
-        public static FooSettingsUpdateProperties FooSettingsUpdateProperties(bool? accessControlEnabled = default)
-        {
-            return new FooSettingsUpdateProperties(accessControlEnabled, additionalBinaryDataProperties: null);
-        }
-
-        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
-        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
-        /// <param name="name"> The name of the resource. </param>
-        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
-        /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
-        /// <param name="tags"> Resource tags. </param>
-        /// <param name="location"> The geo-location where the resource lives. </param>
-        /// <param name="properties"> The resource-specific properties for this resource. </param>
-        /// <returns> A new <see cref="MgmtTypeSpec.BarData"/> instance for mocking. </returns>
-        public static BarData BarData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, string location = default, BarProperties properties = default)
-        {
-            tags ??= new ChangeTrackingDictionary<string, string>();
-
-            return new BarData(
-                id,
-                name,
-                resourceType,
-                systemData,
-                additionalBinaryDataProperties: null,
-                tags,
-                location,
-                properties);
-        }
-
-        /// <summary> The BarProperties. </summary>
-        /// <param name="serviceUri"> the service url. </param>
-        /// <param name="something"> something. </param>
-        /// <param name="boolValue"> boolean value. </param>
-        /// <param name="floatValue"> float value. </param>
-        /// <param name="doubleValue"> double value. </param>
-        /// <returns> A new <see cref="Models.BarProperties"/> instance for mocking. </returns>
-        public static BarProperties BarProperties(Uri serviceUri = default, string something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default)
-        {
-            return new BarProperties(
-                serviceUri,
-                something,
-                boolValue,
-                floatValue,
-                doubleValue,
-                additionalBinaryDataProperties: null);
-        }
-
-        /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
-        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
-        /// <param name="name"> The name of the resource. </param>
-        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
-        /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
-        /// <param name="properties"> The resource-specific properties for this resource. </param>
-        /// <returns> A new <see cref="MgmtTypeSpec.BarSettingsData"/> instance for mocking. </returns>
-        public static BarSettingsData BarSettingsData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, BarSettingsProperties properties = default)
-        {
-            return new BarSettingsData(
-                id,
-                name,
-                resourceType,
-                systemData,
-                additionalBinaryDataProperties: null,
-                properties);
-        }
-
-        /// <summary> The BarSettingsProperties. </summary>
-        /// <param name="isEnabled"> enabled. </param>
-        /// <returns> A new <see cref="Models.BarSettingsProperties"/> instance for mocking. </returns>
-        public static BarSettingsProperties BarSettingsProperties(bool? isEnabled = default)
-        {
-            return new BarSettingsProperties(isEnabled, additionalBinaryDataProperties: null);
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecModelFactory.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Azure.Core;
 using Azure.ResourceManager.Models;
+using Azure.ResourceManager.Resources.Models;
 using MgmtTypeSpec;
 
 namespace MgmtTypeSpec.Models
@@ -18,6 +19,50 @@ namespace MgmtTypeSpec.Models
     public static partial class MgmtTypeSpecModelFactory
     {
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
+        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
+        /// <param name="name"> The name of the resource. </param>
+        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
+        /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="location"> The geo-location where the resource lives. </param>
+        /// <param name="properties"> The resource-specific properties for this resource. </param>
+        /// <param name="extendedLocation"></param>
+        /// <returns> A new <see cref="MgmtTypeSpec.FooData"/> instance for mocking. </returns>
+        public static FooData FooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, string location = default, FooProperties properties = default, ExtendedLocation extendedLocation = default)
+        {
+            tags ??= new ChangeTrackingDictionary<string, string>();
+
+            return new FooData(
+                id,
+                name,
+                resourceType,
+                systemData,
+                additionalBinaryDataProperties: null,
+                tags,
+                location,
+                properties,
+                extendedLocation);
+        }
+
+        /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
+        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
+        /// <param name="name"> The name of the resource. </param>
+        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
+        /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
+        /// <param name="properties"> The resource-specific properties for this resource. </param>
+        /// <returns> A new <see cref="MgmtTypeSpec.FooSettingsData"/> instance for mocking. </returns>
+        public static FooSettingsData FooSettingsData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, FooSettingsProperties properties = default)
+        {
+            return new FooSettingsData(
+                id,
+                name,
+                resourceType,
+                systemData,
+                additionalBinaryDataProperties: null,
+                properties);
+        }
+
         /// <summary> The FooSettingsProperties. </summary>
         /// <param name="accessControlEnabled"></param>
         /// <param name="provisioningState"></param>
@@ -25,6 +70,47 @@ namespace MgmtTypeSpec.Models
         public static FooSettingsProperties FooSettingsProperties(bool accessControlEnabled = default, ResourceProvisioningState? provisioningState = default)
         {
             return new FooSettingsProperties(accessControlEnabled, provisioningState, additionalBinaryDataProperties: null);
+        }
+
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
+        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
+        /// <param name="name"> The name of the resource. </param>
+        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
+        /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="location"> The geo-location where the resource lives. </param>
+        /// <param name="properties"> The resource-specific properties for this resource. </param>
+        /// <returns> A new <see cref="MgmtTypeSpec.BarData"/> instance for mocking. </returns>
+        public static BarData BarData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, string location = default, BarProperties properties = default)
+        {
+            tags ??= new ChangeTrackingDictionary<string, string>();
+
+            return new BarData(
+                id,
+                name,
+                resourceType,
+                systemData,
+                additionalBinaryDataProperties: null,
+                tags,
+                location,
+                properties);
+        }
+
+        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
+        /// <param name="name"> The name of the resource. </param>
+        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
+        /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
+        /// <param name="isEnabled"> enabled. </param>
+        /// <returns> A new <see cref="MgmtTypeSpec.BarSettingsData"/> instance for mocking. </returns>
+        public static BarSettingsData BarSettingsData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, bool? isEnabled = default)
+        {
+            return new BarSettingsData(
+                id,
+                name,
+                resourceType,
+                systemData,
+                additionalBinaryDataProperties: null,
+                isEnabled is null ? default : new BarSettingsProperties(isEnabled, new Dictionary<string, BinaryData>()));
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/BarSettingsProperties.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/BarSettingsProperties.Serialization.cs
@@ -14,7 +14,7 @@ using MgmtTypeSpec;
 namespace MgmtTypeSpec.Models
 {
     /// <summary> The BarSettingsProperties. </summary>
-    public partial class BarSettingsProperties : IJsonModel<BarSettingsProperties>
+    internal partial class BarSettingsProperties : IJsonModel<BarSettingsProperties>
     {
         /// <param name="writer"> The JSON writer. </param>
         /// <param name="options"> The client options for reading and writing models. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/BarSettingsProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/BarSettingsProperties.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 namespace MgmtTypeSpec.Models
 {
     /// <summary> The BarSettingsProperties. </summary>
-    public partial class BarSettingsProperties
+    internal partial class BarSettingsProperties
     {
         /// <summary> Keeps track of any properties unknown to the library. </summary>
         private protected readonly IDictionary<string, BinaryData> _additionalBinaryDataProperties;

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooSettingsUpdateProperties.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooSettingsUpdateProperties.Serialization.cs
@@ -14,7 +14,7 @@ using MgmtTypeSpec;
 namespace MgmtTypeSpec.Models
 {
     /// <summary> The updatable properties of the FooSettings. </summary>
-    public partial class FooSettingsUpdateProperties : IJsonModel<FooSettingsUpdateProperties>
+    internal partial class FooSettingsUpdateProperties : IJsonModel<FooSettingsUpdateProperties>
     {
         /// <param name="writer"> The JSON writer. </param>
         /// <param name="options"> The client options for reading and writing models. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooSettingsUpdateProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooSettingsUpdateProperties.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 namespace MgmtTypeSpec.Models
 {
     /// <summary> The updatable properties of the FooSettings. </summary>
-    public partial class FooSettingsUpdateProperties
+    internal partial class FooSettingsUpdateProperties
     {
         /// <summary> Keeps track of any properties unknown to the library. </summary>
         private protected readonly IDictionary<string, BinaryData> _additionalBinaryDataProperties;


### PR DESCRIPTION
- For MPG, ModelFactory should only contains methods for public models with non-settable properties.
- Remove forcing public modifier for safe-flatten property types, fix the methods with safe-flatten types
