### PR TITLE
Fixing the connect call result issue

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.4.1 (2025-07-22)
+
+### Bugs Fixed
+
+- Fixed an issue when using the event processor connect call result for the `CallConnected` event, which was not being returned correctly.
+
 ## 1.4.0 (2025-06-04)
 
 ### Features Added

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Azure.Communication.CallAutomation.csproj
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Azure.Communication.CallAutomation.csproj
@@ -6,7 +6,7 @@
       Microsoft Azure Communication Call Automation quickstart - https://learn.microsoft.com/azure/communication-services/quickstarts/voice-video-calling/callflows-for-customer-interactions?pivots=programming-language-csharp
     </Description>
     <AssemblyTitle>Azure Communication CallAutomation Service</AssemblyTitle>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <PackageTags>Microsoft Azure Communication CallAutomation Service;Microsoft;Azure;Azure Communication Service;Azure Communication CallAutomation Service;Calling;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/ConnectCallResult.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/ConnectCallResult.cs
@@ -45,7 +45,7 @@ namespace Azure.Communication.CallAutomation
 
             var returnedEvent = _evHandler.WaitForEventProcessor(filter
                 => filter.CallConnectionId == _callConnectionId
-                && (filter.GetType() == typeof(ConnectFailed)),
+                && (filter.GetType() == typeof(CallConnected) || filter.GetType() == typeof(ConnectFailed)),
                 cancellationToken);
 
             return SetReturnedEvent(returnedEvent);
@@ -65,7 +65,7 @@ namespace Azure.Communication.CallAutomation
 
             var returnedEvent = await _evHandler.WaitForEventProcessorAsync(filter
                 => filter.CallConnectionId == _callConnectionId
-                && (filter.GetType() == typeof(ConnectFailed)),
+                && (filter.GetType() == typeof(CallConnected) || filter.GetType() == typeof(ConnectFailed)),
                 cancellationToken).ConfigureAwait(false);
 
             return SetReturnedEvent(returnedEvent);
@@ -73,7 +73,20 @@ namespace Azure.Communication.CallAutomation
 
         private static ConnectCallEventResult SetReturnedEvent(CallAutomationEventBase returnedEvent)
         {
-            return new ConnectCallEventResult(true, (ConnectFailed)returnedEvent, (CallConnected)returnedEvent);
+            ConnectCallEventResult result = default;
+            switch (returnedEvent)
+            {
+                case ConnectFailed:
+                    result = new ConnectCallEventResult(false, (ConnectFailed)returnedEvent, null);
+                    break;
+                case CallConnected:
+                    result = new ConnectCallEventResult(true, null, (CallConnected)returnedEvent);
+                    break;
+                default:
+                    throw new NotSupportedException(returnedEvent.GetType().Name);
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
[Bug 4189320](https://skype.visualstudio.com/SPOOL/_workitems/edit/4189320): 1.4.0 .NET SDK regression with EventProcessor not handling CallConnected