### PR TITLE
[CODEOWNERS] Clean up linter failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -950,10 +950,10 @@
 # AzureSdkOwners:                                                  @ArthurMa1978
 
 # PRLabel: %API Center
-/sdk/apicenter/Azure.ResourceManager.ApiCenter/                    @alexyaang @azaslonov
+/sdk/apicenter/Azure.ResourceManager.ApiCenter/                    @alexyaang @ArthurMa1978
 
 # ServiceLabel: %API Center %Mgmt
-# ServiceOwners:                                                   @alexyaang @azaslonov
+# ServiceOwners:                                                   @alexyaang
 
 # PRLabel: %ARM
 /sdk/resources/Azure.ResourceManager.*/                            @Azure/arm-sdk-owners
@@ -1103,10 +1103,10 @@
 # ServiceOwners:                                                   @aggarwalsw
 
 # PRLabel: %Planetary Computer
-/sdk/planetarycomputer/Azure.ResourceManager.*/                    @shaktichetan23 @thisisdevanshu
+/sdk/planetarycomputer/Azure.ResourceManager.*/                    @shaktichetan23 @ArthurMa1978
 
 # ServiceLabel: %Planetary Computer %Mgmt
-# ServiceOwners:                                                   @shaktichetan23 @thisisdevanshu
+# ServiceOwners:                                                   @shaktichetan23
 
 # PRLabel: %PureStorage
 /sdk/purestorageblock/Azure.ResourceManager.*/                     @deepakmauryams


### PR DESCRIPTION
# Summary

The focus of these changes is to remove owners who no longer have the needed affiliations or permissions and are being flagged by the linter.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5100516&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4)