### PR TITLE
[CODEOWNERS] Fix linter failues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -981,10 +981,10 @@
 /sdk/communication/Azure.ResourceManager.Communication/            @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %Compute - Fleet
-/sdk/computefleet/Azure.ResourceManager.*/                         @sahilarora92 @rahuls-microsoft
+/sdk/computefleet/Azure.ResourceManager.*/                         @sahilarora92
 
 # ServiceLabel: %Compute - Fleet %Mgmt
-# ServiceOwners:                                                   @sahilarora92 @rahuls-microsoft
+# ServiceOwners:                                                   @sahilarora92
 
 # PRLabel: %Container Orchestrator Runtime
 /sdk/containerorchestratorruntime/Azure.ResourceManager.*/         @ArthurMa1978


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner flagged by the linter as no longer having the necessary permissions.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5240613&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_