### PR TITLE
[CODEOWNERS] Fix linting errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -242,10 +242,10 @@
 # ServiceOwners:                                                   @olduroja
 
 # PRLabel: %Cognitive - Language
-/sdk/cognitivelanguage/                                            @quentinRobinson @bidisha-c
+/sdk/cognitivelanguage/                                            @quentinRobinson
 
 # ServiceLabel: %Cognitive - Language
-# ServiceOwners:                                                   @quentinRobinson @bidisha-c
+# ServiceOwners:                                                   @quentinRobinson
 
 # PRLabel: %Cognitive - LUIS
 /sdk/cognitiveservices/Language.LUIS*/                             @cahann @kayousef
@@ -278,10 +278,10 @@
 # ServiceOwners:                                                   @cahann @kayousef
 
 # PRLabel: %Cognitive - Text Analytics
-/sdk/textanalytics/                                                @quentinRobinson @bidisha-c
+/sdk/textanalytics/                                                @quentinRobinson
 
 # ServiceLabel: %Cognitive - Text Analytics
-# ServiceOwners:                                                   @quentinRobinson @bidisha-c
+# ServiceOwners:                                                   @quentinRobinson
 
 # PRLabel: %Cognitive - Translator
 /sdk/translation/                                                  @mikeymcz @vikaspalaskar


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner flagged by the linter as no longer having the necessary permissions.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5224347&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_