### PR TITLE
fix: add @azure-tools/typespec-autorest pkg to unbranded config

### DIFF
--- a/eng/http-client-csharp-emitter-package-lock.json
+++ b/eng/http-client-csharp-emitter-package-lock.json
@@ -9,6 +9,7 @@
         "client-plugin": "file:../../../../eng/packages/plugins/client"
       },
       "devDependencies": {
+        "@azure-tools/typespec-autorest": "0.59.0",
         "@azure-tools/typespec-azure-core": "0.59.0",
         "@azure-tools/typespec-azure-resource-manager": "0.59.0",
         "@azure-tools/typespec-azure-rulesets": "0.59.0",
@@ -22,6 +23,26 @@
       }
     },
     "../../../../eng/packages/plugins/client": {},
+    "node_modules/@azure-tools/typespec-autorest": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.59.0.tgz",
+      "integrity": "sha512-IdjicuLJRNFZUWHJd1Z8e9RQUlVUyUb2v7pT1rYkhpxAxFb9uluVVpi09GkUFimkrUZ+HkFO/jI2zbIAptZ2FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "^0.59.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.59.0",
+        "@azure-tools/typespec-client-generator-core": "^0.59.0",
+        "@typespec/compiler": "^1.3.0",
+        "@typespec/http": "^1.3.0",
+        "@typespec/openapi": "^1.3.0",
+        "@typespec/rest": "^0.73.0",
+        "@typespec/versioning": "^0.73.0"
+      }
+    },
     "node_modules/@azure-tools/typespec-azure-core": {
       "version": "0.59.0",
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.59.0.tgz",

--- a/eng/http-client-csharp-emitter-package.json
+++ b/eng/http-client-csharp-emitter-package.json
@@ -14,6 +14,7 @@
     "@typespec/streams": "0.73.0",
     "@typespec/versioning": "0.73.0",
     "@azure-tools/typespec-azure-rulesets": "0.59.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.59.0"
+    "@azure-tools/typespec-azure-resource-manager": "0.59.0",
+    "@azure-tools/typespec-autorest": "0.59.0"
   }
 }


### PR DESCRIPTION
This PR adds the @azure-tools/typespec-autorest package to the unbranded emitter's `package.json` now that it is being used in the specs repo.
