### PR TITLE
Fix stubbed library detection to not require public client ctor

### DIFF
--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Infrastructure/SpectorTestAttribute.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Infrastructure/SpectorTestAttribute.cs
@@ -46,7 +46,6 @@ namespace TestProjects.Spector.Tests
 
             var constructors = root.DescendantNodes()
                 .OfType<ConstructorDeclarationSyntax>()
-                .Where(c => c.Modifiers.Any(SyntaxKind.PublicKeyword))
                 .ToList();
 
             if (constructors.Count != 0)


### PR DESCRIPTION
For subclients the ctors will be internal, but we can still use those ctors to validate that the library is not stubbed.