### PR TITLE
updated SmsRecipient to be public to expose idempotency functionality

### DIFF
--- a/sdk/communication/Azure.Communication.Sms/src/Generated/Models/SmsRecipient.Serialization.cs
+++ b/sdk/communication/Azure.Communication.Sms/src/Generated/Models/SmsRecipient.Serialization.cs
@@ -5,12 +5,13 @@
 
 #nullable disable
 
+using System.Globalization;
 using System.Text.Json;
 using Azure.Core;
 
 namespace Azure.Communication.Sms.Models
 {
-    internal partial class SmsRecipient : IUtf8JsonSerializable
+    public partial class SmsRecipient : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
@@ -25,7 +26,7 @@ namespace Azure.Communication.Sms.Models
             if (Optional.IsDefined(RepeatabilityFirstSent))
             {
                 writer.WritePropertyName("repeatabilityFirstSent"u8);
-                writer.WriteStringValue(RepeatabilityFirstSent);
+                writer.WriteStringValue(RepeatabilityFirstSent.Value.ToString("r", CultureInfo.InvariantCulture));
             }
             writer.WriteEndObject();
         }

--- a/sdk/communication/Azure.Communication.Sms/src/Generated/Models/SmsRecipient.cs
+++ b/sdk/communication/Azure.Communication.Sms/src/Generated/Models/SmsRecipient.cs
@@ -10,7 +10,7 @@ using System;
 namespace Azure.Communication.Sms.Models
 {
     /// <summary> Recipient details for sending SMS messages. </summary>
-    internal partial class SmsRecipient
+    public partial class SmsRecipient
     {
         /// <summary> Initializes a new instance of <see cref="SmsRecipient"/>. </summary>
         /// <param name="to"> The recipient's phone number in E.164 format. </param>
@@ -26,7 +26,7 @@ namespace Azure.Communication.Sms.Models
         /// <param name="to"> The recipient's phone number in E.164 format. </param>
         /// <param name="repeatabilityRequestId"> If specified, the client directs that the request is repeatable; that is, the client can make the request multiple times with the same Repeatability-Request-ID and get back an appropriate response without the server executing the request multiple times. The value of the Repeatability-Request-ID is an opaque string representing a client-generated, 36-character hexadecimal case-insensitive encoding of a UUID (GUID), identifier for the request. </param>
         /// <param name="repeatabilityFirstSent"> MUST be sent by clients to specify that a request is repeatable. Repeatability-First-Sent is used to specify the date and time at which the request was first created.eg- Tue, 26 Mar 2019 16:06:51 GMT. </param>
-        internal SmsRecipient(string to, string repeatabilityRequestId, string repeatabilityFirstSent)
+        public SmsRecipient(string to, string repeatabilityRequestId, DateTimeOffset? repeatabilityFirstSent)
         {
             To = to;
             RepeatabilityRequestId = repeatabilityRequestId;
@@ -36,8 +36,8 @@ namespace Azure.Communication.Sms.Models
         /// <summary> The recipient's phone number in E.164 format. </summary>
         public string To { get; }
         /// <summary> If specified, the client directs that the request is repeatable; that is, the client can make the request multiple times with the same Repeatability-Request-ID and get back an appropriate response without the server executing the request multiple times. The value of the Repeatability-Request-ID is an opaque string representing a client-generated, 36-character hexadecimal case-insensitive encoding of a UUID (GUID), identifier for the request. </summary>
-        public string RepeatabilityRequestId { get; set; }
+        public string RepeatabilityRequestId { get; }
         /// <summary> MUST be sent by clients to specify that a request is repeatable. Repeatability-First-Sent is used to specify the date and time at which the request was first created.eg- Tue, 26 Mar 2019 16:06:51 GMT. </summary>
-        public string RepeatabilityFirstSent { get; set; }
+        public DateTimeOffset? RepeatabilityFirstSent { get; }
     }
 }


### PR DESCRIPTION
As per title, this PR updates `SmsRecipient` to be public to expose idempotency functionality.

This is more of a RFC to raise awareness about this need and open a discussion.
