### PR TITLE
Add work around for different behaviors in roslyn

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -299,7 +299,7 @@
     <!-- Note: Upgrading the .NET SDK version needs to be synchronized with the autorest.csharp repository -->
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="All"/>
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />
-    <!-- Note: 4.0.0 is required to keep our shipped source generators compatible with most project targets like netstandard2.0-->
+    <!-- Note: 4.3.0 is required to keep our shipped source generators compatible with most project targets like netstandard2.0-->
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version ="4.3.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20467.1" PrivateAssets="All" />

--- a/sdk/core/System.ClientModel/gen/ModelReaderWriterContextGenerator.cs
+++ b/sdk/core/System.ClientModel/gen/ModelReaderWriterContextGenerator.cs
@@ -49,12 +49,7 @@ internal sealed partial class ModelReaderWriterContextGenerator : IIncrementalGe
             TypeSymbolKindCache SymbolToKindCache,
             TypeSymbolTypeRefCache SymbolToTypeRefCache) data)
     {
-        if (data.TypesWithAttribute.Length == 0)
-        {
-            return;
-        }
-
-        if (data.TypesWithAttribute[0].Context is null)
+        if (data.TypesWithAttribute.Length == 0 || data.TypesWithAttribute[0].Context is null)
         {
             return;
         }

--- a/sdk/core/System.ClientModel/tests/gen.unit/CompilationHelper.cs
+++ b/sdk/core/System.ClientModel/tests/gen.unit/CompilationHelper.cs
@@ -44,6 +44,16 @@ namespace System.ClientModel.SourceGeneration.Tests.Unit
             CSharpParseOptions? parseOptions = null,
             string contextName = "LocalContext",
             HashSet<string>? additionalSuppress = null)
+            => CreateCompilation([source], additionalReferences, assemblyName, includeSTJ, parseOptions, contextName, additionalSuppress);
+
+        public static Compilation CreateCompilation(
+            IEnumerable<string> sources,
+            MetadataReference[]? additionalReferences = null,
+            string assemblyName = "TestAssembly",
+            bool includeSTJ = true,
+            CSharpParseOptions? parseOptions = null,
+            string contextName = "LocalContext",
+            HashSet<string>? additionalSuppress = null)
         {
             List<MetadataReference> references =
             [
@@ -70,10 +80,7 @@ namespace System.ClientModel.SourceGeneration.Tests.Unit
                 }
             }
 
-            SyntaxTree[] syntaxTrees =
-            [
-                CSharpSyntaxTree.ParseText(source, parseOptions),
-            ];
+            SyntaxTree[] syntaxTrees = sources.Select(source => CSharpSyntaxTree.ParseText(source, parseOptions)).ToArray();
 
             var compilation = CSharpCompilation.Create(
                 assemblyName,

--- a/sdk/core/System.ClientModel/tests/gen.unit/ContextGeneratorTests.cs
+++ b/sdk/core/System.ClientModel/tests/gen.unit/ContextGeneratorTests.cs
@@ -1088,6 +1088,83 @@ namespace TestProject
         }
 
         [Test]
+        public void TwoPartialClassesSeparateFilesShouldPass()
+        {
+            // Each class/partial declaration is placed in its own "file" (syntax tree) to
+            // simulate a multi-file project layout. Assertions mirror TwoPartialClassesShouldPass.
+            const string localContextPart1 =
+@"using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace TestProject
+{
+    [ModelReaderWriterBuildable(typeof(JsonModel))]
+    public partial class LocalContext : ModelReaderWriterContext { }
+}";
+            const string jsonModelSource =
+@"using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace TestProject
+{
+    public class JsonModel : IJsonModel<JsonModel>
+    {
+        public JsonModel Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => new JsonModel();
+        public JsonModel Create(BinaryData data, ModelReaderWriterOptions options) => new JsonModel();
+        public string GetFormatFromOptions(ModelReaderWriterOptions options) => ""J"";
+        public void Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) { }
+        public BinaryData Write(ModelReaderWriterOptions options) => BinaryData.Empty;
+    }
+}";
+            const string localContextPart2 =
+@"using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace TestProject
+{
+    [ModelReaderWriterBuildable(typeof(JsonModel2))]
+    public partial class LocalContext : ModelReaderWriterContext { }
+}";
+            const string jsonModel2Source =
+@"using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace TestProject
+{
+    public class JsonModel2 : IJsonModel<JsonModel2>
+    {
+        public JsonModel2 Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => new JsonModel2();
+        public JsonModel2 Create(BinaryData data, ModelReaderWriterOptions options) => new JsonModel2();
+        public string GetFormatFromOptions(ModelReaderWriterOptions options) => ""J"";
+        public void Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) { }
+        public BinaryData Write(ModelReaderWriterOptions options) => BinaryData.Empty;
+    }
+}";
+
+            Compilation compilation = CompilationHelper.CreateCompilation([localContextPart1, localContextPart2, jsonModelSource, jsonModel2Source]);
+
+            var result = CompilationHelper.RunSourceGenerator(compilation, out var newCompilation);
+
+            Assert.IsNotNull(result.GenerationSpec);
+            Assert.AreEqual("LocalContext", result.GenerationSpec!.Type.Name);
+            Assert.AreEqual("TestProject", result.GenerationSpec.Type.Namespace);
+            Assert.AreEqual(0, result.Diagnostics.Length);
+            Assert.AreEqual("public", result.GenerationSpec!.Modifier);
+            Assert.AreEqual(2, result.GenerationSpec.TypeBuilders.Count);
+            Assert.AreEqual(0, result.GenerationSpec.ReferencedContexts.Count);
+
+            // Order should match the discovery order (first JsonModel, then JsonModel2).
+            Assert.AreEqual("JsonModel", result.GenerationSpec.TypeBuilders[0].Type.Name);
+            Assert.AreEqual("TestProject", result.GenerationSpec.TypeBuilders[0].Type.Namespace);
+            Assert.AreEqual("JsonModel2", result.GenerationSpec.TypeBuilders[1].Type.Name);
+            Assert.AreEqual("TestProject", result.GenerationSpec.TypeBuilders[1].Type.Namespace);
+        }
+
+        [Test]
         public void TwoPartialClassesShouldPass()
         {
             string source =


### PR DESCRIPTION
Turns out roslyn has 2 different behaviors.  If you put 4 classes in one file `ForAttributeWithMetadataName` works differently than if you put each of those same 4 classes into their own file.

Related to https://github.com/dotnet/roslyn/issues/79519

The new implementation here should handle either case that a customer writes.