### PR TITLE
[Storage] [Webjobs Extension] Fixed scan logic to use the latest Created On time of the blob over Last Modified for the next scan

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed bug where the blob polling strategy will miss blobs that were created before the last scan time. The scan will now evaluate new blobs added to the container based on CreatedOn property and not the LastModifiedTime property (#51030).
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 if (failedNotifications.Any())
                 {
                     // TODO (kasobol-msft) this call to GetProperties is suboptimal figure out how to propagate data from listing here.
-                    latestScan = failedNotifications.Select(p => p.Blob).Min(n => n.BlobClient.GetProperties().Value.LastModified.UtcDateTime);
+                    latestScan = failedNotifications.Select(p => p.Blob).Min(n => n.BlobClient.GetProperties().Value.CreatedOn.UtcDateTime);
                 }
 
                 // Store our timestamp slightly earlier than the last timestamp. This is a failsafe for any blobs that created
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var properties = currentBlob.Properties;
-                DateTime lastModifiedTimestamp = properties.LastModified.Value.UtcDateTime;
+                DateTime lastModifiedTimestamp = properties.CreatedOn.Value.UtcDateTime;
 
                 if (lastModifiedTimestamp > containerScanInfo.CurrentSweepCycleLatestModified)
                 {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ScanBlobScanLogHybridPollingStrategyTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ScanBlobScanLogHybridPollingStrategyTests.cs
@@ -260,11 +260,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             product.Start();
 
             List<string> expectedNames = new List<string>();
-            expectedNames.Add(CreateBlobAndUploadToContainer(_blobContainerMock, _blobItems, lastModified: now));
+            expectedNames.Add(CreateBlobAndUploadToContainer(_blobContainerMock, _blobItems, createdOn: now));
 
             RunExecuterWithExpectedBlobs(expectedNames, product, executor);
 
-            expectedNames.Add(CreateBlobAndUploadToContainer(_blobContainerMock, _blobItems, lastModified: now));
+            expectedNames.Add(CreateBlobAndUploadToContainer(_blobContainerMock, _blobItems, createdOn: now));
 
             // We should see the new item. We'll see 2 blobs, but only process 1 (due to receipt).
             RunExecuterWithExpectedBlobs(expectedNames, product, executor, 1);
@@ -455,21 +455,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             }
         }
 
-        private string CreateBlobAndUploadToContainer(Mock<BlobContainerClient> containerMock, List<BlobItem> blobItems, string blobContent = "test", DateTimeOffset lastModified = default)
+        private string CreateBlobAndUploadToContainer(Mock<BlobContainerClient> containerMock, List<BlobItem> blobItems, string blobContent = "test", DateTimeOffset createdOn = default)
         {
             string blobName = Path.GetRandomFileName().Replace(".", "");
             Mock<BlobBaseClient> item = new Mock<BlobBaseClient>();
 
-            if (lastModified == default)
+            if (createdOn == default)
             {
-                lastModified = DateTimeOffset.UtcNow;
+                createdOn = DateTimeOffset.UtcNow;
             }
-            var blobProperties = BlobsModelFactory.BlobProperties(lastModified: lastModified);
+            var blobProperties = BlobsModelFactory.BlobProperties(createdOn: createdOn);
 
             item.Setup(x => x.GetPropertiesAsync(null, It.IsAny<CancellationToken>())).ReturnsAsync(Response.FromValue(blobProperties, null));
             item.Setup(x => x.Name).Returns(blobName);
 
-            BlobItemProperties blobItemProperties = BlobsModelFactory.BlobItemProperties(true, lastModified: lastModified);
+            BlobItemProperties blobItemProperties = BlobsModelFactory.BlobItemProperties(true, createdOn: createdOn);
             BlobItem blobItem = BlobsModelFactory.BlobItem(
                 name: blobName,
                 properties: blobItemProperties

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
@@ -2,13 +2,8 @@
 
 ## 5.4.0-beta.1 (Unreleased)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
+Please refer to [`Microsoft.Azure.WebJobs.Extension.Storage.Blobs`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md) and [`Microsoft.Azure.WebJobs.Extension.Storage.Queues`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md) for detailed list of changes.
 
 ## 5.3.5 (2025-07-21)
 


### PR DESCRIPTION
Resolves #51030 

This changes the logic to use the latest CreatedOn property from the blob from the latest scan, to determine if a new blob has not be scanned yet. Before this logic used the LastModifiedTime property of the blob to determine the latest scan, which was not friendly to blob containers which had multiple properties accessing the blobs.