### PR TITLE
Ai.location.ip mapping for all telemetry types

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -102,6 +103,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             if (logRecord.SpanId != default)
             {
                 Tags[ContextTagKeys.AiOperationParentId.ToString()] = logRecord.SpanId.ToHexString();
+            }
+
+            var clientAddress = logRecord.Attributes?
+                .FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeClientAddress).Value;
+            if (clientAddress != null)
+            {
+                Tags[ContextTagKeys.AiLocationIp.ToString()] = clientAddress.ToString();
             }
 
             InstrumentationKey = instrumentationKey;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -42,7 +42,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
                 if (activity.Kind == ActivityKind.Server)
                 {
-                    // according to spec, microsoft.client.ip is an override
                     var locationIp = microsoftClientIp ??
                                      AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeClientAddress)?.ToString();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -92,7 +92,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             }
         }
 
-        public TelemetryItem (string name, LogRecord logRecord, AzureMonitorResource? resource, string instrumentationKey) :
+        public TelemetryItem (string name, LogRecord logRecord, AzureMonitorResource? resource, string instrumentationKey, string? clientAddress) :
             this(name, FormatUtcTimestamp(logRecord.Timestamp))
         {
             if (logRecord.TraceId != default)
@@ -105,8 +105,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 Tags[ContextTagKeys.AiOperationParentId.ToString()] = logRecord.SpanId.ToHexString();
             }
 
-            var clientAddress = logRecord.Attributes?
-                .FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeClientAddress).Value;
             if (clientAddress != null)
             {
                 Tags[ContextTagKeys.AiLocationIp.ToString()] = clientAddress.ToString();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -42,12 +42,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
                 if (activity.Kind == ActivityKind.Server)
                 {
-                    // according to spec, microsoft.client.ip is an override, and if not available we follow the precedence below
+                    // according to spec, microsoft.client.ip is an override
                     var locationIp = microsoftClientIp ??
-                                     AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeClientAddress)?.ToString() ??
-                                     AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpClientIp)?.ToString() ??
-                                     AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeNetSockPeerAddress)?.ToString() ??
-                                     AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeNetPeerIp)?.ToString();
+                                     AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeClientAddress)?.ToString();
 
                     if (locationIp != null)
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -53,7 +53,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             }
             else // dependency
             {
-                if (microsoftClientIp != null) // not likely a customer would set this, but just in case
+                if (microsoftClientIp != null)
                 {
                     Tags[ContextTagKeys.AiLocationIp.ToString()] = microsoftClientIp;
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -24,7 +24,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             SemanticConventions.AttributeHttpTarget,
             SemanticConventions.AttributeHttpUserAgent,
             SemanticConventions.AttributeHttpRoute,
-            SemanticConventions.AttributeHttpClientIp, // added only as a fallback
 
             // required - HTTP V2
             SemanticConventions.AttributeHttpRequestMethod,
@@ -47,7 +46,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             SemanticConventions.AttributeNetPeerPort,
             SemanticConventions.AttributeNetHostPort,
             SemanticConventions.AttributeNetHostName,
-            SemanticConventions.AttributeNetSockPeerAddress, // added only as a fallback
             "otel.status_code",
 
             // required - Messaging

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -55,7 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             // Others
             SemanticConventions.AttributeEnduserId,
-            "microsoft.client.ip" // in case a customer manually puts this on a dependency or request
+            "microsoft.client.ip"
         };
 
         internal static readonly HashSet<string> s_semanticsSet = new(s_semantics);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -24,6 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             SemanticConventions.AttributeHttpTarget,
             SemanticConventions.AttributeHttpUserAgent,
             SemanticConventions.AttributeHttpRoute,
+            SemanticConventions.AttributeHttpClientIp, // added only as a fallback
 
             // required - HTTP V2
             SemanticConventions.AttributeHttpRequestMethod,
@@ -46,6 +47,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             SemanticConventions.AttributeNetPeerPort,
             SemanticConventions.AttributeNetHostPort,
             SemanticConventions.AttributeNetHostName,
+            SemanticConventions.AttributeNetSockPeerAddress, // added only as a fallback
             "otel.status_code",
 
             // required - Messaging
@@ -54,7 +56,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             SemanticConventions.AttributeNetworkProtocolName,
 
             // Others
-            SemanticConventions.AttributeEnduserId
+            SemanticConventions.AttributeEnduserId,
+            "microsoft.client.ip" // in case a customer manually puts this on a dependency or request
         };
 
         internal static readonly HashSet<string> s_semanticsSet = new(s_semantics);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -20,6 +20,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     internal static class LogsHelper
     {
         private const string CustomEventAttributeName = "microsoft.custom_event.name";
+        private const string ClientIpAttributeName = "microsoft.client.ip";
         private const int Version = 2;
         private static readonly Action<LogRecordScope, IDictionary<string, string>> s_processScope = (scope, properties) =>
         {
@@ -58,11 +59,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 try
                 {
                     var properties = new ChangeTrackingDictionary<string, string>();
-                    ProcessLogRecordProperties(logRecord, properties, out string? message, out string? eventName, out string? clientAddress);
+                    ProcessLogRecordProperties(logRecord, properties, out string? message, out string? eventName, out string? microsoftClientIp);
 
                     if (logRecord.Exception is not null)
                     {
-                        telemetryItem = new TelemetryItem("Exception", logRecord, resource, instrumentationKey, clientAddress)
+                        telemetryItem = new TelemetryItem("Exception", logRecord, resource, instrumentationKey, microsoftClientIp)
                         {
                             Data = new MonitorBase
                             {
@@ -73,7 +74,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     }
                     else if (eventName is not null)
                     {
-                        telemetryItem = new TelemetryItem("Event", logRecord, resource, instrumentationKey, clientAddress)
+                        telemetryItem = new TelemetryItem("Event", logRecord, resource, instrumentationKey, microsoftClientIp)
                         {
                             Data = new MonitorBase
                             {
@@ -84,7 +85,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     }
                     else
                     {
-                        telemetryItem = new TelemetryItem("Message", logRecord, resource, instrumentationKey, clientAddress)
+                        telemetryItem = new TelemetryItem("Message", logRecord, resource, instrumentationKey, microsoftClientIp)
                         {
                             Data = new MonitorBase
                             {
@@ -105,11 +106,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return telemetryItems;
         }
 
-        internal static void ProcessLogRecordProperties(LogRecord logRecord, IDictionary<string, string> properties, out string? message, out string? eventName, out string? clientAddress)
+        internal static void ProcessLogRecordProperties(LogRecord logRecord, IDictionary<string, string> properties, out string? message, out string? eventName, out string? microsoftClientIp)
         {
             eventName = null;
             message = logRecord.Exception?.Message ?? logRecord.FormattedMessage;
-            clientAddress = null;
+            microsoftClientIp = null;
 
             foreach (KeyValuePair<string, object?> item in logRecord.Attributes ?? Enumerable.Empty<KeyValuePair<string, object?>>())
             {
@@ -118,9 +119,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     eventName = item.Value?.ToString();
                 }
 
-                else if (item.Key == SemanticConventions.AttributeClientAddress)
+                else if (item.Key == ClientIpAttributeName)
                 {
-                    clientAddress = item.Value?.ToString().Truncate(SchemaConstants.MessageData_Properties_MaxValueLength);
+                    microsoftClientIp = item.Value?.ToString().Truncate(SchemaConstants.MessageData_Properties_MaxValueLength);
                 }
                 // Note: if Key exceeds MaxLength, the entire KVP will be dropped.
                 else if (item.Key.Length <= SchemaConstants.MessageData_Properties_MaxKeyLength && item.Value != null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
@@ -163,5 +163,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         // Messaging v1.21.0 https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/messaging.md
         public const string AttributeMessagingDestinationName = "messaging.destination.name";
         public const string AttributeNetworkProtocolName = "network.protocol.name";
+
+        // fallback attributes in case client.address is not available
+        public const string AttributeHttpClientIp = "http.client_ip";
+        public const string AttributeNetSockPeerAddress = "net.sock.peer.addr";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
@@ -163,9 +163,5 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         // Messaging v1.21.0 https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/messaging.md
         public const string AttributeMessagingDestinationName = "messaging.destination.name";
         public const string AttributeNetworkProtocolName = "network.protocol.name";
-
-        // fallback attributes in case client.address is not available
-        public const string AttributeHttpClientIp = "http.client_ip";
-        public const string AttributeNetSockPeerAddress = "net.sock.peer.addr";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/CustomEventLoggerExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/CustomEventLoggerExtensions.cs
@@ -21,6 +21,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
         [LoggerMessage(level: LogLevel.Information, Message = "{microsoft.custom_event.name} {key1} {key2}")]
         public static partial void WriteCustomEventWithAdditionalProperties(this ILogger logger, [TagName("microsoft.custom_event.name")] string customEventName, string key1, string key2);
+
+        [LoggerMessage(level: LogLevel.Information, Message = "{microsoft.custom_event.name} {client.address}")]
+        public static partial void WriteCustomEventWithClientAddress(this ILogger logger, [TagName("microsoft.custom_event.name")] string customEventName, [TagName("client.address")] string clientAddress);
     }
 #pragma warning restore EXTEXP0003
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/CustomEventLoggerExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/CustomEventLoggerExtensions.cs
@@ -22,8 +22,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
         [LoggerMessage(level: LogLevel.Information, Message = "{microsoft.custom_event.name} {key1} {key2}")]
         public static partial void WriteCustomEventWithAdditionalProperties(this ILogger logger, [TagName("microsoft.custom_event.name")] string customEventName, string key1, string key2);
 
-        [LoggerMessage(level: LogLevel.Information, Message = "{microsoft.custom_event.name} {client.address}")]
-        public static partial void WriteCustomEventWithClientAddress(this ILogger logger, [TagName("microsoft.custom_event.name")] string customEventName, [TagName("client.address")] string clientAddress);
+        [LoggerMessage(level: LogLevel.Information, Message = "{microsoft.custom_event.name} {microsoft.client.ip}")]
+        public static partial void WriteCustomEventWithClientAddress(this ILogger logger, [TagName("microsoft.custom_event.name")] string customEventName, [TagName("microsoft.client.ip")] string clientAddress);
     }
 #pragma warning restore EXTEXP0003
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -19,6 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             IDictionary<string, string> expectedMessageProperties,
             string? expectedSpanId,
             string? expectedTraceId,
+            string? expectedClientIp = null,
             string expectedCloudRole = "[testNamespace]/testName",
             string expectedCloudInstance = "testInstance",
             string expectedApplicationVersion = "testVersion")
@@ -36,6 +37,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
                 Assert.Equal(expectedSpanId, telemetryItem.Tags["ai.operation.parentId"]);
                 Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
+            }
+
+            if (expectedClientIp != null)
+            {
+                expectedTagsCount += 1;
+                Assert.Equal(expectedClientIp, telemetryItem.Tags["ai.location.ip"]);
             }
 
             Assert.Equal(expectedTagsCount, telemetryItem.Tags.Count);
@@ -69,6 +76,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             IDictionary<string, string> expectedProperties,
             string? expectedSpanId,
             string? expectedTraceId,
+            string? expectedClientIp = null,
             string expectedCloudRole = "[testNamespace]/testName",
             string expectedCloudInstance = "testInstance",
             string expectedApplicationVersion = "testVersion")
@@ -86,6 +94,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
                 Assert.Equal(expectedSpanId, telemetryItem.Tags["ai.operation.parentId"]);
                 Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
+            }
+
+            if (expectedClientIp != null)
+            {
+                expectedTagsCount += 1;
+                Assert.Equal(expectedClientIp, telemetryItem.Tags["ai.location.ip"]);
             }
 
             Assert.Equal(expectedTagsCount, telemetryItem.Tags.Count);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/CustomEventsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/CustomEventsTests.cs
@@ -129,6 +129,46 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         }
 
         [Fact]
+        public void VerifyCustomEventWithClientAddress()
+        {
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
+
+            List<TelemetryItem>? telemetryItems = null;
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddOpenTelemetry(options =>
+                    {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
+                        options.AddAzureMonitorLogExporterForTest(out telemetryItems);
+                    });
+            });
+
+            // ACT
+            var logger = loggerFactory.CreateLogger(logCategoryName);
+            logger.LogInformation("{microsoft.custom_event.name} {client.address}", "MyCustomEventName", "1.2.3.4");
+
+            // CLEANUP
+            loggerFactory.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Event").Single();
+
+            TelemetryItemValidationHelper.AssertCustomEventTelemetry(
+                telemetryItem: telemetryItem!,
+                expectedName: "MyCustomEventName",
+                expectedProperties: new Dictionary<string, string> { { "client.address", "1.2.3.4" } },
+                expectedSpanId: null,
+                expectedTraceId: null,
+                expectedClientIp: "1.2.3.4");
+        }
+
+        [Fact]
         public void VerifyCustomEventNotExporterViaScopes()
         {
             // SETUP
@@ -234,6 +274,48 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedProperties: new Dictionary<string, string> (),
                 expectedSpanId: null,
                 expectedTraceId: null);
+        }
+
+        [Fact]
+        public void VerifyCustomEventWithClientAddressSourceGenerated()
+        {
+            // This method is testing Compile-time logging source generation for custom event with client.address.
+            // https://learn.microsoft.com/dotnet/core/extensions/logger-message-generator
+
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
+            List<TelemetryItem>? telemetryItems = null;
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddOpenTelemetry(options =>
+                    {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
+                        options.AddAzureMonitorLogExporterForTest(out telemetryItems);
+                    });
+            });
+
+            // ACT
+            var logger = loggerFactory.CreateLogger(logCategoryName);
+            logger.WriteCustomEventWithClientAddress("MyCustomEventName", "1.2.3.4");
+
+            // CLEANUP
+            loggerFactory.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Event").Single();
+
+            TelemetryItemValidationHelper.AssertCustomEventTelemetry(
+                telemetryItem: telemetryItem!,
+                expectedName: "MyCustomEventName",
+                expectedProperties: new Dictionary<string, string> { { "client.address", "1.2.3.4" }},
+                expectedSpanId: null,
+                expectedTraceId: null,
+                expectedClientIp: "1.2.3.4");
         }
 
         [Fact]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/CustomEventsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/CustomEventsTests.cs
@@ -129,7 +129,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         }
 
         [Fact]
-        public void VerifyCustomEventWithClientAddress()
+        public void VerifyCustomEventWithClientIP()
         {
             // SETUP
             var uniqueTestId = Guid.NewGuid();
@@ -149,7 +149,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ACT
             var logger = loggerFactory.CreateLogger(logCategoryName);
-            logger.LogInformation("{microsoft.custom_event.name} {client.address}", "MyCustomEventName", "1.2.3.4");
+            logger.LogInformation("{microsoft.custom_event.name} {microsoft.client.ip}", "MyCustomEventName", "1.2.3.4");
 
             // CLEANUP
             loggerFactory.Dispose();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/CustomEventsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/CustomEventsTests.cs
@@ -162,7 +162,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertCustomEventTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedName: "MyCustomEventName",
-                expectedProperties: new Dictionary<string, string> { { "client.address", "1.2.3.4" } },
+                expectedProperties: new Dictionary<string, string>(),
                 expectedSpanId: null,
                 expectedTraceId: null,
                 expectedClientIp: "1.2.3.4");
@@ -312,7 +312,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertCustomEventTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedName: "MyCustomEventName",
-                expectedProperties: new Dictionary<string, string> { { "client.address", "1.2.3.4" }},
+                expectedProperties: new Dictionary<string, string>(),
                 expectedSpanId: null,
                 expectedTraceId: null,
                 expectedClientIp: "1.2.3.4");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -164,5 +164,45 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedTypeName: "System.Exception",
                 expectedProperties: new Dictionary<string, string> { { "EventId", "1" } });
         }
+
+        [Fact]
+        public void VerifyLogWithClientAddressMapsToAiLocationIp()
+        {
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
+            List<TelemetryItem>? telemetryItems = null;
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddOpenTelemetry(options =>
+                    {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
+                        options.AddAzureMonitorLogExporterForTest(out telemetryItems);
+                    });
+            });
+
+            // ACT
+            var logger = loggerFactory.CreateLogger(logCategoryName);
+            logger.LogInformation("Client address: {client.address}", "1.2.3.4");
+
+            // CLEANUP
+            loggerFactory.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Message").Single();
+
+            TelemetryItemValidationHelper.AssertMessageTelemetry(
+                telemetryItem: telemetryItem!,
+                expectedSeverityLevel: "Information",
+                expectedMessage: "Client address: {client.address}",
+                expectedMessageProperties: new Dictionary<string, string> { { "client.address", "1.2.3.4" }, { "CategoryName", logCategoryName } },
+                expectedSpanId: null,
+                expectedTraceId: null,
+                expectedClientIp: "1.2.3.4");
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -166,7 +166,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         }
 
         [Fact]
-        public void VerifyLogWithClientAddressMapsToAiLocationIp()
+        public void VerifyLogWithClientIPMapsToAiLocationIp()
         {
             // SETUP
             var uniqueTestId = Guid.NewGuid();
@@ -185,7 +185,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ACT
             var logger = loggerFactory.CreateLogger(logCategoryName);
-            logger.LogInformation("Client address: {client.address}", "1.2.3.4");
+            logger.LogInformation("Client IP: {microsoft.client.ip}", "1.2.3.4");
 
             // CLEANUP
             loggerFactory.Dispose();
@@ -198,7 +198,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertMessageTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedSeverityLevel: "Information",
-                expectedMessage: "Client address: {client.address}",
+                expectedMessage: "Client IP: {microsoft.client.ip}",
                 expectedMessageProperties: new Dictionary<string, string> { { "CategoryName", logCategoryName } },
                 expectedSpanId: null,
                 expectedTraceId: null,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -199,7 +199,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 telemetryItem: telemetryItem!,
                 expectedSeverityLevel: "Information",
                 expectedMessage: "Client address: {client.address}",
-                expectedMessageProperties: new Dictionary<string, string> { { "client.address", "1.2.3.4" }, { "CategoryName", logCategoryName } },
+                expectedMessageProperties: new Dictionary<string, string> { { "CategoryName", logCategoryName } },
                 expectedSpanId: null,
                 expectedTraceId: null,
                 expectedClientIp: "1.2.3.4");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -52,10 +52,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var properties = new ChangeTrackingDictionary<string, string>();
 
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Test Exception", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.True(properties.TryGetValue("OriginalFormat", out string value));
             Assert.Equal(log, value);
@@ -86,10 +87,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(log, "tomato", 2.99);
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Hello from tomato 2.99.", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
             Assert.True(properties.TryGetValue("name", out string name));
             Assert.Equal("tomato", name);
             Assert.True(properties.TryGetValue("price", out string price));
@@ -116,10 +118,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(log, "tomato", 2.99);
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal(log, message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
             Assert.False(properties.ContainsKey("OriginalFormat"));
             Assert.True(properties.TryGetValue("name", out string name));
             Assert.Equal("tomato", name);
@@ -150,10 +153,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(log, "tomato", 2.99);
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Hello from {name} {price}.", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.True(properties.TryGetValue("name", out string name));
             Assert.Equal("tomato", name);
@@ -181,10 +185,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(id, "Log Information");
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Log Information", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.True(properties.TryGetValue("EventId", out string eventId));
             Assert.Equal("1", eventId);
@@ -212,10 +217,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation("Information goes here");
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Information goes here", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.True(properties.TryGetValue("CategoryName", out string loggedCategoryName));
             Assert.Equal(categoryName, loggedCategoryName);
@@ -246,10 +252,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             }
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Test Exception", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.True(properties.TryGetValue("CategoryName", out string categoryName));
             Assert.EndsWith(nameof(LogsHelperTests), categoryName);
@@ -276,10 +283,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(id, log, 100, "TestAttributeEventName");
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Log Information {EventId} {EventName}.", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.True(properties.TryGetValue("EventId", out string eventId));
             Assert.Equal("100", eventId);
@@ -371,10 +379,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Some log information message.", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             if (includeScope)
             {
@@ -422,10 +431,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Some log information message.", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             if (scopeValue != null)
             {
@@ -473,10 +483,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Some log information message.", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.False(properties.ContainsKey(expectedScopeKey), "Properties should not contain the key of the CustomObject that threw an exception");
             Assert.True(properties.ContainsKey(validScopeKey), "Properties should contain the key of the valid scope item.");
@@ -520,10 +531,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Some log information message. {attributeKey} {attributeKey}.", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.Equal(3, properties.Count);
             Assert.True(properties.TryGetValue(expectedScopeKey, out string actualScopeValue));
@@ -566,10 +578,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("Some log information message. {Some scope key}.", message);
             Assert.Null(eventName);
+            Assert.Null(clientAddress);
 
             Assert.Equal(2, properties.Count);
             Assert.True(properties.TryGetValue(expectedScopeKey, out string actualScopeValue));
@@ -595,9 +608,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("MyCustomEventName", eventName);
+            Assert.Null(clientAddress);
         }
 
         [Fact]
@@ -619,9 +633,35 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
 
             Assert.Equal("MyCustomEventName", eventName);
+            Assert.Null(clientAddress);
+        }
+
+        [Fact]
+        public void VerifyClientAddress()
+        {
+            // Arrange.
+            var logRecords = new List<LogRecord>(1);
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecords);
+                });
+            });
+
+            var logger = loggerFactory.CreateLogger("Some category");
+            logger.LogInformation("{client.address}", "1.2.3.4");
+
+            // Assert.
+            var logRecord = logRecords.Single();
+            var properties = new ChangeTrackingDictionary<string, string>();
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+
+            Assert.Equal("1.2.3.4", clientAddress);
+            Assert.Null(eventName);
         }
 
         private class CustomObject

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -640,7 +640,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void VerifyClientAddress()
+        public void VerifyClientIP()
         {
             // Arrange.
             var logRecords = new List<LogRecord>(1);
@@ -653,14 +653,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             });
 
             var logger = loggerFactory.CreateLogger("Some category");
-            logger.LogInformation("{client.address}", "1.2.3.4");
+            logger.LogInformation("{microsoft.client.ip}", "1.2.3.4");
 
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientIP);
 
-            Assert.Equal("1.2.3.4", clientAddress);
+            Assert.Equal("1.2.3.4", clientIP);
             Assert.Null(eventName);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -258,33 +258,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void AiLocationIpFallbackOnServerSpan()
-        {
-            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
-            using var activity = activitySource.StartActivity(
-                ActivityName,
-                ActivityKind.Server,
-                null,
-                startTime: DateTime.UtcNow);
-
-            Assert.NotNull(activity);
-            // Fallback to http.client_ip if microsoft.client.ip or client.address is not present on server span
-            activity.SetTag(SemanticConventions.AttributeHttpClientIp, "127.0.0.1");
-            activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, "GET");
-
-            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(new Batch<Activity>(new Activity[] { activity }, 1), null, "instrumentationKey", 1.0f);
-            var telemetryItem = telemetryItems.FirstOrDefault();
-
-            Assert.Equal("127.0.0.1", telemetryItem?.Tags[ContextTagKeys.AiLocationIp.ToString()]);
-
-            // Verify that client.address is not in custom properties (it's mapped to ai.location.ip instead)
-            var requestData = telemetryItem?.Data?.BaseData as RequestData;
-            Assert.NotNull(requestData);
-            Assert.False(requestData.Properties.ContainsKey("http.client_ip"));
-        }
-
-        [Fact]
         public void AiLocationIpIsSetAsMicrosoftClientIPWhenPresentOnClientSpan()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -204,7 +204,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void AiLocationIpIsSetAsHttpClientIpForHttpServerSpans()
+        public void AiLocationIpIsSetAsClientAddressForHttpServerSpansIfNoOverridePresent()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
@@ -222,6 +222,94 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var telemetryItem = telemetryItems.FirstOrDefault();
 
             Assert.Equal("127.0.0.1", telemetryItem?.Tags[ContextTagKeys.AiLocationIp.ToString()]);
+
+            // Verify that client.address is not in custom properties (it's mapped to ai.location.ip instead)
+            var requestData = telemetryItem?.Data?.BaseData as RequestData;
+            Assert.NotNull(requestData);
+            Assert.False(requestData.Properties.ContainsKey("client.address"));
+        }
+
+        [Fact]
+        public void AiLocationIpIsSetAsMicrosoftClientIPWhenPresentOnServerSpan()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Server,
+                null,
+                startTime: DateTime.UtcNow);
+
+            Assert.NotNull(activity);
+            activity.SetTag("microsoft.client.ip", "1.2.3.4");
+            activity.SetTag(SemanticConventions.AttributeClientAddress, "127.0.0.1");
+            activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, "GET");
+
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(new Batch<Activity>(new Activity[] { activity }, 1), null, "instrumentationKey", 1.0f);
+            var telemetryItem = telemetryItems.FirstOrDefault();
+
+            Assert.Equal("1.2.3.4", telemetryItem?.Tags[ContextTagKeys.AiLocationIp.ToString()]);
+
+            // Verify that client.address is not in custom properties (it's mapped to ai.location.ip instead)
+            var requestData = telemetryItem?.Data?.BaseData as RequestData;
+            Assert.NotNull(requestData);
+            Assert.False(requestData.Properties.ContainsKey("microsoft.client.ip"));
+            Assert.False(requestData.Properties.ContainsKey("client.address"));
+        }
+
+        [Fact]
+        public void AiLocationIpFallbackOnServerSpan()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Server,
+                null,
+                startTime: DateTime.UtcNow);
+
+            Assert.NotNull(activity);
+            // Fallback to http.client_ip if microsoft.client.ip or client.address is not present on server span
+            activity.SetTag(SemanticConventions.AttributeHttpClientIp, "127.0.0.1");
+            activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, "GET");
+
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(new Batch<Activity>(new Activity[] { activity }, 1), null, "instrumentationKey", 1.0f);
+            var telemetryItem = telemetryItems.FirstOrDefault();
+
+            Assert.Equal("127.0.0.1", telemetryItem?.Tags[ContextTagKeys.AiLocationIp.ToString()]);
+
+            // Verify that client.address is not in custom properties (it's mapped to ai.location.ip instead)
+            var requestData = telemetryItem?.Data?.BaseData as RequestData;
+            Assert.NotNull(requestData);
+            Assert.False(requestData.Properties.ContainsKey("http.client_ip"));
+        }
+
+        [Fact]
+        public void AiLocationIpIsSetAsMicrosoftClientIPWhenPresentOnClientSpan()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                null,
+                startTime: DateTime.UtcNow);
+
+            Assert.NotNull(activity);
+            activity.SetTag("microsoft.client.ip", "1.2.3.4");
+            activity.SetTag(SemanticConventions.AttributeClientAddress, "127.0.0.1");
+            activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, "GET");
+
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(new Batch<Activity>(new Activity[] { activity }, 1), null, "instrumentationKey", 1.0f);
+            var telemetryItem = telemetryItems.FirstOrDefault();
+
+            Assert.Equal("1.2.3.4", telemetryItem?.Tags[ContextTagKeys.AiLocationIp.ToString()]);
+
+            // Verify that client.address is not in custom properties (it's mapped to ai.location.ip instead)
+            var dependencyData = telemetryItem?.Data?.BaseData as RemoteDependencyData;
+            Assert.NotNull(dependencyData);
+            Assert.False(dependencyData.Properties.ContainsKey("microsoft.client.ip"));
+            Assert.False(dependencyData.Properties.ContainsKey("client.address"));
         }
 
         [Fact]


### PR DESCRIPTION
[Azure Monitor OpenTelemetry Exporter]

This PR implements a mapping to ai.location.ip for all telemetry types