### PR TITLE
[Storage][PerfTest] Add file based perf tests

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/DownloadBlob.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/DownloadBlob.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs.Models;
 
 namespace Azure.Storage.Blobs.Perf.Scenarios
 {
@@ -20,12 +21,18 @@ namespace Azure.Storage.Blobs.Perf.Scenarios
 
         public override void Run(CancellationToken cancellationToken)
         {
-            BlobClient.DownloadTo(Stream.Null, transferOptions: Options.StorageTransferOptions, cancellationToken: cancellationToken);
+            BlobClient.DownloadTo(Stream.Null, new BlobDownloadToOptions()
+            {
+                TransferOptions = Options.StorageTransferOptions,
+            }, cancellationToken);
         }
 
         public override async Task RunAsync(CancellationToken cancellationToken)
         {
-            await BlobClient.DownloadToAsync(Stream.Null, transferOptions: Options.StorageTransferOptions, cancellationToken: cancellationToken);
+            await BlobClient.DownloadToAsync(Stream.Null, new BlobDownloadToOptions()
+            {
+                TransferOptions = Options.StorageTransferOptions,
+            }, cancellationToken);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/DownloadToFile.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/DownloadToFile.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Perf.Options;
+
+namespace Azure.Storage.Blobs.Perf.Scenarios
+{
+    public class DownloadToFile : BlobTest<PartitionedTransferOptions>
+    {
+        private string _tempFile;
+
+        public DownloadToFile(PartitionedTransferOptions options)
+            : base(options, createBlob: true, singletonBlob: true)
+        {
+        }
+
+        public override async Task SetupAsync()
+        {
+            await base.SetupAsync();
+            string tempDir = Path.GetTempPath();
+            string randomFileName = Path.GetRandomFileName();
+            _tempFile = Path.Combine(tempDir, randomFileName);
+        }
+
+        public override async Task CleanupAsync()
+        {
+            if (_tempFile != null && File.Exists(_tempFile))
+            {
+                File.Delete(_tempFile);
+            }
+            await base.CleanupAsync();
+        }
+
+        public override void Run(CancellationToken cancellationToken)
+        {
+            BlobClient.DownloadTo(_tempFile, new BlobDownloadToOptions()
+            {
+                TransferOptions = Options.StorageTransferOptions,
+            }, cancellationToken);
+        }
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            await BlobClient.DownloadToAsync(_tempFile, new BlobDownloadToOptions()
+            {
+                TransferOptions = Options.StorageTransferOptions,
+            }, cancellationToken);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/UploadBlob.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/UploadBlob.cs
@@ -32,7 +32,13 @@ namespace Azure.Storage.Blobs.Perf.Scenarios
         public override void Run(CancellationToken cancellationToken)
         {
             _stream.Seek(0, SeekOrigin.Begin);
-            BlobClient.Upload(_stream, transferOptions: Options.StorageTransferOptions, cancellationToken: cancellationToken);
+            BlobClient.Upload(
+                _stream,
+                new BlobUploadOptions
+                {
+                    TransferOptions = Options.StorageTransferOptions,
+                },
+                cancellationToken: cancellationToken);
         }
 
         public override async Task RunAsync(CancellationToken cancellationToken)

--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/UploadFromFile.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/UploadFromFile.cs
@@ -30,7 +30,7 @@ namespace Azure.Storage.Blobs.Perf.Scenarios
             using (Stream data = RandomStream.Create(Options.Size))
             using (FileStream fileStream = File.Create(_tempFile))
             {
-                data.CopyTo(fileStream);
+                await data.CopyToAsync(fileStream);
             }
         }
 
@@ -38,7 +38,6 @@ namespace Azure.Storage.Blobs.Perf.Scenarios
         {
             if (_tempFile != null && File.Exists(_tempFile))
             {
-                Console.WriteLine($"Deleting {_tempFile}");
                 File.Delete(_tempFile);
             }
             await base.CleanupAsync();

--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/UploadFromFile.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/UploadFromFile.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Perf.Options;
+using Azure.Test.Perf;
+
+namespace Azure.Storage.Blobs.Perf.Scenarios
+{
+    public class UploadFromFile : BlobTest<PartitionedTransferOptions>
+    {
+        private string _tempFile;
+
+        public UploadFromFile(PartitionedTransferOptions options)
+            : base(options, createBlob: true, singletonBlob: true)
+        {
+        }
+
+        public override async Task SetupAsync()
+        {
+            await base.SetupAsync();
+            string tempDir = Path.GetTempPath();
+            string randomFileName = Path.GetRandomFileName();
+            _tempFile = Path.Combine(tempDir, randomFileName);
+
+            using (Stream data = RandomStream.Create(Options.Size))
+            using (FileStream fileStream = File.Create(_tempFile))
+            {
+                data.CopyTo(fileStream);
+            }
+        }
+
+        public override async Task CleanupAsync()
+        {
+            if (_tempFile != null && File.Exists(_tempFile))
+            {
+                Console.WriteLine($"Deleting {_tempFile}");
+                File.Delete(_tempFile);
+            }
+            await base.CleanupAsync();
+        }
+
+        public override void Run(CancellationToken cancellationToken)
+        {
+            BlobClient.Upload(_tempFile, new BlobUploadOptions
+            {
+                TransferOptions = Options.StorageTransferOptions,
+            },
+            cancellationToken);
+        }
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            await BlobClient.UploadAsync(_tempFile, new BlobUploadOptions
+            {
+                TransferOptions = Options.StorageTransferOptions,
+            },
+            cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
This change adds new upload/download perf tests for Blob that interface with a file in case we need them. Also updates existing tests to non-deprecated overloads.