### PR TITLE
Remove project reference of Azure.Generator.Tests.Common, copy it to mgmt generator instead to avoid the csproject dependency

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management.sln
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Generator.Management"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Generator.Mgmt.Tests", "Azure.Generator.Management\test\Azure.Generator.Mgmt.Tests.csproj", "{236F0049-E44C-40C9-90BB-BD19495CB689}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Generator.Tests.Common", "..\..\http-client-csharp\generator\Azure.Generator\test\common\Azure.Generator.Tests.Common.csproj", "{5C43C4D9-AC67-6643-B7AF-DF8096B8265A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Generator.Management.Tests.Common", "Azure.Generator.Management\test\Common\Azure.Generator.Management.Tests.Common.csproj", "{611CC5AD-F05C-06D4-0613-809F36A61315}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,14 +23,10 @@ Global
 		{236F0049-E44C-40C9-90BB-BD19495CB689}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{236F0049-E44C-40C9-90BB-BD19495CB689}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{236F0049-E44C-40C9-90BB-BD19495CB689}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E6E6C66A-E1E2-4D4D-9E8A-FD97A1761F90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E6E6C66A-E1E2-4D4D-9E8A-FD97A1761F90}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E6E6C66A-E1E2-4D4D-9E8A-FD97A1761F90}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E6E6C66A-E1E2-4D4D-9E8A-FD97A1761F90}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5C43C4D9-AC67-6643-B7AF-DF8096B8265A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5C43C4D9-AC67-6643-B7AF-DF8096B8265A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5C43C4D9-AC67-6643-B7AF-DF8096B8265A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5C43C4D9-AC67-6643-B7AF-DF8096B8265A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{611CC5AD-F05C-06D4-0613-809F36A61315}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{611CC5AD-F05C-06D4-0613-809F36A61315}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{611CC5AD-F05C-06D4-0613-809F36A61315}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{611CC5AD-F05C-06D4-0613-809F36A61315}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj
@@ -25,11 +25,11 @@
 
   <ItemGroup>
     <Compile Remove="**\TestData\**\*.cs" />
+		<Compile Remove="Common\**" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\http-client-csharp\generator\Azure.Generator\test\common\Azure.Generator.Tests.Common.csproj" />
-    <ProjectReference Include="..\src\Azure.Generator.Management.csproj" />
+    <ProjectReference Include="Common\Azure.Generator.Management.Tests.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/Azure.Generator.Management.Tests.Common.csproj
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/Azure.Generator.Management.Tests.Common.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestSupportProject>true</IsTestSupportProject>
+    <!-- Don't warn for missing XML comments for test project. -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+	<ItemGroup>
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\src\Azure.Generator.Management.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/BinaryDataAssert.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/BinaryDataAssert.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure.Generator.Management.Tests.Common
+{
+    public static class BinaryDataAssert
+    {
+        public static void AreEqual(BinaryData expected, BinaryData result)
+        {
+            CollectionAssert.AreEqual(expected?.ToArray(), result?.ToArray());
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/Helpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/Helpers.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 namespace Azure.Generator.Management.Tests.Common
 {
     /// <summary>
-    /// Helper methods for Auzre plugin tests
+    /// Helper methods for Azure plugin tests
     /// </summary>
     public static class Helpers
     {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/Helpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/Helpers.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+namespace Azure.Generator.Management.Tests.Common
+{
+    /// <summary>
+    /// Helper methods for Auzre plugin tests
+    /// </summary>
+    public static class Helpers
+    {
+        /// <summary>
+        /// Get expected content from file with naming convention
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <param name="method"></param>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        public static string GetExpectedFromFile(
+            string? parameters = null,
+            [CallerMemberName] string method = "",
+            [CallerFilePath] string filePath = "")
+        {
+            return File.ReadAllText(GetAssetFileOrDirectoryPath(true, parameters, method, filePath)).Replace("\r\n", "\n");
+        }
+
+        private static string GetAssetFileOrDirectoryPath(
+            bool isFile,
+            string? parameters = null,
+            [CallerMemberName] string method = "",
+            [CallerFilePath] string filePath = "")
+        {
+            var callingClass = Path.GetFileName(filePath).Split('.').First();
+            var paramString = parameters is null ? string.Empty : $"({parameters})";
+            var extName = isFile ? ".cs" : string.Empty;
+
+            return Path.Combine(Path.GetDirectoryName(filePath)!, "TestData", callingClass, $"{method}{paramString}{extName}");
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
@@ -144,7 +144,7 @@ namespace Azure.Generator.Management.Tests.Common
                 kind: InputParameterKind.Constant);
 
         /// <summary>
-        /// Construct input paraemter
+        /// Construct input parameter
         /// </summary>
         /// <param name="name"></param>
         /// <param name="type"></param>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
@@ -1,0 +1,605 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
+
+namespace Azure.Generator.Management.Tests.Common
+{
+    /// <summary>
+    /// Provider methods to construct intput test data
+    /// </summary>
+    public static class InputFactory
+    {
+        /// <summary>
+        /// Primitive input data types
+        /// </summary>
+        public static class Primitive
+        {
+            /// <summary>
+            /// Construct string input data
+            /// </summary>
+            /// <param name="name"></param>
+            /// <param name="crossLanguageDefinitionId"></param>
+            /// <param name="encode"></param>
+            /// <returns></returns>
+            public static InputPrimitiveType String(string? name = null, string? crossLanguageDefinitionId = null, string? encode = null)
+            {
+                return new InputPrimitiveType(InputPrimitiveTypeKind.String, name ?? string.Empty, crossLanguageDefinitionId ?? string.Empty, encode);
+            }
+        }
+
+        /// <summary>
+        /// Construct input enum types
+        /// </summary>
+        public static class EnumMember
+        {
+            /// <summary>
+            /// Construct input enum type value for int32
+            /// </summary>
+            /// <param name="name"></param>
+            /// <param name="value"></param>
+            /// <param name="enumType"></param>
+            /// <returns></returns>
+            public static InputEnumTypeValue Int32(string name, int value, InputEnumType enumType)
+            {
+                return new InputEnumTypeValue(name, value, InputPrimitiveType.Int32, "", $"{name} description", enumType);
+            }
+
+            /// <summary>
+            /// Construct input enum type value for float32
+            /// </summary>
+            /// <param name="name"></param>
+            /// <param name="value"></param>
+            /// <param name="enumType"></param>
+            /// <returns></returns>
+            public static InputEnumTypeValue Float32(string name, float value, InputEnumType enumType)
+            {
+                return new InputEnumTypeValue(name, value, InputPrimitiveType.Float32, "", $"{name} description", enumType);
+            }
+
+            /// <summary>
+            /// Construct input enum type value for string
+            /// </summary>
+            /// <param name="name"></param>
+            /// <param name="value"></param>
+            /// <param name="enumType"></param>
+            /// <returns></returns>
+            public static InputEnumTypeValue String(string name, string value, InputEnumType enumType)
+            {
+                return new InputEnumTypeValue(name, value, InputPrimitiveType.String, "", $"{name} description", enumType);
+            }
+        }
+
+        /// <summary>
+        /// Construct input literal types
+        /// </summary>
+        public static class Literal
+        {
+            /// <summary>
+            /// Construct input literal type value for string
+            /// </summary>
+            /// <param name="value"></param>
+            /// <param name="name"></param>
+            /// <param name="namespace"></param>
+            /// <returns></returns>
+            public static InputLiteralType String(string value, string? name = null, string? @namespace = null)
+            {
+                return new InputLiteralType(name ?? string.Empty, @namespace ?? string.Empty, InputPrimitiveType.String, value);
+            }
+
+            /// <summary>
+            /// Construct input enum type value for any
+            /// </summary>
+            /// <param name="value"></param>
+            /// <param name="name"></param>
+            /// <param name="namespace"></param>
+            /// <returns></returns>
+            public static InputLiteralType Int32(int value, string? name = null, string? @namespace = null)
+            {
+                return new InputLiteralType(name ?? string.Empty, @namespace ?? string.Empty, InputPrimitiveType.Int32, value);
+            }
+        }
+
+        /// <summary>
+        /// Construct input constants
+        /// </summary>
+        public static class Constant
+        {
+            /// <summary>
+            /// Construct input constnat for string
+            /// </summary>
+            /// <param name="value"></param>
+            /// <returns></returns>
+            public static InputConstant String(string value)
+            {
+                return new InputConstant(value, InputPrimitiveType.String);
+            }
+
+            /// <summary>
+            /// Construct input constnat for int64
+            /// </summary>
+            /// <param name="value"></param>
+            /// <returns></returns>
+            public static InputConstant Int64(long value)
+            {
+                return new InputConstant(value, InputPrimitiveType.Int64);
+            }
+        }
+
+        /// <summary>
+        /// Construct input parameter with content type
+        /// </summary>
+        /// <param name="contentType"></param>
+        /// <returns></returns>
+        public static InputParameter ContentTypeParameter(string contentType)
+            => Parameter(
+                "contentType",
+                Literal.String(contentType),
+                location: InputRequestLocation.Header,
+                isRequired: true,
+                defaultValue: Constant.String(contentType),
+                nameInRequest: "Content-Type",
+                isContentType: true,
+                kind: InputParameterKind.Constant);
+
+        /// <summary>
+        /// Construct input paraemter
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="type"></param>
+        /// <param name="nameInRequest"></param>
+        /// <param name="defaultValue"></param>
+        /// <param name="location"></param>
+        /// <param name="isRequired"></param>
+        /// <param name="kind"></param>
+        /// <param name="isEndpoint"></param>
+        /// <param name="isContentType"></param>
+        /// <returns></returns>
+        public static InputParameter Parameter(
+            string name,
+            InputType type,
+            string? nameInRequest = null,
+            InputConstant? defaultValue = null,
+            InputRequestLocation location = InputRequestLocation.Body,
+            bool isRequired = false,
+            InputParameterKind kind = InputParameterKind.Method,
+            bool isEndpoint = false,
+            bool isContentType = false)
+        {
+            return new InputParameter(
+                name,
+                nameInRequest ?? name,
+                null,
+                $"{name} description",
+                type,
+                location,
+                defaultValue,
+                kind,
+                isRequired,
+                false,
+                isContentType,
+                isEndpoint,
+                false,
+                false,
+                null,
+                null,
+                null);
+        }
+
+        /// <summary>
+        /// Construct input model property
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="type"></param>
+        /// <param name="isRequired"></param>
+        /// <param name="isReadOnly"></param>
+        /// <param name="isDiscriminator"></param>
+        /// <param name="wireName"></param>
+        /// <param name="summary"></param>
+        /// <param name="serializedName"></param>
+        /// <param name="doc"></param>
+        /// <returns></returns>
+        public static InputModelProperty Property(
+            string name,
+            InputType type,
+            bool isRequired = false,
+            bool isReadOnly = false,
+            bool isDiscriminator = false,
+            string? wireName = null,
+            string? summary = null,
+            string? serializedName = null,
+            string? doc = null)
+        {
+            return new InputModelProperty(
+                name,
+                summary,
+                doc ?? $"Description for {name}",
+                type,
+                isRequired,
+                isReadOnly,
+                access: null,
+                isDiscriminator,
+                serializedName ?? wireName ?? name.ToVariableName(),
+                new(json: new(wireName ?? name)));
+        }
+
+        /// <summary>
+        /// Construct input model type
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="clientNamespace"></param>
+        /// <param name="access"></param>
+        /// <param name="usage"></param>
+        /// <param name="properties"></param>
+        /// <param name="baseModel"></param>
+        /// <param name="modelAsStruct"></param>
+        /// <param name="discriminatedKind"></param>
+        /// <param name="additionalProperties"></param>
+        /// <param name="discriminatedModels"></param>
+        /// <param name="derivedModels"></param>
+        /// <param name="decorators"></param>
+        /// <returns></returns>
+        public static InputModelType Model(
+            string name,
+            string clientNamespace = "Samples.Models",
+            string access = "public",
+            InputModelTypeUsage usage = InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+            IEnumerable<InputModelProperty>? properties = null,
+            InputModelType? baseModel = null,
+            bool modelAsStruct = false,
+            string? discriminatedKind = null,
+            InputType? additionalProperties = null,
+            IDictionary<string, InputModelType>? discriminatedModels = null,
+            IEnumerable<InputModelType>? derivedModels = null,
+            IReadOnlyList<InputDecoratorInfo>? decorators = null)
+        {
+            IEnumerable<InputModelProperty> propertiesList = properties ?? [Property("StringProperty", InputPrimitiveType.String)];
+            var model = new InputModelType(
+                name,
+                clientNamespace,
+                name,
+                access,
+                null,
+                null,
+                $"{name} description",
+                usage,
+                [.. propertiesList],
+                baseModel,
+                derivedModels is null ? [] : [.. derivedModels],
+                discriminatedKind,
+                propertiesList.FirstOrDefault(p => p.IsDiscriminator),
+                discriminatedModels is null ? new Dictionary<string, InputModelType>() : discriminatedModels.AsReadOnly(),
+                additionalProperties,
+                modelAsStruct,
+                new());
+            if (decorators is not null)
+            {
+                var decoratorProperty = typeof(InputModelType).GetProperty(nameof(InputModelType.Decorators));
+                var setDecoratorMethod = decoratorProperty?.GetSetMethod(true);
+                setDecoratorMethod!.Invoke(model, [decorators]);
+            }
+            return model;
+        }
+
+        /// <summary>
+        /// Construct basic service method
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="operation"></param>
+        /// <param name="access"></param>
+        /// <param name="parameters"></param>
+        /// <param name="response"></param>
+        /// <param name="exception"></param>
+        /// <param name="crossLanguageDefinitionId"></param>
+        /// <returns></returns>
+        public static InputBasicServiceMethod BasicServiceMethod(
+            string name,
+            InputOperation operation,
+            string access = "public",
+            IReadOnlyList<InputParameter>? parameters = null,
+            InputServiceMethodResponse? response = null,
+            InputServiceMethodResponse? exception = null,
+            string? crossLanguageDefinitionId = null)
+        {
+            return new InputBasicServiceMethod(
+                name,
+                access,
+                [],
+                null,
+                null,
+                operation,
+                parameters ?? [],
+                response ?? ServiceMethodResponse(null, null),
+                exception,
+                false,
+                true,
+                true,
+                crossLanguageDefinitionId ?? string.Empty);
+        }
+
+        /// <summary>
+        /// Construct service method response
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="resultSegments"></param>
+        /// <returns></returns>
+        public static InputServiceMethodResponse ServiceMethodResponse(InputType? type, IReadOnlyList<string>? resultSegments)
+        {
+            return new InputServiceMethodResponse(type, resultSegments);
+        }
+
+        /// <summary>
+        /// Construct paging service method
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="operation"></param>
+        /// <param name="access"></param>
+        /// <param name="parameters"></param>
+        /// <param name="response"></param>
+        /// <param name="exception"></param>
+        /// <param name="pagingMetadata"></param>
+        /// <returns></returns>
+        public static InputPagingServiceMethod PagingServiceMethod(
+           string name,
+           InputOperation operation,
+           string access = "public",
+           IReadOnlyList<InputParameter>? parameters = null,
+           InputServiceMethodResponse? response = null,
+           InputServiceMethodResponse? exception = null,
+           InputPagingServiceMetadata? pagingMetadata = null)
+        {
+            return new InputPagingServiceMethod(
+                name,
+                access,
+                [],
+                null,
+                null,
+                operation,
+                parameters ?? [],
+                response ?? ServiceMethodResponse(null, null),
+                exception,
+                false,
+                true,
+                true,
+                string.Empty,
+                pagingMetadata ?? PagingMetadata([], null, null));
+        }
+
+        /// <summary>
+        /// Construct paging metadata
+        /// </summary>
+        /// <param name="itemPropertySegments"></param>
+        /// <param name="nextLink"></param>
+        /// <param name="continuationToken"></param>
+        /// <returns></returns>
+        public static InputPagingServiceMetadata PagingMetadata(IReadOnlyList<string> itemPropertySegments, InputNextLink? nextLink, InputContinuationToken? continuationToken)
+        {
+            return new InputPagingServiceMetadata(itemPropertySegments, nextLink, continuationToken);
+        }
+
+        /// <summary>
+        /// Construct paging service method
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="operation"></param>
+        /// <param name="access"></param>
+        /// <param name="parameters"></param>
+        /// <param name="response"></param>
+        /// <param name="exception"></param>
+        /// <param name="longRunningServiceMetadata"></param>
+        /// <returns></returns>
+        public static InputLongRunningServiceMethod LongRunningServiceMethod(
+            string name,
+            InputOperation operation,
+            string access = "public",
+            IReadOnlyList<InputParameter>? parameters = null,
+            InputServiceMethodResponse? response = null,
+            InputServiceMethodResponse? exception = null,
+            InputLongRunningServiceMetadata? longRunningServiceMetadata = null)
+        {
+            return new InputLongRunningServiceMethod(
+                name,
+                access,
+                [],
+                null,
+                null,
+                operation,
+                parameters ?? [],
+                response ?? ServiceMethodResponse(null, null),
+                exception,
+                false,
+                true,
+                true,
+                string.Empty,
+                longRunningServiceMetadata ?? LongRunningServiceMetadata(1, OperationResponse(), null));
+        }
+
+        /// <summary>
+        /// Construct paging metadata
+        /// </summary>
+        /// <param name="finalState"></param>
+        /// <param name="finalResponse"></param>
+        /// <param name="resultPath"></param>
+        /// <returns></returns>
+        public static InputLongRunningServiceMetadata LongRunningServiceMetadata(int finalState, InputOperationResponse finalResponse, string? resultPath)
+        {
+            return new InputLongRunningServiceMetadata(finalState, finalResponse, resultPath);
+        }
+
+        /// <summary>
+        /// Construct input operation
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="access"></param>
+        /// <param name="parameters"></param>
+        /// <param name="responses"></param>
+        /// <param name="requestMediaTypes"></param>
+        /// <param name="path"></param>
+        /// <param name="decorators"></param>
+        /// <returns></returns>
+        public static InputOperation Operation(
+            string name,
+            string access = "public",
+            IEnumerable<InputParameter>? parameters = null,
+            IEnumerable<InputOperationResponse>? responses = null,
+            IEnumerable<string>? requestMediaTypes = null,
+            string? path = null,
+            IReadOnlyList<InputDecoratorInfo>? decorators = null)
+        {
+            var operation = new InputOperation(
+                name,
+                null,
+                "",
+                $"{name} description",
+                null,
+                access,
+                parameters is null ? [] : [.. parameters],
+                responses is null ? [OperationResponse()] : [.. responses],
+                "GET",
+                string.Empty,
+                path ?? string.Empty,
+                null,
+                requestMediaTypes is null ? null : [.. requestMediaTypes],
+                false,
+                true,
+                true,
+                name);
+            if (decorators is not null)
+            {
+                var decoratorProperty = typeof(InputOperation).GetProperty(nameof(InputOperation.Decorators));
+                var setDecoratorMethod = decoratorProperty?.GetSetMethod(true);
+                setDecoratorMethod!.Invoke(operation, [decorators]);
+            }
+            return operation;
+        }
+
+        /// <summary>
+        /// Construct input operation response
+        /// </summary>
+        /// <param name="statusCodes"></param>
+        /// <param name="bodytype"></param>
+        /// <returns></returns>
+        public static InputOperationResponse OperationResponse(IEnumerable<int>? statusCodes = null, InputType? bodytype = null)
+        {
+            return new InputOperationResponse(
+                statusCodes is null ? [200] : [.. statusCodes],
+                bodytype,
+                [],
+                false,
+                ["application/json"]);
+        }
+
+        private static readonly Dictionary<InputClient, IList<InputClient>> _childClientsCache = new();
+        /// <summary>
+        /// Construct input client
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="clientNamespace"></param>
+        /// <param name="doc"></param>
+        /// <param name="methods"></param>
+        /// <param name="parameters"></param>
+        /// <param name="parent"></param>
+        /// <param name="decorators"></param>
+        /// <param name="crossLanguageDefinitionId"></param>
+        /// <returns></returns>
+        public static InputClient Client(string name, string clientNamespace = "Samples", string? doc = null, IEnumerable<InputServiceMethod>? methods = null, IEnumerable<InputParameter>? parameters = null, InputClient? parent = null, IReadOnlyList<InputDecoratorInfo>? decorators = null, string? crossLanguageDefinitionId = null)
+        {
+            // when this client has parent, we add the constructed client into the `children` list of the parent
+            var clientChildren = new List<InputClient>();
+            var client = new InputClient(
+                name,
+                clientNamespace,
+                crossLanguageDefinitionId ?? $"{clientNamespace}.{name}",
+                string.Empty,
+                doc ?? $"{name} description",
+                methods is null ? [] : [.. methods],
+                parameters is null ? [] : [.. parameters],
+                parent,
+                clientChildren
+                );
+            _childClientsCache[client] = clientChildren;
+            // when we have a parent, we need to find the children list of this parent client and update accordingly.
+            if (parent != null && _childClientsCache.TryGetValue(parent, out var children))
+            {
+                children.Add(client);
+            }
+
+            if (decorators is not null)
+            {
+                var decoratorProperty = typeof(InputClient).GetProperty(nameof(InputClient.Decorators));
+                var setDecoratorMethod = decoratorProperty?.GetSetMethod(true);
+                setDecoratorMethod!.Invoke(client, [decorators]);
+            }
+            return client;
+        }
+
+        public static InputPagingServiceMetadata ContinuationTokenPagingMetadata(InputParameter parameter, string itemPropertyName, string continuationTokenName, InputResponseLocation continuationTokenLocation)
+        {
+            return new InputPagingServiceMetadata(
+                [itemPropertyName],
+                null,
+                continuationToken: new InputContinuationToken(parameter, [continuationTokenName], continuationTokenLocation));
+        }
+
+        public static InputType Array(InputType elementType)
+        {
+            return new InputArrayType("list", "list", elementType);
+        }
+
+        public static InputPagingServiceMetadata NextLinkPagingMetadata(string itemPropertyName, string nextLinkName, InputResponseLocation nextLinkLocation, IReadOnlyList<InputParameter>? reinjectedParameters = null)
+        {
+            return PagingMetadata(
+                [itemPropertyName],
+                new InputNextLink(null, [nextLinkName], nextLinkLocation, reinjectedParameters),
+                null);
+        }
+
+        public static InputEnumType StringEnum(
+            string name,
+            IEnumerable<(string Name, string Value)> values,
+            string access = "public",
+            InputModelTypeUsage usage = InputModelTypeUsage.Input | InputModelTypeUsage.Output,
+            bool isExtensible = false,
+            string clientNamespace = "Sample.Models")
+        {
+            var enumValues = new List<InputEnumTypeValue>();
+            var enumType = Enum(
+                name,
+                InputPrimitiveType.String,
+                enumValues,
+                access: access,
+                usage: usage,
+                isExtensible: isExtensible,
+                clientNamespace: clientNamespace);
+
+            foreach (var (valueName, value) in values)
+            {
+                enumValues.Add(EnumMember.String(valueName, value, enumType));
+            }
+
+            return enumType;
+        }
+
+        private static InputEnumType Enum(
+            string name,
+            InputPrimitiveType underlyingType,
+            IReadOnlyList<InputEnumTypeValue> values,
+            string access = "public",
+            InputModelTypeUsage usage = InputModelTypeUsage.Output | InputModelTypeUsage.Input,
+            bool isExtensible = false,
+            string clientNamespace = "Sample.Models")
+            => new InputEnumType(
+                name,
+                clientNamespace,
+                name,
+                access,
+                null,
+                "",
+                $"{name} description",
+                usage,
+                underlyingType,
+                values,
+                isExtensible);
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.TypeSpec.Generator.Input.Extensions;
 namespace Azure.Generator.Management.Tests.Common
 {
     /// <summary>
-    /// Provider methods to construct intput test data
+    /// Provider methods to construct input test data
     /// </summary>
     public static class InputFactory
     {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/ModelTestHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/ModelTestHelper.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace Azure.Generator.Management.Tests.Common
+{
+    public static class ModelTestHelper
+    {
+        public static string GetLocation(string filePath)
+        {
+            StackTrace stackTrace = new StackTrace();
+            MethodBase method = stackTrace.GetFrame(1)!.GetMethod()!;
+            string testsLocation = Directory.GetParent(method.DeclaringType!.Assembly.Location)!.FullName;
+
+            var startNamespace = testsLocation.IndexOf("bin") + 4;
+            var endNamespace = testsLocation.IndexOf("Debug") - 1;
+            var namespaceLength = endNamespace - startNamespace;
+            var testNamespace = method.DeclaringType.Namespace!.Substring(namespaceLength);
+            var segments = testNamespace.Split('.');
+            foreach (var segment in segments)
+            {
+                testsLocation = Path.Combine(testsLocation, segment);
+            }
+            return Path.Combine(testsLocation, filePath);
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/ModelTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/ModelTests.cs
@@ -1,0 +1,270 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Azure.Core;
+using NUnit.Framework;
+
+namespace Azure.Generator.Management.Tests.Common
+{
+    public abstract class ModelTests<T> where T : IPersistableModel<T>
+    {
+        private static readonly ModelReaderWriterOptions _wireOptions = new ModelReaderWriterOptions("W");
+
+        private T? _modelInstance;
+        private T ModelInstance => _modelInstance ??= GetModelInstance();
+
+        private bool IsXmlWireFormat => WirePayload.StartsWith("<", StringComparison.Ordinal);
+
+        protected virtual T GetModelInstance()
+        {
+            var modelInstance = Activator.CreateInstance(typeof(T), true);
+            if (modelInstance is null)
+                throw new Exception($"Unable to create a model instance of {typeof(T).Name}");
+            return (T)modelInstance;
+        }
+
+        protected virtual string GetExpectedResult(string format)
+        {
+            if (format == "J")
+            {
+                return JsonPayload;
+            }
+
+            return WirePayload;
+        }
+        protected abstract void VerifyModel(T model, string format);
+        protected abstract void CompareModels(T model, T model2, string format);
+        protected abstract T ToModel(Response response);
+        protected abstract RequestContent ToRequestContent(T model);
+        protected abstract string JsonPayload { get; }
+        protected abstract string WirePayload { get; }
+
+        public void RoundTripWithModelReaderWriterBase(string format)
+            => RoundTripTest(format, new ModelReaderWriterStrategy<T>());
+
+        public void RoundTripWithModelReaderWriterNonGenericBase(string format)
+            => RoundTripTest(format, new ModelReaderWriterNonGenericStrategy<T>());
+
+        public void RoundTripWithModelInterfaceBase(string format)
+            => RoundTripTest(format, new ModelInterfaceStrategy<T>());
+
+        public void RoundTripWithModelInterfaceNonGenericBase(string format)
+            => RoundTripTest(format, new ModelInterfaceAsObjectStrategy<T>());
+
+        public void RoundTripWithModelCastBase(string format)
+            => RoundTripTest(format, new CastStrategy<T>(ToRequestContent, ToModel));
+
+        protected void RoundTripTest(string format, RoundTripStrategy<T> strategy)
+        {
+            string serviceResponse = format == "J" ? JsonPayload : WirePayload;
+
+            ModelReaderWriterOptions options = new ModelReaderWriterOptions(format);
+
+            var expectedSerializedString = GetExpectedResult(format);
+
+            if (AssertFailures(strategy, format, serviceResponse, options))
+                return;
+
+            var model = (T?)strategy.Read(serviceResponse, ModelInstance, options);
+            Assert.NotNull(model);
+            VerifyModel(model!, format);
+            var data = strategy.Write(model!, options);
+            string roundTrip = data.ToString();
+
+            // we validate those are equivalent element, representing the same json object (ignoring the spaces and orders, etc)
+            AssertJsonEquivalency(expectedSerializedString, roundTrip);
+
+            var model2 = (T?)strategy.Read(roundTrip, ModelInstance, options);
+            Assert.NotNull(model2);
+            CompareModels(model!, model2!, format);
+        }
+
+        private void AssertJsonEquivalency(string expected, string result)
+        {
+            using var expectedDoc = JsonDocument.Parse(expected);
+            using var resultDoc = JsonDocument.Parse(result);
+
+            AssertJsonEquivalency(expectedDoc.RootElement, resultDoc.RootElement);
+        }
+
+        private void AssertJsonEquivalency(JsonElement expected, JsonElement result)
+        {
+            string expectedKind = expected.ValueKind.ToString();
+            string resultKind = result.ValueKind.ToString();
+            if (!expectedKind.Equals(resultKind))
+            {
+                Assert.Fail($"kind does not match between {expected} and {result}");
+            }
+
+            switch (result.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    AssertJsonObjectEquivalency(expected, result);
+                    break;
+                case JsonValueKind.Array:
+                    AssertJsonArrayEquivalency(expected, result);
+                    break;
+                default:
+                    Assert.AreEqual(expected.ToString(), result.ToString());
+                    break;
+            }
+        }
+
+        private void AssertJsonObjectEquivalency(JsonElement expected, JsonElement result)
+        {
+            // check result should have all properties in expected
+            foreach (var expectedProperty in expected.EnumerateObject())
+            {
+                if (!result.TryGetProperty(expectedProperty.Name, out var resultPropertyValue))
+                {
+                    Assert.Fail($"expected property {expectedProperty} not found in {result}. Expected: {expected}");
+                }
+                AssertJsonEquivalency(expectedProperty.Value, resultPropertyValue);
+            }
+
+            foreach (var resultProperty in result.EnumerateObject())
+            {
+                if (!expected.TryGetProperty(resultProperty.Name, out var expectedPropertyValue))
+                {
+                    Assert.Fail($"result property {resultProperty} not found in {expected}.");
+                }
+                AssertJsonEquivalency(resultProperty.Value, expectedPropertyValue);
+            }
+        }
+
+        private void AssertJsonArrayEquivalency(JsonElement expected, JsonElement result)
+        {
+            var expectedArray = expected.EnumerateArray().ToArray();
+            var resultArray = result.EnumerateArray().ToArray();
+
+            if (expectedArray.Length != resultArray.Length)
+            {
+                Assert.Fail($"expected array {expected} but got {result}");
+            }
+
+            for (int i = 0; i < expectedArray.Length; i++)
+            {
+                var ee = expectedArray[i];
+                var re = resultArray[i];
+                AssertJsonEquivalency(ee, re);
+            }
+        }
+
+        private bool AssertFailures(RoundTripStrategy<T> strategy, string format, string serviceResponse, ModelReaderWriterOptions options)
+        {
+            bool result = false;
+            if (IsXmlWireFormat && (strategy.IsExplicitJsonRead || strategy.IsExplicitJsonWrite) && format == "W")
+            {
+                if (strategy.IsExplicitJsonRead)
+                {
+                    if (strategy.GetType().Name.StartsWith("ModelJsonConverterStrategy"))
+                    {
+                        //we never get to the interface implementation because JsonSerializer errors before that
+                        Assert.Throws<JsonException>(() => { var model = (T?)strategy.Read(serviceResponse, ModelInstance, options); });
+                        result = true;
+                    }
+                    else
+                    {
+                        Assert.Throws<InvalidOperationException>(() => { var model = (T?)strategy.Read(serviceResponse, ModelInstance, options); });
+                        result = true;
+                    }
+                }
+
+                if (strategy.IsExplicitJsonWrite)
+                {
+                    Assert.Throws<InvalidOperationException>(() => { var data = strategy.Write(ModelInstance, options); });
+                    result = true;
+                }
+            }
+            else if (ModelInstance is not IJsonModel<T> && format == "J")
+            {
+                Assert.Throws<FormatException>(() => { T model = (T)strategy.Read(serviceResponse, ModelInstance, options)!; });
+                Assert.Throws<FormatException>(() => { var data = strategy.Write(ModelInstance, options); });
+                result = true;
+            }
+            return result;
+        }
+
+        public static IDictionary<string, BinaryData> GetRawData(object model)
+        {
+            Type modelType = model.GetType();
+            while (modelType.BaseType != typeof(object) && modelType.BaseType != typeof(ValueType))
+            {
+                modelType = modelType.BaseType!;
+            }
+            var propertyInfo = modelType.GetField("_additionalBinaryDataProperties", BindingFlags.Instance | BindingFlags.NonPublic);
+            return propertyInfo?.GetValue(model) as IDictionary<string, BinaryData> ?? throw new InvalidOperationException($"unable to get raw data from {model.GetType().Name}");
+        }
+
+        public void ThrowsIfUnknownFormatBase()
+        {
+            ModelReaderWriterOptions options = new ModelReaderWriterOptions("x");
+            Assert.Throws<FormatException>(() => ModelReaderWriter.Write(ModelInstance, options));
+            Assert.Throws<FormatException>(() => ModelReaderWriter.Read<T>(new BinaryData("x"), options));
+
+            Assert.Throws<FormatException>(() => ModelReaderWriter.Write((IPersistableModel<object>)ModelInstance, options));
+            Assert.Throws<FormatException>(() => ModelReaderWriter.Read(new BinaryData("x"), typeof(T), options));
+            if (ModelInstance is IJsonModel<T> jsonModel)
+            {
+                Assert.Throws<FormatException>(() => jsonModel.Write(new Utf8JsonWriter(new MemoryStream()), options));
+                Assert.Throws<FormatException>(() => ((IJsonModel<object>)jsonModel).Write(new Utf8JsonWriter(new MemoryStream()), options));
+                bool gotException = false;
+                try
+                {
+                    Utf8JsonReader reader = default;
+                    jsonModel.Create(ref reader, options);
+                }
+                catch (FormatException)
+                {
+                    gotException = true;
+                }
+                finally
+                {
+                    Assert.IsTrue(gotException);
+                }
+
+                gotException = false;
+                try
+                {
+                    Utf8JsonReader reader = default;
+                    ((IJsonModel<object>)jsonModel).Create(ref reader, options);
+                }
+                catch (FormatException)
+                {
+                    gotException = true;
+                }
+                finally
+                {
+                    Assert.IsTrue(gotException);
+                }
+            }
+        }
+
+        public void ThrowsIfWireIsNotJsonBase()
+        {
+            if (ModelInstance is IJsonModel<T> jsonModel && IsXmlWireFormat)
+            {
+                Assert.Throws<FormatException>(() => jsonModel.Write(new Utf8JsonWriter(new MemoryStream()), _wireOptions));
+                Utf8JsonReader reader = new Utf8JsonReader(new byte[] { });
+                bool exceptionCaught = false;
+                try
+                {
+                    jsonModel.Create(ref reader, _wireOptions);
+                }
+                catch (FormatException)
+                {
+                    exceptionCaught = true;
+                }
+                Assert.IsTrue(exceptionCaught, "Expected FormatException to be thrown when deserializing wire format as json");
+            }
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/ProcessTracker.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/ProcessTracker.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Azure.Generator.Management.Tests.Common
+{
+    // Uses Windows Job Objects to ensure external processes are killed if the current process is terminated non-gracefully.
+    internal static class ProcessTracker
+    {
+        private static readonly IntPtr _jobHandle;
+
+        static ProcessTracker()
+        {
+            // Requires Win8 or later
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || Environment.OSVersion.Version < new Version(6, 2))
+            {
+                return;
+            }
+
+            // Job name is optional but helps with diagnostics.  Job name must be unique if non-null.
+            _jobHandle = CreateJobObject(IntPtr.Zero, name: $"ProcessTracker{Process.GetCurrentProcess().Id}");
+
+            var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+            {
+                BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+                {
+                    LimitFlags = JOBOBJECTLIMIT.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                }
+            };
+
+            var length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            var extendedInfoPtr = Marshal.AllocHGlobal(length);
+            try
+            {
+                Marshal.StructureToPtr(extendedInfo, extendedInfoPtr, false);
+
+                if (!SetInformationJobObject(_jobHandle, JobObjectInfoType.ExtendedLimitInformation,
+                    extendedInfoPtr, (uint)length))
+                {
+                    throw new Win32Exception();
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(extendedInfoPtr);
+            }
+        }
+
+        public static void Add(Process process)
+        {
+            if (_jobHandle != IntPtr.Zero)
+            {
+                var success = AssignProcessToJobObject(_jobHandle, process.Handle);
+                if (!success && !process.HasExited)
+                {
+                    throw new Win32Exception();
+                }
+            }
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string name);
+
+        [DllImport("kernel32.dll")]
+        private static extern bool SetInformationJobObject(IntPtr job, JobObjectInfoType infoType,
+            IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+        private enum JobObjectInfoType
+        {
+            AssociateCompletionPortInformation = 7,
+            BasicLimitInformation = 2,
+            BasicUIRestrictions = 4,
+            EndOfJobTimeInformation = 6,
+            ExtendedLimitInformation = 9,
+            SecurityLimitInformation = 5,
+            GroupInformation = 11
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public Int64 PerProcessUserTimeLimit;
+            public Int64 PerJobUserTimeLimit;
+            public JOBOBJECTLIMIT LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public UInt32 ActiveProcessLimit;
+            public Int64 Affinity;
+            public UInt32 PriorityClass;
+            public UInt32 SchedulingClass;
+        }
+
+        [Flags]
+        private enum JOBOBJECTLIMIT : uint
+        {
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IO_COUNTERS
+        {
+            public UInt64 ReadOperationCount;
+            public UInt64 WriteOperationCount;
+            public UInt64 OtherOperationCount;
+            public UInt64 ReadTransferCount;
+            public UInt64 WriteTransferCount;
+            public UInt64 OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/RoundTripStrategy.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/RoundTripStrategy.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.Generator.Management.Tests.Common
+{
+#pragma warning disable SA1402
+    public abstract class RoundTripStrategy<T>
+    {
+        public abstract object? Read(string payload, object model, ModelReaderWriterOptions options);
+        public abstract BinaryData Write(T model, ModelReaderWriterOptions options);
+        public abstract bool IsExplicitJsonWrite { get; }
+        public abstract bool IsExplicitJsonRead { get; }
+
+        protected BinaryData WriteWithJsonInterface<U>(IJsonModel<U> model, ModelReaderWriterOptions options)
+        {
+            using MemoryStream stream = new MemoryStream();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(stream);
+            model.Write(writer, options);
+            writer.Flush();
+            if (stream.Position > int.MaxValue)
+            {
+                return BinaryData.FromStream(stream);
+            }
+            else
+            {
+                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+            }
+        }
+    }
+
+    public class ModelReaderWriterStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return ModelReaderWriter.Write(model, options);
+        }
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ModelReaderWriter.Read<T>(new BinaryData(Encoding.UTF8.GetBytes(payload)), options) ?? throw new InvalidOperationException($"Reading model of type {model.GetType().Name} resulted in null");
+        }
+    }
+
+    public class ModelReaderWriterNonGenericStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return ModelReaderWriter.Write((object)model, options);
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ModelReaderWriter.Read(new BinaryData(Encoding.UTF8.GetBytes(payload)), typeof(T), options) ?? throw new InvalidOperationException($"Reading model of type {model.GetType().Name} resulted in null");
+        }
+    }
+
+    public class ModelInterfaceStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return model.Write(options);
+        }
+
+        public override object? Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ((IPersistableModel<T>)model).Create(new BinaryData(Encoding.UTF8.GetBytes(payload)), options);
+        }
+    }
+
+    public class ModelInterfaceAsObjectStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return ((IPersistableModel<object>)model).Write(options);
+        }
+
+        public override object? Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ((IPersistableModel<object>)model).Create(new BinaryData(Encoding.UTF8.GetBytes(payload)), options);
+        }
+    }
+
+    public class JsonInterfaceStrategy<T> : RoundTripStrategy<T> where T : IJsonModel<T>
+    {
+        public override bool IsExplicitJsonWrite => true;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return WriteWithJsonInterface(model, options);
+        }
+
+        public override object? Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ((IJsonModel<T>)model).Create(new BinaryData(Encoding.UTF8.GetBytes(payload)), options);
+        }
+    }
+
+    public class JsonInterfaceAsObjectStrategy<T> : RoundTripStrategy<T> where T : IJsonModel<T>
+    {
+        public override bool IsExplicitJsonWrite => true;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return WriteWithJsonInterface((IJsonModel<object>)model, options);
+        }
+
+        public override object? Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ((IJsonModel<object>)model).Create(new BinaryData(Encoding.UTF8.GetBytes(payload)), options);
+        }
+    }
+
+    public class JsonInterfaceUtf8ReaderStrategy<T> : RoundTripStrategy<T> where T : IJsonModel<T>
+    {
+        public override bool IsExplicitJsonWrite => true;
+        public override bool IsExplicitJsonRead => true;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return WriteWithJsonInterface(model, options);
+        }
+
+        public override object? Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            var reader = new Utf8JsonReader(new BinaryData(Encoding.UTF8.GetBytes(payload)));
+            return ((IJsonModel<T>)model).Create(ref reader, options);
+        }
+    }
+
+    public class JsonInterfaceUtf8ReaderAsObjectStrategy<T> : RoundTripStrategy<T> where T : IJsonModel<T>
+    {
+        public override bool IsExplicitJsonWrite => true;
+        public override bool IsExplicitJsonRead => true;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return WriteWithJsonInterface((IJsonModel<object>)model, options);
+        }
+
+        public override object? Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            var reader = new Utf8JsonReader(new BinaryData(Encoding.UTF8.GetBytes(payload)));
+            return ((IJsonModel<object>)model).Create(ref reader, options);
+        }
+    }
+
+    public class CastStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        private readonly Func<T, RequestContent> _toRequestContent;
+        private readonly Func<Response, T> _fromResponse;
+
+        public CastStrategy(Func<T, RequestContent> toRequestContent, Func<Response, T> fromResponse)
+        {
+            _toRequestContent = toRequestContent;
+            _fromResponse = fromResponse;
+        }
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            RequestContent content = _toRequestContent(model);
+            content.TryComputeLength(out var length);
+            using var stream = new MemoryStream((int)length);
+            content.WriteTo(stream, default);
+            if (stream.Position > int.MaxValue)
+            {
+                return BinaryData.FromStream(stream);
+            }
+            else
+            {
+                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+            }
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            var responseWithBody = new TestResponse(200);
+            responseWithBody.SetContent(payload);
+
+            return _fromResponse(responseWithBody);
+        }
+    }
+#pragma warning restore SA1402
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/TestResponse.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/TestResponse.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Azure.Core;
+
+#nullable disable
+
+namespace Azure.Generator.Management.Tests.Common
+{
+    public class TestResponse : Response
+    {
+        private int _status;
+        private string _reasonPhrase;
+        private Stream _contentStream;
+
+        private readonly ResponseHeaders _headers;
+
+        private bool _disposed;
+
+        public TestResponse(int status = 0, string reasonPhrase = "")
+        {
+            _status = status;
+            _reasonPhrase = reasonPhrase;
+            _headers = new ResponseHeaders();
+        }
+
+        public override int Status => _status;
+
+        public void SetStatus(int value) => _status = value;
+
+        public override string ReasonPhrase => _reasonPhrase;
+
+        public void SetReasonPhrase(string value) => _reasonPhrase = value;
+
+        public void SetContent(byte[] content)
+        {
+            ContentStream = new MemoryStream(content, 0, content.Length, false, true);
+        }
+
+        public Response SetContent(string content)
+        {
+            SetContent(Encoding.UTF8.GetBytes(content));
+            return this;
+        }
+
+        public override Stream ContentStream
+        {
+            get => _contentStream;
+            set => _contentStream = value;
+        }
+
+        public override string ClientRequestId { get; set; }
+
+        public override BinaryData Content
+        {
+            get
+            {
+                if (_contentStream is null)
+                {
+                    return new BinaryData(Array.Empty<byte>());
+                }
+
+                if (ContentStream is not MemoryStream memoryContent)
+                {
+                    throw new InvalidOperationException($"The response is not buffered.");
+                }
+
+                if (memoryContent.TryGetBuffer(out ArraySegment<byte> segment))
+                {
+                    return new BinaryData(segment.AsMemory());
+                }
+                else
+                {
+                    return new BinaryData(memoryContent.ToArray());
+                }
+            }
+        }
+
+        public override ResponseHeaders Headers
+            => _headers;
+
+        public sealed override void Dispose()
+        {
+            Dispose(true);
+
+            GC.SuppressFinalize(this);
+        }
+
+        protected override bool TryGetHeader(string name, out string value)
+        {
+            return _headers.TryGetValue(name, out value);
+        }
+
+        protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+        {
+            return _headers.TryGetValues(name, out values);
+        }
+
+        protected override bool ContainsHeader(string name)
+        {
+            return _headers.Contains(name);
+        }
+
+        protected override IEnumerable<HttpHeader> EnumerateHeaders()
+        {
+            foreach (var header in _headers)
+            {
+                yield return header;
+            }
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                Stream content = _contentStream;
+                if (content != null)
+                {
+                    _contentStream = null;
+                    content.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Generator.Management.Models;
-using Azure.Generator.Tests.Common;
 using Microsoft.TypeSpec.Generator.Input;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT License.
 
 using Azure.Generator.Management;
+using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
-using Azure.Generator.Management.Visitors;
-using Azure.Generator.Tests.Common;
-using Microsoft.TypeSpec.Generator;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Providers;
 using NUnit.Framework;
 
 namespace Azure.Generator.Mgmt.Tests

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/MgmtLroProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/MgmtLroProviderTests.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using Azure.Generator.Management.Providers;
+using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
-using Azure.Generator.Tests.Common;
 using Microsoft.TypeSpec.Generator.Primitives;
 using NUnit.Framework;
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/OperationSourceProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/OperationSourceProviderTests.cs
@@ -4,7 +4,6 @@
 using Azure.Generator.Management.Providers;
 using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
-using Azure.Generator.Tests.Common;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using NUnit.Framework;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceClientProviderTests.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 using Azure.Generator.Management.Providers;
 using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
-using Azure.Generator.Tests.Common;
 using Azure.ResourceManager;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
@@ -4,7 +4,6 @@
 using Azure.Generator.Management.Providers;
 using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
-using Azure.Generator.Tests.Common;
 using Azure.ResourceManager;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TagMethodProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TagMethodProviderTests.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core.Pipeline;
 using Azure.Generator.Management.Models;
 using Azure.Generator.Management.Providers;
 using Azure.Generator.Management.Providers.TagMethodProviders;
 using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
-using Azure.Generator.Tests.Common;
 using Azure.ResourceManager;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Primitives;


### PR DESCRIPTION
Right now, `Azure.Generator.Management` has a package reference of `Azure.Generator`. 
But `Azure.Generator.Mgmt.Tests` has a project reference of `Azure.Generator.Tests.Common`, which has a package reference of `Microsoft.Typespec.Generator.Input`. It causes version mismatch issues every time we bump MTG versions to have both package reference and project reference.
Remove project reference to be able to pin the package version for mgmt generator.