### PR TITLE
Add missing buildable type for MRWContext in PortalServices

### DIFF
--- a/sdk/portalservices/Azure.ResourceManager.PortalServicesCopilot/src/Custom/AzureResourceManagerPortalServicesCopilotContext.cs
+++ b/sdk/portalservices/Azure.ResourceManager.PortalServicesCopilot/src/Custom/AzureResourceManagerPortalServicesCopilotContext.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ClientModel.Primitives;
+using Azure.ResourceManager.Models;
+
+namespace Azure.ResourceManager.PortalServicesCopilot
+{
+    [ModelReaderWriterBuildable(typeof(ResponseError))]
+    [ModelReaderWriterBuildable(typeof(SystemData))]
+    public partial class AzureResourceManagerPortalServicesCopilotContext
+    {
+    }
+}


### PR DESCRIPTION
We need a proper fix in MPG generator to fix this, tracked in https://github.com/Azure/azure-sdk-for-net/issues/52293