### PR TITLE
Update the list methods of resources in extensions to always have a name of `Get{ResourceNames}`

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableArmClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableArmClientProvider.cs
@@ -16,7 +16,8 @@ namespace Azure.Generator.Management.Providers
     internal sealed class MockableArmClientProvider : MockableResourceProvider
     {
         // TODO -- we also need to put operations here when we want to support scope resources/operations https://github.com/Azure/azure-sdk-for-net/issues/51821
-        public MockableArmClientProvider(IReadOnlyList<ResourceClientProvider> resources) : base(typeof(ArmClient), RequestPathPattern.Tenant, resources, [], [])
+        public MockableArmClientProvider(IReadOnlyList<ResourceClientProvider> resources)
+            : base(typeof(ArmClient), RequestPathPattern.Tenant, resources, new Dictionary<ResourceClientProvider, IReadOnlyList<ResourceMethod>>(), [])
         {
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableResourceProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableResourceProvider.cs
@@ -25,7 +25,7 @@ namespace Azure.Generator.Management.Providers
     internal class MockableResourceProvider : TypeProvider
     {
         private protected readonly IReadOnlyList<ResourceClientProvider> _resources;
-        private protected readonly IReadOnlyList<ResourceMethod> _resourceMethods;
+        private protected readonly IReadOnlyDictionary<ResourceClientProvider, IReadOnlyList<ResourceMethod>> _resourceMethods;
         private protected readonly IReadOnlyList<NonResourceMethod> _nonResourceMethods;
         private readonly Dictionary<InputClient, RestClientInfo> _clientInfos;
 
@@ -38,28 +38,27 @@ namespace Azure.Generator.Management.Providers
         /// <param name="resources">the resources in this scope.</param>
         /// <param name="resourceMethods">the resource methods that belong to this scope.</param>
         /// <param name="nonResourceMethods">the non-resource methods that belong to this scope.</param>
-        public MockableResourceProvider(ResourceScope resourceScope, IReadOnlyList<ResourceClientProvider> resources, IReadOnlyList<ResourceMethod> resourceMethods, IReadOnlyList<NonResourceMethod> nonResourceMethods)
+        public MockableResourceProvider(ResourceScope resourceScope, IReadOnlyList<ResourceClientProvider> resources, IReadOnlyDictionary<ResourceClientProvider, IReadOnlyList<ResourceMethod>> resourceMethods, IReadOnlyList<NonResourceMethod> nonResourceMethods)
             : this(ResourceHelpers.GetArmCoreTypeFromScope(resourceScope), RequestPathPattern.GetFromScope(resourceScope), resources, resourceMethods, nonResourceMethods)
         {
         }
 
-        private protected MockableResourceProvider(CSharpType armCoreType, RequestPathPattern contextualPath, IReadOnlyList<ResourceClientProvider> resources, IReadOnlyList<ResourceMethod> resourceMethods, IReadOnlyList<NonResourceMethod> nonResourceMethods)
+        private protected MockableResourceProvider(CSharpType armCoreType, RequestPathPattern contextualPath, IReadOnlyList<ResourceClientProvider> resources, IReadOnlyDictionary<ResourceClientProvider, IReadOnlyList<ResourceMethod>> resourceMethods, IReadOnlyList<NonResourceMethod> nonResourceMethods)
         {
             _resources = resources;
             _resourceMethods = resourceMethods;
             _nonResourceMethods = nonResourceMethods;
             ArmCoreType = armCoreType;
             _contextualPath = contextualPath;
-            _clientInfos = BuildRestClientInfos(resourceMethods, nonResourceMethods, this);
+            _clientInfos = BuildRestClientInfos(resourceMethods.Values.SelectMany(m => m).Select(m => m.InputClient).Concat(nonResourceMethods.Select(m => m.InputClient)), this);
         }
 
         private static Dictionary<InputClient, RestClientInfo> BuildRestClientInfos(
-            IReadOnlyList<ResourceMethod> resourceMethods,
-            IReadOnlyList<NonResourceMethod> nonResourceMethods,
+            IEnumerable<InputClient> inputClients,
             TypeProvider enclosingType)
         {
             var clientInfos = new Dictionary<InputClient, RestClientInfo>();
-            foreach (var inputClient in resourceMethods.Select(m => m.InputClient).Concat(nonResourceMethods.Select(m => m.InputClient)))
+            foreach (var inputClient in inputClients)
             {
                 if (clientInfos.ContainsKey(inputClient))
                 {
@@ -184,10 +183,13 @@ namespace Azure.Generator.Management.Providers
                 methods.AddRange(BuildMethodsForResource(resource));
             }
 
-            foreach (var method in _resourceMethods)
+            foreach (var (resource, resourceMethods) in _resourceMethods)
             {
-                methods.Add(BuildServiceMethod(method.InputMethod, method.InputClient, true));
-                methods.Add(BuildServiceMethod(method.InputMethod, method.InputClient, false));
+                foreach (var resourceMethod in resourceMethods)
+                {
+                    methods.Add(BuildResourceServiceMethod(resource, resourceMethod, true));
+                    methods.Add(BuildResourceServiceMethod(resource, resourceMethod, false));
+                }
             }
 
             foreach (var method in _nonResourceMethods)
@@ -276,13 +278,20 @@ namespace Azure.Generator.Management.Providers
             }
         }
 
-        private MethodProvider BuildServiceMethod(InputServiceMethod method, InputClient inputClient, bool isAsync)
+        private MethodProvider BuildResourceServiceMethod(ResourceClientProvider resource, ResourceMethod resourceMethod, bool isAsync)
+        {
+            var methodName = ResourceHelpers.GetExtensionOperationMethodName(resourceMethod.Kind, resource.ResourceName, isAsync);
+
+            return BuildServiceMethod(resourceMethod.InputMethod, resourceMethod.InputClient, isAsync, methodName);
+        }
+
+        private MethodProvider BuildServiceMethod(InputServiceMethod method, InputClient inputClient, bool isAsync, string? methodName = null)
         {
             var clientInfo = _clientInfos[inputClient];
             return method switch
             {
-                InputPagingServiceMethod pagingMethod => new PageableOperationMethodProvider(this, _contextualPath, clientInfo, pagingMethod, isAsync),
-                _ => new ResourceOperationMethodProvider(this, _contextualPath, clientInfo, method, isAsync)
+                InputPagingServiceMethod pagingMethod => new PageableOperationMethodProvider(this, _contextualPath, clientInfo, pagingMethod, isAsync, methodName: methodName),
+                _ => new ResourceOperationMethodProvider(this, _contextualPath, clientInfo, method, isAsync, methodName: methodName)
             };
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceHelpers.cs
@@ -4,6 +4,7 @@
 using Azure.Generator.Management.Models;
 using Azure.ResourceManager.ManagementGroups;
 using Azure.ResourceManager.Resources;
+using Humanizer;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
@@ -57,6 +58,22 @@ namespace Azure.Generator.Management.Utilities
             {
                 ResourceOperationKind.Create => isAsync ? "CreateOrUpdateAsync" : "CreateOrUpdate",
                 ResourceOperationKind.List => isAsync ? "GetAllAsync" : "GetAll",
+                _ => null
+            };
+        }
+
+        /// <summary>
+        /// Gets the appropriate method name for an extension operation based on its kind and corresponding resource name.
+        /// </summary>
+        /// <param name="operationKind"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="isAsync"></param>
+        /// <returns></returns>
+        public static string? GetExtensionOperationMethodName(ResourceOperationKind operationKind, string resourceName, bool isAsync)
+        {
+            return operationKind switch
+            {
+                ResourceOperationKind.List => isAsync ? $"Get{resourceName.Pluralize()}Async" : $"Get{resourceName.Pluralize()}",
                 _ => null
             };
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceHelpers.cs
@@ -68,7 +68,10 @@ namespace Azure.Generator.Management.Utilities
         /// <param name="operationKind"></param>
         /// <param name="resourceName"></param>
         /// <param name="isAsync"></param>
-        /// <returns></returns>
+        /// <param name="operationKind">The kind of resource operation to perform (e.g., List, Create).</param>
+        /// <param name="resourceName">The name of the resource for which the operation is being performed.</param>
+        /// <param name="isAsync">Whether the method should be asynchronous.</param>
+        /// <returns>The method name to use for the extension operation, or null if no override is needed.</returns>
         public static string? GetExtensionOperationMethodName(ResourceOperationKind operationKind, string resourceName, bool isAsync)
         {
             return operationKind switch

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MgmtTypeSpecExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MgmtTypeSpecExtensions.cs
@@ -200,12 +200,7 @@ namespace MgmtTypeSpec
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionResource"/> is null. </exception>
         /// <returns> A collection of <see cref="ZooResource"/> that may take multiple service requests to iterate over. </returns>
-<<<<<<< HEAD
-        [ForwardsClientCalls]
         public static AsyncPageable<ZooResource> GetZoosAsync(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
-=======
-        public static AsyncPageable<ZooResource> GetBySubscriptionAsync(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
->>>>>>> origin/main
         {
             Argument.AssertNotNull(subscriptionResource, nameof(subscriptionResource));
 
@@ -217,12 +212,7 @@ namespace MgmtTypeSpec
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionResource"/> is null. </exception>
         /// <returns> A collection of <see cref="ZooResource"/> that may take multiple service requests to iterate over. </returns>
-<<<<<<< HEAD
-        [ForwardsClientCalls]
         public static Pageable<ZooResource> GetZoos(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
-=======
-        public static Pageable<ZooResource> GetBySubscription(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
->>>>>>> origin/main
         {
             Argument.AssertNotNull(subscriptionResource, nameof(subscriptionResource));
 

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MgmtTypeSpecExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MgmtTypeSpecExtensions.cs
@@ -210,11 +210,11 @@ namespace MgmtTypeSpec
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionResource"/> is null. </exception>
         /// <returns> A collection of <see cref="ZooResource"/> that may take multiple service requests to iterate over. </returns>
         [ForwardsClientCalls]
-        public static AsyncPageable<ZooResource> GetBySubscriptionAsync(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
+        public static AsyncPageable<ZooResource> GetZoosAsync(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(subscriptionResource, nameof(subscriptionResource));
 
-            return GetMockableMgmtTypeSpecSubscriptionResource(subscriptionResource).GetBySubscriptionAsync(cancellationToken);
+            return GetMockableMgmtTypeSpecSubscriptionResource(subscriptionResource).GetZoosAsync(cancellationToken);
         }
 
         /// <summary> List Zoo resources by subscription ID. </summary>
@@ -223,11 +223,11 @@ namespace MgmtTypeSpec
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionResource"/> is null. </exception>
         /// <returns> A collection of <see cref="ZooResource"/> that may take multiple service requests to iterate over. </returns>
         [ForwardsClientCalls]
-        public static Pageable<ZooResource> GetBySubscription(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
+        public static Pageable<ZooResource> GetZoos(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(subscriptionResource, nameof(subscriptionResource));
 
-            return GetMockableMgmtTypeSpecSubscriptionResource(subscriptionResource).GetBySubscription(cancellationToken);
+            return GetMockableMgmtTypeSpecSubscriptionResource(subscriptionResource).GetZoos(cancellationToken);
         }
 
         /// <summary> Runs the input conditions against input object metadata properties and designates matched objects in response. </summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MockableMgmtTypeSpecSubscriptionResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Extensions/MockableMgmtTypeSpecSubscriptionResource.cs
@@ -49,7 +49,7 @@ namespace MgmtTypeSpec.Mocking
         /// <summary> List Zoo resources by subscription ID. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="ZooResource"/> that may take multiple service requests to iterate over. </returns>
-        public virtual AsyncPageable<ZooResource> GetBySubscriptionAsync(CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<ZooResource> GetZoosAsync(CancellationToken cancellationToken = default)
         {
             RequestContext context = new RequestContext
             {
@@ -61,7 +61,7 @@ namespace MgmtTypeSpec.Mocking
         /// <summary> List Zoo resources by subscription ID. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="ZooResource"/> that may take multiple service requests to iterate over. </returns>
-        public virtual Pageable<ZooResource> GetBySubscription(CancellationToken cancellationToken = default)
+        public virtual Pageable<ZooResource> GetZoos(CancellationToken cancellationToken = default)
         {
             RequestContext context = new RequestContext
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZoosGetBySubscriptionAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZoosGetBySubscriptionAsyncCollectionResultOfT.cs
@@ -61,7 +61,7 @@ namespace MgmtTypeSpec
         private async ValueTask<Response> GetNextResponseAsync(int? pageSizeHint, Uri nextLink)
         {
             HttpMessage message = nextLink != null ? _client.CreateNextGetBySubscriptionRequest(nextLink, _subscriptionId, _context) : _client.CreateGetBySubscriptionRequest(_subscriptionId, _context);
-            using DiagnosticScope scope = _client.ClientDiagnostics.CreateScope("MockableMgmtTypeSpecSubscriptionResource.GetBySubscription");
+            using DiagnosticScope scope = _client.ClientDiagnostics.CreateScope("MockableMgmtTypeSpecSubscriptionResource.GetZoos");
             scope.Start();
             try
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZoosGetBySubscriptionCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZoosGetBySubscriptionCollectionResultOfT.cs
@@ -60,7 +60,7 @@ namespace MgmtTypeSpec
         private Response GetNextResponse(int? pageSizeHint, Uri nextLink)
         {
             HttpMessage message = nextLink != null ? _client.CreateNextGetBySubscriptionRequest(nextLink, _subscriptionId, _context) : _client.CreateGetBySubscriptionRequest(_subscriptionId, _context);
-            using DiagnosticScope scope = _client.ClientDiagnostics.CreateScope("MockableMgmtTypeSpecSubscriptionResource.GetBySubscription");
+            using DiagnosticScope scope = _client.ClientDiagnostics.CreateScope("MockableMgmtTypeSpecSubscriptionResource.GetZoos");
             scope.Start();
             try
             {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/51925
