### PR TITLE
Add llm artifact upload step (test results artifacts)

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -73,6 +73,11 @@ jobs:
           artifactName: "Crash Dump - $(System.JobName) - $(System.JobAttempt)"
           condition: eq(variables['uploadDump'], 'true')
           sbomEnabled: false
+        - output: pipelineArtifact
+          targetPath: '$(Build.ArtifactStagingDirectory)/llm-artifacts'
+          artifactName: "LLM Artifacts - $(System.JobName) - $(System.JobAttempt)"
+          condition: eq(variables['uploadTestResults'], 'true')
+          sbomEnabled: false
 
     steps:
       - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
@@ -185,6 +190,7 @@ jobs:
           testResultsFormat: "VSTest"
           mergeTestResults: true
       - template: /eng/pipelines/templates/steps/upload-dumps.yml
+      - template: /eng/pipelines/templates/steps/upload-llm-artifacts.yml
       - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@5
         condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))
         displayName: Generate Code Coverage Reports

--- a/eng/pipelines/templates/steps/upload-llm-artifacts.yml
+++ b/eng/pipelines/templates/steps/upload-llm-artifacts.yml
@@ -1,0 +1,29 @@
+# This template serves as a place to upload artifacts intended to be used by LLMs
+# that handle data from the pipeline (for example github copilot).
+
+steps:
+  - pwsh: |
+      $artifactsDirectory = "$(Build.ArtifactStagingDirectory)/llm-artifacts"
+      New-Item $artifactsDirectory -ItemType directory -Force
+
+      Write-Host "================="
+      Get-ChildItem -Path $(TestTargetFramework)*.trx -Recurse -File
+      Write-Host "================="
+
+      foreach($testResultsFile in (Get-ChildItem -Path $(TestTargetFramework)*.trx -Recurse -File))
+      {
+        $fileFullName = $testResultsFile.FullName
+
+        # Convert a path like
+        #   /mnt/vss/_work/1/s/sdk/template/Azure.Template/tests/TestResults/net8.0.trx
+        # to
+        #   template-Azure.Template-net8.0.trx
+        $serviceAndPackage = ($fileFullName -split 'sdk[\\/]|[\\/]tests')[1] -replace '[\\/]', '-'
+        $trxFile     = Split-Path $fileFullName -Leaf
+        $fileName  = "$serviceAndPackage-$trxFile"
+
+        Move-Item -Path $fileFullName -Destination "$artifactsDirectory/$fileName" -ErrorAction Continue
+        Write-Host "##vso[task.setvariable variable=uploadTestResults]true"
+      }
+    condition: succeededOrFailed()
+    displayName: Copy test results files to llm artifacts staging directory


### PR DESCRIPTION
This PR adds a pipeline step to upload the `.trx` (xml) files from tests as a devops artifact. This allows the azsdk cli/mcp to fetch the artifacts and parse them for analysis.

This is necessary as we would like to support pipeline analysis for the github coding agent and/or partner developers without any auth requiremnts. The devops test results API requires auth, even for public projects, otherwise we would be able to use that directly like we do in for the `azsdk azp analyze --agent` flow.

I'm using a more generic naming (llm artifacts) as we may end up wanting to upload other generic files for use by LLMs in the future.