### PR TITLE
Customize deserialization for `ArmDeploymentOperationProperties.StatusCode` to be able to handle string or number

### DIFF
--- a/sdk/resources/Azure.ResourceManager.Resources/CHANGELOG.md
+++ b/sdk/resources/Azure.ResourceManager.Resources/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue in `ArmDeploymentOperationProperties` deserialization where `StatusCode` could be either a string or a number in JSON, causing `InvalidOperationException` when parsing an integer `StatusCode`.
+
 ### Other Changes
 
 ## 1.11.0 (2025-06-23)

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Custom/Models/ArmDeploymentOperationProperties.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Custom/Models/ArmDeploymentOperationProperties.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.ResourceManager.Resources.Models
+{
+    // Custom deserialization hook for handling mixed-type status codes.
+    // Addresses issue where the status code can be either a string or an integer in the JSON response.
+    [CodeGenSerialization(nameof(StatusCode), DeserializationValueHook = nameof(DeserializeStatusCode))]
+    public partial class ArmDeploymentOperationProperties
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DeserializeStatusCode(JsonProperty property, ref string statusCode)
+        {
+            if (property.Value.ValueKind == JsonValueKind.Null)
+                return;
+
+            statusCode = property.Value.ValueKind == JsonValueKind.Number
+                ? property.Value.GetInt32().ToString()
+                : property.Value.GetString();
+        }
+    }
+}

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/ArmDeploymentOperationProperties.Serialization.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/ArmDeploymentOperationProperties.Serialization.cs
@@ -182,7 +182,7 @@ namespace Azure.ResourceManager.Resources.Models
                 }
                 if (property.NameEquals("statusCode"u8))
                 {
-                    statusCode = property.Value.GetString();
+                    DeserializeStatusCode(property, ref statusCode);
                     continue;
                 }
                 if (property.NameEquals("statusMessage"u8))

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/Custom/Models/ArmDeploymentOperationProperties.cs
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/Custom/Models/ArmDeploymentOperationProperties.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.ResourceManager.Resources.Models;
+using NUnit.Framework;
+using System.Text.Json;
+
+namespace Azure.ResourceManager.Resources.Tests;
+
+public class ArmDeploymentOperationPropertiesTests
+{
+    [Test]
+    public void DeserializeStatusCode_String()
+    {
+        // Arrange
+        var json = """
+                   {
+                       "provisioningOperation": "Create",
+                       "provisioningState": "Failed",
+                       "timestamp": "2025-08-15T04:59:34.9900267Z",
+                       "duration": "PT0.4692629S",
+                       "statusCode": "Conflict",
+                       "statusMessage": {
+                           "status": "Failed",
+                           "error": {
+                               "code": "ServiceIsInMaintenance",
+                               "message": "[Conflict] Storage account 'seashore' is in process of maintenance for a short period. Please try again later."
+                           }
+                       },
+                       "targetResource": {
+                           "id": "/subscriptions/xxxxxxxxx/resourceGroups/my-rg/providers/Microsoft.Storage/storageAccounts/seashore",
+                           "resourceType": "Microsoft.Storage/storageAccounts",
+                           "resourceName": "seashore"
+                       }
+                   }
+                   """;
+        var jsonDocument = JsonDocument.Parse(json);
+        var deploymentOperations = ArmDeploymentOperationProperties.DeserializeArmDeploymentOperationProperties(jsonDocument.RootElement);
+        Assert.AreEqual("Conflict", deploymentOperations.StatusCode);
+    }
+
+    [Test]
+    public void DeserializeStatusCode_Integer()
+    {
+        // Arrange
+        var json = """
+                   {
+                       "provisioningOperation": "Create",
+                       "provisioningState": "Failed",
+                       "timestamp": "2025-08-15T04:59:34.9900267Z",
+                       "duration": "PT0.4692629S",
+                       "statusCode": 429,
+                       "statusMessage": {
+                           "status": "Failed",
+                           "error": {
+                               "code": "TooManyRequests",
+                               "message": "The request is being throttled as the limit has been reached. Please try again later."
+                           }
+                       },
+                       "targetResource": {
+                           "id": "/subscriptions/xxxxxxxxx/resourceGroups/my-rg/providers/Microsoft.Storage/storageAccounts/seashore",
+                           "resourceType": "Microsoft.Storage/storageAccounts",
+                           "resourceName": "seashore"
+                       }
+                   }
+                   """;
+        var jsonDocument = JsonDocument.Parse(json);
+        var deploymentOperations = ArmDeploymentOperationProperties.DeserializeArmDeploymentOperationProperties(jsonDocument.RootElement);
+        Assert.AreEqual("429", deploymentOperations.StatusCode);
+    }
+}


### PR DESCRIPTION
For #52022.
Adds serialization customization hook for `ArmDeploymentOperationProperties.StatusCode`.