### PR TITLE
Fix thread-safety bug in System.ClientModel's ReflectionContext

### DIFF
--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ReflectionContext.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ReflectionContext.cs
@@ -1,23 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
+
 namespace System.ClientModel.Primitives;
 
 internal class ReflectionContext : ModelReaderWriterContext
 {
-    private Dictionary<Type, ModelReaderWriterTypeBuilder>? _typeBuilders;
-    private Dictionary<Type, ModelReaderWriterTypeBuilder> TypeBuilders => _typeBuilders ??= [];
+    private ConcurrentDictionary<Type, ModelReaderWriterTypeBuilder>? _typeBuilders;
+    private ConcurrentDictionary<Type, ModelReaderWriterTypeBuilder> TypeBuilders =>
+        LazyInitializer.EnsureInitialized(ref _typeBuilders, static () => [])!;
 
     protected override bool TryGetTypeBuilderCore(Type type, out ModelReaderWriterTypeBuilder? builder)
     {
-        if (TypeBuilders.TryGetValue(type, out builder))
-        {
-            return true;
-        }
-
-        builder = new ReflectionModelBuilder(type);
-        TypeBuilders[type] = builder;
-
+        builder = TypeBuilders.GetOrAdd(type, static type => new ReflectionModelBuilder(type));
         return true;
     }
 }


### PR DESCRIPTION
ReflectionContext holds onto a Dictionary and doesn't use any synchronization to access it, but ModelReaderWriter stores a singleton into a static field, which is also used unprotected. This leads to corruption of the dictionary as the ReflectionContext gets hammered on by concurrent usage.