### PR TITLE
[CODEOWNERS] Remove invalid owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -353,10 +353,10 @@
 # ServiceOwners:                                                   @TravisCragg-MSFT @hilaryw29
 
 # PRLabel: %Confidential Ledger
-/sdk/confidentialledger/                                           @christothes @PallabPaul @amruthashree18 @andpiccione @ivarprudnikov
+/sdk/confidentialledger/                                           @christothes @PallabPaul @andpiccione @ivarprudnikov
 
 # ServiceLabel: %Confidential Ledger
-# ServiceOwners:                                                   @PallabPaul @amruthashree18 @andpiccione @ivarprudnikov
+# ServiceOwners:                                                   @PallabPaul @andpiccione @ivarprudnikov
 
 # ServiceLabel: %Connected Kubernetes
 # ServiceOwners:                                                   @akashkeshari


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner that is being flagged by the linter as invalid.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5257761&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_