### PR TITLE
chore(loadtestservice): removed useCloudHostedBrowsers

### DIFF
--- a/sdk/loadtestservice/Azure.Developer.Playwright.MSTest/samples/Sample2_CustomisingServiceParameters.md
+++ b/sdk/loadtestservice/Azure.Developer.Playwright.MSTest/samples/Sample2_CustomisingServiceParameters.md
@@ -27,7 +27,6 @@ public class PlaywrightServiceMSTestSetup
     {
         playwrightClient = new PlaywrightServiceBrowserMSTest(credential: new ManagedIdentityCredential(), options: new Azure.Developer.Playwright.PlaywrightServiceBrowserClientOptions()
         {
-            UseCloudHostedBrowsers = true,
             OS = OSPlatform.Linux,
             ExposeNetwork = "<loopback>",
             RunId = Guid.NewGuid().ToString(),

--- a/sdk/loadtestservice/Azure.Developer.Playwright.MSTest/tests/samples/Sample2_CustomisingServiceParameters.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright.MSTest/tests/samples/Sample2_CustomisingServiceParameters.cs
@@ -29,7 +29,6 @@ public class Sample2ServiceSetup
     {
         playwrightClient = new PlaywrightServiceBrowserMSTest(credential: new ManagedIdentityCredential(), options: new Azure.Developer.Playwright.PlaywrightServiceBrowserClientOptions()
         {
-            UseCloudHostedBrowsers = true,
             OS = OSPlatform.Linux,
             ExposeNetwork = "<loopback>",
             RunId = Guid.NewGuid().ToString(),

--- a/sdk/loadtestservice/Azure.Developer.Playwright.NUnit/samples/Sample2_CustomisingServiceParameters.md
+++ b/sdk/loadtestservice/Azure.Developer.Playwright.NUnit/samples/Sample2_CustomisingServiceParameters.md
@@ -23,7 +23,6 @@ public class PlaywrightServiceNUnitSetup : PlaywrightServiceBrowserNUnit
         credential: new ManagedIdentityCredential(),
         options: new PlaywrightServiceBrowserClientOptions()
         {
-            UseCloudHostedBrowsers = true,
             OS = OSPlatform.Linux,
             ExposeNetwork = "<loopback>",
             RunId = Guid.NewGuid().ToString(),

--- a/sdk/loadtestservice/Azure.Developer.Playwright.NUnit/src/PlaywrightServiceBrowserNUnit.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright.NUnit/src/PlaywrightServiceBrowserNUnit.cs
@@ -76,8 +76,6 @@ public class PlaywrightServiceBrowserNUnit : PlaywrightServiceBrowserClient
     [OneTimeSetUp]
     public async Task InitializeAsync()
     {
-        if (!_options.UseCloudHostedBrowsers)
-            return;
         nunitLogger.LogInformation("\nRunning tests using Azure Playwright service.\n");
 
         await base.InitializeAsync().ConfigureAwait(false);

--- a/sdk/loadtestservice/Azure.Developer.Playwright.NUnit/tests/samples/Sample2_CustomisingServiceParameters.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright.NUnit/tests/samples/Sample2_CustomisingServiceParameters.cs
@@ -26,7 +26,6 @@ public class Sample2ServiceSetup : PlaywrightServiceBrowserNUnit
         credential: new ManagedIdentityCredential(),
         options: new PlaywrightServiceBrowserClientOptions()
         {
-            UseCloudHostedBrowsers = true,
             OS = OSPlatform.Linux,
             ExposeNetwork = "<loopback>",
             RunId = Guid.NewGuid().ToString(),
@@ -41,7 +40,6 @@ public class Sample2ServiceSetup : PlaywrightServiceBrowserNUnit
         credential: new ManagedIdentityCredential(),
         options: new PlaywrightServiceBrowserClientOptions()
         {
-            UseCloudHostedBrowsers = true,
             OS = OSPlatform.Linux,
             ExposeNetwork = "<loopback>",
             RunId = Guid.NewGuid().ToString(),

--- a/sdk/loadtestservice/Azure.Developer.Playwright/api/Azure.Developer.Playwright.net8.0.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/api/Azure.Developer.Playwright.net8.0.cs
@@ -29,7 +29,6 @@ namespace Azure.Developer.Playwright
         public string RunName { get { throw null; } set { } }
         public Azure.Developer.Playwright.ServiceAuthType ServiceAuth { get { throw null; } set { } }
         public string? ServiceEndpoint { get { throw null; } set { } }
-        public bool UseCloudHostedBrowsers { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V2025_07_01_Preview = 1,

--- a/sdk/loadtestservice/Azure.Developer.Playwright/api/Azure.Developer.Playwright.netstandard2.0.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/api/Azure.Developer.Playwright.netstandard2.0.cs
@@ -29,7 +29,6 @@ namespace Azure.Developer.Playwright
         public string RunName { get { throw null; } set { } }
         public Azure.Developer.Playwright.ServiceAuthType ServiceAuth { get { throw null; } set { } }
         public string? ServiceEndpoint { get { throw null; } set { } }
-        public bool UseCloudHostedBrowsers { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V2025_07_01_Preview = 1,

--- a/sdk/loadtestservice/Azure.Developer.Playwright/src/Constants.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/src/Constants.cs
@@ -143,7 +143,6 @@ internal class Constants
 
     // Error messages
     internal static readonly string s_no_service_endpoint_error_message = "Please set PLAYWRIGHT_SERVICE_URL in your environment variables.";
-    internal static readonly string s_service_endpoint_removed_since_scalable_execution_disabled_error_message = "GetConnectOptions method cannot be used when UseCloudHostedBrowsers is set to false in the setup file.";
     internal static readonly string s_no_auth_error = "Could not authenticate with the service. Please refer to https://aka.ms/pww/docs/authentication for more information.";
     internal static readonly string s_entra_no_cred_error = "Azure credentials not found when using Entra ID authentication. Please refer to https://aka.ms/pww/docs/authentication for more information.";
     internal static readonly string s_invalid_mpt_pat_error = "The Access Token provided in the environment variable is invalid.";

--- a/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClient.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClient.cs
@@ -104,7 +104,6 @@ public class PlaywrightServiceBrowserClient : IDisposable
         _ = _options.RunName;
         _ = _options.ExposeNetwork;
         _ = _options.ServiceAuth;
-        _ = _options.UseCloudHostedBrowsers;
     }
 
     /// <summary>
@@ -120,14 +119,6 @@ public class PlaywrightServiceBrowserClient : IDisposable
     public virtual async Task<ConnectOptions<T>> GetConnectOptionsAsync<T>(OSPlatform? os = null, string? runId = null, string? exposeNetwork = null, CancellationToken cancellationToken = default) where T : class, new()
 #pragma warning restore AZC0015 // Unexpected client method return type.
     {
-        var environmentValueForUseCloudHostedBrowsers = _environment.GetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable);
-        if (bool.TryParse(environmentValueForUseCloudHostedBrowsers, out var useCloudHostedBrowsers) && !useCloudHostedBrowsers)
-        {
-            if (!useCloudHostedBrowsers)
-            {
-                throw new Exception(Constants.s_service_endpoint_removed_since_scalable_execution_disabled_error_message);
-            }
-        }
         if (string.IsNullOrEmpty(_options.ServiceEndpoint))
             throw new Exception(Constants.s_no_service_endpoint_error_message);
         string _serviceOs = Uri.EscapeDataString(ClientUtilities.GetServiceCompatibleOs(os) ?? ClientUtilities.GetServiceCompatibleOs(_options.OS)!);
@@ -174,14 +165,6 @@ public class PlaywrightServiceBrowserClient : IDisposable
     public virtual ConnectOptions<T> GetConnectOptions<T>(OSPlatform? os = null, string? runId = null, string? exposeNetwork = null, CancellationToken cancellationToken = default) where T : class, new()
 #pragma warning restore AZC0015 // Unexpected client method return type.
     {
-        var environmentValueForUseCloudHostedBrowsers = _environment.GetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable);
-        if (bool.TryParse(environmentValueForUseCloudHostedBrowsers, out var useCloudHostedBrowsers) && !useCloudHostedBrowsers)
-        {
-            if (!useCloudHostedBrowsers)
-            {
-                throw new Exception(Constants.s_service_endpoint_removed_since_scalable_execution_disabled_error_message);
-            }
-        }
         if (string.IsNullOrEmpty(_options.ServiceEndpoint))
             throw new Exception(Constants.s_no_service_endpoint_error_message);
         string _serviceOs = Uri.EscapeDataString(ClientUtilities.GetServiceCompatibleOs(os) ?? ClientUtilities.GetServiceCompatibleOs(_options.OS)!);
@@ -227,14 +210,6 @@ public class PlaywrightServiceBrowserClient : IDisposable
             _logger?.LogInformation("Exiting initialization as service endpoint is not set.");
             return;
         }
-        if (!_options.UseCloudHostedBrowsers)
-        {
-            // Since playwright-dotnet checks PLAYWRIGHT_SERVICE_ACCESS_TOKEN and PLAYWRIGHT_SERVICE_URL to be set, remove PLAYWRIGHT_SERVICE_URL so that tests are run locally.
-            // If customers use GetConnectOptionsAsync, after setting disableScalableExecution, an error will be thrown.
-            _logger?.LogInformation("Disabling scalable execution since UseCloudHostedBrowsers is set to false.");
-            _environment.SetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceUri.ToString(), null);
-            return;
-        }
         // If default auth mechanism is Access token and token is available in the environment variable, no need to setup rotation handler
         if (_options.ServiceAuth == ServiceAuthType.AccessToken)
         {
@@ -260,14 +235,6 @@ public class PlaywrightServiceBrowserClient : IDisposable
         if (string.IsNullOrEmpty(_options.ServiceEndpoint))
         {
             _logger?.LogInformation("Exiting initialization as service endpoint is not set.");
-            return;
-        }
-        if (!_options.UseCloudHostedBrowsers)
-        {
-            // Since playwright-dotnet checks PLAYWRIGHT_SERVICE_ACCESS_TOKEN and PLAYWRIGHT_SERVICE_URL to be set, remove PLAYWRIGHT_SERVICE_URL so that tests are run locally.
-            // If customers use GetConnectOptionsAsync, after setting disableScalableExecution, an error will be thrown.
-            _logger?.LogInformation("Disabling scalable execution since UseCloudHostedBrowsers is set to false.");
-            _environment.SetEnvironmentVariable(ServiceEnvironmentVariable.PlaywrightServiceUri.ToString(), null);
             return;
         }
         // If default auth mechanism is Access token and token is available in the environment variable, no need to setup rotation handler

--- a/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClientOptions.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClientOptions.cs
@@ -183,37 +183,6 @@ namespace Azure.Developer.Playwright
             }
         }
 
-        private bool? _useCloudHostedBrowsers;
-        /// <summary>
-        /// Gets or sets a flag indicating whether to use cloud-hosted browsers.
-        /// </summary>
-        public bool UseCloudHostedBrowsers
-        {
-            get
-            {
-                if (_useCloudHostedBrowsers != null)
-                    return (bool)_useCloudHostedBrowsers!;
-                var envValue = _environment.GetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable);
-                if (envValue != null)
-                {
-                    if (bool.TryParse(envValue, out var result))
-                        return result;
-                    throw new ArgumentException($"Invalid value for UseCloudHostedBrowsers. Supported values are true or false");
-                }
-                _environment.SetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable, true.ToString());
-                return true;
-            }
-            set
-            {
-                _useCloudHostedBrowsers = value;
-                // Set use cloud hosted browsers if not already set in the environment
-                if (_environment.GetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable) == null)
-                {
-                    _environment.SetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable, value.ToString());
-                }
-            }
-        }
-
         /// <summary>
         /// Gets the service endpoint for Playwright service.
         /// </summary>

--- a/sdk/loadtestservice/Azure.Developer.Playwright/tests/PlaywrightServiceBrowserClientOptionsTests.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/tests/PlaywrightServiceBrowserClientOptionsTests.cs
@@ -19,7 +19,6 @@ namespace Azure.Developer.Playwright.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(options.OS, Is.EqualTo(OSPlatform.Linux));
-                Assert.That(options.UseCloudHostedBrowsers, Is.True);
                 Assert.That(options.ServiceAuth, Is.EqualTo(ServiceAuthType.EntraId));
                 Assert.That(options.VersionString, Is.EqualTo("2025-07-01-preview"));
             });
@@ -83,25 +82,6 @@ namespace Azure.Developer.Playwright.Tests
             var ex = Assert.Throws<ArgumentException>(() =>
                 options.ServiceAuth = new ServiceAuthType("InvalidAuth"));
             Assert.That(ex!.Message, Does.Contain("Invalid value for ServiceAuth"));
-        }
-
-        [Test]
-        public void UseCloudHostedBrowsers_WhenEnvironmentVariableIsInvalid_ThrowsArgumentException()
-        {
-            var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(
-                Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable,
-                "not-a-boolean");
-
-            var options = new PlaywrightServiceBrowserClientOptions(
-                environment: environment,
-                serviceVersion: PlaywrightServiceBrowserClientOptions.ServiceVersion.V2025_07_01_Preview);
-
-            var ex = Assert.Throws<ArgumentException>(() =>
-            {
-                var _ = options.UseCloudHostedBrowsers;
-            });
-            Assert.That(ex!.Message, Does.Contain("Invalid value for UseCloudHostedBrowsers"));
         }
 
         [Test]
@@ -218,36 +198,6 @@ namespace Azure.Developer.Playwright.Tests
         }
 
         [Test]
-        public void UseCloudHostedBrowsers_WhenSetAndEnvironmentIsSet_DoesNotUpdateEnvironmentVariable()
-        {
-            var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable, "true");
-
-            _ = new PlaywrightServiceBrowserClientOptions(
-                environment: environment,
-                serviceVersion: PlaywrightServiceBrowserClientOptions.ServiceVersion.V2025_07_01_Preview)
-            {
-                UseCloudHostedBrowsers = false
-            };
-
-            Assert.That(environment.GetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable),
-                Is.EqualTo("true"));
-        }
-
-        [Test]
-        public void UseCloudHostedBrowsers_WhenEnvironmentVariableIsSet_ReturnsEnvironmentValue()
-        {
-            var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable, "false");
-
-            var options = new PlaywrightServiceBrowserClientOptions(
-                environment: environment,
-                serviceVersion: PlaywrightServiceBrowserClientOptions.ServiceVersion.V2025_07_01_Preview);
-
-            Assert.That(options.UseCloudHostedBrowsers, Is.False);
-        }
-
-        [Test]
         public void RunId_WhenNoValueSet_ReturnsDefaultRunId()
         {
             var environment = new TestEnvironment();
@@ -320,22 +270,6 @@ namespace Azure.Developer.Playwright.Tests
 
             Assert.That(environment.GetEnvironmentVariable(Constants.s_playwright_service_auth_type_environment_variable),
                 Is.EqualTo(ServiceAuthType.AccessToken.ToString()));
-        }
-
-        [Test]
-        public void UseCloudHostedBrowsers_WhenSetAndEnvironmentNotSet_UpdatesEnvironment()
-        {
-            var environment = new TestEnvironment();
-
-            _ = new PlaywrightServiceBrowserClientOptions(
-                environment: environment,
-                serviceVersion: PlaywrightServiceBrowserClientOptions.ServiceVersion.V2025_07_01_Preview)
-            {
-                UseCloudHostedBrowsers = false
-            };
-
-            Assert.That(environment.GetEnvironmentVariable(Constants.s_playwright_service_use_cloud_hosted_browsers_environment_variable),
-                Is.EqualTo(false.ToString()));
         }
     }
 }


### PR DESCRIPTION
# Contributing to the Azure SDK

The useCloudHostedBrowsers option previously allowed users to choose whether they wanted to use cloud-hosted browsers or not. This is no longer necessary because if customers do not want to use cloud-hosted browsers, they can simply run the tests using their local configuration. Therefore, we are removing this option.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
