### PR TITLE
Support `FormattableString` as argument of `BicepFunction.Interpolate`

### DIFF
--- a/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
+## 1.3.0 (2025-08-01)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Supported `FormattableString` in `BicepFunction.Interpolate` method.
 
 ## 1.2.1 (2025-07-09)
 

--- a/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Supported `FormattableString` in `BicepFunction.Interpolate` method.
+- Supported `FormattableString` in `BicepFunction.Interpolate` method. ([#47360](https://github.com/Azure/azure-sdk-for-net/issues/47360))
 
 ## 1.2.1 (2025-07-09)
 

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
@@ -610,6 +610,7 @@ namespace Azure.Provisioning.Expressions
         public BicepInterpolatedStringHandler(int literalLength, int formattedCount) { throw null; }
         public void AppendFormatted<T>(T t) { }
         public void AppendLiteral(string text) { }
+        public static implicit operator Azure.Provisioning.Expressions.BicepInterpolatedStringHandler (System.FormattableString formattable) { throw null; }
     }
     public partial class BicepProgram
     {
@@ -629,6 +630,7 @@ namespace Azure.Provisioning.Expressions
         public BicepStringBuilder() { }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepExpression expression) { throw null; }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepInterpolatedStringHandler handler) { throw null; }
+        public Azure.Provisioning.Expressions.BicepStringBuilder Append(System.FormattableString value) { throw null; }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(string text) { throw null; }
         public Azure.Provisioning.BicepValue<string> Build() { throw null; }
         public static implicit operator Azure.Provisioning.BicepValue<string> (Azure.Provisioning.Expressions.BicepStringBuilder value) { throw null; }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
@@ -630,7 +630,6 @@ namespace Azure.Provisioning.Expressions
         public BicepStringBuilder() { }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepExpression expression) { throw null; }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepInterpolatedStringHandler handler) { throw null; }
-        public Azure.Provisioning.Expressions.BicepStringBuilder Append(System.FormattableString value) { throw null; }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(string text) { throw null; }
         public Azure.Provisioning.BicepValue<string> Build() { throw null; }
         public static implicit operator Azure.Provisioning.BicepValue<string> (Azure.Provisioning.Expressions.BicepStringBuilder value) { throw null; }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -628,7 +628,6 @@ namespace Azure.Provisioning.Expressions
         public BicepStringBuilder() { }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepExpression expression) { throw null; }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepInterpolatedStringHandler handler) { throw null; }
-        public Azure.Provisioning.Expressions.BicepStringBuilder Append(System.FormattableString value) { throw null; }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(string text) { throw null; }
         public Azure.Provisioning.BicepValue<string> Build() { throw null; }
         public static implicit operator Azure.Provisioning.BicepValue<string> (Azure.Provisioning.Expressions.BicepStringBuilder value) { throw null; }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -608,6 +608,7 @@ namespace Azure.Provisioning.Expressions
         public BicepInterpolatedStringHandler(int literalLength, int formattedCount) { throw null; }
         public void AppendFormatted<T>(T t) { }
         public void AppendLiteral(string text) { }
+        public static implicit operator Azure.Provisioning.Expressions.BicepInterpolatedStringHandler (System.FormattableString formattable) { throw null; }
     }
     public partial class BicepProgram
     {
@@ -627,6 +628,7 @@ namespace Azure.Provisioning.Expressions
         public BicepStringBuilder() { }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepExpression expression) { throw null; }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(Azure.Provisioning.Expressions.BicepInterpolatedStringHandler handler) { throw null; }
+        public Azure.Provisioning.Expressions.BicepStringBuilder Append(System.FormattableString value) { throw null; }
         public Azure.Provisioning.Expressions.BicepStringBuilder Append(string text) { throw null; }
         public Azure.Provisioning.BicepValue<string> Build() { throw null; }
         public static implicit operator Azure.Provisioning.BicepValue<string> (Azure.Provisioning.Expressions.BicepStringBuilder value) { throw null; }

--- a/sdk/provisioning/Azure.Provisioning/src/Azure.Provisioning.csproj
+++ b/sdk/provisioning/Azure.Provisioning/src/Azure.Provisioning.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains the core functionality for defining Azure infrastructure with dotnet code.</Description>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.3.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
@@ -294,8 +294,7 @@ public static class BicepFunction
     /// Combines multiple string values <paramref name="values"/> and returns
     /// the concatenated string.  This represents the <c>concat</c> Bicep
     /// function.  To improve readability, prefer
-    /// <see cref="BicepFunction.Interpolate"/> instead of
-    /// <see cref="Concat"/>.
+    /// <see cref="Interpolate"/> instead of <see cref="Concat"/>.
     /// </summary>
     /// <param name="values">Strings in sequential order for concatenation.</param>
     /// <returns>A string or array of concatenated values.</returns>
@@ -318,28 +317,4 @@ public static class BicepFunction
     /// <returns>An interpolated string.</returns>
     public static BicepValue<string> Interpolate(BicepInterpolatedStringHandler handler) =>
         handler.Build();
-
-    /// <summary>
-    /// Convert a <see cref="FormattableString"/> with literal text, C# expressions,
-    /// and Bicep expressions into an interpolated Bicep string.
-    /// </summary>
-    /// <param name="formattableString"></param>
-    /// <returns></returns>
-    public static BicepValue<string> Interpolate(FormattableString formattableString)
-    {
-        // TODO -- maybe it makes more sense that we instantiate a bicep string builder here, by adding an overload to accept FormattableString.
-        var handler = new BicepInterpolatedStringHandler();
-        foreach (var (span, isLiteral) in StringExtensions.GetFormattableStringFormatParts(formattableString.Format.AsSpan()))
-        {
-            if (isLiteral)
-            {
-                handler.AppendLiteral(span.ToString());
-            }
-            else
-            {
-                handler.AppendFormatted(span);
-            }
-        }
-        return Interpolate(handler);
-    }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
@@ -310,11 +310,17 @@ public static class BicepFunction
     }
 
     /// <summary>
-    /// Convert a formattable string with literal text, C# expressions, and
-    /// Bicep expressions into an interpolated Bicep string.
+    /// Builds a Bicep interpolated string expression from C# interpolated string syntax
+    /// or a <see cref="FormattableString"/> instance.
+    /// Use this method to combine literal text, C# expressions and Bicep expressions
+    /// into a single Bicep string value.
     /// </summary>
-    /// <param name="handler">A bicep interpolated string handler.</param>
-    /// <returns>An interpolated string.</returns>
+    /// <param name="handler">
+    /// The <see cref="BicepInterpolatedStringHandler"/> that collects literal and formatted segments from the interpolated string.
+    /// </param>
+    /// <returns>
+    /// A <see cref="BicepValue{String}"/> representing the constructed Bicep interpolated string expression of type <c>string</c>.
+    /// </returns>
     public static BicepValue<string> Interpolate(BicepInterpolatedStringHandler handler) =>
         handler.Build();
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Azure.Core;
 using Azure.Provisioning.Resources;
+using Azure.Provisioning.Utilities;
 
 namespace Azure.Provisioning.Expressions;
 
@@ -317,4 +318,28 @@ public static class BicepFunction
     /// <returns>An interpolated string.</returns>
     public static BicepValue<string> Interpolate(BicepInterpolatedStringHandler handler) =>
         handler.Build();
+
+    /// <summary>
+    /// Convert a <see cref="FormattableString"/> with literal text, C# expressions,
+    /// and Bicep expressions into an interpolated Bicep string.
+    /// </summary>
+    /// <param name="formattableString"></param>
+    /// <returns></returns>
+    public static BicepValue<string> Interpolate(FormattableString formattableString)
+    {
+        // TODO -- maybe it makes more sense that we instantiate a bicep string builder here, by adding an overload to accept FormattableString.
+        var handler = new BicepInterpolatedStringHandler();
+        foreach (var (span, isLiteral) in StringExtensions.GetFormattableStringFormatParts(formattableString.Format.AsSpan()))
+        {
+            if (isLiteral)
+            {
+                handler.AppendLiteral(span.ToString());
+            }
+            else
+            {
+                handler.AppendFormatted(span);
+            }
+        }
+        return Interpolate(handler);
+    }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepStringBuilder.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepStringBuilder.cs
@@ -55,13 +55,6 @@ public class BicepStringBuilder
         return this;
     }
 
-    public BicepStringBuilder Append(FormattableString value)
-    {
-        var handler = new BicepInterpolatedStringHandler(value.Format.Length, value.ArgumentCount);
-        handler.AppendFormattableString(value);
-        return Append(handler);
-    }
-
     /// <summary>
     /// Combine all the subexpressions into a single interpolated string.
     /// </summary>

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepStringBuilder.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepStringBuilder.cs
@@ -76,8 +76,8 @@ public class BicepStringBuilder
 /// <summary>
 /// Interpolated string handler for building interpolated Bicep string
 /// expressions.  This is an implementation detail for the C# compiler.  Users
-/// should prefer either <see cref="BicepFunction.Interpolate"/> or
-/// <see cref="BicepStringBuilder"/> for constructing interpolated strings.
+/// should prefer either <see cref="BicepFunction.Interpolate(BicepInterpolatedStringHandler)"/>
+/// <see cref="BicepFunction.Interpolate(System.FormattableString)"/> or <see cref="BicepStringBuilder"/> for constructing interpolated strings.
 /// </summary>
 /// <param name="literalLength">Combined length of all literal segments.</param>
 /// <param name="formattedCount">Number of formatted segments.</param>

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepStringBuilder.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepStringBuilder.cs
@@ -134,7 +134,7 @@ public ref struct BicepInterpolatedStringHandler(int literalLength, int formatte
     internal void AppendFormattableString(FormattableString value)
     {
         var formatSpan = value.Format.AsSpan();
-        foreach (var (span, isLiteral, index) in StringExtensions.GetFormattableStringFormatParts(formatSpan))
+        foreach (var (span, isLiteral, index) in FormattableStringHelpers.GetFormattableStringFormatParts(formatSpan))
         {
             if (isLiteral)
             {

--- a/sdk/provisioning/Azure.Provisioning/src/Utilities/FormattableStringHelpers.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Utilities/FormattableStringHelpers.cs
@@ -7,6 +7,12 @@ namespace Azure.Provisioning.Utilities
 {
     internal static class FormattableStringHelpers
     {
+        /// <summary>
+        /// Parses the format from a <see cref="FormattableString"/> and returns an enumerator
+        /// that yields the parts of the format.
+        /// </summary>
+        /// <param name="format"></param>
+        /// <returns></returns>
         public static GetFormatPartsEnumerator GetFormattableStringFormatParts(ReadOnlySpan<char> format) => new GetFormatPartsEnumerator(format);
 
         public ref struct GetFormatPartsEnumerator

--- a/sdk/provisioning/Azure.Provisioning/src/Utilities/FormattableStringHelpers.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Utilities/FormattableStringHelpers.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Azure.Provisioning.Utilities
 {
-    internal static class StringExtensions
+    internal static class FormattableStringHelpers
     {
         public static GetPathPartsEnumerator GetFormattableStringFormatParts(ReadOnlySpan<char> format) => new GetPathPartsEnumerator(format);
 
@@ -102,7 +102,11 @@ namespace Azure.Provisioning.Utilities
                     {
                         var formatSeparatorIndex = span.IndexOf(':');
                         var indexSpan = formatSeparatorIndex == -1 ? span : span.Slice(0, formatSeparatorIndex);
+#if NET8_0_OR_GREATER
+                        argumentIndex = int.Parse(indexSpan);
+#else
                         argumentIndex = int.Parse(indexSpan.ToString());
+#endif
                     }
                 }
             }

--- a/sdk/provisioning/Azure.Provisioning/src/Utilities/StringExtensions.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Utilities/StringExtensions.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Provisioning.Utilities
+{
+    internal static class StringExtensions
+    {
+        public static GetPathPartsEnumerator GetFormattableStringFormatParts(ReadOnlySpan<char> format) => new GetPathPartsEnumerator(format);
+
+        public ref struct GetPathPartsEnumerator
+        {
+            private ReadOnlySpan<char> _path;
+            public Part Current { get; private set; }
+
+            public GetPathPartsEnumerator(ReadOnlySpan<char> format)
+            {
+                _path = format;
+                Current = default;
+            }
+
+            public readonly GetPathPartsEnumerator GetEnumerator() => this;
+
+            public bool MoveNext()
+            {
+                var span = _path;
+                if (span.Length == 0)
+                {
+                    return false;
+                }
+
+                var separatorIndex = span.IndexOfAny('{', '}');
+
+                if (separatorIndex == -1)
+                {
+                    Current = new Part(span, true);
+                    _path = ReadOnlySpan<char>.Empty;
+                    return true;
+                }
+
+                var separator = span[separatorIndex];
+                // Handle {{ and }} escape sequences
+                if (separatorIndex + 1 < span.Length && span[separatorIndex + 1] == separator)
+                {
+                    Current = new Part(span.Slice(0, separatorIndex + 1), true);
+                    _path = span.Slice(separatorIndex + 2);
+                    return true;
+                }
+
+                var isLiteral = separator == '{';
+
+                // Skip empty literals
+                if (isLiteral && separatorIndex == 0 && span.Length > 1)
+                {
+                    separatorIndex = span.IndexOf('}');
+                    if (separatorIndex == -1)
+                    {
+                        Current = new Part(span.Slice(1), true);
+                        _path = ReadOnlySpan<char>.Empty;
+                        return true;
+                    }
+
+                    Current = new Part(span.Slice(1, separatorIndex - 1), false);
+                }
+                else
+                {
+                    Current = new Part(span.Slice(0, separatorIndex), isLiteral);
+                }
+
+                _path = span.Slice(separatorIndex + 1);
+                return true;
+            }
+
+            internal readonly ref struct Part
+            {
+                public Part(ReadOnlySpan<char> span, bool isLiteral)
+                {
+                    Span = span;
+                    IsLiteral = isLiteral;
+                }
+
+                public ReadOnlySpan<char> Span { get; }
+                public bool IsLiteral { get; }
+
+                public void Deconstruct(out ReadOnlySpan<char> span, out bool isLiteral)
+                {
+                    span = Span;
+                    isLiteral = IsLiteral;
+                }
+
+                public void Deconstruct(out ReadOnlySpan<char> span, out bool isLiteral, out int argumentIndex)
+                {
+                    span = Span;
+                    isLiteral = IsLiteral;
+
+                    if (IsLiteral)
+                    {
+                        argumentIndex = -1;
+                    }
+                    else
+                    {
+                        var formatSeparatorIndex = span.IndexOf(':');
+                        var indexSpan = formatSeparatorIndex == -1 ? span : span.Slice(0, formatSeparatorIndex);
+                        argumentIndex = int.Parse(indexSpan.ToString());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning/tests/Expressions/BicepFunctionTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/Expressions/BicepFunctionTests.cs
@@ -1,0 +1,363 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Provisioning.Expressions;
+using NUnit.Framework;
+
+namespace Azure.Provisioning.Tests.Expressions
+{
+    public class BicepFunctionTests
+    {
+        [Test]
+        public void Interpolate_WithLiteralText_ReturnsCorrectFormat()
+        {
+            // Act - test literal interpolated string (cast to FormattableString to resolve ambiguity)
+            var result = BicepFunction.Interpolate($"Hello, World!");
+
+            // Assert
+            Assert.AreEqual("'Hello, World!'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithSingleVariable_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var variable = new ProvisioningVariable("myVar", typeof(string));
+
+            // Act
+            var result = BicepFunction.Interpolate($"Value: {variable}");
+
+            // Assert
+            Assert.AreEqual("'Value: ${myVar}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithMultipleVariables_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var nameVar = new ProvisioningVariable("name", typeof(string));
+            var valueVar = new ProvisioningVariable("value", typeof(string));
+
+            // Act
+            var result = BicepFunction.Interpolate($"Name: {nameVar}, Value: {valueVar}");
+
+            // Assert
+            Assert.AreEqual("'Name: ${name}, Value: ${value}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithBicepExpression_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var expression = new IdentifierExpression("resourceGroup");
+
+            // Act
+            var result = BicepFunction.Interpolate($"Resource Group: {expression}");
+
+            // Assert
+            Assert.AreEqual("'Resource Group: ${resourceGroup}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithBicepValue_ReturnsCorrectFormat()
+        {
+            // Arrange - BicepValue with literal strings are compiled as string literals in interpolation
+            var bicepValue = new BicepValue<string>("test-value");
+
+            // Act
+            var result = BicepFunction.Interpolate($"Static: {bicepValue}");
+
+            // Assert - Literal BicepValues get compiled as string literals, not expressions
+            Assert.AreEqual("'Static: test-value'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithMixedContent_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var variable = new ProvisioningVariable("location", typeof(string));
+            var expression = new IdentifierExpression("resourceGroup");
+            var bicepValue = new BicepValue<string>("suffix");
+
+            // Act
+            var result = BicepFunction.Interpolate($"Prefix-{variable}-{expression}-{bicepValue}");
+
+            // Assert - Literal BicepValues get compiled as string literals, not expressions
+            Assert.AreEqual("'Prefix-${location}-${resourceGroup}-suffix'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithNestedFormattableString_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var variable = new ProvisioningVariable("name", typeof(string));
+            FormattableString nested = $"nested-{variable}";
+
+            // Act
+            var result = BicepFunction.Interpolate($"Outer: {nested}");
+
+            // Assert
+            Assert.AreEqual("'Outer: nested-${name}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithNullValue_HandlesGracefully()
+        {
+            // Arrange
+            string? nullValue = null;
+
+            // Act
+            var result = BicepFunction.Interpolate($"Value: {nullValue}");
+
+            // Assert
+            Assert.AreEqual("'Value: '", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithComplexExpression_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var indexExpression = new IndexExpression(
+                new IdentifierExpression("properties"),
+                new StringLiteralExpression("endpoint")
+            );
+
+            // Act
+            var result = BicepFunction.Interpolate($"Endpoint: {indexExpression}");
+
+            // Assert
+            Assert.AreEqual("'Endpoint: ${properties['endpoint']}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_FormattableStringOverload_WithLiteralText_ReturnsCorrectFormat()
+        {
+            // Arrange
+            FormattableString formattable = $"Hello, World!";
+
+            // Act - explicitly call the FormattableString overload
+            var result = BicepFunction.Interpolate(formattable);
+
+            // Assert
+            Assert.AreEqual("'Hello, World!'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_FormattableStringOverload_WithVariable_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var variable = new ProvisioningVariable("testVar", typeof(string));
+            FormattableString formattable = $"Variable: {variable}";
+
+            // Act - explicitly call the FormattableString overload
+            var result = BicepFunction.Interpolate(formattable);
+
+            // Assert
+            Assert.AreEqual("'Variable: ${testVar}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_EmptyString_ReturnsCorrectFormat()
+        {
+            // Act - cast to FormattableString to resolve ambiguity
+            var result = BicepFunction.Interpolate((FormattableString)$"");
+
+            // Assert
+            Assert.AreEqual("''", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_OnlyVariables_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var variable = new ProvisioningVariable("onlyVar", typeof(string));
+
+            // Act
+            var result = BicepFunction.Interpolate($"{variable}");
+
+            // Assert
+            Assert.AreEqual("'${onlyVar}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithSpecialCharacters_EscapesCorrectly()
+        {
+            // Arrange
+            var variable = new ProvisioningVariable("path", typeof(string));
+
+            // Act
+            var result = BicepFunction.Interpolate($"Path: {variable}\\folder\\file.txt");
+
+            // Assert
+            Assert.AreEqual("'Path: ${path}\\\\folder\\\\file.txt'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithQuotes_EscapesCorrectly()
+        {
+            // Arrange
+            var variable = new ProvisioningVariable("message", typeof(string));
+
+            // Act
+            var result = BicepFunction.Interpolate($"Message: '{variable}' is quoted");
+
+            // Assert
+            Assert.AreEqual("'Message: \\'${message}\\' is quoted'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithCSharpExpressions_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var variable = new ProvisioningVariable("count", typeof(int));
+            int multiplier = 2;
+
+            // Act
+            var result = BicepFunction.Interpolate($"Count: {variable} x {multiplier}");
+
+            // Assert
+            Assert.AreEqual("'Count: ${count} x 2'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_FormattableStringWithComplexArguments_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var resourceGroup = new ProvisioningVariable("rgName", typeof(string));
+            var location = new ProvisioningVariable("location", typeof(string));
+
+            // Create a more complex FormattableString
+            FormattableString formattable = $"RG: {resourceGroup} in {location}";
+
+            // Act
+            var result = BicepFunction.Interpolate(formattable);
+
+            // Assert
+            Assert.AreEqual("'RG: ${rgName} in ${location}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithBicepValueExpression_ReturnsCorrectFormat()
+        {
+            // Arrange - test BicepValue created from expression rather than literal
+            var bicepValue = new BicepValue<string>(new IdentifierExpression("dynamicValue"));
+
+            // Act
+            var result = BicepFunction.Interpolate($"Dynamic: {bicepValue}");
+
+            // Assert
+            Assert.AreEqual("'Dynamic: ${dynamicValue}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithSimpleInterpolation_ReturnsCorrectFormat()
+        {
+            // Arrange - test the specific use case from the user's request
+            var myVariable = new ProvisioningVariable("myVariable", typeof(string));
+
+            // Act - use natural interpolated string syntax
+            var result = BicepFunction.Interpolate($"Hello {myVariable}!");
+
+            // Assert
+            Assert.AreEqual("'Hello ${myVariable}!'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithMultipleInterpolatedValues_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var prefix = new ProvisioningVariable("prefix", typeof(string));
+            var suffix = new ProvisioningVariable("suffix", typeof(string));
+
+            // Act
+            var result = BicepFunction.Interpolate($"{prefix}-{suffix}");
+
+            // Assert
+            Assert.AreEqual("'${prefix}-${suffix}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithResourceReferences_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var resourceName = new ProvisioningVariable("resourceName", typeof(string));
+            var location = new ProvisioningVariable("location", typeof(string));
+
+            // Act - test a more realistic scenario
+            var result = BicepFunction.Interpolate($"Creating resource '{resourceName}' in location '{location}'");
+
+            // Assert
+            Assert.AreEqual("'Creating resource \\'${resourceName}\\' in location \\'${location}\\''", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithNumericInterpolation_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var port = new ProvisioningVariable("port", typeof(int));
+            var timeout = 30;
+
+            // Act
+            var result = BicepFunction.Interpolate($"Server running on port {port} with timeout {timeout}s");
+
+            // Assert
+            Assert.AreEqual("'Server running on port ${port} with timeout 30s'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithConditionalExpression_ReturnsCorrectFormat()
+        {
+            // Arrange
+            var condition = new IdentifierExpression("isDevelopment");
+            var prodValue = new IdentifierExpression("prodConfig");
+            var devValue = new IdentifierExpression("devConfig");
+            var conditionalExpr = new ConditionalExpression(condition, devValue, prodValue);
+
+            // Act
+            var result = BicepFunction.Interpolate($"Config: {conditionalExpr}");
+
+            // Assert
+            Assert.AreEqual("'Config: ${isDevelopment ? devConfig : prodConfig}'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithNestedFormattableInLiteralInterpolation_ReturnsCorrectFormat()
+        {
+            // Arrange - test case 1: literal interpolated string with FormattableString as argument
+            var outerVar = new ProvisioningVariable("outerVar", typeof(string));
+            var innerVar = new ProvisioningVariable("innerVar", typeof(string));
+            var middleVar = new ProvisioningVariable("middleVar", typeof(string));
+
+            // Create nested FormattableString
+            FormattableString innerFormattable = $"inner[{innerVar}]";
+            FormattableString middleFormattable = $"middle({middleVar}|{innerFormattable})";
+
+            // Act - Use literal interpolated string with nested FormattableString
+            var result = BicepFunction.Interpolate($"Outer: {outerVar} -> {middleFormattable}");
+
+            // Assert
+            Assert.AreEqual("'Outer: ${outerVar} -> middle(${middleVar}|inner[${innerVar}])'", result.ToString());
+        }
+
+        [Test]
+        public void Interpolate_WithFormattableStringContainingNestedFormattable_ReturnsCorrectFormat()
+        {
+            // Arrange - test case 2: FormattableString as argument with nested FormattableString
+            var level1Var = new ProvisioningVariable("level1", typeof(string));
+            var level2Var = new ProvisioningVariable("level2", typeof(string));
+            var level3Var = new ProvisioningVariable("level3", typeof(string));
+
+            // Create deeply nested FormattableStrings
+            FormattableString level3Formattable = $"L3:{level3Var}";
+            FormattableString level2Formattable = $"L2:{level2Var}->{level3Formattable}";
+            FormattableString level1Formattable = $"L1:{level1Var}->{level2Formattable}";
+
+            // Act - Pass FormattableString containing nested FormattableStrings to Interpolate
+            var result = BicepFunction.Interpolate(level1Formattable);
+
+            // Assert
+            Assert.AreEqual("'L1:${level1}->L2:${level2}->L3:${level3}'", result.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/47360

Our current overloads only support the "literal interpolated strings", for instance:
```
BicepFunction.Interpolate($"Hello {world}");
```
this works fine now, but if we do this:
```
FormattableString fs = $"Hello {world}";
Bicep.Function.Interpolate(fs); // error
```
this would not compile.

This PR adds an implicit operator for the `BicepInterpolatedStringHandler` from `FormattableString` to make the second usage of above available.

**Why we do not make another overload that takes the `FormattableString` directly?**
Because if we do that, like this:
```
public static BicepExpression Interpolate(BicepInterpolatedStringHandler handler);
public static BicepExpression Interpolate(FormattableString fs);
```
and when we call this:
```
BicepFunction.Interpolate($"Hello world");
```
this would not compile complaining about "ambiguous call from the above two overloads".

Therefore the current approach I am taking is that I added an implicit operator, therefore when you are using FormattableString as argument, the compiler would call the cast operator first, and then follow the old way to give you the interpolated result.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
