### PR TITLE
Bump SCM version for Azure.Core release

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -86,7 +86,7 @@
 
     <!-- BCL packages -->
     <PackageReference Update="System.Buffers" Version="4.5.1" />
-    <PackageReference Update="System.ClientModel" Version="1.5.0" />
+    <PackageReference Update="System.ClientModel" Version="1.5.1" />
     <PackageReference Update="System.IO.Hashing" Version="8.0.0" />
     <PackageReference Update="System.Memory" Version="4.5.5" />
     <PackageReference Update="System.Memory.Data" Version="8.0.1" />
@@ -426,7 +426,7 @@
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />
-    <PackageReference Update="System.ClientModel" Version="1.5.0" />
+    <PackageReference Update="System.ClientModel" Version="1.5.1" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.48.0-beta.1 (Unreleased)
+## 1.47.1 (2025-07-15)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Adopt System.ClientModel 1.5.1
 
 ## 1.47.0 (2025-07-09)
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.48.0-beta.1</Version>
+    <Version>1.47.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.47.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/51067 so the transitive dependency through Azure.Core also has the updates
