### PR TITLE
Flattened property should honor readability of internal property

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SafeFlattenVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SafeFlattenVisitor.cs
@@ -59,7 +59,7 @@ namespace Azure.Generator.Management.Visitors
                             };
                         var flattenPropertyBody = new MethodPropertyBody(
                             Return(new TernaryConditionalExpression(checkNullExpression, Default, new MemberExpression(internalSingleProperty, singleProperty.Name))),
-                            singleProperty.Body?.HasSetter == true ? setter : null
+                            singleProperty.Body?.HasSetter == true ? setter : null // only add setter for flattend property if the internal property has a setter
                         );
                         var flattenedProperty = new PropertyProvider(singleProperty.Description, singleProperty.Modifiers, singleProperty.Type, flattenPropertyName, flattenPropertyBody, type, singleProperty.ExplicitInterface, singleProperty.WireInfo, singleProperty.Attributes);
                         flattenedProperties.Add(flattenedProperty);

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/bar.tsp
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/bar.tsp
@@ -52,6 +52,7 @@ model BarSettings is ProxyResource<BarSettingsProperties> {
 
 model BarSettingsProperties {
   /** enabled */
+  @visibility(Lifecycle.Read)
   isEnabled?: boolean;
 }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsData.cs
@@ -47,19 +47,11 @@ namespace MgmtTypeSpec
         public IList<string> StringArray { get; }
 
         /// <summary> enabled. </summary>
-        public bool? IsEnabled
+        public bool? PropertiesIsEnabled
         {
             get
             {
                 return Properties is null ? default : Properties.IsEnabled;
-            }
-            set
-            {
-                if (Properties is null)
-                {
-                    Properties = new BarSettingsProperties();
-                }
-                Properties.IsEnabled = value;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecModelFactory.cs
@@ -100,10 +100,10 @@ namespace MgmtTypeSpec.Models
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
         /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
-        /// <param name="isEnabled"> enabled. </param>
+        /// <param name="propertiesIsEnabled"> enabled. </param>
         /// <param name="stringArray"></param>
         /// <returns> A new <see cref="MgmtTypeSpec.BarSettingsData"/> instance for mocking. </returns>
-        public static BarSettingsData BarSettingsData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, bool? isEnabled = default, IEnumerable<string> stringArray = default)
+        public static BarSettingsData BarSettingsData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, bool? propertiesIsEnabled = default, IEnumerable<string> stringArray = default)
         {
             stringArray ??= new ChangeTrackingList<string>();
 
@@ -113,7 +113,7 @@ namespace MgmtTypeSpec.Models
                 resourceType,
                 systemData,
                 additionalBinaryDataProperties: null,
-                isEnabled is null ? default : new BarSettingsProperties(isEnabled, new Dictionary<string, BinaryData>()),
+                propertiesIsEnabled is null ? default : new BarSettingsProperties(propertiesIsEnabled, new Dictionary<string, BinaryData>()),
                 stringArray.ToList());
         }
 
@@ -123,10 +123,10 @@ namespace MgmtTypeSpec.Models
         /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
         /// <param name="tags"> Resource tags. </param>
         /// <param name="location"> The geo-location where the resource lives. </param>
-        /// <param name="something"> something. </param>
+        /// <param name="propertiesSomething"> something. </param>
         /// <param name="extendedLocation"></param>
         /// <returns> A new <see cref="MgmtTypeSpec.ZooData"/> instance for mocking. </returns>
-        public static ZooData ZooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, string location = default, string something = default, ExtendedLocation extendedLocation = default)
+        public static ZooData ZooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, string location = default, string propertiesSomething = default, ExtendedLocation extendedLocation = default)
         {
             tags ??= new ChangeTrackingDictionary<string, string>();
 
@@ -138,18 +138,18 @@ namespace MgmtTypeSpec.Models
                 additionalBinaryDataProperties: null,
                 tags,
                 location,
-                something is null ? default : new ZooProperties(something, new Dictionary<string, BinaryData>()),
+                propertiesSomething is null ? default : new ZooProperties(propertiesSomething, new Dictionary<string, BinaryData>()),
                 extendedLocation);
         }
 
         /// <param name="tags"> Resource tags. </param>
-        /// <param name="something"> something. </param>
+        /// <param name="propertiesSomething"> something. </param>
         /// <returns> A new <see cref="Models.ZooPatch"/> instance for mocking. </returns>
-        public static ZooPatch ZooPatch(IDictionary<string, string> tags = default, string something = default)
+        public static ZooPatch ZooPatch(IDictionary<string, string> tags = default, string propertiesSomething = default)
         {
             tags ??= new ChangeTrackingDictionary<string, string>();
 
-            return new ZooPatch(tags, something is null ? default : new ZooUpdateProperties(something, new Dictionary<string, BinaryData>()), additionalBinaryDataProperties: null);
+            return new ZooPatch(tags, propertiesSomething is null ? default : new ZooUpdateProperties(propertiesSomething, new Dictionary<string, BinaryData>()), additionalBinaryDataProperties: null);
         }
 
         /// <summary> The ZooRecommendation. </summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/BarSettingsProperties.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/BarSettingsProperties.Serialization.cs
@@ -34,7 +34,7 @@ namespace MgmtTypeSpec.Models
             {
                 throw new FormatException($"The model {nameof(BarSettingsProperties)} does not support writing '{format}' format.");
             }
-            if (Optional.IsDefined(IsEnabled))
+            if (options.Format != "W" && Optional.IsDefined(IsEnabled))
             {
                 writer.WritePropertyName("isEnabled"u8);
                 writer.WriteBooleanValue(IsEnabled.Value);

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/BarSettingsProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/BarSettingsProperties.cs
@@ -31,6 +31,6 @@ namespace MgmtTypeSpec.Models
         }
 
         /// <summary> enabled. </summary>
-        public bool? IsEnabled { get; set; }
+        public bool? IsEnabled { get; }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooSettingsPatch.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooSettingsPatch.cs
@@ -34,7 +34,7 @@ namespace MgmtTypeSpec.Models
         internal FooSettingsUpdateProperties Properties { get; set; }
 
         /// <summary> Gets or sets the AccessControlEnabled. </summary>
-        public bool? AccessControlEnabled
+        public bool? PropertiesAccessControlEnabled
         {
             get
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/ZooPatch.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/ZooPatch.cs
@@ -41,7 +41,7 @@ namespace MgmtTypeSpec.Models
         internal ZooUpdateProperties Properties { get; set; }
 
         /// <summary> something. </summary>
-        public string Something
+        public string PropertiesSomething
         {
             get
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZooData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZooData.cs
@@ -53,7 +53,7 @@ namespace MgmtTypeSpec
         public ExtendedLocation ExtendedLocation { get; set; }
 
         /// <summary> something. </summary>
-        public string Something
+        public string PropertiesSomething
         {
             get
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
@@ -12230,8 +12230,13 @@
   ],
   "auth": {
     "oAuth2": {
-      "scopes": [
-        "user_impersonation"
+      "flows": [
+        {
+          "scopes": [
+            "user_impersonation"
+          ],
+          "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize"
+        }
       ]
     }
   }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
@@ -4175,7 +4175,7 @@
                   "decorators": []
                 },
                 "optional": true,
-                "readOnly": false,
+                "readOnly": true,
                 "discriminator": false,
                 "flatten": false,
                 "decorators": [],
@@ -12230,13 +12230,8 @@
   ],
   "auth": {
     "oAuth2": {
-      "flows": [
-        {
-          "scopes": [
-            "user_impersonation"
-          ],
-          "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize"
-        }
+      "scopes": [
+        "user_impersonation"
       ]
     }
   }


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/51303
Also rename the flattened property as autorest.csharp
