### PR TITLE
Use operator precedence to avoid unnecessary parentheses and nesting

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -12,7 +12,8 @@
 - Fixed an issue when comparing `TableErrorCode` with null strings using equality operators.
 
 ### Other Changes
-
+- Use precedence rules to reduce the parenthesis nesting in OData filters generated from LINQ expressions.
+ 
 ## 12.11.0 (2025-05-06)
 
 ### Features Added

--- a/sdk/tables/Azure.Data.Tables/assets.json
+++ b/sdk/tables/Azure.Data.Tables/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/tables/Azure.Data.Tables",
-  "Tag": "net/tables/Azure.Data.Tables_f74f623264"
+  "Tag": "net/tables/Azure.Data.Tables_36f4ccc6ab"
 }

--- a/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionPrecedenceComparer.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionPrecedenceComparer.cs
@@ -10,7 +10,7 @@ namespace Azure.Data.Tables.Queryable
     {
         //From (2.2.3.6.1.1.2 Operator Precedence) https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-odata/f3380585-3f87-41d9-a2dc-ff46cc38e7a6
 
-        private const byte UnknownPrecedencyCategory = byte.MaxValue;
+        private const byte UnknownPrecedenceCategory = byte.MaxValue;
         private const byte PrimaryPrecedenceCategory = 8;
         private const byte UnaryPrecedenceCategory = 7;
         private const byte MultiplicativePrecedenceCategory = 6;
@@ -70,7 +70,7 @@ namespace Azure.Data.Tables.Queryable
                 case ExpressionType.OrElse:
                     return ConditionalOrPrecedenceCategory;
                 default:
-                    return UnknownPrecedencyCategory;
+                    return UnknownPrecedenceCategory;
             };
         }
     }

--- a/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionPrecedenceComparer.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionPrecedenceComparer.cs
@@ -9,6 +9,7 @@ namespace Azure.Data.Tables.Queryable
     internal sealed class ExpressionPrecedenceComparer : IComparer<Expression>
     {
         //From (2.2.3.6.1.1.2 Operator Precedence) https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-odata/f3380585-3f87-41d9-a2dc-ff46cc38e7a6
+        //and https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#operator-precedence
 
         private const byte UnknownPrecedenceCategory = byte.MaxValue;
         private const byte PrimaryPrecedenceCategory = 8;
@@ -44,6 +45,8 @@ namespace Azure.Data.Tables.Queryable
                 case ExpressionType.NegateChecked:
                 case ExpressionType.Not:
                 case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                case ExpressionType.UnaryPlus:
                     return UnaryPrecedenceCategory;
                 case ExpressionType.Multiply:
                 case ExpressionType.MultiplyChecked:
@@ -59,6 +62,7 @@ namespace Azure.Data.Tables.Queryable
                 case ExpressionType.GreaterThan:
                 case ExpressionType.LessThanOrEqual:
                 case ExpressionType.GreaterThanOrEqual:
+                case ExpressionType.TypeAs:
                     return RelationalPrecedenceCategory;
                 case ExpressionType.Equal:
                 case ExpressionType.NotEqual:

--- a/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionPrecedenceComparer.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionPrecedenceComparer.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Azure.Data.Tables.Queryable
+{
+    internal sealed class ExpressionPrecedenceComparer : IComparer<Expression>
+    {
+        //From (2.2.3.6.1.1.2 Operator Precedence) https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-odata/f3380585-3f87-41d9-a2dc-ff46cc38e7a6
+
+        private const byte UnknownPrecedencyCategory = byte.MaxValue;
+        private const byte PrimaryPrecedenceCategory = 8;
+        private const byte UnaryPrecedenceCategory = 7;
+        private const byte MultiplicativePrecedenceCategory = 6;
+        private const byte AdditivePrecedenceCategory = 5;
+        private const byte RelationalPrecedenceCategory = 4;
+        private const byte EqualityPrecedenceCategory = 3;
+        private const byte ConditionalAndPrecedenceCategory = 2;
+        private const byte ConditionalOrPrecedenceCategory = 1;
+
+        static ExpressionPrecedenceComparer()
+        {
+            Instance = new ExpressionPrecedenceComparer();
+        }
+
+        public static ExpressionPrecedenceComparer Instance { get; }
+
+        private ExpressionPrecedenceComparer()
+        {
+        }
+        public int Compare(Expression x, Expression y) => GetCategoryLevel(x).CompareTo(GetCategoryLevel(y));
+
+        private static byte GetCategoryLevel(Expression x)
+        {
+            switch (x.NodeType)
+            {
+                case ExpressionType.Constant:
+                case ExpressionType.MemberAccess:
+                case ExpressionType.Call:
+                    return PrimaryPrecedenceCategory;
+                case ExpressionType.Negate:
+                case ExpressionType.NegateChecked:
+                case ExpressionType.Not:
+                case ExpressionType.Convert:
+                    return UnaryPrecedenceCategory;
+                case ExpressionType.Multiply:
+                case ExpressionType.MultiplyChecked:
+                case ExpressionType.Divide:
+                case ExpressionType.Modulo:
+                    return MultiplicativePrecedenceCategory;
+                case ExpressionType.Add:
+                case ExpressionType.AddChecked:
+                case ExpressionType.Subtract:
+                case ExpressionType.SubtractChecked:
+                    return AdditivePrecedenceCategory;
+                case ExpressionType.LessThan:
+                case ExpressionType.GreaterThan:
+                case ExpressionType.LessThanOrEqual:
+                case ExpressionType.GreaterThanOrEqual:
+                    return RelationalPrecedenceCategory;
+                case ExpressionType.Equal:
+                case ExpressionType.NotEqual:
+                    return EqualityPrecedenceCategory;
+                case ExpressionType.And:
+                case ExpressionType.AndAlso:
+                    return ConditionalAndPrecedenceCategory;
+                case ExpressionType.Or:
+                case ExpressionType.OrElse:
+                    return ConditionalOrPrecedenceCategory;
+                default:
+                    return UnknownPrecedencyCategory;
+            };
+        }
+    }
+}

--- a/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionWriter.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionWriter.cs
@@ -119,18 +119,20 @@ namespace Azure.Data.Tables.Queryable
 
         protected override Expression VisitUnary(UnaryExpression u)
         {
+            var addParens = OperandRequiresParentheses(u, u.Operand);
+
             switch (u.NodeType)
             {
                 case ExpressionType.Not:
                     _builder.Append(UriHelper.NOT);
                     _builder.Append(UriHelper.SPACE);
-                    VisitOperand(u.Operand);
+                    VisitOperand(u.Operand, addParens);
                     break;
                 case ExpressionType.Negate:
                 case ExpressionType.NegateChecked:
                     _builder.Append(UriHelper.SPACE);
                     _builder.Append(TranslateOperator(u.NodeType));
-                    VisitOperand(u.Operand);
+                    VisitOperand(u.Operand, addParens);
                     break;
                 case ExpressionType.Convert:
                 case ExpressionType.ConvertChecked:
@@ -146,7 +148,10 @@ namespace Azure.Data.Tables.Queryable
 
         protected override Expression VisitBinary(BinaryExpression b)
         {
-            VisitOperand(b.Left);
+            var addParens = OperandRequiresParentheses(b, b.Left);
+
+            VisitOperand(b.Left, addParens);
+
             _builder.Append(UriHelper.SPACE);
             string operatorString = TranslateOperator(b.NodeType);
             if (string.IsNullOrEmpty(operatorString))
@@ -159,8 +164,17 @@ namespace Azure.Data.Tables.Queryable
             }
 
             _builder.Append(UriHelper.SPACE);
-            VisitOperand(b.Right);
+
+            addParens = OperandRequiresParentheses(b, b.Right);
+
+            VisitOperand(b.Right, addParens);
+
             return b;
+        }
+
+        private static bool OperandRequiresParentheses(Expression outerExpression, Expression innerExpression)
+        {
+            return ExpressionPrecedenceComparer.Instance.Compare(outerExpression, innerExpression) > 0;
         }
 
         protected override Expression VisitParameter(ParameterExpression p)
@@ -173,8 +187,12 @@ namespace Azure.Data.Tables.Queryable
             return exp is ParameterExpression;
         }
 
-        private void VisitOperand(Expression e)
+        private void VisitOperand(Expression e, bool addParens = false)
         {
+            if (addParens)
+            {
+                _builder.Append(UriHelper.LEFTPAREN);
+            }
             if (e is BinaryExpression || e is UnaryExpression)
             {
                 if (e is UnaryExpression unary && unary.NodeType == ExpressionType.TypeAs)
@@ -183,14 +201,16 @@ namespace Azure.Data.Tables.Queryable
                 }
                 else
                 {
-                    _builder.Append(UriHelper.LEFTPAREN);
                     Visit(e);
-                    _builder.Append(UriHelper.RIGHTPAREN);
                 }
             }
             else
             {
                 Visit(e);
+            }
+            if (addParens)
+            {
+                _builder.Append(UriHelper.RIGHTPAREN);
             }
         }
 

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientQueryExpressionTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientQueryExpressionTests.cs
@@ -86,6 +86,7 @@ namespace Azure.Data.Tables.Tests
         private static readonly Expression<Func<TableEntity, bool>> s_binaryExpDE = ent => ent.GetBinaryData("Binary") == s_someBinaryData;
         private static readonly Expression<Func<ComplexEntity, bool>> s_complexExp = ent => ent.String.CompareTo(SomeString) >= 0 && ent.Int64 >= SomeInt64 && ent.Int32 >= SomeInt && ent.DateTime >= s_someDateTime;
         private static readonly Expression<Func<TableEntity, bool>> s_complexExpDE = ent => ent.GetString("String").CompareTo(SomeString) >= 0 && ent.GetInt64("Int64") >= SomeInt64 && ent.GetInt32("Int32") >= SomeInt && ent.GetDateTime("DateTime") >= s_someDateTime;
+        private static readonly Expression<Func<ComplexEntity, bool>> s_veryComplexExp = ent => ent.String.CompareTo(SomeString) >= 0 && (ent.Int64 >= SomeInt64 || ent.Int32 >= SomeInt) && ent.DateTime >= s_someDateTime && !ent.Bool;
         private static readonly Expression<Func<ComplexEntity, bool>> s_complexExpImplicitBooleanCmp = ent => ent.Bool;
         private static readonly Expression<Func<ComplexEntity, bool>> s_complexExpImplicitNullableBooleanCmp = ent => ent.BoolN.Value;
         private static readonly Expression<Func<ComplexEntity, bool>> s_complexExpImplicitBooleanCmpNot = ent => !ent.Bool;
@@ -107,14 +108,14 @@ namespace Azure.Data.Tables.Tests
         public static object[] TableEntityExpressionTestCases =
         {
             new object[] {$"SomeNewName eq 'someString'", s_rename},
-            new object[] {$"(SomeNewName ne 'someString') and (PartitionKey eq '{Partition}')", s_renameAndNonrename},
+            new object[] {$"SomeNewName ne 'someString' and PartitionKey eq '{Partition}'", s_renameAndNonrename},
             new object[] {$"DataMemberImplictNameProperty ne 'someString'", s_nonRenameDataMember },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ne '{Row}')", s_ne },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey gt '{Row}')", s_gt },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ge '{Row}')", s_ge },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey lt '{Row}')", s_lt },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey le '{Row}')", s_le },
-            new object[] { $"(PartitionKey eq '{Partition}') or (RowKey eq '{Row}')", s_or },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey ne '{Row}'", s_ne },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey gt '{Row}'", s_gt },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey ge '{Row}'", s_ge },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey lt '{Row}'", s_lt },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey le '{Row}'", s_le },
+            new object[] { $"PartitionKey eq '{Partition}' or RowKey eq '{Row}'", s_or },
             new object[] { $"String ge '{SomeString}'", s_compareToExp },
             new object[] { $"Guid eq guid'{s_someGuidString}'", s_guidExp },
             new object[] { $"Int64 ge {SomeInt64}L", s_int64Exp },
@@ -128,13 +129,14 @@ namespace Azure.Data.Tables.Tests
             new object[] { $"Bool eq false", s_boolFalseExp },
             new object[] { $"Binary eq X'{string.Join(string.Empty, s_someBinary.Select(b => b.ToString("X2")))}'", s_binaryExp },
             new object[] { $"Binary eq X'{string.Join(string.Empty, s_someBinaryData.ToArray().Select(b => b.ToString("X2")))}'", s_binaryExp },
-            new object[] { $"(((String ge '{SomeString}') and (Int64 ge {SomeInt64}L)) and (Int32 ge {SomeInt})) and (DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}')", s_complexExp },
+            new object[] { $"String ge '{SomeString}' and Int64 ge {SomeInt64}L and Int32 ge {SomeInt} and DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}'", s_complexExp },
+            new object[] { $"String ge '{SomeString}' and (Int64 ge {SomeInt64}L or Int32 ge {SomeInt}) and DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}' and not (Bool eq true)", s_veryComplexExp },
             new object[] { $"Bool eq true", s_complexExpImplicitBooleanCmp },
             new object[] { $"BoolN eq true", s_complexExpImplicitNullableBooleanCmp },
             new object[] { $"not (Bool eq true)", s_complexExpImplicitBooleanCmpNot },
             new object[] { $"BoolN eq true", s_complexExpImplicitCastedNullableBooleanCmp },
-            new object[] { $"(Bool eq true) and (BoolN eq true)", s_complexExpImplicitBooleanCmpAnd },
-            new object[] { $"(Bool eq true) or (BoolN eq true)", s_complexExpImplicitCastedBooleanCmpOr  },
+            new object[] { $"Bool eq true and BoolN eq true", s_complexExpImplicitBooleanCmpAnd },
+            new object[] { $"Bool eq true or BoolN eq true", s_complexExpImplicitCastedBooleanCmpOr },
             new object[] { $"String eq '{Partition}'", s_CEtableEntExpEquals },
             new object[] { $"String eq '{Partition}'", s_CEtableEntExpStaticEquals },
         };
@@ -144,20 +146,20 @@ namespace Azure.Data.Tables.Tests
             new object[] { $"TableName ne '{TableName}'", s_ne_TI },
             new object[] { $"TableName gt '{TableName}'", s_gt_TI },
             new object[] { $"TableName ge '{TableName}'", s_ge_TI },
-            new object[] { $"(TableName le '{TableName}') and (TableName ge '{TableName2}')", s_lege_TI },
+            new object[] { $"TableName le '{TableName}' and TableName ge '{TableName2}'", s_lege_TI },
             new object[] { $"TableName lt '{TableName}'", s_lt_TI },
             new object[] { $"TableName le '{TableName}'", s_le_TI },
-            new object[] { $"(TableName eq '{TableName}') or (TableName eq '{TableName2}')", s_or_TI },
+            new object[] { $"TableName eq '{TableName}' or TableName eq '{TableName2}'", s_or_TI },
         };
 
         public static object[] DictionaryTableEntityExpressionTestCases =
         {
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ne '{Row}')", s_neDE },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey gt '{Row}')", s_gtDE },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ge '{Row}')", s_geDE },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey lt '{Row}')", s_ltDE },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey le '{Row}')", s_leDE },
-            new object[] { $"(PartitionKey eq '{Partition}') or (RowKey eq '{Row}')", s_orDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey ne '{Row}'", s_neDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey gt '{Row}'", s_gtDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey ge '{Row}'", s_geDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey lt '{Row}'", s_ltDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey le '{Row}'", s_leDE },
+            new object[] { $"PartitionKey eq '{Partition}' or RowKey eq '{Row}'", s_orDE },
             new object[] { $"String ge '{SomeString}'", s_compareToExpDE },
             new object[] { $"Guid eq guid'{s_someGuidString}'", s_guidExpDE },
             new object[] { $"Int64 ge {SomeInt64}L", s_int64ExpDE },
@@ -169,10 +171,10 @@ namespace Azure.Data.Tables.Tests
             new object[] { $"Bool eq false", s_boolFalseExpDE },
             new object[] { $"Binary eq X'{string.Join(string.Empty, s_someBinary.Select(b => b.ToString("X2")))}'", s_binaryExpDE },
             new object[] { $"Binary eq X'{string.Join(string.Empty, s_someBinaryData.ToArray().Select(b => b.ToString("X2")))}'", s_binaryExpDE },
-            new object[] { $"(((String ge '{SomeString}') and (Int64 ge {SomeInt64}L)) and (Int32 ge {SomeInt})) and (DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}')", s_complexExpDE },
+            new object[] { $"String ge '{SomeString}' and Int64 ge {SomeInt64}L and Int32 ge {SomeInt} and DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}'", s_complexExpDE },
             new object[] { $"Bool eq true", s_tableEntExpImplicitBooleanCmp },
             new object[] { $"Bool eq true", s_tableEntExpImplicitBooleanCmpCasted },
-            new object[] { $"(Bool eq true) or (Bool eq true)", s_tableEntExpImplicitBooleanCmpOr },
+            new object[] { $"Bool eq true or Bool eq true", s_tableEntExpImplicitBooleanCmpOr },
             new object[] { $"not (Bool eq true)", s_tableEntExpImplicitBooleanCmpNot },
             new object[] { $"PartitionKey eq '{Partition}'", s_tableEntExpEquals },
         };


### PR DESCRIPTION
Originally submitted as #32525 

When the LINQ expression is converted to a query string, lots of parentheses are included, for good measure. It's certainly correct, but:

1. It increases the length, sometimes significantly.
2. The parser on the receiving end doesn't like the nesting.

This PR was initiated by what happened when we moved from the old Cosmos library to this. We had a very large, dynamically generated query (one partitionkey, lots of suggested rowkeys), which utilized the old TableQuery class to generate the query string. We converted this to a LINQ expression but ran into issues in production, when the table service responded with a Bad Request: "Recursion depth exceeded allowed limit".
We realized this was due to all the "RowKey='a' or (RowKey='b' or (RowKey='c' .....", where every binary expression is encapsulated in parentheses. An OData "in" would have been nicer, but the table service doesn't support it.

The PR attempts to check operator precedence in order to insert parentheses only when it's necessary.
