### PR TITLE
Fix issue when N partial classes exist each with buildable attributes

### DIFF
--- a/sdk/core/System.ClientModel/tests/gen.unit/ContextGeneratorTests.cs
+++ b/sdk/core/System.ClientModel/tests/gen.unit/ContextGeneratorTests.cs
@@ -1086,5 +1086,59 @@ namespace TestProject
             Assert.AreEqual("JsonModel", result.GenerationSpec.TypeBuilders[0].Type.Name);
             Assert.AreEqual("TestProject", result.GenerationSpec.TypeBuilders[0].Type.Namespace);
         }
+
+        [Test]
+        public void TwoPartialClassesShouldPass()
+        {
+            string source =
+$$"""
+using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace TestProject
+{
+    [ModelReaderWriterBuildable(typeof(JsonModel))]
+    public partial class LocalContext : ModelReaderWriterContext { }
+
+    public class JsonModel : IJsonModel<JsonModel>
+    {
+        public JsonModel Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => new JsonModel();
+        public JsonModel Create(BinaryData data, ModelReaderWriterOptions options) => new JsonModel();
+        public string GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+        public void Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) { }
+        public BinaryData Write(ModelReaderWriterOptions options) => BinaryData.Empty;
+    }
+
+    [ModelReaderWriterBuildable(typeof(JsonModel2))]
+    public partial class LocalContext : ModelReaderWriterContext { }
+
+    public class JsonModel2 : IJsonModel<JsonModel2>
+    {
+        public JsonModel2 Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => new JsonModel2();
+        public JsonModel2 Create(BinaryData data, ModelReaderWriterOptions options) => new JsonModel2();
+        public string GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+        public void Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) { }
+        public BinaryData Write(ModelReaderWriterOptions options) => BinaryData.Empty;
+    }
+}
+""";
+
+            Compilation compilation = CompilationHelper.CreateCompilation(source);
+
+            var result = CompilationHelper.RunSourceGenerator(compilation, out var newCompilation);
+
+            Assert.IsNotNull(result.GenerationSpec);
+            Assert.AreEqual("LocalContext", result.GenerationSpec!.Type.Name);
+            Assert.AreEqual("TestProject", result.GenerationSpec.Type.Namespace);
+            Assert.AreEqual(0, result.Diagnostics.Length);
+            Assert.AreEqual("public", result.GenerationSpec!.Modifier);
+            Assert.AreEqual(2, result.GenerationSpec.TypeBuilders.Count);
+            Assert.AreEqual(0, result.GenerationSpec.ReferencedContexts.Count);
+            Assert.AreEqual("JsonModel", result.GenerationSpec.TypeBuilders[0].Type.Name);
+            Assert.AreEqual("TestProject", result.GenerationSpec.TypeBuilders[0].Type.Namespace);
+            Assert.AreEqual("JsonModel2", result.GenerationSpec.TypeBuilders[1].Type.Name);
+            Assert.AreEqual("TestProject", result.GenerationSpec.TypeBuilders[1].Type.Namespace);
+        }
     }
 }


### PR DESCRIPTION
SyntaxProvider.ForAttributeWithMetadataName will return duplicate entries for multiple partial classes.  We need to dedupe them and not treat it as multiple contexts when the symbol the attributes are on were identical.

Related rolsyn issue since this may not be expected behavior https://github.com/dotnet/roslyn/issues/79519.