### PR TITLE
SDK Readme update to use Microsoft's Signing Transparency instead of Azure Code Transparency

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -109,6 +109,7 @@ known_content_issues:
   - ['sdk/search/README.md','Not a package: azure-sdk-tools/issues/42']
   - ['sdk/storage/README.md','Not a package: azure-sdk-tools/issues/42']
 
+  - ['sdk/confidentialledger/Azure.Security.CodeTransparency/README.md', 'https://github.com/Azure/azure-sdk-tools/issues/404 Title needs to start with Microsoft`s']
   - ['sdk/core/Azure.Core.Amqp/README.md', 'Opt out of sections: https://github.com/Azure/azure-sdk-tools/issues/404']
   - ['sdk/core/Azure.Core.Experimental/README.md', 'Opt out of sections: https://github.com/Azure/azure-sdk-tools/issues/404']
   - ['sdk/core/Azure.Core.TestFramework/README.md', 'Opt out of sections: https://github.com/Azure/azure-sdk-tools/issues/404']

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/README.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/README.md
@@ -1,4 +1,4 @@
-# Azure Code Transparency client library for .NET
+# Microsoft's Signing Transparency client library for .NET
 
 <!-- cspell:ignore cose merkle scitt -->
 
@@ -20,7 +20,7 @@ dotnet add package Azure.Security.CodeTransparency --prerelease
 
 ### Prerequisites
 
-- A running and accessible Code Transparency Service
+- A running and accessible Signing Transparency Service
 - Ability to create `COSE_Sign1` envelopes, [an example script][CTS_claim_generator_script]
 - Your signer details (CA cert) have to be configured in the running service, [about available configuration][CTS_configuration_doc]
 - You can get a valid Bearer token if the service authentication is configured to require one, [see example](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/confidentialledger/Azure.Security.CodeTransparency/samples/Sample3_UseYourCredentials.md)


### PR DESCRIPTION
New name was coined for the service going through the preview. CELA approved Signing Transparency and Microsoft's Signing Transparency.

SDK Readme update to use Microsoft's Signing Transparency instead of Azure Code Transparency.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
