### PR TITLE
docs: update ACR service owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -402,7 +402,6 @@
 /sdk/containerregistry/                                            @Azure/azsdk-acr
 
 # ServiceLabel: %Container Registry
-# AzureSdkOwners:                                                  @jsquire
 # ServiceOwners:                                                   @toddysm @shizhMSFT
 
 # ServiceLabel: %Container Service

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -403,7 +403,7 @@
 
 # ServiceLabel: %Container Registry
 # AzureSdkOwners:                                                  @jsquire
-# ServiceOwners:                                                   @toddysm @yugangw-MSFT
+# ServiceOwners:                                                   @toddysm @shizhMSFT
 
 # ServiceLabel: %Container Service
 # ServiceOwners:                                                   @qike-ms @jwilder @thomas1206 @seanmck


### PR DESCRIPTION
Update Azure Container Registry service owners from @yugangw-MSFT to @shizhMSFT in `CODEOWNERS` file.