### PR TITLE
[EngSys] Update Analyzers version

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -124,6 +124,16 @@
       AZC0012; <!-- Single word class names -->
       AZC0008;
       SCM0005; <!-- Resources currently do not have a parameterless ctor so builders cannot be created for them -->
+
+      <!--
+        Temporarily disable warnings from new analyzers:
+          AZC0034: Typename is already used in another library.
+          AZC0035: Missing model factory method
+
+        Tracked by # 51312
+      -->
+      AZC0034;
+      AZC0035;
     </NoWarn>
   </PropertyGroup>
 

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -294,7 +294,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20250728.3" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20250422.1" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20250715.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <!-- Note: Upgrading the .NET SDK version needs to be synchronized with the autorest.csharp repository -->
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="All"/>

--- a/eng/globalconfigs/disable_enhanced_analysis.globalconfig
+++ b/eng/globalconfigs/disable_enhanced_analysis.globalconfig
@@ -6,3 +6,5 @@ dotnet_diagnostic.AZC0030.severity = none
 dotnet_diagnostic.AZC0031.severity = none
 dotnet_diagnostic.AZC0032.severity = none
 dotnet_diagnostic.AZC0033.severity = none
+dotnet_diagnostic.AZC0034.severity = none
+dotnet_diagnostic.AZC0036.severity = none

--- a/sdk/ai/Azure.AI.Inference/src/Azure.AI.Inference.csproj
+++ b/sdk/ai/Azure.AI.Inference/src/Azure.AI.Inference.csproj
@@ -5,7 +5,7 @@
     <Version>1.0.0-beta.6</Version>
     <PackageTags>Azure Inference</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591;AZC0030;AZC0031</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;AZC0030;AZC0031;AZC0035;AZC0034</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/ai/Azure.AI.Projects/api/Azure.AI.Projects.net8.0.cs
+++ b/sdk/ai/Azure.AI.Projects/api/Azure.AI.Projects.net8.0.cs
@@ -90,13 +90,13 @@ namespace Azure.AI.Projects
         protected AIProjectClient() : base (default(int)) { }
         public AIProjectClient(System.Uri endpoint, Azure.Core.TokenCredential credential = null) : base (default(int)) { }
         public AIProjectClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.AI.Projects.AIProjectClientOptions options) : base (default(int)) { }
-        public Azure.AI.Projects.Connections Connections { get { throw null; } }
-        public Azure.AI.Projects.Datasets Datasets { get { throw null; } }
-        public Azure.AI.Projects.Deployments Deployments { get { throw null; } }
-        public Azure.AI.Projects.Evaluations Evaluations { get { throw null; } }
-        public Azure.AI.Projects.Indexes Indexes { get { throw null; } }
+        public virtual Azure.AI.Projects.Connections Connections { get { throw null; } }
+        public virtual Azure.AI.Projects.Datasets Datasets { get { throw null; } }
+        public virtual Azure.AI.Projects.Deployments Deployments { get { throw null; } }
+        public virtual Azure.AI.Projects.Evaluations Evaluations { get { throw null; } }
+        public virtual Azure.AI.Projects.Indexes Indexes { get { throw null; } }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
-        public Azure.AI.Projects.Telemetry Telemetry { get { throw null; } }
+        public virtual Azure.AI.Projects.Telemetry Telemetry { get { throw null; } }
         public override System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> GetAllConnections() { throw null; }
         public OpenAI.Chat.ChatClient GetAzureOpenAIChatClient(string? connectionName = null, string? apiVersion = null, string? deploymentName = null) { throw null; }
         public OpenAI.Embeddings.EmbeddingClient GetAzureOpenAIEmbeddingClient(string? connectionName = null, string? apiVersion = null, string? deploymentName = null) { throw null; }

--- a/sdk/ai/Azure.AI.Projects/api/Azure.AI.Projects.netstandard2.0.cs
+++ b/sdk/ai/Azure.AI.Projects/api/Azure.AI.Projects.netstandard2.0.cs
@@ -90,13 +90,13 @@ namespace Azure.AI.Projects
         protected AIProjectClient() : base (default(int)) { }
         public AIProjectClient(System.Uri endpoint, Azure.Core.TokenCredential credential = null) : base (default(int)) { }
         public AIProjectClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.AI.Projects.AIProjectClientOptions options) : base (default(int)) { }
-        public Azure.AI.Projects.Connections Connections { get { throw null; } }
-        public Azure.AI.Projects.Datasets Datasets { get { throw null; } }
-        public Azure.AI.Projects.Deployments Deployments { get { throw null; } }
-        public Azure.AI.Projects.Evaluations Evaluations { get { throw null; } }
-        public Azure.AI.Projects.Indexes Indexes { get { throw null; } }
+        public virtual Azure.AI.Projects.Connections Connections { get { throw null; } }
+        public virtual Azure.AI.Projects.Datasets Datasets { get { throw null; } }
+        public virtual Azure.AI.Projects.Deployments Deployments { get { throw null; } }
+        public virtual Azure.AI.Projects.Evaluations Evaluations { get { throw null; } }
+        public virtual Azure.AI.Projects.Indexes Indexes { get { throw null; } }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
-        public Azure.AI.Projects.Telemetry Telemetry { get { throw null; } }
+        public virtual Azure.AI.Projects.Telemetry Telemetry { get { throw null; } }
         public override System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> GetAllConnections() { throw null; }
         public OpenAI.Chat.ChatClient GetAzureOpenAIChatClient(string? connectionName = null, string? apiVersion = null, string? deploymentName = null) { throw null; }
         public OpenAI.Embeddings.EmbeddingClient GetAzureOpenAIEmbeddingClient(string? connectionName = null, string? apiVersion = null, string? deploymentName = null) { throw null; }

--- a/sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj
+++ b/sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj
@@ -7,7 +7,19 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>true</GenerateAPIListing>
-    <NoWarn>$(NoWarn);CS1591;AZC0012;SA1649;SA1402;</NoWarn>
+    <LangVersion>latest</LangVersion>
+    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>
+        $(NoWarn);
+        CS1591;
+        AZC0012;
+        SA1649;
+        SA1402;
+        AZC0035; <!-- Missing model factory methods. #51265-->
+    </NoWarn>
     <!--
       Suppression of OPENAI001 handles temporary [Experimental] leakage from OpenAI library internals for generated MRWContext.
       The longer-term fix is tracked along with:
@@ -15,8 +27,6 @@
         - https://github.com/Azure/autorest.csharp/issues/5364
     -->
     <NoWarn>$(NoWarn);OPENAI001;</NoWarn>
-    <LangVersion>latest</LangVersion>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/attestation/Azure.Security.Attestation/src/Azure.Security.Attestation.csproj
+++ b/sdk/attestation/Azure.Security.Attestation/src/Azure.Security.Attestation.csproj
@@ -9,6 +9,7 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/batch/Azure.Compute.Batch/src/Azure.Compute.Batch.csproj
+++ b/sdk/batch/Azure.Compute.Batch/src/Azure.Compute.Batch.csproj
@@ -6,6 +6,7 @@
     <PackageTags>Azure.Compute.Batch</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0034;AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Azure.AI.Language.Conversations.csproj
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Azure.AI.Language.Conversations.csproj
@@ -8,6 +8,7 @@
     <PackageTags>Azure AI Language Conversations</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0034;AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Azure.AI.Language.QuestionAnswering.csproj
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Azure.AI.Language.QuestionAnswering.csproj
@@ -10,6 +10,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);EXPERIMENTAL</DefineConstants>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text/samples/Sample5_AnalyzeText_RecognizePiiEntities.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text/samples/Sample5_AnalyzeText_RecognizePiiEntities.md
@@ -152,7 +152,7 @@ foreach (DocumentError analyzeTextDocumentError in piiTaskResult.Results.Errors)
 }
 ```
 
-The new features — `ValueExclusion`, `Synonyms`, and `new entity types` — are supported in version V2025_05_15_Preview or later.
+The new features ï¿½ `ValueExclusion`, `Synonyms`, and `new entity types` ï¿½ are supported in version V2025_05_15_Preview or later.
 ```C#
 Uri endpoint = new Uri("{endpoint}");
 AzureKeyCredential credential = new AzureKeyCredential("{api-key}");

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text/src/Azure.AI.Language.Text.csproj
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text/src/Azure.AI.Language.Text.csproj
@@ -6,6 +6,7 @@
     <PackageTags>Azure Text</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0034;AZC0035</NoWarn>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Azure.Communication.CallAutomation.csproj
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Azure.Communication.CallAutomation.csproj
@@ -11,6 +11,7 @@
     <PackageTags>Microsoft Azure Communication CallAutomation Service;Microsoft;Azure;Azure Communication Service;Azure Communication CallAutomation Service;Calling;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/communication/Azure.Communication.Identity/src/Azure.Communication.Identity.csproj
+++ b/sdk/communication/Azure.Communication.Identity/src/Azure.Communication.Identity.csproj
@@ -12,6 +12,7 @@
     <PackageTags>Microsoft Azure Communication Identity Service;Microsoft;Azure;Azure Communication Service;Azure Communication Identity Service;Identity;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,7 +27,7 @@
   <ItemGroup>
     <Compile Include="..\..\Shared\src\ClientOptionsExtensions.cs" LinkBase="Shared\Communication" />
     <Compile Include="..\..\Shared\src\HMACAuthenticationPolicy.cs" LinkBase="Shared\Communication" />
-    <Compile Include="..\..\Shared\Properties\CommunicationAssembyInfo.cs" LinkBase="Shared\Communication" />    
+    <Compile Include="..\..\Shared\Properties\CommunicationAssembyInfo.cs" LinkBase="Shared\Communication" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" LinkBase="Shared" />

--- a/sdk/communication/Azure.Communication.JobRouter/src/Azure.Communication.JobRouter.csproj
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Azure.Communication.JobRouter.csproj
@@ -14,6 +14,7 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/communication/Azure.Communication.Messages/src/Azure.Communication.Messages.csproj
+++ b/sdk/communication/Azure.Communication.Messages/src/Azure.Communication.Messages.csproj
@@ -11,8 +11,7 @@
     <PackageTags>Microsoft Azure Communication Messages Service;Microsoft;Azure;Azure Communication Service;Azure Communication Messages Service;Messages;Communication</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <NoWarn>$(NoWarn);AZC0007</NoWarn>
-    <NoWarn>$(NoWarn);AZC0030</NoWarn>
+    <NoWarn>$(NoWarn);AZC0007;AZC0030;AZC0034</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/communication/Azure.Communication.ShortCodes/src/Azure.Communication.ShortCodes.csproj
+++ b/sdk/communication/Azure.Communication.ShortCodes/src/Azure.Communication.ShortCodes.csproj
@@ -9,6 +9,7 @@
     <PackageTags>Microsoft Azure Communication Short Codes Service;Microsoft;Azure;Azure Communication Service;Azure Communication Short Codes Service;Short Codes;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Azure.Security.CodeTransparency.csproj
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Azure.Security.CodeTransparency.csproj
@@ -6,6 +6,7 @@
     <PackageTags>Azure.Security.CodeTransparency;scitt;cose;ccf;receipt;countersignature;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0034;AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
@@ -8,6 +8,7 @@
     <PackageTags>Azure ConfidentialLedger</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <DefineConstants>$(DefineConstants)</DefineConstants>
+    <NoWarn>$(NoWarn);AZC0034;AZC0035</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
@@ -19,7 +20,7 @@
     <PackageReference Include="Azure.Core" />
   </ItemGroup>
 
-<!-- Shared source from Azure.Core -->
+  <!-- Shared source from Azure.Core -->
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)AzureKeyCredentialPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Azure.Containers.ContainerRegistry.csproj
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Azure.Containers.ContainerRegistry.csproj
@@ -8,6 +8,7 @@
     <PackageTags>Azure Container Registry;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Azure.Developer.DevCenter.csproj
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Azure.Developer.DevCenter.csproj
@@ -8,6 +8,7 @@
     <PackageTags>Azure DevCenter</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC003;AZC0034</NoWarn>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/documentintelligence/Azure.AI.DocumentIntelligence/src/Azure.AI.DocumentIntelligence.csproj
+++ b/sdk/documentintelligence/Azure.AI.DocumentIntelligence/src/Azure.AI.DocumentIntelligence.csproj
@@ -8,6 +8,7 @@
     <PackageTags>Microsoft Azure Document Intelligence Cognitive Services Applied AI Form Recognizer</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0034;</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/easm/Azure.Analytics.Defender.Easm/src/Azure.Analytics.Defender.Easm.csproj
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/src/Azure.Analytics.Defender.Easm.csproj
@@ -6,6 +6,7 @@
     <PackageTags>Azure Easm; Microsoft Defender EASM; EASM API; External Attack Surface Management; REST HTTPclient;</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0034</NoWarn>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/eventgrid/Azure.Messaging.EventGrid.SystemEvents/src/Azure.Messaging.EventGrid.SystemEvents.csproj
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid.SystemEvents/src/Azure.Messaging.EventGrid.SystemEvents.csproj
@@ -8,6 +8,10 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
+    <NoWarn>
+      $(NoWarn);
+      AZC0034; <!-- Cannot reuse type names; expected due to system event type forwarding. -->
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
@@ -9,6 +9,10 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>
+      $(NoWarn);
+      AZC0034; <!-- Cannot reuse type names; expected due to system event type forwarding. -->
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -21,6 +22,7 @@ namespace Azure.Messaging.EventHubs
     ///   An Event Hubs event, encapsulating a set of data and its associated metadata.
     /// </summary>
     ///
+    [SuppressMessage("Usage", "AZC0034:Type name 'EventData' conflicts with 'EventData (from Azure.Storage.Blobs)'. Consider renaming to 'EventHubsEventDataClient' or 'EventHubsEventDataService' to avoid confusion.", Justification = "Existing name with a stable release.")]
     public class EventData : MessageContent
     {
         /// <summary>The AMQP representation of the event, allowing access to additional protocol data elements not used directly by the Event Hubs client library.</summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessErrorEventArgs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Azure.Core;
 
@@ -14,6 +15,7 @@ namespace Azure.Messaging.EventHubs.Processor
     ///
     /// <seealso href="https://www.nuget.org/packages/Azure.Messaging.EventHubs.Processor">Azure.Messaging.EventHubs.Processor (NuGet)</seealso>
     ///
+    [SuppressMessage("Usage", "AZC0034:Type name 'ProcessErrorEventArgs' conflicts with 'Azure.Messaging.ServiceBus.ProcessErrorEventArgs (from Azure.Messaging.ServiceBus)'. Consider renaming to 'ProcessorProcessErrorEventArgsClient' or 'ProcessorProcessErrorEventArgsService' to avoid confusion.", Justification = "Existing name with a stable release.")]
     public struct ProcessErrorEventArgs
     {
         /// <summary>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
@@ -8,7 +8,7 @@
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.1</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
-    <NoWarn>$(NoWarn);AZC0102</NoWarn>
+    <NoWarn>$(NoWarn);AZC0102;AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Azure.AI.FormRecognizer.csproj
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Azure.AI.FormRecognizer.csproj
@@ -9,6 +9,7 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/iot/Azure.IoT.Hub.Service/src/Azure.IoT.Hub.Service.csproj
+++ b/sdk/iot/Azure.IoT.Hub.Service/src/Azure.IoT.Hub.Service.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableBannedApiAnalyzers>false</EnableBannedApiAnalyzers>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <!-- Nuget properties -->

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/src/Azure.Developer.LoadTesting.csproj
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/src/Azure.Developer.LoadTesting.csproj
@@ -8,6 +8,7 @@
     <PackageTags>Azure LoadTestService</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0034</NoWarn>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/maps/Azure.Maps.Geolocation/src/Azure.Maps.Geolocation.csproj
+++ b/sdk/maps/Azure.Maps.Geolocation/src/Azure.Maps.Geolocation.csproj
@@ -5,7 +5,7 @@
     <Version>1.0.0-beta.4</Version>
     <PackageTags>Azure;Azure Maps;Maps Azure.Maps.Geolocation</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);AZC0012</NoWarn>
+    <NoWarn>$(NoWarn);AZC0012;AZC0035</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/maps/Azure.Maps.Rendering/src/Azure.Maps.Rendering.csproj
+++ b/sdk/maps/Azure.Maps.Rendering/src/Azure.Maps.Rendering.csproj
@@ -5,7 +5,7 @@
     <Version>2.0.0-beta.2</Version>
     <PackageTags>Azure;Azure Maps;Maps Azure.Maps.Rendering</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);AZC0012</NoWarn>
+    <NoWarn>$(NoWarn);AZC0012;AZC0035</NoWarn>
     <AzureMapsSharedSources>$(RepoRoot)/sdk/maps/Azure.Maps.Common/src/</AzureMapsSharedSources>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>

--- a/sdk/maps/Azure.Maps.Routing/src/Azure.Maps.Routing.csproj
+++ b/sdk/maps/Azure.Maps.Routing/src/Azure.Maps.Routing.csproj
@@ -6,8 +6,12 @@
     <PackageTags>Azure;Azure Maps;Maps Azure.Maps.Routing</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);AZC0012</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>
+      $(NoWarn);
+      AZC0012;
+      AZC0035; <!-- Missing model factory methods.  #51231 -->
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/maps/Azure.Maps.Search/src/Azure.Maps.Search.csproj
+++ b/sdk/maps/Azure.Maps.Search/src/Azure.Maps.Search.csproj
@@ -6,9 +6,14 @@
     <PackageTags>Azure;Azure Maps;Maps Azure.Maps.Search</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);AZC0012;CA1835</NoWarn>
     <AzureMapsSharedSources>$(RepoRoot)/sdk/maps/Azure.Maps.Common/src/</AzureMapsSharedSources>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>
+      $(NoWarn);
+      AZC0012;
+      CA1835;
+      AZC0035; <!-- Missing model factory methods.  #51230-->
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/maps/Azure.Maps.TimeZones/src/Azure.Maps.TimeZones.csproj
+++ b/sdk/maps/Azure.Maps.TimeZones/src/Azure.Maps.TimeZones.csproj
@@ -5,9 +5,13 @@
     <Version>1.0.0-beta.2</Version>
     <PackageTags>Azure;Azure Maps;Maps;Azure.Maps.TimeZones</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);AZC0012</NoWarn>
     <AzureMapsSharedSources>$(RepoRoot)/sdk/maps/Azure.Maps.Common/src/</AzureMapsSharedSources>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>
+      $(NoWarn);
+      AZC0012;
+      AZC0035; <!-- Missing model factory methods.  #51229-->
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Azure.AI.MetricsAdvisor.csproj
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Azure.AI.MetricsAdvisor.csproj
@@ -9,6 +9,7 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035;</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
@@ -10,6 +10,7 @@
     <PackageProjectUrl>https://azure.microsoft.com/topic/mixed-reality/</PackageProjectUrl>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/monitor/Azure.Monitor.Query/src/Azure.Monitor.Query.csproj
+++ b/sdk/monitor/Azure.Monitor.Query/src/Azure.Monitor.Query.csproj
@@ -13,9 +13,15 @@
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>
+      $(NoWarn);
+      AZC0035; <!-- Missing model factory methods.  #51228-->
+    </NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="System.Memory.Data" /> <!-- TODO remove after Azure.Core release with updated version -->
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/openai/Azure.AI.OpenAI.Assistants/src/Azure.AI.OpenAI.Assistants.csproj
+++ b/sdk/openai/Azure.AI.OpenAI.Assistants/src/Azure.AI.OpenAI.Assistants.csproj
@@ -10,7 +10,7 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>true</GenerateAPIListing>
-    <NoWarn>$(NoWarn);CS1591;AZC0012</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;AZC0012;AZC0035</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -9,15 +9,28 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>true</GenerateAPIListing>
-    <NoWarn>$(NoWarn);CS1591;AZC0012;AZC0102;CS8002;CS0436;AZC0112;OPENAI001;OPENAI002;AOAI001</NoWarn>
-    <!-- Needs System.ClientModel 1.5.0 in order to add the context and use the new overloads -->
-    <!-- After this https://github.com/Azure/azure-sdk-for-net/issues/49916 we can remove this no warn -->
-    <NoWarn>$(NoWarn);AZC0150</NoWarn>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>disable</Nullable>
     <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>
+        $(NoWarn);
+        CS1591;
+        AZC0012;
+        AZC0102;
+        CS8002;
+        CS0436;
+        AZC0112;
+        OPENAI001;
+        OPENAI002;
+        AOAI001;
+        AZC0150;
+        AZC0035; <!-- Missing model factory methods.  #51226-->
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/personalizer/Azure.AI.Personalizer/src/Azure.AI.Personalizer.csproj
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/Azure.AI.Personalizer.csproj
@@ -10,6 +10,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Azure.Provisioning.AppService.csproj
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Azure.Provisioning.AppService.csproj
@@ -9,7 +9,7 @@
     <LangVersion>12</LangVersion>
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Azure.Provisioning.CognitiveServices.csproj
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Azure.Provisioning.CognitiveServices.csproj
@@ -9,7 +9,7 @@
     <LangVersion>12</LangVersion>
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Azure.Provisioning.CosmosDB.csproj
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Azure.Provisioning.CosmosDB.csproj
@@ -9,7 +9,7 @@
     <LangVersion>12</LangVersion>
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Azure.Provisioning.KeyVault.csproj
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Azure.Provisioning.KeyVault.csproj
@@ -9,7 +9,7 @@
     <LangVersion>12</LangVersion>
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Azure.Provisioning.Kubernetes.csproj
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Azure.Provisioning.Kubernetes.csproj
@@ -7,7 +7,7 @@
     <LangVersion>12</LangVersion>
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Azure.Provisioning.Storage.csproj
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Azure.Provisioning.Storage.csproj
@@ -9,7 +9,7 @@
     <LangVersion>12</LangVersion>
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="$('EXPERIMENTAL_PROVISIONING') == true">

--- a/sdk/provisioning/Directory.Build.props
+++ b/sdk/provisioning/Directory.Build.props
@@ -14,6 +14,21 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <!--
+    Temporarily disable warnings from new analyzers:
+      AZC0034: Typename is already used in another library.
+      AZC0035: Missing model factory method
+
+      Tracked by # 51311
+  -->
+  <PropertyGroup>
+    <NoWarn>
+      $(NoWarn);
+      AZC0034;
+      AZC0035;
+    </NoWarn>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(AssemblyName)' != 'Generator'">
     <Compile Include="$(AzureCoreSharedSources)ExperimentalAttribute.cs" LinkBase="Shared\Core" />
   </ItemGroup>

--- a/sdk/purview/Azure.Analytics.Purview.DataMap/src/Azure.Analytics.Purview.DataMap.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.DataMap/src/Azure.Analytics.Purview.DataMap.csproj
@@ -5,7 +5,7 @@
     <Version>1.0.0-beta.3</Version>
     <PackageTags>Azure.Analytics.Purview.DataMap</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);AZC0012;AZC0030</NoWarn>
+    <NoWarn>$(NoWarn);AZC0012;AZC0030;AZC0034</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
+++ b/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
@@ -13,9 +13,12 @@
     <PackageTags>Azure Cognitive Search;Azure Search Documents;Azure Search;Search;Cognitive;Search Engine;Azure</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <!-- These are still firing but not valid -->
-    <NoWarn>$(NoWarn);AZC0004</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>
+     $(NoWarn);
+     AZC0004;
+     AZC0035; <!-- Missing model factory methods.  #51224-->
+    </NoWarn>
   </PropertyGroup>
 
   <!-- Pull in Shared Source from Azure.Core -->

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueueProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueueProperties.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
 using Azure.Core;
 
@@ -11,6 +12,7 @@ namespace Azure.Messaging.ServiceBus.Administration
     /// <summary>
     /// Represents the static properties of the queue.
     /// </summary>
+    [SuppressMessage("Usage", "AZC0034:Type name 'QueueProperties' conflicts with 'Azure.Storage.Queues.Models.QueueProperties (from Azure.Storage.Queues)'. Consider renaming to 'AdministrationQueuePropertiesClient' or 'AdministrationQueuePropertiesService' to avoid confusion.", Justification = "The type name is already approved in a stable version.")]
     public class QueueProperties : IEquatable<QueueProperties>
     {
         private TimeSpan _duplicateDetectionHistoryTimeWindow = TimeSpan.FromMinutes(1);

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/Azure.Storage.Blobs.Batch.csproj
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/Azure.Storage.Blobs.Batch.csproj
@@ -20,6 +20,15 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>
+      $(NoWarn);
+      AZC0034; <!-- Type name conflict; irrelevant here due to prior approval -->
+      AZC0035; <!-- Missing model factory methods.  #51227-->
+    </NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Common\src\Azure.Storage.Common.csproj" />

--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -25,6 +25,14 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>
+      $(NoWarn);
+      AZC0035; <!-- Missing model factory methods.  #51227-->
+    </NoWarn>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="$(AzureStorageSharedSources)AesGcm\**\*.cs" LinkBase="Shared" />
   </ItemGroup>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
@@ -20,6 +20,7 @@
     </Description>
     <GenerateAPIListing>true</GenerateAPIListing>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0035</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" />

--- a/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.net8.0.cs
+++ b/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.net8.0.cs
@@ -354,6 +354,7 @@ namespace Azure.Data.Tables.Models
     {
         public static Azure.Data.Tables.Models.TableGeoReplicationInfo TableGeoReplicationInfo(Azure.Data.Tables.Models.TableGeoReplicationStatus status = default(Azure.Data.Tables.Models.TableGeoReplicationStatus), System.DateTimeOffset lastSyncedOn = default(System.DateTimeOffset)) { throw null; }
         public static Azure.Data.Tables.Models.TableItem TableItem(string name = null, string odataType = null, string odataId = null, string odataEditLink = null) { throw null; }
+        public static Azure.Data.Tables.Models.TableServiceProperties TableServiceProperties(Azure.Data.Tables.Models.TableAnalyticsLoggingSettings logging = null, Azure.Data.Tables.Models.TableMetrics hourMetrics = null, Azure.Data.Tables.Models.TableMetrics minuteMetrics = null, System.Collections.Generic.IList<Azure.Data.Tables.Models.TableCorsRule> cors = null) { throw null; }
         public static Azure.Data.Tables.Models.TableServiceStatistics TableServiceStatistics(Azure.Data.Tables.Models.TableGeoReplicationInfo geoReplication = null) { throw null; }
     }
     public partial class TableServiceProperties

--- a/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
+++ b/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
@@ -353,6 +353,7 @@ namespace Azure.Data.Tables.Models
     {
         public static Azure.Data.Tables.Models.TableGeoReplicationInfo TableGeoReplicationInfo(Azure.Data.Tables.Models.TableGeoReplicationStatus status = default(Azure.Data.Tables.Models.TableGeoReplicationStatus), System.DateTimeOffset lastSyncedOn = default(System.DateTimeOffset)) { throw null; }
         public static Azure.Data.Tables.Models.TableItem TableItem(string name = null, string odataType = null, string odataId = null, string odataEditLink = null) { throw null; }
+        public static Azure.Data.Tables.Models.TableServiceProperties TableServiceProperties(Azure.Data.Tables.Models.TableAnalyticsLoggingSettings logging = null, Azure.Data.Tables.Models.TableMetrics hourMetrics = null, Azure.Data.Tables.Models.TableMetrics minuteMetrics = null, System.Collections.Generic.IList<Azure.Data.Tables.Models.TableCorsRule> cors = null) { throw null; }
         public static Azure.Data.Tables.Models.TableServiceStatistics TableServiceStatistics(Azure.Data.Tables.Models.TableGeoReplicationInfo geoReplication = null) { throw null; }
     }
     public partial class TableServiceProperties

--- a/sdk/tables/Azure.Data.Tables/src/TableModelFactory.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableModelFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.Data.Tables.Models
@@ -17,6 +18,17 @@ namespace Azure.Data.Tables.Models
         public static TableItem TableItem(string name = default, string odataType = default, string odataId = default, string odataEditLink = default)
         {
             return new TableItem(name, odataType, odataId, odataEditLink);
+        }
+
+        /// <summary> Initializes new instance of TableServiceProperties class. </summary>
+        /// <param name="logging"> Azure Analytics Logging settings. </param>
+        /// <param name="hourMetrics"> A summary of request statistics grouped by API in hourly aggregates for tables. </param>
+        /// <param name="minuteMetrics"> A summary of request statistics grouped by API in minute aggregates for tables. </param>
+        /// <param name="cors"> The set of CORS rules. </param>
+        /// <returns> A new <see cref="Models.TableServiceProperties"/> instance for mocking. </returns>
+        public static TableServiceProperties TableServiceProperties(TableAnalyticsLoggingSettings logging = default, TableMetrics hourMetrics = default, TableMetrics minuteMetrics = default, IList<TableCorsRule> cors = default)
+        {
+            return new TableServiceProperties(logging, hourMetrics, minuteMetrics, cors);
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
@@ -8,7 +8,7 @@
     <PackageTags>Microsoft Azure Text Analytics</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <!-- AZC0012 - Single word class names are too generic for Entity.cs class  -->
-    <NoWarn>$(NoWarn);3021;AZC0012</NoWarn>
+    <NoWarn>$(NoWarn);3021;AZC0012;AZC0034</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/translation/Azure.AI.Translation.Text/src/Azure.AI.Translation.Text.csproj
+++ b/sdk/translation/Azure.AI.Translation.Text/src/Azure.AI.Translation.Text.csproj
@@ -8,6 +8,7 @@
     <PackageTags>Azure Text Translation;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <NoWarn>$(NoWarn);AZC0034</NoWarn>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->


### PR DESCRIPTION
# Summary

The focus of these changes is to update the Azure analyzers to the latest version, which refines messages and naming suggestions.  Included are AZC0034 (Duplicate type names) and AZC0035 (Missing model factory methods) which had been previously added but were never released.  A number of temporary suppressions have been added to allow the analyzers to be present without causing build failures.  GitHub issues have been created to track the work of fixing the underlying causes.

## References and resources

- [Initial failure set](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5072911&view=logs&j=faa47979-6d8b-510b-85a4-7e3555625ffa&t=79865fc6-c5cc-522c-6d27-3f5e5c582e93) _(Microsoft internal)_
