### PR TITLE
[CODEOWNERS] Linter failure cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -756,10 +756,10 @@
 # ServiceOwners:                                                   @rhurey @dargilco
 
 # PRLabel: %Microsoft Playwright Testing
-/sdk/playwrighttesting/                                            @Sid200026 @puagarwa @ShreyaAnand
+/sdk/playwrighttesting/                                            @puagarwa @ShreyaAnand
 
 # ServiceLabel: %Microsoft Playwright Testing
-# ServiceOwners:                                                   @Sid200026 @puagarwa @ShreyaAnand
+# ServiceOwners:                                                   @puagarwa @ShreyaAnand
 
 # ServiceLabel: %Policy
 # ServiceOwners:                                                   @aperezcloud @kenieva


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner flagged by the linter due to no longer being compliant.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5192530&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_
