### PR TITLE
Add virtual public members in AIProjectClient for mocking or unit testing

### DIFF
--- a/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
@@ -144,16 +144,16 @@ namespace Azure.AI.Projects
         }
 
         /// <summary> Gets the client for managing connections. </summary>
-        public Connections Connections { get => GetConnectionsClient(); }
+        public virtual Connections Connections { get => GetConnectionsClient(); }
         /// <summary> Gets the client for managing datasets. </summary>
-        public Datasets Datasets { get => GetDatasetsClient(); }
+        public virtual Datasets Datasets { get => GetDatasetsClient(); }
         /// <summary> Gets the client for managing deployments. </summary>
-        public Deployments Deployments { get => GetDeploymentsClient(); }
+        public virtual Deployments Deployments { get => GetDeploymentsClient(); }
         /// <summary> Gets the client for evaluations operations. </summary>
-        public Evaluations Evaluations { get => GetEvaluationsClient(); }
+        public virtual Evaluations Evaluations { get => GetEvaluationsClient(); }
         /// <summary> Gets the client for managing indexes. </summary>
-        public Indexes Indexes { get => GetIndexesClient(); }
+        public virtual Indexes Indexes { get => GetIndexesClient(); }
         /// <summary> Gets the client for telemetry operations. </summary>
-        public Telemetry Telemetry { get => new Telemetry(this); }
+        public virtual Telemetry Telemetry { get => new Telemetry(this); }
     }
 }


### PR DESCRIPTION
AIProjectClient class public members Evaluations, Connections, Datasets etc. are not currently marked as virtual and not able to setup unit tests for this. So, marking these members as virtual to support unit testing
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
