### PR TITLE
Revert "add tspclientconfig"

### DIFF
--- a/eng/tspclientconfig.yaml
+++ b/eng/tspclientconfig.yaml
@@ -1,5 +1,0 @@
-supportedEmitters:
-  - name: "@azure-typespec/http-client-csharp"
-    path: eng/azure-typespec-http-client-csharp-emitter-package.json
-  - name: "@azure-typespec/http-client-csharp-mgmt"
-    path: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#51775

tsp-client is throwing validation errors due to a missing `package-dir` property for the new emitter entries. Reverting this PR for now to avoid defaulting to the new generators until this issue is fixed.