### PR TITLE
[Identity] Update Broker's Azure.Identity dependency to unlock beta release

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -13,8 +13,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <!--<PackageReference Include="Azure.Identity" VersionOverride="1.14.0-beta.3" />-->
-    <ProjectReference Include="..\..\Azure.Identity\src\Azure.Identity.csproj" />
+    <PackageReference Include="Azure.Identity" VersionOverride="1.14.0-beta.4" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" />
   </ItemGroup>
 </Project>

--- a/sdk/identity/Azure.Identity.Broker/src/DevelopmentBrokerOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/DevelopmentBrokerOptions.cs
@@ -36,7 +36,7 @@ namespace Azure.Identity.Broker
             // Set default value for UseDefaultBrokerAccount on macOS
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                RedirectUri = new(Constants.MacBrokerRedirectUri);
+                RedirectUri = new(TemporaryConstants.MacBrokerRedirectUri);
             }
         }
 

--- a/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
@@ -37,7 +37,7 @@ namespace Azure.Identity.Broker
             // Set default value for UseDefaultBrokerAccount on macOS
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                RedirectUri = new(Constants.MacBrokerRedirectUri);
+                RedirectUri = new(TemporaryConstants.MacBrokerRedirectUri);
             }
         }
 

--- a/sdk/identity/Azure.Identity.Broker/src/TemporaryConstants.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/TemporaryConstants.cs
@@ -12,6 +12,6 @@ namespace Azure.Identity.Broker
         /// Redirect URI for macOS broker authentication.
         /// TODO: Remove this once Azure.Identity dependency includes Constants.MacBrokerRedirectUri
         /// </summary>
-        public const string MacBrokerRedirectUri = "msauth.com.msauth.unsignedapp://auth";
+        internal const string MacBrokerRedirectUri = "msauth.com.msauth.unsignedapp://auth";
     }
 }

--- a/sdk/identity/Azure.Identity.Broker/src/TemporaryConstants.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/TemporaryConstants.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Identity.Broker
+{
+    /// <summary>
+    /// Temporary constants for Azure.Identity.Broker until Azure.Identity dependency is updated.
+    /// </summary>
+    internal static class TemporaryConstants
+    {
+        /// <summary>
+        /// Redirect URI for macOS broker authentication.
+        /// TODO: Remove this once Azure.Identity dependency includes Constants.MacBrokerRedirectUri
+        /// </summary>
+        public const string MacBrokerRedirectUri = "msauth.com.msauth.unsignedapp://auth";
+    }
+}


### PR DESCRIPTION
In order to bump Microsoft.Identity.Client dependencies in the beta version, we have to reference Azure.Identity directly as a package and not as a project reference, which will cause some compilation issues in the tests. For these, I have added a temporary constant while we work on this release.

Once the beta for Azure.Identity that supports MacOS broker releases, we can get rid of this temporary constant.