### PR TITLE
Use MRW serialization for ResponseError

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -457,7 +457,7 @@
 
   <PropertyGroup>
     <TestProxyVersion>1.0.0-dev.20250805.1</TestProxyVersion>
-    <UnbrandedGeneratorVersion>1.0.0-alpha.20250825.2</UnbrandedGeneratorVersion>
+    <UnbrandedGeneratorVersion>1.0.0-alpha.20250825.5</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20250818.3</AzureGeneratorVersion>
   </PropertyGroup>
 </Project>

--- a/eng/http-client-csharp-emitter-package-lock.json
+++ b/eng/http-client-csharp-emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20250825.2",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20250825.5",
         "client-plugin": "file:../../../../eng/packages/plugins/client"
       },
       "devDependencies": {
@@ -592,9 +592,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20250825.2",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20250825.2.tgz",
-      "integrity": "sha512-5wYCF+PDqw5x57INv5fyDjb6cQHGzLCR4oeq5RtyRqIOIlQF4Rxn6+rakzJ+ORlRLFpQyaX84UUzNOc+V0y/+Q==",
+      "version": "1.0.0-alpha.20250825.5",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20250825.5.tgz",
+      "integrity": "sha512-/pczDlFFOsukHkmFxGW4BBtd++f+Y5lpLR1yv228FxmBhoPGadTk4ersgEEdprlj+5kndbm1l7GPjA7nIP4uNw==",
       "license": "MIT",
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.59.0 <0.60.0 || ~0.60.0-0",

--- a/eng/http-client-csharp-emitter-package.json
+++ b/eng/http-client-csharp-emitter-package.json
@@ -2,7 +2,7 @@
   "main": "dist/src/index.js",
   "dependencies": {
     "client-plugin": "file:../../../../eng/packages/plugins/client",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20250825.2"
+    "@typespec/http-client-csharp": "1.0.0-alpha.20250825.5"
   },
   "devDependencies": {
     "@azure-tools/typespec-azure-core": "0.59.0",

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureTypeFactory.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureTypeFactory.cs
@@ -116,21 +116,24 @@ namespace Azure.Generator
         }
 
         /// <inheritdoc/>
-#pragma warning disable AZC0014 // Avoid using banned types in public API
-        public override ValueExpression DeserializeJsonValue(Type valueType, ScopedApi<JsonElement> element, SerializationFormat format)
-#pragma warning restore AZC0014 // Avoid using banned types in public API
+        public override ValueExpression DeserializeJsonValue(
+            Type valueType,
+            ScopedApi<JsonElement> element,
+            ScopedApi<ModelReaderWriterOptions> mrwOptionsParameter,
+            SerializationFormat format)
         {
-            var expression = DeserializeJsonValueCore(valueType, element, format);
-            return expression ?? base.DeserializeJsonValue(valueType, element, format);
+            var expression = DeserializeJsonValueCore(valueType, element, mrwOptionsParameter, format);
+            return expression ?? base.DeserializeJsonValue(valueType, element, mrwOptionsParameter, format);
         }
 
         private ValueExpression? DeserializeJsonValueCore(
             Type valueType,
             ScopedApi<JsonElement> element,
+            ScopedApi<ModelReaderWriterOptions> mrwOptionsParameter,
             SerializationFormat format)
         {
             return KnownAzureTypes.TryGetJsonDeserializationExpression(valueType, out var deserializationExpression) ?
-                deserializationExpression(valueType, element, format) :
+                deserializationExpression(valueType, element, mrwOptionsParameter, format) :
                 null;
         }
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/KnownAzureTypes.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/KnownAzureTypes.cs
@@ -13,6 +13,7 @@ using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Text;
 using System.Text.Json;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
@@ -21,7 +22,7 @@ namespace Azure.Generator.Primitives
     internal static class KnownAzureTypes
     {
         public delegate MethodBodyStatement SerializationExpression(ValueExpression value, ScopedApi<Utf8JsonWriter> writer, ScopedApi<ModelReaderWriterOptions> options, SerializationFormat format);
-        public delegate ValueExpression DeserializationExpression(CSharpType valueType, ScopedApi<JsonElement> element, SerializationFormat format);
+        public delegate ValueExpression DeserializationExpression(CSharpType valueType, ScopedApi<JsonElement> element, ScopedApi<ModelReaderWriterOptions> options, SerializationFormat format);
 
         private const string UuidId = "Azure.Core.uuid";
         private const string IPv4AddressId = "Azure.Core.ipV4Address";
@@ -35,22 +36,36 @@ namespace Azure.Generator.Primitives
         private static MethodBodyStatement SerializeTypeWithImplicitOperatorToString(ValueExpression value, ScopedApi<Utf8JsonWriter> writer, ScopedApi<ModelReaderWriterOptions> options, SerializationFormat format)
             => writer.WriteStringValue(value);
 
-        private static ValueExpression DeserializeNewInstanceStringLikeType(CSharpType valueType, ScopedApi<JsonElement> element, SerializationFormat format)
+        private static ValueExpression DeserializeNewInstanceStringLikeType(CSharpType valueType, ScopedApi<JsonElement> element, ScopedApi<ModelReaderWriterOptions> options, SerializationFormat format)
             => New.Instance(valueType, element.GetString());
 
         private static MethodBodyStatement SerializeTypeWithToString(ValueExpression value, ScopedApi<Utf8JsonWriter> writer, ScopedApi<ModelReaderWriterOptions> options, SerializationFormat format)
             => writer.WriteStringValue(value.InvokeToString());
 
-        private static ValueExpression DeserializeParsableStringLikeType(CSharpType valueType, ScopedApi<JsonElement> element, SerializationFormat format)
+        private static ValueExpression DeserializeParsableStringLikeType(CSharpType valueType, ScopedApi<JsonElement> element, ScopedApi<ModelReaderWriterOptions> options, SerializationFormat format)
             => Static(valueType).Invoke("Parse", element.GetString());
 
         private static MethodBodyStatement SerializeResponseError(ValueExpression value, ScopedApi<Utf8JsonWriter> writer, ScopedApi<ModelReaderWriterOptions> options, SerializationFormat format)
-            => Static(typeof(JsonSerializer)).Invoke(nameof(JsonSerializer.Serialize), writer, value).Terminate();
+        {
+            var asJsonModel = value.CastTo(typeof(IJsonModel<ResponseError>));
+            return asJsonModel.Invoke(nameof(IJsonModel<ResponseError>.Write), writer, options).Terminate();
+        }
 
-        private static ValueExpression DeserializeResponseError(CSharpType valueType,
+        private static ValueExpression DeserializeResponseError(
+            CSharpType valueType,
             ScopedApi<JsonElement> element,
+            ScopedApi<ModelReaderWriterOptions> options,
             SerializationFormat format)
-            => Static(typeof(JsonSerializer)).Invoke(nameof(JsonSerializer.Deserialize), arguments: [element.GetRawText()], typeArguments: [valueType], callAsAsync: false);
+        {
+            var serializedData = New.Instance(
+                typeof(BinaryData),
+                Static(typeof(Encoding)).Property(nameof(Encoding.UTF8)).Invoke(nameof(Encoding.UTF8.GetBytes), element.GetRawText()));
+            // ModelReaderWriter.Read<ResponseError>(new BinaryData(Encoding.UTF8.GetBytes(prop.Value.GetRawText())), options, Context.Default);
+            return Static(typeof(ModelReaderWriter)).Invoke(
+                nameof(ModelReaderWriter.Read),
+                [serializedData, options, ModelReaderWriterContextSnippets.Default],
+                [typeof(ResponseError)]);
+        }
 
         private static readonly IReadOnlyDictionary<string, Type> _idToTypes = new Dictionary<string, Type>
         {

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/AzureTypeFactoryTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/AzureTypeFactoryTests.cs
@@ -4,6 +4,7 @@
 using Azure.Core;
 using Azure.Generator.Tests.Common;
 using Azure.Generator.Tests.TestHelpers;
+using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -28,7 +29,7 @@ namespace Azure.Generator.Tests
         [TestCase(typeof(ETag), ExpectedResult = "writer.WriteStringValue(value.ToString());\n")]
         [TestCase(typeof(AzureLocation), ExpectedResult = "writer.WriteStringValue(value);\n")]
         [TestCase(typeof(ResourceIdentifier), ExpectedResult = "writer.WriteStringValue(value);\n")]
-        [TestCase(typeof(ResponseError), ExpectedResult = "global::System.Text.Json.JsonSerializer.Serialize(writer, value);\n")]
+        [TestCase(typeof(ResponseError), ExpectedResult = "((global::System.ClientModel.Primitives.IJsonModel<global::Azure.ResponseError>)value).Write(writer, options);\n")]
         public string ValidateSerializationStatement(Type type)
         {
             var value = new ParameterProvider("value", $"", type).AsExpression().As(type);
@@ -46,12 +47,16 @@ namespace Azure.Generator.Tests
         [TestCase(typeof(ETag), ExpectedResult = "new global::Azure.ETag(element.GetString())")]
         [TestCase(typeof(AzureLocation), ExpectedResult = "new global::Azure.Core.AzureLocation(element.GetString())")]
         [TestCase(typeof(ResourceIdentifier), ExpectedResult = "new global::Azure.Core.ResourceIdentifier(element.GetString())")]
-        [TestCase(typeof(ResponseError), ExpectedResult = "global::System.Text.Json.JsonSerializer.Deserialize<global::Azure.ResponseError>(element.GetRawText())")]
+        [TestCase(typeof(ResponseError), ExpectedResult = "global::System.ClientModel.Primitives.ModelReaderWriter.Read<global::Azure.ResponseError>(new global::System.BinaryData(global::System.Text.Encoding.UTF8.GetBytes(element.GetRawText())), options, global::Samples.SamplesContext.Default)")]
         public string ValidateDeserializationExpression(Type type)
         {
             var element = new ParameterProvider("element", $"", typeof(JsonElement)).AsExpression().As<JsonElement>();
 
-            var expression = AzureClientGenerator.Instance.TypeFactory.DeserializeJsonValue(type, element, SerializationFormat.Default);
+            var expression = AzureClientGenerator.Instance.TypeFactory.DeserializeJsonValue(
+                type,
+                element,
+                new ScopedApi<ModelReaderWriterOptions>(new VariableExpression(typeof(ModelReaderWriterOptions), "options")),
+                SerializationFormat.Default);
             Assert.IsNotNull(expression);
 
             return expression.ToDisplayString();

--- a/eng/packages/http-client-csharp/package-lock.json
+++ b/eng/packages/http-client-csharp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20250825.2"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20250825.5"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.27",
@@ -2797,9 +2797,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20250825.2",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20250825.2.tgz",
-      "integrity": "sha512-5wYCF+PDqw5x57INv5fyDjb6cQHGzLCR4oeq5RtyRqIOIlQF4Rxn6+rakzJ+ORlRLFpQyaX84UUzNOc+V0y/+Q==",
+      "version": "1.0.0-alpha.20250825.5",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20250825.5.tgz",
+      "integrity": "sha512-/pczDlFFOsukHkmFxGW4BBtd++f+Y5lpLR1yv228FxmBhoPGadTk4ersgEEdprlj+5kndbm1l7GPjA7nIP4uNw==",
       "license": "MIT",
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.59.0 <0.60.0 || ~0.60.0-0",

--- a/eng/packages/http-client-csharp/package.json
+++ b/eng/packages/http-client-csharp/package.json
@@ -38,7 +38,7 @@
     "dist/generator/**"
   ],
   "dependencies": {
-    "@typespec/http-client-csharp": "1.0.0-alpha.20250825.2"
+    "@typespec/http-client-csharp": "1.0.0-alpha.20250825.5"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.27",


### PR DESCRIPTION
This PR updates the serialization for ResponseError model property types to use MRW.

fixes https://github.com/Azure/azure-sdk-for-net/issues/50548