### PR TITLE
[Identity] Increment version for identity releases

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -31,6 +31,12 @@
 ### Other Changes
 - Updated Microsoft.Identity.Client.Broker dependency to version 4.69.1.
 
+## 1.2.1 (2025-07-11)
+
+### Other Changes
+
+- Updated `Azure.Identity` to 1.14.2 to apply a security fix in the updated `Microsoft.Identity.Client` dependency.
+
 ## 1.2.0 (2024-11-18)
 
 ### Other Changes

--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Microsoft Azure.Identity.Broker Component</AssemblyTitle>
     <Version>1.3.0-beta.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.2.0</ApiCompatVersion>
+    <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity Broker;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(RequiredTargetFrameworks);net462;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(RequiredTargetFrameworks);net8.0</TargetFrameworks>


### PR DESCRIPTION
After Azure.Identity.Broker 1.2.1 released from a hotfix branch.