### PR TITLE
Fix Identity null reference when debugging

### DIFF
--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -319,18 +319,29 @@ namespace Azure.Identity
                 // AOT friendly.
 
                 // Try to get the options type
-                Type optionsType = Type.GetType("Azure.Identity.Broker.DevelopmentBrokerOptions, Azure.Identity.Broker", throwOnError: false);
-                ConstructorInfo optionsCtor = optionsType?.GetConstructor(Type.EmptyTypes);
-                object optionsInstance = optionsCtor?.Invoke(null);
-                options = optionsInstance as InteractiveBrowserCredentialOptions;
+                var optionsType = Type.GetType("Azure.Identity.Broker.DevelopmentBrokerOptions, Azure.Identity.Broker", throwOnError: false);
+                if (optionsType == null)
+                    return false;
+
+                var constructor = optionsType.GetConstructor(Type.EmptyTypes);
+                if (constructor == null)
+                    return false;
+
+                var instance = constructor.Invoke(null);
+                options = instance as InteractiveBrowserCredentialOptions;
+
+                if (options == null)
+                    return false;
+
                 options.IsChainedCredential = true;
-                // Set default value for UseDefaultBrokerAccount on macOS
+
+                // Set platform-specific options
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    options.RedirectUri = new(Constants.MacBrokerRedirectUri);
+                    options.RedirectUri = new Uri(Constants.MacBrokerRedirectUri);
                 }
 
-                return options != null;
+                return true;
             }
             catch
             {


### PR DESCRIPTION
The current reflection-based code for creating `DevelopmentBrokerOptions` in https://github.com/Azure/azure-sdk-for-net/blob/4634e0a6d2183bf4b35e229eb80e556787428f82/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs#L313  works correctly during normal execution but causes issues when debugging in Visual Studio with "Just My Code" disabled. This occurs because `System.NullReferenceException` is enabled by default in the debugger.

To solve this I've added explicit null checks at each reflection step.

Ref https://github.com/Azure/azure-sdk-for-net/issues/52122
