### PR TITLE
Use `VisitMethod` instead of `VisitType` for SerializationVisitor

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/NameVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/NameVisitor.cs
@@ -43,7 +43,6 @@ internal class NameVisitor : ScmLibraryVisitor
         };
 
     private readonly HashSet<CSharpType> _resourceUpdateModelTypes = new();
-    private readonly Dictionary<MrwSerializationTypeDefinition, string> _deserializationRename = new();
 
     protected override ModelProvider? PreVisitModel(InputModelType model, ModelProvider? type)
     {
@@ -101,7 +100,6 @@ internal class NameVisitor : ScmLibraryVisitor
         {
             // Update the serialization provider name to match the model name
             serializationProvider.Update(name: newName);
-            _deserializationRename.Add(serializationProvider, $"Deserialize{newName}");
         }
     }
 
@@ -158,12 +156,6 @@ internal class NameVisitor : ScmLibraryVisitor
         {
             // This is required as a workaround to update documentation for the method signature
             method.Update(signature: method.Signature);
-        }
-
-        // TODO: we will remove this manual updated when https://github.com/microsoft/typespec/issues/8079 is resolved
-        if (method.EnclosingType is MrwSerializationTypeDefinition serializationTypeDefinition && _deserializationRename.TryGetValue(serializationTypeDefinition, out var newName) && method.Signature.Name.StartsWith("Deserialize"))
-        {
-            method.Signature.Update(name: newName);
         }
 
         return base.VisitMethod(method);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SerializationVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SerializationVisitor.cs
@@ -14,29 +14,22 @@ internal class SerializationVisitor : ScmLibraryVisitor
     internal const string FromResponseMethodName = "FromResponse";
 
     /// <inheritdoc/>
-    protected override TypeProvider? VisitType(TypeProvider type)
+    protected override MethodProvider? VisitMethod(MethodProvider method)
     {
-        if (type is MrwSerializationTypeDefinition serializationTypeDefinition)
+        if (method.EnclosingType is MrwSerializationTypeDefinition && method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator))
         {
-            foreach (var method in serializationTypeDefinition.Methods)
+            var modifiers = method.Signature.Modifiers & ~MethodSignatureModifiers.Operator & ~MethodSignatureModifiers.Public | MethodSignatureModifiers.Internal;
+            if (modifiers.HasFlag(MethodSignatureModifiers.Implicit))
             {
-                if (method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator))
-                {
-                    var modifiers = method.Signature.Modifiers & ~MethodSignatureModifiers.Operator & ~MethodSignatureModifiers.Public | MethodSignatureModifiers.Internal;
-                    if (modifiers.HasFlag(MethodSignatureModifiers.Implicit))
-                    {
-                        modifiers &= ~MethodSignatureModifiers.Implicit;
-                        method.Signature.Update(modifiers: modifiers, name: ToRequestContentMethodName);
-                    }
-                    else if (modifiers.HasFlag(MethodSignatureModifiers.Explicit))
-                    {
-                        modifiers &= ~MethodSignatureModifiers.Explicit;
-                        method.Signature.Update(modifiers: modifiers, name: FromResponseMethodName);
-                    }
-                }
+                modifiers &= ~MethodSignatureModifiers.Implicit;
+                method.Signature.Update(modifiers: modifiers, name: ToRequestContentMethodName);
             }
-            return type;
+            else if (modifiers.HasFlag(MethodSignatureModifiers.Explicit))
+            {
+                modifiers &= ~MethodSignatureModifiers.Explicit;
+                method.Signature.Update(modifiers: modifiers, name: FromResponseMethodName);
+            }
         }
-        return base.VisitType(type);
+        return base.VisitMethod(method);
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
@@ -34,11 +34,11 @@ namespace Azure.Generator.Mgmt.Tests
                 decorators: []);
 
             var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [model], clients: () => [client]);
-            var visitor = new TestVisitor();
+
+            // PreVisitModel is called during the model creation
             var type = plugin.Object.TypeFactory.CreateModel(model);
-            var transformedModel = visitor.InvokeVisit(model, type);
-            Assert.That(transformedModel?.Name, Is.EqualTo(TestModelName.Replace("Url", "Uri")));
-            Assert.That(transformedModel?.Properties[0].Name, Is.EqualTo(TestProtyName.Replace("Url", "Uri")));
+            Assert.That(type?.Name, Is.EqualTo(TestModelName.Replace("Url", "Uri")));
+            Assert.That(type?.Properties[0].Name, Is.EqualTo(TestProtyName.Replace("Url", "Uri")));
         }
 
         [Test]
@@ -58,26 +58,18 @@ namespace Azure.Generator.Mgmt.Tests
                 decorators: []);
 
             var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [model], clients: () => [client]);
-            var visitor = new TestVisitor();
+
+            // PreVisitModel is called during the model creation
             var type = plugin.Object.TypeFactory.CreateModel(model);
-            var transformedModel = visitor.InvokeVisit(model, type);
             var resourceProviderName = ManagementClientGenerator.Instance.TypeFactory.ResourceProviderName;
             var updatedSkuModelName = $"{resourceProviderName}{skuModelName}";
-            Assert.AreEqual(transformedModel?.Name, updatedSkuModelName);
-            Assert.AreEqual(transformedModel!.Constructors[0].Signature.Name, $"{resourceProviderName}{skuModelName}");
-            var serializationProvider = transformedModel?.SerializationProviders.SingleOrDefault();
+            Assert.AreEqual(type?.Name, updatedSkuModelName);
+            Assert.AreEqual(type!.Constructors[0].Signature.Name, $"{resourceProviderName}{skuModelName}");
+            var serializationProvider = type?.SerializationProviders.SingleOrDefault();
             Assert.NotNull(serializationProvider);
             Assert.AreEqual(serializationProvider!.Name, updatedSkuModelName);
-            var deserializationMethod = serializationProvider.Methods.SingleOrDefault(m => m.Signature.Name.Equals($"Deserialize{updatedSkuModelName}"));
-            Assert.NotNull(deserializationMethod);
-        }
-
-        private class TestVisitor : NameVisitor
-        {
-            public ModelProvider? InvokeVisit(InputModelType model, ModelProvider? type)
-            {
-                return base.PreVisitModel(model, type);
-            }
+            var deserializationMethod = serializationProvider.Methods.SingleOrDefault(m => m.Signature.Name.StartsWith("Deserialize"));
+            Assert.NotNull("DeserializeSamplesSku", deserializationMethod!.Signature.Name);
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
@@ -69,7 +69,7 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.NotNull(serializationProvider);
             Assert.AreEqual(serializationProvider!.Name, updatedSkuModelName);
             var deserializationMethod = serializationProvider.Methods.SingleOrDefault(m => m.Signature.Name.StartsWith("Deserialize"));
-            Assert.NotNull("DeserializeSamplesSku", deserializationMethod!.Signature.Name);
+            Assert.AreEqual("DeserializeSamplesSku", deserializationMethod!.Signature.Name);
         }
     }
 }


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
