### PR TITLE
Fix naming for Resource

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -85,7 +85,7 @@ namespace Azure.Generator.Management.Providers
 
         internal ResourceCollectionClientProvider? ResourceCollection { get; private set; }
 
-        protected override string BuildName() => $"{ResourceName}Resource";
+        protected override string BuildName() => ResourceName.EndsWith("Resource") ? ResourceName : $"{ResourceName}Resource";
 
         private OperationSourceProvider? _source;
         internal OperationSourceProvider Source => _source ??= new OperationSourceProvider(this);

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/bar.tsp
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/bar.tsp
@@ -44,8 +44,8 @@ interface Bars {
 
 @singleton("current")
 @parentResource(Bar)
-model BarSettings is ProxyResource<BarSettingsProperties> {
-  ...ResourceNameParameter<BarSettings, SegmentName = "settings">;
+model BarSettingsResource is ProxyResource<BarSettingsProperties> {
+  ...ResourceNameParameter<BarSettingsResource, SegmentName = "settings">;
 
   stringArray?: string[];
 }
@@ -58,7 +58,7 @@ model BarSettingsProperties {
 
 @armResourceOperations
 interface BarSettingsOperations {
-  createOrUpdate is ArmResourceCreateOrUpdateAsync<BarSettings>;
+  createOrUpdate is ArmResourceCreateOrUpdateAsync<BarSettingsResource>;
   
-  get is ArmResourceRead<BarSettings>;
+  get is ArmResourceRead<BarSettingsResource>;
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarResource.cs
@@ -533,9 +533,9 @@ namespace MgmtTypeSpec
             }
         }
 
-        /// <summary> Gets an object representing a BarSettings along with the instance operations that can be performed on it in the Bar. </summary>
+        /// <summary> Gets an object representing a BarSettingsResource along with the instance operations that can be performed on it in the Bar. </summary>
         /// <returns> Returns a <see cref="BarSettingsResource"/> object. </returns>
-        public virtual BarSettingsResource GetBarSettings()
+        public virtual BarSettingsResource GetBarSettingsResource()
         {
             return new BarSettingsResource(Client, Id.AppendChildResource("settings", "current"));
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResource.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResource.Serialization.cs
@@ -12,28 +12,28 @@ using System.Text.Json;
 namespace MgmtTypeSpec
 {
     /// <summary></summary>
-    public partial class BarSettingsResource : IJsonModel<BarSettingsData>
+    public partial class BarSettingsResource : IJsonModel<BarSettingsResourceData>
     {
-        private static IJsonModel<BarSettingsData> s_dataDeserializationInstance;
+        private static IJsonModel<BarSettingsResourceData> s_dataDeserializationInstance;
 
-        private static IJsonModel<BarSettingsData> DataDeserializationInstance => s_dataDeserializationInstance ??= new BarSettingsData();
+        private static IJsonModel<BarSettingsResourceData> DataDeserializationInstance => s_dataDeserializationInstance ??= new BarSettingsResourceData();
 
         /// <param name="writer"> The writer to serialize the model to. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        void IJsonModel<BarSettingsData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) => ((IJsonModel<BarSettingsData>)Data).Write(writer, options);
+        void IJsonModel<BarSettingsResourceData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) => ((IJsonModel<BarSettingsResourceData>)Data).Write(writer, options);
 
         /// <param name="reader"> The reader for deserializing the model. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        BarSettingsData IJsonModel<BarSettingsData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => DataDeserializationInstance.Create(ref reader, options);
+        BarSettingsResourceData IJsonModel<BarSettingsResourceData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => DataDeserializationInstance.Create(ref reader, options);
 
         /// <param name="options"> The client options for reading and writing models. </param>
-        BinaryData IPersistableModel<BarSettingsData>.Write(ModelReaderWriterOptions options) => ModelReaderWriter.Write<BarSettingsData>(Data, options, MgmtTypeSpecContext.Default);
+        BinaryData IPersistableModel<BarSettingsResourceData>.Write(ModelReaderWriterOptions options) => ModelReaderWriter.Write<BarSettingsResourceData>(Data, options, MgmtTypeSpecContext.Default);
 
         /// <param name="data"> The binary data to be processed. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        BarSettingsData IPersistableModel<BarSettingsData>.Create(BinaryData data, ModelReaderWriterOptions options) => ModelReaderWriter.Read<BarSettingsData>(data, options, MgmtTypeSpecContext.Default);
+        BarSettingsResourceData IPersistableModel<BarSettingsResourceData>.Create(BinaryData data, ModelReaderWriterOptions options) => ModelReaderWriter.Read<BarSettingsResourceData>(data, options, MgmtTypeSpecContext.Default);
 
         /// <param name="options"> The client options for reading and writing models. </param>
-        string IPersistableModel<BarSettingsData>.GetFormatFromOptions(ModelReaderWriterOptions options) => DataDeserializationInstance.GetFormatFromOptions(options);
+        string IPersistableModel<BarSettingsResourceData>.GetFormatFromOptions(ModelReaderWriterOptions options) => DataDeserializationInstance.GetFormatFromOptions(options);
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResource.cs
@@ -21,7 +21,7 @@ namespace MgmtTypeSpec
     {
         private readonly ClientDiagnostics _barSettingsOperationsClientDiagnostics;
         private readonly BarSettingsOperations _barSettingsOperationsRestClient;
-        private readonly BarSettingsData _data;
+        private readonly BarSettingsResourceData _data;
         /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "MgmtTypeSpec/foos/bars/settings";
 
@@ -33,7 +33,7 @@ namespace MgmtTypeSpec
         /// <summary> Initializes a new instance of <see cref="BarSettingsResource"/> class. </summary>
         /// <param name="client"> The client parameters to use in these operations. </param>
         /// <param name="data"> The resource that is the target of operations. </param>
-        internal BarSettingsResource(ArmClient client, BarSettingsData data) : this(client, data.Id)
+        internal BarSettingsResource(ArmClient client, BarSettingsResourceData data) : this(client, data.Id)
         {
             HasData = true;
             _data = data;
@@ -44,9 +44,9 @@ namespace MgmtTypeSpec
         /// <param name="id"> The identifier of the resource that is the target of operations. </param>
         internal BarSettingsResource(ArmClient client, ResourceIdentifier id) : base(client, id)
         {
-            TryGetApiVersion(ResourceType, out string barSettingsApiVersion);
+            TryGetApiVersion(ResourceType, out string barSettingsResourceApiVersion);
             _barSettingsOperationsClientDiagnostics = new ClientDiagnostics("MgmtTypeSpec", ResourceType.Namespace, Diagnostics);
-            _barSettingsOperationsRestClient = new BarSettingsOperations(_barSettingsOperationsClientDiagnostics, Pipeline, Endpoint, barSettingsApiVersion);
+            _barSettingsOperationsRestClient = new BarSettingsOperations(_barSettingsOperationsClientDiagnostics, Pipeline, Endpoint, barSettingsResourceApiVersion);
             ValidateResourceId(id);
         }
 
@@ -54,7 +54,7 @@ namespace MgmtTypeSpec
         public virtual bool HasData { get; }
 
         /// <summary> Gets the data representing this Feature. </summary>
-        public virtual BarSettingsData Data
+        public virtual BarSettingsResourceData Data
         {
             get
             {
@@ -87,12 +87,12 @@ namespace MgmtTypeSpec
             }
         }
 
-        /// <summary> Create a BarSettings. </summary>
+        /// <summary> Create a BarSettingsResource. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="data"> Resource create parameters. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="data"/> is null. </exception>
-        public virtual ArmOperation<BarSettingsResource> CreateOrUpdate(WaitUntil waitUntil, BarSettingsData data, CancellationToken cancellationToken = default)
+        public virtual ArmOperation<BarSettingsResource> CreateOrUpdate(WaitUntil waitUntil, BarSettingsResourceData data, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(data, nameof(data));
 
@@ -104,10 +104,10 @@ namespace MgmtTypeSpec
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _barSettingsOperationsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.Name, BarSettingsData.ToRequestContent(data), context);
+                HttpMessage message = _barSettingsOperationsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.Name, BarSettingsResourceData.ToRequestContent(data), context);
                 Response response = Pipeline.ProcessMessage(message, context);
                 MgmtTypeSpecArmOperation<BarSettingsResource> operation = new MgmtTypeSpecArmOperation<BarSettingsResource>(
-                    new BarSettingsOperationSource(Client),
+                    new BarSettingsResourceOperationSource(Client),
                     _barSettingsOperationsClientDiagnostics,
                     Pipeline,
                     message.Request,
@@ -126,12 +126,12 @@ namespace MgmtTypeSpec
             }
         }
 
-        /// <summary> Create a BarSettings. </summary>
+        /// <summary> Create a BarSettingsResource. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="data"> Resource create parameters. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="data"/> is null. </exception>
-        public virtual async Task<ArmOperation<BarSettingsResource>> CreateOrUpdateAsync(WaitUntil waitUntil, BarSettingsData data, CancellationToken cancellationToken = default)
+        public virtual async Task<ArmOperation<BarSettingsResource>> CreateOrUpdateAsync(WaitUntil waitUntil, BarSettingsResourceData data, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(data, nameof(data));
 
@@ -143,10 +143,10 @@ namespace MgmtTypeSpec
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _barSettingsOperationsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.Name, BarSettingsData.ToRequestContent(data), context);
+                HttpMessage message = _barSettingsOperationsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.Name, BarSettingsResourceData.ToRequestContent(data), context);
                 Response response = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
                 MgmtTypeSpecArmOperation<BarSettingsResource> operation = new MgmtTypeSpecArmOperation<BarSettingsResource>(
-                    new BarSettingsOperationSource(Client),
+                    new BarSettingsResourceOperationSource(Client),
                     _barSettingsOperationsClientDiagnostics,
                     Pipeline,
                     message.Request,
@@ -165,7 +165,7 @@ namespace MgmtTypeSpec
             }
         }
 
-        /// <summary> Get a BarSettings. </summary>
+        /// <summary> Get a BarSettingsResource. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response<BarSettingsResource> Get(CancellationToken cancellationToken = default)
         {
@@ -179,7 +179,7 @@ namespace MgmtTypeSpec
                 };
                 HttpMessage message = _barSettingsOperationsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.Name, context);
                 Response result = Pipeline.ProcessMessage(message, context);
-                Response<BarSettingsData> response = Response.FromValue(BarSettingsData.FromResponse(result), result);
+                Response<BarSettingsResourceData> response = Response.FromValue(BarSettingsResourceData.FromResponse(result), result);
                 if (response.Value == null)
                 {
                     throw new RequestFailedException(response.GetRawResponse());
@@ -193,7 +193,7 @@ namespace MgmtTypeSpec
             }
         }
 
-        /// <summary> Get a BarSettings. </summary>
+        /// <summary> Get a BarSettingsResource. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response<BarSettingsResource>> GetAsync(CancellationToken cancellationToken = default)
         {
@@ -207,7 +207,7 @@ namespace MgmtTypeSpec
                 };
                 HttpMessage message = _barSettingsOperationsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.Name, context);
                 Response result = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
-                Response<BarSettingsData> response = Response.FromValue(BarSettingsData.FromResponse(result), result);
+                Response<BarSettingsResourceData> response = Response.FromValue(BarSettingsResourceData.FromResponse(result), result);
                 if (response.Value == null)
                 {
                     throw new RequestFailedException(response.GetRawResponse());

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResourceData.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResourceData.Serialization.cs
@@ -18,11 +18,11 @@ using MgmtTypeSpec.Models;
 namespace MgmtTypeSpec
 {
     /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
-    public partial class BarSettingsData : IJsonModel<BarSettingsData>
+    public partial class BarSettingsResourceData : IJsonModel<BarSettingsResourceData>
     {
         /// <param name="writer"> The JSON writer. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        void IJsonModel<BarSettingsData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        void IJsonModel<BarSettingsResourceData>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
             writer.WriteStartObject();
             JsonModelWriteCore(writer, options);
@@ -33,10 +33,10 @@ namespace MgmtTypeSpec
         /// <param name="options"> The client options for reading and writing models. </param>
         protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
-            string format = options.Format == "W" ? ((IPersistableModel<BarSettingsData>)this).GetFormatFromOptions(options) : options.Format;
+            string format = options.Format == "W" ? ((IPersistableModel<BarSettingsResourceData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(BarSettingsData)} does not support writing '{format}' format.");
+                throw new FormatException($"The model {nameof(BarSettingsResourceData)} does not support writing '{format}' format.");
             }
             base.JsonModelWriteCore(writer, options);
             if (Optional.IsDefined(Properties))
@@ -63,24 +63,24 @@ namespace MgmtTypeSpec
 
         /// <param name="reader"> The JSON reader. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        BarSettingsData IJsonModel<BarSettingsData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => (BarSettingsData)JsonModelCreateCore(ref reader, options);
+        BarSettingsResourceData IJsonModel<BarSettingsResourceData>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => (BarSettingsResourceData)JsonModelCreateCore(ref reader, options);
 
         /// <param name="reader"> The JSON reader. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
         protected virtual ResourceData JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
-            string format = options.Format == "W" ? ((IPersistableModel<BarSettingsData>)this).GetFormatFromOptions(options) : options.Format;
+            string format = options.Format == "W" ? ((IPersistableModel<BarSettingsResourceData>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")
             {
-                throw new FormatException($"The model {nameof(BarSettingsData)} does not support reading '{format}' format.");
+                throw new FormatException($"The model {nameof(BarSettingsResourceData)} does not support reading '{format}' format.");
             }
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
-            return DeserializeBarSettingsData(document.RootElement, options);
+            return DeserializeBarSettingsResourceData(document.RootElement, options);
         }
 
         /// <param name="element"> The JSON element to deserialize. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        internal static BarSettingsData DeserializeBarSettingsData(JsonElement element, ModelReaderWriterOptions options)
+        internal static BarSettingsResourceData DeserializeBarSettingsResourceData(JsonElement element, ModelReaderWriterOptions options)
         {
             if (element.ValueKind == JsonValueKind.Null)
             {
@@ -162,7 +162,7 @@ namespace MgmtTypeSpec
                     additionalBinaryDataProperties.Add(prop.Name, BinaryData.FromString(prop.Value.GetRawText()));
                 }
             }
-            return new BarSettingsData(
+            return new BarSettingsResourceData(
                 id,
                 name,
                 resourceType,
@@ -173,63 +173,63 @@ namespace MgmtTypeSpec
         }
 
         /// <param name="options"> The client options for reading and writing models. </param>
-        BinaryData IPersistableModel<BarSettingsData>.Write(ModelReaderWriterOptions options) => PersistableModelWriteCore(options);
+        BinaryData IPersistableModel<BarSettingsResourceData>.Write(ModelReaderWriterOptions options) => PersistableModelWriteCore(options);
 
         /// <param name="options"> The client options for reading and writing models. </param>
         protected virtual BinaryData PersistableModelWriteCore(ModelReaderWriterOptions options)
         {
-            string format = options.Format == "W" ? ((IPersistableModel<BarSettingsData>)this).GetFormatFromOptions(options) : options.Format;
+            string format = options.Format == "W" ? ((IPersistableModel<BarSettingsResourceData>)this).GetFormatFromOptions(options) : options.Format;
             switch (format)
             {
                 case "J":
                     return ModelReaderWriter.Write(this, options, MgmtTypeSpecContext.Default);
                 default:
-                    throw new FormatException($"The model {nameof(BarSettingsData)} does not support writing '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(BarSettingsResourceData)} does not support writing '{options.Format}' format.");
             }
         }
 
         /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        BarSettingsData IPersistableModel<BarSettingsData>.Create(BinaryData data, ModelReaderWriterOptions options) => (BarSettingsData)PersistableModelCreateCore(data, options);
+        BarSettingsResourceData IPersistableModel<BarSettingsResourceData>.Create(BinaryData data, ModelReaderWriterOptions options) => (BarSettingsResourceData)PersistableModelCreateCore(data, options);
 
         /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
         protected virtual ResourceData PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
         {
-            string format = options.Format == "W" ? ((IPersistableModel<BarSettingsData>)this).GetFormatFromOptions(options) : options.Format;
+            string format = options.Format == "W" ? ((IPersistableModel<BarSettingsResourceData>)this).GetFormatFromOptions(options) : options.Format;
             switch (format)
             {
                 case "J":
                     using (JsonDocument document = JsonDocument.Parse(data))
                     {
-                        return DeserializeBarSettingsData(document.RootElement, options);
+                        return DeserializeBarSettingsResourceData(document.RootElement, options);
                     }
                 default:
-                    throw new FormatException($"The model {nameof(BarSettingsData)} does not support reading '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(BarSettingsResourceData)} does not support reading '{options.Format}' format.");
             }
         }
 
         /// <param name="options"> The client options for reading and writing models. </param>
-        string IPersistableModel<BarSettingsData>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+        string IPersistableModel<BarSettingsResourceData>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
-        /// <param name="barSettingsData"> The <see cref="BarSettingsData"/> to serialize into <see cref="RequestContent"/>. </param>
-        internal static RequestContent ToRequestContent(BarSettingsData barSettingsData)
+        /// <param name="barSettingsResourceData"> The <see cref="BarSettingsResourceData"/> to serialize into <see cref="RequestContent"/>. </param>
+        internal static RequestContent ToRequestContent(BarSettingsResourceData barSettingsResourceData)
         {
-            if (barSettingsData == null)
+            if (barSettingsResourceData == null)
             {
                 return null;
             }
             Utf8JsonRequestContent content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(barSettingsData, ModelSerializationExtensions.WireOptions);
+            content.JsonWriter.WriteObjectValue(barSettingsResourceData, ModelSerializationExtensions.WireOptions);
             return content;
         }
 
-        /// <param name="result"> The <see cref="Response"/> to deserialize the <see cref="BarSettingsData"/> from. </param>
-        internal static BarSettingsData FromResponse(Response result)
+        /// <param name="result"> The <see cref="Response"/> to deserialize the <see cref="BarSettingsResourceData"/> from. </param>
+        internal static BarSettingsResourceData FromResponse(Response result)
         {
             using Response response = result;
             using JsonDocument document = JsonDocument.Parse(response.Content);
-            return DeserializeBarSettingsData(document.RootElement, ModelSerializationExtensions.WireOptions);
+            return DeserializeBarSettingsResourceData(document.RootElement, ModelSerializationExtensions.WireOptions);
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResourceData.cs
@@ -14,18 +14,18 @@ using MgmtTypeSpec.Models;
 namespace MgmtTypeSpec
 {
     /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
-    public partial class BarSettingsData : ResourceData
+    public partial class BarSettingsResourceData : ResourceData
     {
         /// <summary> Keeps track of any properties unknown to the library. </summary>
         private protected readonly IDictionary<string, BinaryData> _additionalBinaryDataProperties;
 
-        /// <summary> Initializes a new instance of <see cref="BarSettingsData"/>. </summary>
-        public BarSettingsData()
+        /// <summary> Initializes a new instance of <see cref="BarSettingsResourceData"/>. </summary>
+        public BarSettingsResourceData()
         {
             StringArray = new ChangeTrackingList<string>();
         }
 
-        /// <summary> Initializes a new instance of <see cref="BarSettingsData"/>. </summary>
+        /// <summary> Initializes a new instance of <see cref="BarSettingsResourceData"/>. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -33,7 +33,7 @@ namespace MgmtTypeSpec
         /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
         /// <param name="properties"> The resource-specific properties for this resource. </param>
         /// <param name="stringArray"></param>
-        internal BarSettingsData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, BinaryData> additionalBinaryDataProperties, BarSettingsProperties properties, IList<string> stringArray) : base(id, name, resourceType, systemData)
+        internal BarSettingsResourceData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, BinaryData> additionalBinaryDataProperties, BarSettingsProperties properties, IList<string> stringArray) : base(id, name, resourceType, systemData)
         {
             _additionalBinaryDataProperties = additionalBinaryDataProperties;
             Properties = properties;

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/LongRunningOperation/BarSettingsResourceOperationSource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/LongRunningOperation/BarSettingsResourceOperationSource.cs
@@ -16,13 +16,13 @@ using Azure.ResourceManager;
 namespace MgmtTypeSpec
 {
     /// <summary></summary>
-    internal partial class BarSettingsOperationSource : IOperationSource<BarSettingsResource>
+    internal partial class BarSettingsResourceOperationSource : IOperationSource<BarSettingsResource>
     {
         private readonly ArmClient _client;
 
         /// <summary></summary>
         /// <param name="client"></param>
-        internal BarSettingsOperationSource(ArmClient client)
+        internal BarSettingsResourceOperationSource(ArmClient client)
         {
             _client = client;
         }
@@ -33,7 +33,7 @@ namespace MgmtTypeSpec
         BarSettingsResource IOperationSource<BarSettingsResource>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using JsonDocument document = JsonDocument.Parse(response.ContentStream);
-            BarSettingsData data = BarSettingsData.DeserializeBarSettingsData(document.RootElement, new ModelReaderWriterOptions("W"));
+            BarSettingsResourceData data = BarSettingsResourceData.DeserializeBarSettingsResourceData(document.RootElement, new ModelReaderWriterOptions("W"));
             return new BarSettingsResource(_client, data);
         }
 
@@ -43,7 +43,7 @@ namespace MgmtTypeSpec
         async ValueTask<BarSettingsResource> IOperationSource<BarSettingsResource>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using JsonDocument document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            BarSettingsData data = BarSettingsData.DeserializeBarSettingsData(document.RootElement, ModelSerializationExtensions.WireOptions);
+            BarSettingsResourceData data = BarSettingsResourceData.DeserializeBarSettingsResourceData(document.RootElement, ModelSerializationExtensions.WireOptions);
             return new BarSettingsResource(_client, data);
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecModelFactory.cs
@@ -102,12 +102,12 @@ namespace MgmtTypeSpec.Models
         /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
         /// <param name="isEnabled"> enabled. </param>
         /// <param name="stringArray"></param>
-        /// <returns> A new <see cref="MgmtTypeSpec.BarSettingsData"/> instance for mocking. </returns>
-        public static BarSettingsData BarSettingsData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, bool? isEnabled = default, IEnumerable<string> stringArray = default)
+        /// <returns> A new <see cref="MgmtTypeSpec.BarSettingsResourceData"/> instance for mocking. </returns>
+        public static BarSettingsResourceData BarSettingsResourceData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, bool? isEnabled = default, IEnumerable<string> stringArray = default)
         {
             stringArray ??= new ChangeTrackingList<string>();
 
-            return new BarSettingsData(
+            return new BarSettingsResourceData(
                 id,
                 name,
                 resourceType,

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/MgmtTypeSpecContext.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/MgmtTypeSpecContext.cs
@@ -31,7 +31,7 @@ namespace MgmtTypeSpec
     [ModelReaderWriterBuildable(typeof(BarData))]
     [ModelReaderWriterBuildable(typeof(BarProperties))]
     [ModelReaderWriterBuildable(typeof(BarListResult))]
-    [ModelReaderWriterBuildable(typeof(BarSettingsData))]
+    [ModelReaderWriterBuildable(typeof(BarSettingsResourceData))]
     [ModelReaderWriterBuildable(typeof(BarSettingsProperties))]
     [ModelReaderWriterBuildable(typeof(ZooData))]
     [ModelReaderWriterBuildable(typeof(ZooProperties))]

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
@@ -4114,9 +4114,9 @@
     {
       "$id": "367",
       "kind": "model",
-      "name": "BarSettings",
+      "name": "BarSettingsResource",
       "namespace": "MgmtTypeSpec",
-      "crossLanguageDefinitionId": "MgmtTypeSpec.BarSettings",
+      "crossLanguageDefinitionId": "MgmtTypeSpec.BarSettingsResource",
       "usage": "Input,Output,Json,LroInitial,LroFinalEnvelope",
       "doc": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
       "decorators": [
@@ -4154,7 +4154,7 @@
             "resourceScope": "ResourceGroup",
             "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/MgmtTypeSpec/foos/{fooName}/bars/{barName}",
             "singletonResourceName": "current",
-            "resourceName": "BarSettings"
+            "resourceName": "BarSettingsResource"
           }
         }
       ],
@@ -4209,7 +4209,7 @@
           "discriminator": false,
           "flatten": false,
           "decorators": [],
-          "crossLanguageDefinitionId": "MgmtTypeSpec.BarSettings.properties",
+          "crossLanguageDefinitionId": "MgmtTypeSpec.BarSettingsResource.properties",
           "serializationOptions": {
             "json": {
               "name": "properties"
@@ -4221,7 +4221,7 @@
           "kind": "path",
           "name": "name",
           "serializedName": "name",
-          "doc": "The name of the BarSettings",
+          "doc": "The name of the BarSettingsResource",
           "type": {
             "$id": "375",
             "kind": "string",
@@ -4232,7 +4232,7 @@
           "optional": false,
           "readOnly": true,
           "decorators": [],
-          "crossLanguageDefinitionId": "MgmtTypeSpec.BarSettings.name",
+          "crossLanguageDefinitionId": "MgmtTypeSpec.BarSettingsResource.name",
           "explode": false,
           "style": "simple",
           "allowReserved": false,
@@ -4251,7 +4251,7 @@
           "discriminator": false,
           "flatten": false,
           "decorators": [],
-          "crossLanguageDefinitionId": "MgmtTypeSpec.BarSettings.stringArray",
+          "crossLanguageDefinitionId": "MgmtTypeSpec.BarSettingsResource.stringArray",
           "serializationOptions": {
             "json": {
               "name": "stringArray"
@@ -9814,12 +9814,12 @@
               "apiVersions": [
                 "2024-05-01"
               ],
-              "doc": "Create a BarSettings",
+              "doc": "Create a BarSettingsResource",
               "operation": {
                 "$id": "771",
                 "name": "createOrUpdate",
-                "resourceName": "BarSettings",
-                "doc": "Create a BarSettings",
+                "resourceName": "BarSettingsResource",
+                "doc": "Create a BarSettingsResource",
                 "accessibility": "public",
                 "parameters": [
                   {
@@ -10222,12 +10222,12 @@
               "apiVersions": [
                 "2024-05-01"
               ],
-              "doc": "Get a BarSettings",
+              "doc": "Get a BarSettingsResource",
               "operation": {
                 "$id": "799",
                 "name": "get",
-                "resourceName": "BarSettings",
-                "doc": "Get a BarSettings",
+                "resourceName": "BarSettingsResource",
+                "doc": "Get a BarSettingsResource",
                 "accessibility": "public",
                 "parameters": [
                   {


### PR DESCRIPTION
If a resource name ends with `Resource` we should not append extra `Resource`. 