### PR TITLE
refactor: make AuthenticationRestClient a public class

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/autorest.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/autorest.md
@@ -193,3 +193,12 @@ directive:
   where: $..[?(@.operationId=='ContainerRegistryBlob_GetBlob' || @.operationId=='ContainerRegistryBlob_GetChunk')]
   transform: $["x-csharp-buffer-response"] = false;
 ```
+
+# Make AuthenticationRestClient a public class
+``` yaml
+directive:
+- from: swagger-document
+  where: $..[?(@.operationId=='Authentication_ExchangeAadAccessTokenForAcrRefreshToken' || @.operationId=='Authentication_ExchangeAcrRefreshTokenForAcrAccessToken')]
+  transform: >
+    $["x-accessibility"] = "public";
+```


### PR DESCRIPTION
Help needed, running `dotnet build /t:GenerateCode` under `\sdk\containerregistry\Azure.Containers.ContainerRegistry\src` currently takes no effect.

Our goal is to make [AuthenticationRestClient](https://github.com/Azure/azure-sdk-for-net/blob/ca6cfccb202e9f6517cbd71e87263d5f06877a4a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Generated/AuthenticationRestClient.cs#L17) a public class.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
