### PR TITLE
[Identity] Remove Azure Kubernetes Managed Identity from TROUBLESHOOTING

### DIFF
--- a/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
+++ b/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
@@ -229,16 +229,6 @@ curl 'http://169.254.169.254/metadata/identity/oauth2/token?resource=https://man
 
 > Note that the output of this command will contain a valid access token, and SHOULD NOT BE SHARED to avoid compromising account security.
 
-### Azure Kubernetes Service managed identity
-
-#### Pod identity for Kubernetes
-
-`CredentialUnavailableException`
-
-| Error Message |Description| Mitigation |
-|---|---|---|
-|No Managed Identity endpoint found|The application attempted to authenticate before an identity was assigned to its pod|Verify the pod is labeled correctly. This error also occurs when a correctly labeled pod authenticates before the identity is ready. To prevent initialization races, configure NMI to set the `Retry-After` header in its responses (see [Pod Identity documentation](https://azure.github.io/aad-pod-identity/docs/configure/feature_flags/#set-retry-after-header-in-nmi-response)).
-
 ## Troubleshoot `VisualStudioCredential` authentication issues
 
 `CredentialUnavailableException`


### PR DESCRIPTION
Removing the **Azure Kubernetes Service managed identity** section from the TROUBLESHOOTING guide since this is no longer supported.