### PR TITLE
refactor `RestClientInfo` stuff for preparation of non-resource operations in extension classes

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceMetadata.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceMetadata.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.TypeSpec.Generator.Input;
 
 namespace Azure.Generator.Management.Models
 {
@@ -13,6 +12,5 @@ namespace Azure.Generator.Management.Models
         IReadOnlyList<ResourceMethod> Methods,
         string? SingletonResourceName,
         string? ParentResourceId,
-        string ResourceName,
-        IReadOnlyDictionary<string, InputClient> MethodToClientMap);
+        string ResourceName);
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceMethod.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.TypeSpec.Generator.Input;
+
 namespace Azure.Generator.Management.Models
 {
-    internal record ResourceMethod(string Id, ResourceOperationKind Kind);
+    internal record ResourceMethod(ResourceOperationKind Kind, InputServiceMethod InputMethod, InputClient InputClient);
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RestClientInfo.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RestClientInfo.cs
@@ -9,5 +9,11 @@ namespace Azure.Generator.Management.Models
     /// <summary>
     /// Record to combine client provider and related field providers
     /// </summary>
-    internal record RestClientInfo(ClientProvider RestClientProvider, FieldProvider RestClientField, FieldProvider DiagnosticsField);
+    internal record RestClientInfo(ClientProvider RestClientProvider, FieldProvider RestClientField, PropertyProvider? RestClientProperty, FieldProvider DiagnosticsField, PropertyProvider? DiagnosticProperty)
+    {
+        internal RestClientInfo(ClientProvider restClientProvider, FieldProvider restClientField, FieldProvider diagnosticsField)
+            : this(restClientProvider, restClientField, null, diagnosticsField, null)
+        {
+        }
+    }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -48,7 +48,7 @@ namespace Azure.Generator.Management.Providers
             return resource;
         }
 
-        private IEnumerable<(ResourceOperationKind, InputServiceMethod)> _resourceServiceMethods;
+        private IReadOnlyList<ResourceMethod> _resourceServiceMethods;
 
         private readonly FieldProvider _dataField;
         private readonly FieldProvider _resourceTypeField;
@@ -69,8 +69,7 @@ namespace Azure.Generator.Management.Providers
 
             ResourceName = resourceName;
 
-            // We should be able to assume that all operations in the resource client are for the same resource
-            _resourceServiceMethods = resourceMetadata.Methods.Select(m => (m.Kind, ManagementClientGenerator.Instance.InputLibrary.GetMethodByCrossLanguageDefinitionId(m.Id)!));
+            _resourceServiceMethods = resourceMetadata.Methods;
             ResourceData = ManagementClientGenerator.Instance.TypeFactory.CreateModel(model)!;
 
             // Initialize client info dictionary using extension method
@@ -93,7 +92,8 @@ namespace Azure.Generator.Management.Providers
 
         internal ModelProvider ResourceData { get; }
         internal string ResourceName { get; }
-        internal IEnumerable<(ResourceOperationKind Kind, InputServiceMethod Method)> ResourceServiceMethods => _resourceServiceMethods;
+        // TODO -- we should not need to expose this.
+        internal IEnumerable<ResourceMethod> ResourceServiceMethods => _resourceServiceMethods;
 
         internal string? SingletonResourceName => _resourceMetadata.SingletonResourceName;
 
@@ -233,7 +233,7 @@ namespace Azure.Generator.Management.Providers
         // TODO -- this is temporary. We should change this to find the corresponding parameters in ContextualParameters after it is refactored to consume parent resources.
         private CSharpType GetPathParameterType(string parameterName)
         {
-            foreach (var (kind, method) in _resourceServiceMethods)
+            foreach (var (kind, method, _) in _resourceServiceMethods)
             {
                 if (!kind.IsCrudKind())
                 {
@@ -319,7 +319,7 @@ namespace Azure.Generator.Management.Providers
             var operationMethods = new List<MethodProvider>();
             UpdateOperationMethodProvider? updateMethodProvider = null;
 
-            foreach (var (methodKind, method) in _resourceServiceMethods)
+            foreach (var (methodKind, method, inputClient) in _resourceServiceMethods)
             {
                 // exclude the List operations for resource and Create operations for non-singleton resources (they will be in ResourceCollection)
                 if (methodKind == ResourceOperationKind.List || (!IsSingleton && methodKind == ResourceOperationKind.Create))
@@ -330,7 +330,7 @@ namespace Azure.Generator.Management.Providers
                 var isFakeLro = ResourceHelpers.ShouldMakeLro(methodKind);
 
                 // Get the appropriate rest client for this specific method
-                var restClientInfo = _resourceMetadata.GetRestClientForServiceMethod(method, _clientInfos);
+                var restClientInfo = _clientInfos[inputClient];
 
                 var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(method.Operation, false);
                 var asyncConvenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(method.Operation, true);
@@ -378,8 +378,7 @@ namespace Azure.Generator.Management.Providers
                 var updateMethod = _resourceMetadata.Methods.FirstOrDefault(m => m.Kind == ResourceOperationKind.Update || m.Kind == ResourceOperationKind.Create);
                 if (updateMethod is not null)
                 {
-                    var updateRestClientInfo = _resourceMetadata.GetRestClientForServiceMethod(
-                        ManagementClientGenerator.Instance.InputLibrary.GetMethodByCrossLanguageDefinitionId(updateMethod.Id)!, _clientInfos);
+                    var updateRestClientInfo = _clientInfos[updateMethod.InputClient];
 
                     methods.AddRange([
                         new AddTagMethodProvider(this, updateMethodProvider, updateRestClientInfo, true),

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Management.Providers
@@ -30,9 +29,9 @@ namespace Azure.Generator.Management.Providers
         private readonly ResourceMetadata _resourceMetadata;
 
         private readonly ResourceClientProvider _resource;
-        private readonly InputServiceMethod? _getAll;
-        private readonly InputServiceMethod? _create;
-        private readonly InputServiceMethod? _get;
+        private readonly ResourceMethod? _getAll;
+        private readonly ResourceMethod? _create;
+        private readonly ResourceMethod? _get;
 
         // Support for multiple rest clients
         private readonly Dictionary<InputClient, RestClientInfo> _clientInfos;
@@ -79,9 +78,9 @@ namespace Azure.Generator.Management.Providers
 
         private static void InitializeMethods(
             ResourceMetadata resourceMetadata,
-            ref InputServiceMethod? getMethod,
-            ref InputServiceMethod? createMethod,
-            ref InputServiceMethod? getAllMethod)
+            ref ResourceMethod? getMethod,
+            ref ResourceMethod? createMethod,
+            ref ResourceMethod? getAllMethod)
         {
             foreach (var method in resourceMetadata.Methods)
             {
@@ -93,30 +92,14 @@ namespace Azure.Generator.Management.Providers
                 switch (method.Kind)
                 {
                     case ResourceOperationKind.Get:
-                        AssignMethodKind(ref getMethod, resourceMetadata.ResourceIdPattern, method);
+                        getMethod = method;
                         break;
                     case ResourceOperationKind.List:
-                        AssignMethodKind(ref getAllMethod, resourceMetadata.ResourceIdPattern, method);
+                        getAllMethod = method;
                         break;
                     case ResourceOperationKind.Create:
-                        AssignMethodKind(ref createMethod, resourceMetadata.ResourceIdPattern, method);
+                        createMethod = method;
                         break;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static void AssignMethodKind(ref InputServiceMethod? method, string resourceIdPattern, ResourceMethod resourceMethod)
-            {
-                if (method is not null)
-                {
-                    ManagementClientGenerator.Instance.Emitter.ReportDiagnostic(
-                        "general-warning", // TODO -- in the near future, we should have a resource-specific diagnostic ID
-                        $"Resource {resourceIdPattern} has multiple '{resourceMethod.Kind}' methods."
-                        );
-                }
-                else
-                {
-                    method = ManagementClientGenerator.Instance.InputLibrary.GetMethodByCrossLanguageDefinitionId(resourceMethod.Id);
                 }
             }
         }
@@ -262,46 +245,46 @@ namespace Azure.Generator.Management.Providers
 
         private List<MethodProvider> BuildCreateOrUpdateMethods()
         {
-            var result = new List<MethodProvider>();
             if (_create is null)
             {
-                return result;
+                return [];
             }
 
-            var restClientInfo = _resourceMetadata.GetRestClientForServiceMethod(_create, _clientInfos);
+            var result = new List<MethodProvider>();
+            var restClientInfo = _clientInfos[_create.InputClient];
             foreach (var isAsync in new List<bool> { true, false })
             {
-                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_create!.Operation, isAsync);
+                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_create.InputMethod.Operation, isAsync);
                 var methodName = ResourceHelpers.GetOperationMethodName(ResourceOperationKind.Create, isAsync);
-                result.Add(new ResourceOperationMethodProvider(this, ContextualPath, restClientInfo, _create, isAsync, methodName, forceLro: true));
+                result.Add(new ResourceOperationMethodProvider(this, ContextualPath, restClientInfo, _create.InputMethod, isAsync, methodName: methodName, forceLro: true));
             }
 
             return result;
         }
 
-        private MethodProvider BuildGetAllMethod(InputServiceMethod getAll, bool isAsync)
+        private MethodProvider BuildGetAllMethod(ResourceMethod getAll, bool isAsync)
         {
-            var restClientInfo = _resourceMetadata.GetRestClientForServiceMethod(getAll, _clientInfos);
-            return getAll switch
+            var restClientInfo = _clientInfos[getAll.InputClient];
+            return getAll.InputMethod switch
             {
                 InputPagingServiceMethod pagingGetAll => new PageableOperationMethodProvider(this, ContextualPath, restClientInfo, pagingGetAll, isAsync, ResourceOperationKind.List),
-                _ => new ResourceOperationMethodProvider(this, ContextualPath, restClientInfo, getAll, isAsync, ResourceHelpers.GetOperationMethodName(ResourceOperationKind.List, isAsync))
+                _ => new ResourceOperationMethodProvider(this, ContextualPath, restClientInfo, getAll.InputMethod, isAsync, ResourceHelpers.GetOperationMethodName(ResourceOperationKind.List, isAsync))
             };
         }
 
         private List<MethodProvider> BuildGetMethods()
         {
-            var result = new List<MethodProvider>();
             if (_get is null)
             {
-                return result;
+                return [];
             }
 
-            var restClientInfo = _resourceMetadata.GetRestClientForServiceMethod(_get, _clientInfos);
+            var result = new List<MethodProvider>();
+            var restClientInfo = _clientInfos[_get.InputClient];
             foreach (var isAsync in new List<bool> { true, false })
             {
-                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_get!.Operation, isAsync);
-                result.Add(new ResourceOperationMethodProvider(this, ContextualPath, restClientInfo, _get, isAsync));
+                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_get.InputMethod.Operation, isAsync);
+                result.Add(new ResourceOperationMethodProvider(this, ContextualPath, restClientInfo, _get.InputMethod, isAsync));
             }
 
             return result;
@@ -309,17 +292,17 @@ namespace Azure.Generator.Management.Providers
 
         private List<MethodProvider> BuildExistsMethods()
         {
-            var result = new List<MethodProvider>();
             if (_get is null)
             {
-                return result;
+                return [];
             }
 
-            var restClientInfo = _resourceMetadata.GetRestClientForServiceMethod(_get, _clientInfos);
+            var result = new List<MethodProvider>();
+            var restClientInfo = _clientInfos[_get.InputClient];
             foreach (var isAsync in new List<bool> { true, false })
             {
-                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_get!.Operation, isAsync);
-                var existsMethodProvider = new ExistsOperationMethodProvider(this, restClientInfo, _get, isAsync);
+                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_get.InputMethod.Operation, isAsync);
+                var existsMethodProvider = new ExistsOperationMethodProvider(this, restClientInfo, _get.InputMethod, isAsync);
                 result.Add(existsMethodProvider);
             }
 
@@ -334,11 +317,11 @@ namespace Azure.Generator.Management.Providers
                 return result;
             }
 
-            var restClientInfo = _resourceMetadata.GetRestClientForServiceMethod(_get, _clientInfos);
+            var restClientInfo = _clientInfos[_get.InputClient];
             foreach (var isAsync in new List<bool> { true, false })
             {
-                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_get!.Operation, isAsync);
-                var getIfExistsMethodProvider = new GetIfExistsOperationMethodProvider(this, restClientInfo, _get, isAsync);
+                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_get.InputMethod.Operation, isAsync);
+                var getIfExistsMethodProvider = new GetIfExistsOperationMethodProvider(this, restClientInfo, _get.InputMethod, isAsync);
                 result.Add(getIfExistsMethodProvider);
             }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/TagMethodProviders/BaseTagMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/TagMethodProviders/BaseTagMethodProvider.cs
@@ -102,7 +102,7 @@ namespace Azure.Generator.Management.Providers.TagMethodProviders
 
             InputServiceMethod? getServiceMethod = null;
 
-            foreach (var (kind, method) in resourceClientProvider.ResourceServiceMethods)
+            foreach (var (kind, method, _) in resourceClientProvider.ResourceServiceMethods)
             {
                 var operation = method.Operation;
                 if (kind == ResourceOperationKind.Get)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceMetadataExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceMetadataExtensions.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Generator.Management.Models;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Azure.Generator.Management.Utilities
 {
@@ -26,36 +23,23 @@ namespace Azure.Generator.Management.Utilities
             var clientInfos = new Dictionary<InputClient, RestClientInfo>();
 
             // Create rest client providers and fields for each unique InputClient
-            foreach (var inputClient in resourceMetadata.MethodToClientMap.Values.Distinct())
+            foreach (var (_, _, inputClient) in resourceMetadata.Methods)
             {
+                if (clientInfos.ContainsKey(inputClient))
+                {
+                    continue; // Skip if the client is already processed
+                }
+
                 var restClientProvider = ManagementClientGenerator.Instance.TypeFactory.CreateClient(inputClient)!;
                 var restClientField = new FieldProvider(FieldModifiers.Private | FieldModifiers.ReadOnly, restClientProvider.Type, ResourceHelpers.GetRestClientFieldName(restClientProvider.Name), clientProvider);
 
                 var clientDiagnosticsFieldName = ResourceHelpers.GetClientDiagnosticFieldName(restClientProvider.Name);
                 var clientDiagnosticsField = new FieldProvider(FieldModifiers.Private | FieldModifiers.ReadOnly, typeof(ClientDiagnostics), clientDiagnosticsFieldName, clientProvider);
 
-                clientInfos[inputClient] = new RestClientInfo(restClientProvider, restClientField, clientDiagnosticsField);
+                clientInfos.Add(inputClient, new RestClientInfo(restClientProvider, restClientField, clientDiagnosticsField));
             }
 
             return clientInfos;
-        }
-
-        /// <summary>
-        /// Gets the RestClientInfo for a specific service method based on the method-to-client mapping.
-        /// </summary>
-        /// <param name="resourceMetadata">The resource metadata containing the method to client mapping.</param>
-        /// <param name="serviceMethod">The service method to get the rest client info for.</param>
-        /// <param name="clientInfos">The dictionary mapping InputClient to RestClientInfo.</param>
-        /// <returns>The RestClientInfo for the specified service method.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when no client mapping is found for the service method.</exception>
-        internal static RestClientInfo GetRestClientForServiceMethod(this ResourceMetadata resourceMetadata, InputServiceMethod serviceMethod, Dictionary<InputClient, RestClientInfo> clientInfos)
-        {
-            if (!resourceMetadata.MethodToClientMap.TryGetValue(serviceMethod.CrossLanguageDefinitionId, out var inputClient))
-            {
-                throw new InvalidOperationException($"No client mapping found for resource method {serviceMethod.Name}");
-            }
-
-            return clientInfos[inputClient];
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputResourceData.cs
@@ -32,18 +32,15 @@ namespace Azure.Generator.Management.Tests.Common
             var dataParameter = InputFactory.Parameter("data", responseModel, location: InputRequestLocation.Body);
             var getOperation = InputFactory.Operation(name: "get", responses: [responseType], parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}");
             var createOperation = InputFactory.Operation(name: "createTest", responses: [responseType], parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}");
-            var getCrossLanguageDefinitionId = Guid.NewGuid().ToString();
-            var createCrossLanguageDefinitionId = Guid.NewGuid().ToString();
+            var getMethod = InputFactory.BasicServiceMethod("get", getOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var createMethod = InputFactory.BasicServiceMethod("createTest", createOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
             var client = InputFactory.Client(
                 TestClientName,
-                methods: [
-                    InputFactory.BasicServiceMethod("get", getOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: getCrossLanguageDefinitionId),
-                    InputFactory.BasicServiceMethod("createTest", createOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: createCrossLanguageDefinitionId)
-                ],
+                methods: [getMethod, createMethod],
                 crossLanguageDefinitionId: $"Test.{TestClientName}");
             decorators.Add(BuildResourceMetadata(responseModel, client, "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}", "Microsoft.Tests/tests", null, ResourceScope.ResourceGroup, [
-                new ResourceMethod(ResourceOperationKind.Get, getCrossLanguageDefinitionId),
-                new ResourceMethod(ResourceOperationKind.Create, createCrossLanguageDefinitionId)
+                new ResourceMethod(ResourceOperationKind.Get, getMethod, client),
+                new ResourceMethod(ResourceOperationKind.Create, createMethod, client)
             ], "ResponseType"));
             return (client, [responseModel]);
         }
@@ -61,7 +58,12 @@ namespace Azure.Generator.Management.Tests.Common
                 ["resourceIdPattern"] = FromLiteralString(resourceIdPattern),
                 ["resourceType"] = FromLiteralString(resourceType),
                 ["resourceScope"] = FromLiteralString(resourceScope.ToString()),
-                ["methods"] = BinaryData.FromObjectAsJson(methods, options),
+                ["methods"] = BinaryData.FromObjectAsJson(methods.Select(m => new Dictionary<string, string>
+                {
+                    ["id"] = m.InputMethod.CrossLanguageDefinitionId,
+                    ["kind"] = m.Kind.ToString()
+                }
+                ), options),
                 ["singletonResourceName"] = BinaryData.FromObjectAsJson(singletonResourceName, options),
                 ["resourceName"] = BinaryData.FromObjectAsJson(resourceName, options),
             };

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputResourceData.cs
@@ -42,8 +42,8 @@ namespace Azure.Generator.Management.Tests.Common
                 ],
                 crossLanguageDefinitionId: $"Test.{TestClientName}");
             decorators.Add(BuildResourceMetadata(responseModel, client, "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}", "Microsoft.Tests/tests", null, ResourceScope.ResourceGroup, [
-                new ResourceMethod(getCrossLanguageDefinitionId, ResourceOperationKind.Get),
-                new ResourceMethod(createCrossLanguageDefinitionId, ResourceOperationKind.Create)
+                new ResourceMethod(ResourceOperationKind.Get, getCrossLanguageDefinitionId),
+                new ResourceMethod(ResourceOperationKind.Create, createCrossLanguageDefinitionId)
             ], "ResponseType"));
             return (client, [responseModel]);
         }


### PR DESCRIPTION
This PR contains three changes:

1. We now unwraps the `id`s from the input into its concrete instances for simplicity. For instance, previously, the `ResourceMethod` input model holds a `id` representing a `InputServiceMethod`, now it directly holds the instance.
2. Added a `InputClient` property into `ResourceMethod`. We have massive scenarios that we have a InputServiceMethod, and we need to know which client it comes from. Previously we are querying this through the InputLibrary, which is cumbersome.
3. Added two new properties in `RestClientInfo` which would be used in the non resource operation implementation.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
