### PR TITLE
[Identity] Broker release prep

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Other Changes
 
-- Updated `Azure.Identity` to 1.14.2 to apply a security fix in the updated Microsoft.Identity.Client` dependency.
+- Updated `Azure.Identity` to 1.14.2 to apply a security fix in the updated `Microsoft.Identity.Client` dependency.
 
 ## 1.3.0-beta.3 (2025-06-10)
 

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 1.3.0-beta.4 (Unreleased)
+## 1.3.0-beta.4 (2025-07-11)
 
 ### Features Added
 
 - Support Microsoft Broker on macOS.
 
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
+
+- Updated `Azure.Identity` to 1.14.2 to apply a security fix in the updated Microsoft.Identity.Client` dependency.
 
 ## 1.3.0-beta.3 (2025-06-10)
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.15.0-beta.1
 
 ### Features Added
+
 - Expanded the set of acceptable values for environment variable `AZURE_TOKEN_CREDENTIALS` to allow for selection of a specific credential in the `DefaultAzureCredential` chain. The valid values now include any of the credential names available in the default chain (`VisualStudioCredential`, `VisualStudioCodeCredential`, `AzureCliCredential`, `AzurePowerShellCredential`, `AzureDeveloperCliCredential`, `EnvironmentCredential`, `WorkloadIdentityCredential`, `ManagedIdentityCredential`, `InteractiveBrowserCredential`, or `BrokerAuthenticationCredential`.) **Note:** `BrokerAuthenticationCredential` requires that the project include a reference to package Azure.Identity.Broker.
 
 ### Breaking Changes
@@ -20,7 +21,8 @@
 ## 1.14.2 (2025-07-10)
 
 ### Other changes
-- Updated `Microsoft.Identity.Client` dependency to version 4.73.1
+
+- Updated `Microsoft.Identity.Client` dependency to version 4.73.1 to take a security fix.
 
 ## 1.14.1 (2025-06-24)
 


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Azure.Identity.Broker package for a new beta  release, needed to apply a security fix from the transitive MSAL dependency.

## References and resources

- [Azure.Identity version bump](https://github.com/Azure/azure-sdk-for-net/pull/51211)