### PR TITLE
Tracing conventions: move .NET-only attributes from azure-sdk to this repo

### DIFF
--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -177,7 +177,7 @@ Azure client libraries produce the following kinds of activities:
 Prior to November 2023, OpenTelemetry support was experimental for all Azure client libraries (see [Enabling experimental tracing features](#enabling-experimental-tracing-features) for the details).
 Most of Azure client libraries released in or after November 2023 have OpenTelemetry support enabled by default. Tracing support in messaging libraries (`Azure.Messaging.ServiceBus` and `Azure.Messaging.EventHubs`) remains experimental.
 
-More detailed distributed tracing convention can be found at [Azure SDK semantic conventions](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md). Additional attributes emitted by
+More detailed distributed tracing convention can be found at [Azure SDK semantic conventions](https://github.com/Azure/azure-sdk/blob/main/docs/observability/opentelemetry-conventions.md). Additional attributes emitted by
 Azure client libraries in .NET are documented [here](./OpenTelemetrySemanticConventions.md).
 
 ### OpenTelemetry configuration
@@ -284,7 +284,7 @@ To see an example of distributed tracing in action, take a look at our [sample a
 
 ### Enabling experimental tracing features
 
-Certain tracing features remain experimental and still need to be enabled explicitly. Check out [Azure SDK semantic conventions](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md) to see which conventions are considered experimental.
+Certain tracing features remain experimental and still need to be enabled explicitly. Check out [Azure SDK semantic conventions](https://github.com/Azure/azure-sdk/blob/main/docs/observability/opentelemetry-conventions.md) to see which conventions are considered experimental.
 
 The shape of experimental Activities may change in the future without notice. This includes:
 - the kinds of operations that are tracked

--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -178,7 +178,7 @@ Prior to November 2023, OpenTelemetry support was experimental for all Azure cli
 Most of Azure client libraries released in or after November 2023 have OpenTelemetry support enabled by default. Tracing support in messaging libraries (`Azure.Messaging.ServiceBus` and `Azure.Messaging.EventHubs`) remains experimental.
 
 More detailed distributed tracing convention can be found at [Azure SDK semantic conventions](https://github.com/Azure/azure-sdk/blob/main/docs/observability/opentelemetry-conventions.md). Additional attributes emitted by
-Azure client libraries in .NET are documented [here](./OpenTelemetrySemanticConventions.md).
+Azure client libraries in .NET are documented [here](https://github.com/Azure/azure-sdk-for-net/blob/95b7ac20eebea0c13eab4a9bed0ee3ae1908d2bd/sdk/core/Azure.Core/samples/OpenTelemetrySemanticConventions.md).
 
 ### OpenTelemetry configuration
 

--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -178,7 +178,7 @@ Prior to November 2023, OpenTelemetry support was experimental for all Azure cli
 Most of Azure client libraries released in or after November 2023 have OpenTelemetry support enabled by default. Tracing support in messaging libraries (`Azure.Messaging.ServiceBus` and `Azure.Messaging.EventHubs`) remains experimental.
 
 More detailed distributed tracing convention can be found at [Azure SDK semantic conventions](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md). Additional attributes emitted by
-Azure client libraries in .NET are documented [here](./SemanticConventions.md).
+Azure client libraries in .NET are documented [here](./OpenTelemetrySemanticConventions.md).
 
 ### OpenTelemetry configuration
 

--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -174,14 +174,15 @@ Azure client libraries produce the following kinds of activities:
 - *client method calls*: for example, `BlobClient.DownloadTo` or `SecretClient.StartDeleteSecret`.
 - *messaging events*: Event Hubs and Service Bus message creation is traced and correlated with its sending, receiving, and processing.
 
-Prior to November 2023, OpenTelemetry support was experimental for all Azure client libraries (see [Enabling experimental tracing features](#enabling-experimental-tracing-features) for the details). 
-Most of Azure client libraries released in or after November 2023 have OpenTelemetry support enabled by default. Tracing support in messaging libraries (`Azure.Messaging.ServiceBus` and `Azure.Messaging.EventHubs`) remains experimental. 
+Prior to November 2023, OpenTelemetry support was experimental for all Azure client libraries (see [Enabling experimental tracing features](#enabling-experimental-tracing-features) for the details).
+Most of Azure client libraries released in or after November 2023 have OpenTelemetry support enabled by default. Tracing support in messaging libraries (`Azure.Messaging.ServiceBus` and `Azure.Messaging.EventHubs`) remains experimental.
 
-More detailed distributed tracing convention can be found at [Azure SDK semantic conventions](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md).
+More detailed distributed tracing convention can be found at [Azure SDK semantic conventions](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md). Additional attributes emitted by
+Azure client libraries in .NET are documented [here](./SemanticConventions.md).
 
 ### OpenTelemetry configuration
 
-OpenTelemetry relies on `ActivitySource` to collect distributed traces. 
+OpenTelemetry relies on `ActivitySource` to collect distributed traces.
 Follow the [OpenTelemetry configuration guide](https://opentelemetry.io/docs/instrumentation/net/getting-started/#instrumentation) to configure collection and exporting pipeline.
 
 Your observability vendor may enable Azure SDK activities by default. For example, stable Azure SDK instrumentations are enabled by [Azure Monitor OpenTelemetry Distro](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md#enable-azure-sdk-instrumentation).
@@ -212,7 +213,7 @@ Azure SDK traces all HTTP calls using `Azure.Core.Http` source. If you enable it
 
 Unlike generic HTTP activities, Azure SDK HTTP activities include Azure-specific attributes such as request identifiers usually passed to and from Azure services in `x-ms-client-request-id`, `x-ms-request-id` or similar request and response headers. This data may be important when correlating client and server telemetry or creating support tickets.
 
-To avoid double-collection you may either 
+To avoid double-collection you may either
 - enrich generic HTTP client activities with Azure request identifiers and disable Azure SDK HTTP activities.
 - filter out duplicated generic HTTP client activities.
 

--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -213,7 +213,7 @@ Azure SDK traces all HTTP calls using `Azure.Core.Http` source. If you enable it
 
 Unlike generic HTTP activities, Azure SDK HTTP activities include Azure-specific attributes such as request identifiers usually passed to and from Azure services in `x-ms-client-request-id`, `x-ms-request-id` or similar request and response headers. This data may be important when correlating client and server telemetry or creating support tickets.
 
-To avoid double-collection you may either
+To avoid double-collection you may either:
 - enrich generic HTTP client activities with Azure request identifiers and disable Azure SDK HTTP activities.
 - filter out duplicated generic HTTP client activities.
 

--- a/sdk/core/Azure.Core/samples/OpenTelemetrySemanticConventions.md
+++ b/sdk/core/Azure.Core/samples/OpenTelemetrySemanticConventions.md
@@ -1,7 +1,7 @@
-# OpenTelemetry semantic conventions for Azure SDK
+# OpenTelemetry Semantic Conventions
 
 Azure client libraries follow OpenTelemetry semantic conventions on distributed traces.
-In addition to general conventions described in [azure-sdk repo](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md), some of the .NET libraries emit
+In addition to general conventions described in the [azure-sdk repo](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md), some of the .NET libraries emit
 additional attributes on public API spans. Such attributes are described below.
 
 ## Azure Application Configuration attributes

--- a/sdk/core/Azure.Core/samples/OpenTelemetrySemanticConventions.md
+++ b/sdk/core/Azure.Core/samples/OpenTelemetrySemanticConventions.md
@@ -1,7 +1,7 @@
 # OpenTelemetry Semantic Conventions
 
 Azure client libraries follow OpenTelemetry semantic conventions on distributed traces.
-In addition to general conventions described in the [azure-sdk repo](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md), some of the .NET libraries emit
+In addition to general conventions described in the [azure-sdk repo](https://github.com/Azure/azure-sdk/blob/main/docs/observability/opentelemetry-conventions.md), some of the .NET libraries emit
 additional attributes on public API spans. Such attributes are described below.
 
 ## Azure Application Configuration attributes

--- a/sdk/core/Azure.Core/samples/OpenTelemetrySemanticConventions.md
+++ b/sdk/core/Azure.Core/samples/OpenTelemetrySemanticConventions.md
@@ -1,25 +1,23 @@
-# Azure SDK semantic conventions
+# OpenTelemetry semantic conventions for Azure SDK
 
 Azure client libraries follow OpenTelemetry semantic conventions on distributed traces.
-In addition to general conventions described [here](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md#azure-application-configuration-attributes), some of the .NET libraries emit
+In addition to general conventions described in [azure-sdk repo](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md), some of the .NET libraries emit
 additional attributes on public API spans. Such attributes are described below.
 
-## Library-specific attributes
-
-### Azure Application Configuration attributes
+## Azure Application Configuration attributes
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `az.appconfiguration.key` | string | Value of the Azure Application Configuration property [key](https://learn.microsoft.com/azure/azure-app-configuration/concept-key-value). | `AppName:Service1:ApiEndpoint` | Recommended |
 
-### Azure Cognitive Language Question Answering SDK attributes
+## Azure Cognitive Language Question Answering SDK attributes
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `az.cognitivelanguage.deployment.name` | string | Name of the [Azure Questions Answering](https://learn.microsoft.com/azure/ai-services/language-service/question-answering/overview) deployment. | `production` | Recommended |
 | `az.cognitivelanguage.project.name` | string | Name of the [Azure Questions Answering](https://learn.microsoft.com/azure/ai-services/language-service/question-answering/overview) project. | `production` | Recommended |
 
-### Azure Digital Twins attributes
+## Azure Digital Twins attributes
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
@@ -32,9 +30,9 @@ additional attributes on public API spans. Such attributes are described below.
 | `az.digitaltwins.relationship.name` | string | The name of the relationship between twins. | `contains` | Recommended |
 | `az.digitaltwins.twin.id` | string | The unique identifier of a [digital twin](https://learn.microsoft.com/azure/digital-twins/concepts-twins-graph). | `edf41622` | Recommended |
 
-### Azure Key Vault attributes
+## Azure Key Vault attributes
 
-#### Azure Key Vault Certificates attributes
+### Azure Key Vault Certificates attributes
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
@@ -42,7 +40,7 @@ additional attributes on public API spans. Such attributes are described below.
 | `az.keyvault.certificate.name` | string | The Azure Key Vault certificate name. | `selfSignedCert01` | Recommended |
 | `az.keyvault.certificate.version` | string | The Azure Key Vault certificate version. | `c3d31d7b36c942ad83ef36fc0785a4fc` | Recommended |
 
-#### Azure Key Vault Keys attributes
+### Azure Key Vault Keys attributes
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
@@ -50,14 +48,14 @@ additional attributes on public API spans. Such attributes are described below.
 | `az.keyvault.key.name` | string | The Azure Key Vault key name. | `test-key` | Recommended |
 | `az.keyvault.key.version` | string | The Azure Key Vault key version. | `3d31e6e5c4c14eaf9be8d42c00225088` | Recommended |
 
-#### Azure Key Vault Secrets attributes
+### Azure Key Vault Secrets attributes
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `az.keyvault.secret.name` | string | The Azure Key Vault secret name. | `test-secret` | Recommended |
 | `az.keyvault.secret.version` | string | The Azure Key Vault secret version. | `4387e9f3d6e14c459867679a90fd0f79` | Recommended |
 
-#### Azure Mixed Reality Remote Rendering attributes
+### Azure Mixed Reality Remote Rendering attributes
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|

--- a/sdk/core/Azure.Core/samples/SemanticConventions.md
+++ b/sdk/core/Azure.Core/samples/SemanticConventions.md
@@ -46,7 +46,7 @@ additional attributes on public API spans. Such attributes are described below.
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `az.keyvault.key.id` | string | The Azure Key Vault key ID (full URL). | `"https://myvault.vault.azure.net/keys/CreateSoftKeyTest/78deebed173b48e48f55abf87ed4cf71` | Recommended |
+| `az.keyvault.key.id` | string | The Azure Key Vault key ID (full URL). | `"https://myvault.vault.azure.net/keys/CreateSoftKeyTest/78deebed173b48e48f55abf87ed4cf71"` | Recommended |
 | `az.keyvault.key.name` | string | The Azure Key Vault key name. | `test-key` | Recommended |
 | `az.keyvault.key.version` | string | The Azure Key Vault key version. | `3d31e6e5c4c14eaf9be8d42c00225088` | Recommended |
 

--- a/sdk/core/Azure.Core/samples/SemanticConventions.md
+++ b/sdk/core/Azure.Core/samples/SemanticConventions.md
@@ -1,0 +1,65 @@
+# Azure SDK semantic conventions
+
+Azure client libraries follow OpenTelemetry semantic conventions on distributed traces.
+In addition to general conventions described [here](https://github.com/Azure/azure-sdk/blob/main/docs/tracing/distributed-tracing-conventions.md#azure-application-configuration-attributes), some of the .NET libraries emit
+additional attributes on public API spans. Such attributes are described below.
+
+## Library-specific attributes
+
+### Azure Application Configuration attributes
+
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `az.appconfiguration.key` | string | Value of the Azure Application Configuration property [key](https://learn.microsoft.com/azure/azure-app-configuration/concept-key-value). | `AppName:Service1:ApiEndpoint` | Recommended |
+
+### Azure Cognitive Language Question Answering SDK attributes
+
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `az.cognitivelanguage.deployment.name` | string | Name of the [Azure Questions Answering](https://learn.microsoft.com/azure/ai-services/language-service/question-answering/overview) deployment. | `production` | Recommended |
+| `az.cognitivelanguage.project.name` | string | Name of the [Azure Questions Answering](https://learn.microsoft.com/azure/ai-services/language-service/question-answering/overview) project. | `production` | Recommended |
+
+### Azure Digital Twins attributes
+
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `az.digitaltwins.component.name` | string | The name of the digital twin component. | `thermostat` | Recommended |
+| `az.digitaltwins.event_route.id` | string | The [event route](https://learn.microsoft.com/azure/digital-twins/concepts-route-events) identifier used by the digital twin. | `6f8741b1` | Recommended |
+| `az.digitaltwins.job.id` | string | Digital twin job ID. | `test-job` | Recommended |
+| `az.digitaltwins.message.id` | string | A unique message identifier (in the scope of the digital twin ID) used to de-duplicate telemetry messages. | `a40896c5ab954ab1` | Recommended |
+| `az.digitaltwins.model.id` | string | The digital twin model ID. | `dtmi:example:Room23;1` | Recommended |
+| `az.digitaltwins.query` | string | Digital twin graph query. | `SELECT * FROM DIGITALTWINS WHERE Name = "DSouza"` | Recommended |
+| `az.digitaltwins.relationship.name` | string | The name of the relationship between twins. | `contains` | Recommended |
+| `az.digitaltwins.twin.id` | string | The unique identifier of a [digital twin](https://learn.microsoft.com/azure/digital-twins/concepts-twins-graph). | `edf41622` | Recommended |
+
+### Azure Key Vault attributes
+
+#### Azure Key Vault Certificates attributes
+
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `az.keyvault.certificate.issuer.name` | string | The Azure Key Vault certificate issuer name. | `issuer01` | Recommended |
+| `az.keyvault.certificate.name` | string | The Azure Key Vault certificate name. | `selfSignedCert01` | Recommended |
+| `az.keyvault.certificate.version` | string | The Azure Key Vault certificate version. | `c3d31d7b36c942ad83ef36fc0785a4fc` | Recommended |
+
+#### Azure Key Vault Keys attributes
+
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `az.keyvault.key.id` | string | The Azure Key Vault key ID (full URL). | `"https://myvault.vault.azure.net/keys/CreateSoftKeyTest/78deebed173b48e48f55abf87ed4cf71` | Recommended |
+| `az.keyvault.key.name` | string | The Azure Key Vault key name. | `test-key` | Recommended |
+| `az.keyvault.key.version` | string | The Azure Key Vault key version. | `3d31e6e5c4c14eaf9be8d42c00225088` | Recommended |
+
+#### Azure Key Vault Secrets attributes
+
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `az.keyvault.secret.name` | string | The Azure Key Vault secret name. | `test-secret` | Recommended |
+| `az.keyvault.secret.version` | string | The Azure Key Vault secret version. | `4387e9f3d6e14c459867679a90fd0f79` | Recommended |
+
+#### Azure Mixed Reality Remote Rendering attributes
+
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `az.remoterendering.conversion.id` | string | A conversion ID uniquely identifying the conversion for the given [Azure Remote Rendering](https://learn.microsoft.com/windows/mixed-reality/develop/mixed-reality-cloud-services#azure-remote-rendering) account. | `contoso-conversion-6fae2bfb754e` | Recommended |
+| `az.remoterendering.session.id` | string | A session ID uniquely identifying the conversion for the given [Azure Remote Rendering](https://learn.microsoft.com/windows/mixed-reality/develop/mixed-reality-cloud-services#azure-remote-rendering) account. | `contoso-session-8c28813adc28` | Recommended |


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk/pull/9007 - sdk-specific attributes mentioned in that doc do not belong in azure-sdk repo. They documented ad-hoc attributes added in .NET client libs.

Moving them here. 

Going forward we should only keep cross-language conventions in azure-sdk (or better document them in https://github.com/open-telemetry/semantic-conventions/)


This PR depends on https://github.com/Azure/azure-sdk/pull/9007. Once that one is merged, I'll need to update links here to point to new file names.