### PR TITLE
User agent policy updates

### DIFF
--- a/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
@@ -451,8 +451,8 @@ namespace System.ClientModel.Primitives
         public UserAgentPolicy(System.Reflection.Assembly callerAssembly, string? applicationId = null) { }
         public string? ApplicationId { get { throw null; } }
         public System.Reflection.Assembly Assembly { get { throw null; } }
+        public string UserAgentValue { get { throw null; } }
         public override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
-        public override string ToString() { throw null; }
     }
 }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
@@ -451,8 +451,8 @@ namespace System.ClientModel.Primitives
         public UserAgentPolicy(System.Reflection.Assembly callerAssembly, string? applicationId = null) { }
         public string? ApplicationId { get { throw null; } }
         public System.Reflection.Assembly Assembly { get { throw null; } }
-        public static string GenerateUserAgentString(System.Reflection.Assembly callerAssembly, string? applicationId = null) { throw null; }
         public override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+        public override string ToString() { throw null; }
     }
 }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -449,8 +449,8 @@ namespace System.ClientModel.Primitives
         public UserAgentPolicy(System.Reflection.Assembly callerAssembly, string? applicationId = null) { }
         public string? ApplicationId { get { throw null; } }
         public System.Reflection.Assembly Assembly { get { throw null; } }
+        public string UserAgentValue { get { throw null; } }
         public override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
-        public override string ToString() { throw null; }
     }
 }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -449,8 +449,8 @@ namespace System.ClientModel.Primitives
         public UserAgentPolicy(System.Reflection.Assembly callerAssembly, string? applicationId = null) { }
         public string? ApplicationId { get { throw null; } }
         public System.Reflection.Assembly Assembly { get { throw null; } }
-        public static string GenerateUserAgentString(System.Reflection.Assembly callerAssembly, string? applicationId = null) { throw null; }
         public override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+        public override string ToString() { throw null; }
     }
 }

--- a/sdk/core/System.ClientModel/src/Internal/RuntimeInformationWrapper.cs
+++ b/sdk/core/System.ClientModel/src/Internal/RuntimeInformationWrapper.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+
+namespace System.ClientModel.Internal;
+
+internal class RuntimeInformationWrapper
+{
+    public virtual string FrameworkDescription => RuntimeInformation.FrameworkDescription;
+    public virtual string OSDescription => RuntimeInformation.OSDescription;
+    public virtual Architecture OSArchitecture => RuntimeInformation.OSArchitecture;
+    public virtual Architecture ProcessArchitecture => RuntimeInformation.ProcessArchitecture;
+    public virtual bool IsOSPlatform(OSPlatform osPlatform) => RuntimeInformation.IsOSPlatform(osPlatform);
+}

--- a/sdk/core/System.ClientModel/src/Pipeline/UserAgentPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/UserAgentPolicy.cs
@@ -28,6 +28,11 @@ public class UserAgentPolicy : PipelinePolicy
     public string? ApplicationId { get; }
 
     /// <summary>
+    /// The formatted user agent string that will be added to HTTP requests by this policy.
+    /// </summary>
+    public string UserAgentValue => _userAgent;
+
+    /// <summary>
     /// Initialize an instance of <see cref="UserAgentPolicy"/> by extracting the name and version information from the <see cref="System.Reflection.Assembly"/> associated with the <paramref name="callerAssembly"/>.
     /// </summary>
     /// <param name="callerAssembly">The <see cref="System.Reflection.Assembly"/> used to generate the package name and version information for the user agent.</param>
@@ -69,11 +74,6 @@ public class UserAgentPolicy : PipelinePolicy
         AddUserAgentHeader(message);
         await ProcessNextAsync(message, pipeline, currentIndex).ConfigureAwait(false);
     }
-
-    /// <summary>
-    /// The properly formatted UserAgent string based on this <see cref="UserAgentPolicy"/> instance.
-    /// </summary>
-    public override string ToString() => _userAgent;
 
     private void AddUserAgentHeader(PipelineMessage message)
     {

--- a/sdk/core/System.ClientModel/src/Pipeline/UserAgentPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/UserAgentPolicy.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT License.
 
 using System.ClientModel.Internal;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace System.ClientModel.Primitives;
 
@@ -18,7 +15,7 @@ namespace System.ClientModel.Primitives;
 public class UserAgentPolicy : PipelinePolicy
 {
     private const int MaxApplicationIdLength = 24;
-    private readonly string _defaultHeader;
+    private readonly string _userAgent;
 
     /// <summary>
     /// The package type represented by this <see cref="UserAgentPolicy"/> instance.
@@ -45,7 +42,7 @@ public class UserAgentPolicy : PipelinePolicy
 
         Assembly = callerAssembly;
         ApplicationId = applicationId;
-        _defaultHeader = GenerateUserAgentString(callerAssembly, applicationId);
+        _userAgent = GenerateUserAgentString(callerAssembly, applicationId, new RuntimeInformationWrapper());
     }
 
     /// <summary>
@@ -73,18 +70,25 @@ public class UserAgentPolicy : PipelinePolicy
         await ProcessNextAsync(message, pipeline, currentIndex).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// The properly formatted UserAgent string based on this <see cref="UserAgentPolicy"/> instance.
+    /// </summary>
+    public override string ToString() => _userAgent;
+
     private void AddUserAgentHeader(PipelineMessage message)
     {
-        message.Request.Headers.Add("User-Agent", _defaultHeader);
+        message.Request.Headers.Add("User-Agent", _userAgent);
     }
 
     /// <summary>
-    /// Generates a user agent string from the provided assembly and optional application ID.
+    /// Generates a user agent string from the provided assembly and optional application ID using custom runtime information.
+    /// This method is intended for testing scenarios that need to mock runtime information.
     /// </summary>
     /// <param name="callerAssembly">The caller assembly to extract name and version information from.</param>
     /// <param name="applicationId">An optional application ID to prepend to the user agent string.</param>
+    /// <param name="runtimeInformation">Custom runtime information for testing scenarios.</param>
     /// <returns>A formatted user agent string.</returns>
-    public static string GenerateUserAgentString(Assembly callerAssembly, string? applicationId = null)
+    internal static string GenerateUserAgentString(Assembly callerAssembly, string? applicationId, RuntimeInformationWrapper runtimeInformation)
     {
         AssemblyInformationalVersionAttribute? versionAttribute = callerAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
         if (versionAttribute == null)
@@ -107,14 +111,14 @@ public class UserAgentPolicy : PipelinePolicy
         // can use an encoding, such as the one defined in RFC8187." RFC8187 is targeted at parameter values, almost always filename, so using url encoding here instead, which is
         // more widely used. Since user-agent does not usually contain non-ascii, only encode when necessary.
         // This was added to support operating systems with non-ascii characters in their release names.
-        string osDescription;
+        string osDescription = runtimeInformation.OSDescription;
 #if NET8_0_OR_GREATER
-        osDescription = System.Text.Ascii.IsValid(RuntimeInformation.OSDescription) ? RuntimeInformation.OSDescription : WebUtility.UrlEncode(RuntimeInformation.OSDescription);
+        osDescription = System.Text.Ascii.IsValid(osDescription) ? osDescription : WebUtility.UrlEncode(osDescription);
 #else
-        osDescription = ContainsNonAscii(RuntimeInformation.OSDescription) ? WebUtility.UrlEncode(RuntimeInformation.OSDescription) : RuntimeInformation.OSDescription;
+        osDescription = ContainsNonAscii(osDescription) ? WebUtility.UrlEncode(osDescription) : osDescription;
 #endif
 
-        var platformInformation = EscapeProductInformation($"({RuntimeInformation.FrameworkDescription}; {osDescription})");
+        var platformInformation = EscapeProductInformation($"({runtimeInformation.FrameworkDescription}; {osDescription})");
 
         return applicationId != null
             ? $"{applicationId} {assemblyName}/{version} {platformInformation}"

--- a/sdk/core/System.ClientModel/tests/Pipeline/UserAgentPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/UserAgentPolicyTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace System.ClientModel.Tests.Pipeline;
@@ -181,11 +182,14 @@ public class UserAgentPolicyTests : SyncAsyncTestBase
         Assembly assembly = Assembly.GetExecutingAssembly();
 
         // Test without application ID
-        string userAgent = UserAgentPolicy.GenerateUserAgentString(assembly);
-        Assert.IsNotNull(userAgent);
-        Assert.IsNotEmpty(userAgent);
+        var policy = new UserAgentPolicy(assembly);
+        Assert.IsNotNull(policy);
+        Assert.IsNotNull(policy);
+        Assert.IsNull(policy.ApplicationId);
+        Assert.AreEqual(assembly, policy.Assembly);
 
         // Should contain assembly name and version
+        var userAgent = policy.ToString();
         string assemblyName = assembly.GetName().Name!;
         Assert.That(userAgent, Does.Contain(assemblyName));
 
@@ -200,9 +204,11 @@ public class UserAgentPolicyTests : SyncAsyncTestBase
         Assembly assembly = Assembly.GetExecutingAssembly();
         string applicationId = "TestApp/1.0";
 
-        string userAgent = UserAgentPolicy.GenerateUserAgentString(assembly, applicationId);
-        Assert.IsNotNull(userAgent);
-        Assert.IsNotEmpty(userAgent);
+        var policy = new UserAgentPolicy(assembly, applicationId);
+        Assert.IsNotNull(policy);
+        Assert.AreEqual(applicationId, policy.ApplicationId);
+        Assert.AreEqual(assembly, policy.Assembly);
+        var userAgent = policy.ToString();
 
         // Should start with application ID
         Assert.That(userAgent, Does.StartWith(applicationId));
@@ -210,5 +216,151 @@ public class UserAgentPolicyTests : SyncAsyncTestBase
         // Should contain assembly name and version
         string assemblyName = assembly.GetName().Name!;
         Assert.That(userAgent, Does.Contain(assemblyName));
+    }
+
+    [Test]
+    [TestCase("ValidParens (2023-)", "ValidParens (2023-)")]
+    [TestCase("(ValidParens (2023-))", "(ValidParens (2023-))")]
+    [TestCase("ProperlyEscapedParens \\(2023-\\)", "ProperlyEscapedParens \\(2023-\\)")]
+    [TestCase("UnescapedOnlyParens (2023-)", "UnescapedOnlyParens (2023-)")]
+    [TestCase("UnmatchedOpenParen (2023-", "UnmatchedOpenParen \\(2023-")]
+    [TestCase("UnEscapedParenWithValidParens (()", "UnEscapedParenWithValidParens \\(\\(\\)")]
+    [TestCase("UnEscapedInvalidParen (", "UnEscapedInvalidParen \\(")]
+    [TestCase("UnEscapedParenWithValidParens2 ())", "UnEscapedParenWithValidParens2 \\(\\)\\)")]
+    [TestCase("InvalidParen )", "InvalidParen \\)")]
+    [TestCase("(InvalidParen ", "\\(InvalidParen ")]
+    [TestCase("UnescapedParenInText MyO)SDescription ", "UnescapedParenInText MyO\\)SDescription ")]
+    [TestCase("UnescapedParenInText MyO(SDescription ", "UnescapedParenInText MyO\\(SDescription ")]
+    public void ValidatesProperParenthesisMatching(string input, string output)
+    {
+        var mockRuntimeInformation = new MockRuntimeInformation
+        {
+            OSDescriptionMock = input,
+            FrameworkDescriptionMock = RuntimeInformation.FrameworkDescription
+        };
+        var assembly = Assembly.GetExecutingAssembly();
+        AssemblyInformationalVersionAttribute? versionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        string version = versionAttribute!.InformationalVersion;
+        int hashSeparator = version.IndexOf('+');
+        if (hashSeparator != -1)
+        {
+            version = version.Substring(0, hashSeparator);
+        }
+
+        string userAgent = UserAgentPolicy.GenerateUserAgentString(assembly, null, mockRuntimeInformation);
+        string assemblyName = assembly.GetName().Name!;
+
+        Assert.AreEqual(
+                $"{assemblyName}/{version} ({mockRuntimeInformation.FrameworkDescription}; {output})",
+                userAgent);
+    }
+
+    [Test]
+    [TestCase("Win64; x64", "Win64; x64")]
+    [TestCase("Intel Mac OS X 10_15_7", "Intel Mac OS X 10_15_7")]
+    [TestCase("Android 10; SM-G973F", "Android 10; SM-G973F")]
+    [TestCase("Win64; x64; Xbox; Xbox One", "Win64; x64; Xbox; Xbox One")]
+    public void AsciiDoesNotEncode(string input, string output)
+    {
+        var mockRuntimeInformation = new MockRuntimeInformation
+        {
+            OSDescriptionMock = input,
+            FrameworkDescriptionMock = RuntimeInformation.FrameworkDescription
+        };
+        var assembly = Assembly.GetExecutingAssembly();
+        AssemblyInformationalVersionAttribute? versionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        string version = versionAttribute!.InformationalVersion;
+        int hashSeparator = version.IndexOf('+');
+        if (hashSeparator != -1)
+        {
+            version = version.Substring(0, hashSeparator);
+        }
+
+        string userAgent = UserAgentPolicy.GenerateUserAgentString(assembly, null, mockRuntimeInformation);
+        string assemblyName = assembly.GetName().Name!;
+
+        Assert.AreEqual(
+                $"{assemblyName}/{version} ({mockRuntimeInformation.FrameworkDescription}; {output})",
+                userAgent);
+    }
+
+    [Test]
+    [TestCase("»-Browser¢sample", "%C2%BB-Browser%C2%A2sample")]
+    [TestCase("NixOS 24.11 (Vicuña)", "NixOS+24.11+(Vicu%C3%B1a)")]
+    public void NonAsciiCharactersAreUrlEncoded(string input, string output)
+    {
+        var mockRuntimeInformation = new MockRuntimeInformation
+        {
+            OSDescriptionMock = input,
+            FrameworkDescriptionMock = RuntimeInformation.FrameworkDescription
+        };
+        var assembly = Assembly.GetExecutingAssembly();
+        AssemblyInformationalVersionAttribute? versionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        string version = versionAttribute!.InformationalVersion;
+        int hashSeparator = version.IndexOf('+');
+        if (hashSeparator != -1)
+        {
+            version = version.Substring(0, hashSeparator);
+        }
+
+        string userAgent = UserAgentPolicy.GenerateUserAgentString(assembly, null, mockRuntimeInformation);
+        string assemblyName = assembly.GetName().Name!;
+
+        Assert.AreEqual(
+                $"{assemblyName}/{version} ({mockRuntimeInformation.FrameworkDescription}; {output})",
+                userAgent);
+    }
+
+    [Test]
+    public void GenerateUserAgentString_WithCustomRuntimeInfo_ProducesValidUserAgent()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var mockRuntimeInfo = new MockRuntimeInformation
+        {
+            OSDescriptionMock = "Test OS",
+            FrameworkDescriptionMock = "Test Framework"
+        };
+
+        string userAgent = UserAgentPolicy.GenerateUserAgentString(assembly, null, mockRuntimeInfo);
+
+        // Get expected values
+        string assemblyName = assembly.GetName().Name!;
+        AssemblyInformationalVersionAttribute? versionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        string version = versionAttribute!.InformationalVersion;
+        int hashSeparator = version.IndexOf('+');
+        if (hashSeparator != -1)
+        {
+            version = version.Substring(0, hashSeparator);
+        }
+
+        string expectedUserAgent = $"{assemblyName}/{version} ({mockRuntimeInfo.FrameworkDescriptionMock}; {mockRuntimeInfo.OSDescriptionMock})";
+        Assert.AreEqual(expectedUserAgent, userAgent);
+    }
+
+    [Test]
+    public void GenerateUserAgentString_WithCustomRuntimeInfoAndApplicationId_ProducesValidUserAgent()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        string applicationId = "TestApp/1.0";
+        var mockRuntimeInfo = new MockRuntimeInformation
+        {
+            OSDescriptionMock = "Test OS",
+            FrameworkDescriptionMock = "Test Framework"
+        };
+
+        string userAgent = UserAgentPolicy.GenerateUserAgentString(assembly, applicationId, mockRuntimeInfo);
+
+        // Get expected values
+        string assemblyName = assembly.GetName().Name!;
+        AssemblyInformationalVersionAttribute? versionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        string version = versionAttribute!.InformationalVersion;
+        int hashSeparator = version.IndexOf('+');
+        if (hashSeparator != -1)
+        {
+            version = version.Substring(0, hashSeparator);
+        }
+
+        string expectedUserAgent = $"{applicationId} {assemblyName}/{version} ({mockRuntimeInfo.FrameworkDescriptionMock}; {mockRuntimeInfo.OSDescriptionMock})";
+        Assert.AreEqual(expectedUserAgent, userAgent);
     }
 }

--- a/sdk/core/System.ClientModel/tests/Pipeline/UserAgentPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/UserAgentPolicyTests.cs
@@ -184,7 +184,6 @@ public class UserAgentPolicyTests : SyncAsyncTestBase
         // Test without application ID
         var policy = new UserAgentPolicy(assembly);
         Assert.IsNotNull(policy);
-        Assert.IsNotNull(policy);
         Assert.IsNull(policy.ApplicationId);
         Assert.AreEqual(assembly, policy.Assembly);
 

--- a/sdk/core/System.ClientModel/tests/Pipeline/UserAgentPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/UserAgentPolicyTests.cs
@@ -188,7 +188,7 @@ public class UserAgentPolicyTests : SyncAsyncTestBase
         Assert.AreEqual(assembly, policy.Assembly);
 
         // Should contain assembly name and version
-        var userAgent = policy.ToString();
+        var userAgent = policy.UserAgentValue;
         string assemblyName = assembly.GetName().Name!;
         Assert.That(userAgent, Does.Contain(assemblyName));
 
@@ -207,7 +207,7 @@ public class UserAgentPolicyTests : SyncAsyncTestBase
         Assert.IsNotNull(policy);
         Assert.AreEqual(applicationId, policy.ApplicationId);
         Assert.AreEqual(assembly, policy.Assembly);
-        var userAgent = policy.ToString();
+        var userAgent = policy.UserAgentValue;
 
         // Should start with application ID
         Assert.That(userAgent, Does.StartWith(applicationId));

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRuntimeInformation.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRuntimeInformation.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Internal;
+using System.Runtime.InteropServices;
+
+namespace ClientModel.Tests.Mocks
+{
+    internal class MockRuntimeInformation : RuntimeInformationWrapper
+    {
+        public string? FrameworkDescriptionMock { get; set; }
+        public string? OSDescriptionMock { get; set; }
+        public Architecture OSArchitectureMock { get; set; }
+        public Architecture ProcessArchitectureMock { get; set; }
+        public Func<OSPlatform, bool>? IsOSPlatformMock { get; set; }
+
+        public override string OSDescription => OSDescriptionMock ?? base.OSDescription;
+        public override string FrameworkDescription => FrameworkDescriptionMock ?? base.FrameworkDescription;
+        public override Architecture OSArchitecture => OSArchitectureMock;
+        public override Architecture ProcessArchitecture => ProcessArchitectureMock;
+        public override bool IsOSPlatform(OSPlatform osPlatform) => IsOSPlatformMock?.Invoke(osPlatform) ?? base.IsOSPlatform(osPlatform);
+    }
+}


### PR DESCRIPTION
We decided against attempting to reuse this policy in Azure.Core.
- removed the public static GenerateUserAgentString method
- Added UserAgentValue property
- Added equivalent Azure.Core unit tests