### PR TITLE
SDK MCP Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ ipch/
 # VS Code
 **/.vscode/*
 !.vscode/cspell.json
+!.vscode/mcp.json
 
 # Code analysis
 *.CodeAnalysisLog.xml

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{  
+    "servers": {
+      "azure-sdk-mcp": {
+        "type": "stdio",
+        "command": "pwsh",        
+        "args": ["${workspaceFolder}/eng/common/mcp/azure-sdk-mcp.ps1", "-Run"]
+    },
+  }
+} 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -2,7 +2,7 @@
     "servers": {
       "azure-sdk-mcp": {
         "type": "stdio",
-        "command": "pwsh",        
+        "command": "pwsh",
         "args": ["${workspaceFolder}/eng/common/mcp/azure-sdk-mcp.ps1", "-Run"]
     },
   }


### PR DESCRIPTION
- Enable SDK MCP server so TypeSpec workflow can be started from language repo. This will also enable language team to use package readiness and release SDK tool.