### PR TITLE
[Perf Tests] Add supports for writing operation latencies to results file

### DIFF
--- a/common/Perf/Azure.Test.Perf/OperationResult.cs
+++ b/common/Perf/Azure.Test.Perf/OperationResult.cs
@@ -7,7 +7,7 @@ namespace Azure.Test.Perf
 {
     public class OperationResult
     {
-        public TimeSpan Time { get; set; }
+        public double Time { get; set; }
         public long Size { get; set; }
     }
 }

--- a/common/Perf/Azure.Test.Perf/OperationResult.cs
+++ b/common/Perf/Azure.Test.Perf/OperationResult.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Test.Perf
+{
+    public class OperationResult
+    {
+        public TimeSpan Time { get; set; }
+        public long Size { get; set; }
+    }
+}

--- a/common/Perf/Azure.Test.Perf/OperationResult.cs
+++ b/common/Perf/Azure.Test.Perf/OperationResult.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-
 namespace Azure.Test.Perf
 {
     public class OperationResult

--- a/common/Perf/Azure.Test.Perf/PerfOptions.cs
+++ b/common/Perf/Azure.Test.Perf/PerfOptions.cs
@@ -54,6 +54,9 @@ namespace Azure.Test.Perf
         [Option('x', "test-proxies", Separator = ';', HelpText = "URIs of TestProxy Servers (separated by ';')")]
         public IEnumerable<Uri> TestProxies { get; set; }
 
+        [Option("results-file", HelpText = "File path location to store the results for the test run.")]
+        public string ResultsFile { get; set; }
+
         [Option('w', "warmup", Default = 5, HelpText = "Duration of warmup in seconds")]
         public int Warmup { get; set; }
     }

--- a/common/Perf/Azure.Test.Perf/PerfProgram.cs
+++ b/common/Perf/Azure.Test.Perf/PerfProgram.cs
@@ -508,7 +508,7 @@ namespace Azure.Test.Perf
         {
             var latencies = _latencies.Aggregate<IEnumerable<TimeSpan>>((list1, list2) => list1.Concat(list2)).Select(l => new OperationResult
             {
-                Time = l,
+                Time = l.TotalMilliseconds,
                 Size = operationSize,
             }).ToArray();
             string json = JsonSerializer.Serialize(latencies, options: new JsonSerializerOptions()

--- a/common/Perf/Azure.Test.Perf/PerfProgram.cs
+++ b/common/Perf/Azure.Test.Perf/PerfProgram.cs
@@ -7,6 +7,7 @@ using CommandLine;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime;
@@ -457,6 +458,11 @@ namespace Azure.Test.Perf
                 {
                     PrintLatencies("Corrected Latency Distribution", _correctedLatencies);
                 }
+
+                if (!string.IsNullOrEmpty(options.ResultsFile))
+                {
+                    WriteResults(options.ResultsFile, (options as SizeOptions)?.Size ?? -1);
+                }
             }
 
             if (jobStatistics)
@@ -496,6 +502,20 @@ namespace Azure.Test.Perf
                 Console.WriteLine($"{percentile * 100,7:N3}%   {sortedLatencies[(int)(sortedLatencies.Length * percentile) - 1].TotalMilliseconds,8:N2}ms");
             }
             Console.WriteLine();
+        }
+
+        private static void WriteResults(string path, long operationSize)
+        {
+            var latencies = _latencies.Aggregate<IEnumerable<TimeSpan>>((list1, list2) => list1.Concat(list2)).Select(l => new OperationResult
+            {
+                Time = l,
+                Size = operationSize,
+            }).ToArray();
+            string json = JsonSerializer.Serialize(latencies, options: new JsonSerializerOptions()
+            {
+                WriteIndented = true,
+            });
+            File.WriteAllText(path, json);
         }
 
         private static Thread WritePendingOperations(int rate, CancellationToken token)

--- a/common/Perf/Azure.Test.Perf/PerfProgram.cs
+++ b/common/Perf/Azure.Test.Perf/PerfProgram.cs
@@ -506,7 +506,7 @@ namespace Azure.Test.Perf
 
         private static void WriteResults(string path, long operationSize)
         {
-            var latencies = _latencies.Aggregate<IEnumerable<TimeSpan>>((list1, list2) => list1.Concat(list2)).Select(l => new OperationResult
+            var latencies = _latencies.SelectMany(x => x).Select(l => new OperationResult
             {
                 Time = l.TotalMilliseconds,
                 Size = operationSize,


### PR DESCRIPTION
Introduces a new flag to perf tests, `--results-file` which, by specifying a file path, indicates that the per-operation latency results should be written to a results file. This requires the `--latency` flag also be enabled to track per-operation latency.

This is mostly intended to be used by the PerfAutomation tool to calculate latency metrics.
