### PR TITLE
Update class-level XML docs for DefaultAzureCredential

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
@@ -22,13 +22,13 @@ namespace Azure.Identity
     /// <item><description><see cref="EnvironmentCredential"/></description></item>
     /// <item><description><see cref="WorkloadIdentityCredential"/></description></item>
     /// <item><description><see cref="ManagedIdentityCredential"/></description></item>
-    /// <item><description><see cref="SharedTokenCacheCredential"/></description></item>
     /// <item><description><see cref="VisualStudioCredential"/></description></item>
-    /// <item><description><see cref="VisualStudioCodeCredential"/> (enabled by default for SSO with VS Code on supported platforms when Azure.Identity.Broker is referenced)</description></item>
+    /// <item><description><see cref="VisualStudioCodeCredential"/> (enabled by default for SSO with VS Code on supported platforms when Azure.Identity.Broker is installed)</description></item>
     /// <item><description><see cref="AzureCliCredential"/></description></item>
     /// <item><description><see cref="AzurePowerShellCredential"/></description></item>
     /// <item><description><see cref="AzureDeveloperCliCredential"/></description></item>
     /// <item><description><see cref="InteractiveBrowserCredential"/></description></item>
+    /// <item><description>BrokerCredential (a broker-enabled instance of <see cref="InteractiveBrowserCredential"/> that requires Azure.Identity.Broker is installed)</description></item>
     /// </list>
     /// Consult the documentation of these credentials for more information on how they attempt authentication.
     /// </summary>


### PR DESCRIPTION
`SharedTokenCacheCredential` is deprecated and disabled in the chain by default. Remove mention of it in the XML docs, since we don't want to promote it. Also mention the presence of `BrokerCredential` at the end of the chain.
