### PR TITLE
Clean-up some of the SDL tool configurations

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -145,8 +145,6 @@ stages:
     jobs:
       - job: ComplianceTools
         timeoutInMinutes: 120
-        variables:
-        - template: /eng/pipelines/templates/variables/codeql.yml
 
         steps:
           - template: /eng/common/pipelines/templates/steps/policheck.yml

--- a/eng/pipelines/templates/jobs/batched-build-analyze.yml
+++ b/eng/pipelines/templates/jobs/batched-build-analyze.yml
@@ -43,9 +43,6 @@ jobs:
       matrix: $[ ${{ parameters.Matrix }} ]
 
     variables:
-    - template: /eng/pipelines/templates/variables/codeql.yml
-    - name: Codeql.BuildIdentifier
-      value: ${{ parameters.ServiceDirectory }}
     - name: SDKType
       value: ${{ parameters.SDKType }}
 

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -94,11 +94,18 @@ jobs:
         os: windows
 
       variables:
-      - template: /eng/pipelines/templates/variables/codeql.yml
-      - name: Codeql.BuildIdentifier
-        value: ${{ parameters.ServiceDirectory }}
       - name: SDKType
         value: ${{ parameters.SDKType }}
+
+      # Only run CG and codeql on internal build job
+      ${{ if and(eq(variables['System.TeamProject'], 'internal') }}:
+        templateContext:
+          sdl:
+            componentgovernance:
+              enabled: true
+            codeql:
+              compiled:
+                enabled: false
 
       steps:
         - template: /eng/pipelines/templates/steps/build.yml

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -98,7 +98,7 @@ jobs:
         value: ${{ parameters.SDKType }}
 
       # Only run CG and codeql on internal build job
-      ${{ if and(eq(variables['System.TeamProject'], 'internal') }}:
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         templateContext:
           sdl:
             componentgovernance:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -66,6 +66,9 @@ extends:
       componentgovernance:
         enabled: false
         justificationForDisabling: "To reduce redundant CG runs across all our pipeline jobs we are disabling and only running in our main build job."
+      eslint:
+        enabled: false
+        justificationForDisabling: 'ESLint is interesting for this repo as it is .NET code mostly and any JS/TS in the repo is updated outside of this repo.'
       psscriptanalyzer:
         compiled: true
         break: true

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,9 +40,6 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-    ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
-      featureFlags:
-        autoBaseline: true
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:
@@ -62,13 +59,13 @@ extends:
         analyzeTargetGlob: +:file|**/*.dll;+:file|**/*.exe;-:f|**/net452/Microsoft.Azure.KeyVault.Core.dll;-:f|**/net461/Microsoft.Azure.KeyVault.Core.dll;-:f|**/tools/NuGet.exe;-:f|**/tools/gpg/**/*.dll;-:f|**/tools/gpg/**/*.exe;-:f|**/tools/azcopy/**/*.exe;-:f|**/tools/azcopy/**/*.dll;-:f|**/aotcompatibility/**/*.exe
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false
-      eslint:
-        enabled: false
-        justificationForDisabling: 'ESLint injected task has failures because it uses an old version of mkdirp. We should not fail for tools not controlled by the repo. See: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3499746'
       codeql:
         compiled:
           enabled: false
-          justificationForDisabling: CodeQL times our pipelines out by running for 2+ hours before being force canceled.
+          justificationForDisabling: "To reduce redundant CG runs across all our pipeline jobs we are disabling and only running in our main build job."
+      componentgovernance:
+        enabled: false
+        justificationForDisabling: "To reduce redundant CG runs across all our pipeline jobs we are disabling and only running in our main build job."
       psscriptanalyzer:
         compiled: true
         break: true

--- a/eng/pipelines/templates/variables/codeql.yml
+++ b/eng/pipelines/templates/variables/codeql.yml
@@ -1,3 +1,0 @@
-variables:
-  Codeql.Enabled: true
-  Codeql.SkipTaskAutoInjection: false


### PR DESCRIPTION
Run CG and codeql only on the build jobs for our internal builds.