### PR TITLE
Updated ACS Rooms test to use TS TM

### DIFF
--- a/sdk/communication/Azure.Communication.Rooms/assets.json
+++ b/sdk/communication/Azure.Communication.Rooms/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/communication/Azure.Communication.Rooms",
-  "Tag": "net/communication/Azure.Communication.Rooms_d36b9da2ca"
+  "Tag": "net/communication/Azure.Communication.Rooms_2ff8db129e"
 }

--- a/sdk/communication/Azure.Communication.Rooms/assets.json
+++ b/sdk/communication/Azure.Communication.Rooms/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/communication/Azure.Communication.Rooms",
-  "Tag": "net/communication/Azure.Communication.Rooms_2ff8db129e"
+  "Tag": "net/communication/Azure.Communication.Rooms_1b3d22d78d"
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/Infrastructure/RoomsClientTestEnvironment.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/Infrastructure/RoomsClientTestEnvironment.cs
@@ -10,6 +10,8 @@ namespace Azure.Communication.Rooms.Tests
     public class RoomsClientTestEnvironment : CommunicationTestEnvironment
     {
         public const string CommunicationConnectionStringRoomsVariableName = "COMMUNICATION_CONNECTION_STRING_ROOMS";
+        private const string TrafficManagerUrl = "https://flighting-api.scheduler.teams.microsoft.com";
+
         public string CommunicationConnectionStringRooms => GetRecordedVariable(
             CommunicationConnectionStringRoomsVariableName,
             options => options.HasSecretConnectionStringParameter("accessKey", SanitizedValue.Base64));
@@ -17,5 +19,7 @@ namespace Azure.Communication.Rooms.Tests
         public Uri CommunicationRoomsEndpoint => new(Core.ConnectionString.Parse(CommunicationConnectionStringRooms).GetRequired("endpoint"));
 
         public string CommunicationRoomsAccessKey => Core.ConnectionString.Parse(CommunicationConnectionStringRooms).GetRequired("accesskey");
+
+        public Uri CommunicationRoomsTrafficManagerUrl => new(TrafficManagerUrl);
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomClientPstnDialOutLiveTest.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomClientPstnDialOutLiveTest.cs
@@ -9,11 +9,9 @@ using System.Linq;
 #endregion Snippet:Azure_Communication_Rooms_Tests_UsingStatements
 using System.Threading.Tasks;
 using Azure.Communication.Identity;
-using Azure.Communication.Rooms;
 using Azure.Communication.Rooms.Tests;
 using Azure.Communication.Tests;
 using Azure.Core.TestFramework;
-using Microsoft.AspNetCore.Http.Features.Authentication;
 using NUnit.Framework;
 using static Azure.Communication.Rooms.RoomsClientOptions;
 
@@ -1368,10 +1366,10 @@ namespace Azure.Communication.Rooms.Test
 
             // Arrange
             var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
-            var ivnalidRoomId = "123";
+            var invalidRoomId = "123";
 
             // Act and Assert:
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(ivnalidRoomId));
+            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(invalidRoomId));
             Assert.NotNull(ex);
             Assert.AreEqual(400, ex?.Status);
         }

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomClientPstnDialOutLiveTest.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomClientPstnDialOutLiveTest.cs
@@ -13,6 +13,7 @@ using Azure.Communication.Rooms;
 using Azure.Communication.Rooms.Tests;
 using Azure.Communication.Tests;
 using Azure.Core.TestFramework;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using NUnit.Framework;
 using static Azure.Communication.Rooms.RoomsClientOptions;
 
@@ -20,13 +21,36 @@ namespace Azure.Communication.Rooms.Test
 {
     public class RoomClientPstnDialOutLiveTest : RoomsClientLiveTestBase
     {
+        public static object[] AuthenticationVersionSource =
+        [
+            new object[] { AuthMethod.ConnectionString, ServiceVersion.V2024_04_15 },
+            new object[] { AuthMethod.KeyCredential, ServiceVersion.V2024_04_15},
+            new object[] { AuthMethod.ConnectionString, ServiceVersion.V2025_03_13 },
+            new object[] { AuthMethod.KeyCredential, ServiceVersion.V2025_03_13 }
+        ];
+
+        public static readonly object[] AuthenticationVersionPstnEnabledSource =
+        [
+            new object?[] { AuthMethod.ConnectionString, ServiceVersion.V2024_04_15, false },
+            new object?[] { AuthMethod.ConnectionString, ServiceVersion.V2024_04_15, true },
+            new object?[] { AuthMethod.ConnectionString, ServiceVersion.V2024_04_15, null },
+            new object?[] { AuthMethod.KeyCredential, ServiceVersion.V2024_04_15, false },
+            new object?[] { AuthMethod.KeyCredential, ServiceVersion.V2024_04_15, true },
+            new object?[] { AuthMethod.KeyCredential, ServiceVersion.V2024_04_15, null },
+            new object?[] { AuthMethod.ConnectionString, ServiceVersion.V2025_03_13, false },
+            new object?[] { AuthMethod.ConnectionString, ServiceVersion.V2025_03_13, true },
+            new object?[] { AuthMethod.ConnectionString, ServiceVersion.V2025_03_13, null },
+            new object?[] { AuthMethod.KeyCredential, ServiceVersion.V2025_03_13, false },
+            new object?[] { AuthMethod.KeyCredential, ServiceVersion.V2025_03_13, true },
+            new object?[] { AuthMethod.KeyCredential, ServiceVersion.V2025_03_13, null }
+        ];
+
         public RoomClientPstnDialOutLiveTest(bool isAsync) : base(isAsync)
         {
         }
 
-        [TestCase(AuthMethod.ConnectionString, ServiceVersion.V2024_04_15, TestName = "AcsRoomRequestLiveWithoutParticipantsUsingConnectionString")]
-        [TestCase(AuthMethod.KeyCredential, ServiceVersion.V2024_04_15, TestName = "AcsRoomRequestLiveWithoutParticipantsUsingKeyCredential")]
-        public async Task AcsRoomRequestLiveWithoutParticipantsTest(AuthMethod authMethod, ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task AcsRoomLiveWithoutParticipantsTest(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             Rooms.RoomsClient roomsClient = CreateClient(authMethod, true, apiVersion);
@@ -93,21 +117,11 @@ namespace Azure.Communication.Rooms.Test
             {
                 Assert.Fail($"Unexpected error: {ex}");
             }
+            await Task.Run(() => Console.WriteLine("Test Completed"));
         }
 
-        [TestCase(AuthMethod.ConnectionString, ServiceVersion.V2024_04_15, false, TestName = "AcsRoomRequestWithPstnDialOutEnabledFalseLiveWithoutParticipantsUsingConnectionString")]
-        [TestCase(AuthMethod.ConnectionString, ServiceVersion.V2024_04_15, true, TestName = "AcsRoomRequestWithPstnDialOutEnabledTrueLiveWithoutParticipantsUsingConnectionString")]
-        [TestCase(AuthMethod.ConnectionString, ServiceVersion.V2024_04_15, null, TestName = "AcsRoomRequestWithPstnDialOutEnabledNullLiveWithoutParticipantsUsingConnectionString")]
-        [TestCase(AuthMethod.KeyCredential, ServiceVersion.V2024_04_15, false, TestName = "AcsRoomRequestWithPstnDialOutEnabledFalseLiveWithoutParticipantsUsingKeyCredential")]
-        [TestCase(AuthMethod.KeyCredential, ServiceVersion.V2024_04_15, true, TestName = "AcsRoomRequestWithPstnDialOutEnabledTrueLiveWithoutParticipantsUsingKeyCredential")]
-        [TestCase(AuthMethod.KeyCredential, ServiceVersion.V2024_04_15, null, TestName = "AcsRoomRequestWithPstnDialOutEnabledNullLiveWithoutParticipantsUsingKeyCredential")]
-        [TestCase(AuthMethod.ConnectionString, ServiceVersion.V2025_03_13, false, TestName = "AcsRoomRequestWithPstnDialOutEnabledFalseLiveV2025-03-13WithoutParticipantsUsingConnectionString")]
-        [TestCase(AuthMethod.ConnectionString, ServiceVersion.V2025_03_13, true, TestName = "AcsRoomRequestWithPstnDialOutEnabledTrueLiveV2025-03-13WithoutParticipantsUsingConnectionString")]
-        [TestCase(AuthMethod.ConnectionString, ServiceVersion.V2025_03_13, null, TestName = "AcsRoomRequestWithPstnDialOutEnabledNullLiveV2025-03-13WithoutParticipantsUsingConnectionString")]
-        [TestCase(AuthMethod.KeyCredential, ServiceVersion.V2025_03_13, false, TestName = "AcsRoomRequestWithPstnDialOutEnabledFalseLiveV2025-03-13WithoutParticipantsUsingKeyCredential")]
-        [TestCase(AuthMethod.KeyCredential, ServiceVersion.V2025_03_13, true, TestName = "AcsRoomRequestWithPstnDialOutEnabledTrueLiveV2025-03-13WithoutParticipantsUsingKeyCredential")]
-        [TestCase(AuthMethod.KeyCredential, ServiceVersion.V2025_03_13, null, TestName = "AcsRoomRequestWithPstnDialOutEnabledNullLiveV2025-03-13WithoutParticipantsUsingKeyCredential")]
-        public async Task AcsRoomRequestWithPstnLiveWithoutParticipantsTest(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task AcsRoomWithPstnLiveWithoutParticipantsTest(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             Rooms.RoomsClient roomsClient = CreateClient(authMethod, true, apiVersion);
@@ -178,17 +192,15 @@ namespace Azure.Communication.Rooms.Test
             }
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task AcsRoomLifeCycleLiveTest(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task AcsRoomLifeCycleLiveTest(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
-            Rooms.RoomsClient roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            RoomsClient roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
 
             var communicationUser1 = communicationIdentityClient.CreateUserAsync().Result.Value;
             var communicationUser2 = communicationIdentityClient.CreateUserAsync().Result.Value;
-            var communicationUser3 = communicationIdentityClient.CreateUserAsync().Result.Value;
 
             var validFrom = DateTimeOffset.UtcNow;
             var validUntil = validFrom.AddDays(1);
@@ -197,7 +209,6 @@ namespace Azure.Communication.Rooms.Test
             {
                 RoomParticipant participant1 = new RoomParticipant(communicationUser1) { Role = ParticipantRole.Presenter };
                 RoomParticipant participant2 = new RoomParticipant(communicationUser2);
-                RoomParticipant participant3 = new RoomParticipant(communicationUser3) { Role = ParticipantRole.Consumer };
 
                 List<RoomParticipant> createRoomParticipants = new List<RoomParticipant>
                 {
@@ -268,16 +279,11 @@ namespace Azure.Communication.Rooms.Test
             }
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public async Task AcsRoomWithPstnLifeCycleLiveTest(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task AcsRoomWithPstnLifeCycleLiveTest(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
-            Rooms.RoomsClient roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            RoomsClient roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
 
             var communicationUser1 = communicationIdentityClient.CreateUserAsync().Result.Value;
@@ -364,12 +370,11 @@ namespace Azure.Communication.Rooms.Test
             }
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task CreateRoom_WithNullRoomCreateOptionsAttributes_Succeed(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task CreateRoom_WithNullRoomCreateOptionsAttributes_Succeed(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            RoomsClient roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             // Act
             var createdRoom = await roomsClient.CreateRoomAsync(options: null);
@@ -379,12 +384,11 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(createdRoom.Value);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task CreateRoom_WithEmptyRoomCreateOptionsAttributes_Succeed(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task CreateRoom_WithEmptyRoomCreateOptionsAttributes_Succeed(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            RoomsClient roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             // Act
             var createdRoom = await roomsClient.CreateRoomAsync(new CreateRoomOptions());
@@ -393,22 +397,18 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value);
         }
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public async Task CreateRoomWithPstn_WithOnlyPstnDialOutEnabledAttribute(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task CreateRoomWithPstn_WithOnlyPstnDialOutEnabledAttribute(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
+            RoomsClient roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
             var participant1 = await communicationIdentityClient.CreateUserAsync();
             List<RoomParticipant> roomParticipants = new List<RoomParticipant>()
             {
                 new RoomParticipant(participant1.Value)
             };
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
 
             // Act
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
@@ -423,9 +423,8 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task CreateRoom_WithOnlyParticipants_Succeed(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task CreateRoom_WithOnlyParticipants_Succeed(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
@@ -434,7 +433,7 @@ namespace Azure.Communication.Rooms.Test
             {
                 new RoomParticipant(participant1.Value)
             };
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
@@ -449,13 +448,8 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(createdRoom.Value);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public async Task CreateRoomWithPstn_WithOnlyParticipants_Succeed(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task CreateRoomWithPstn_WithOnlyParticipants_Succeed(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
@@ -464,7 +458,7 @@ namespace Azure.Communication.Rooms.Test
             {
                 new RoomParticipant(participant1.Value)
             };
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             // Act
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
@@ -480,9 +474,8 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task CreateRoom_WithAllOptionalParameters_Succeed(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task CreateRoom_WithAllOptionalParameters_Succeed(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
@@ -493,7 +486,7 @@ namespace Azure.Communication.Rooms.Test
             };
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(1);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
@@ -510,13 +503,8 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(createdRoom.Value);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public async Task CreateRoomWithPstn_WithAllOptionalParameters_Succeed(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task CreateRoomWithPstn_WithAllOptionalParameters_Succeed(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
@@ -527,7 +515,7 @@ namespace Azure.Communication.Rooms.Test
             };
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(1);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
@@ -545,14 +533,13 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public void CreateRoom_WithTimeRangeExceedMax_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public void CreateRoom_WithTimeRangeExceedMax_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(200);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
@@ -566,18 +553,13 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public void CreateRoomWithPstn_WithTimeRangeExceedMax_Fail(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public void CreateRoomWithPstn_WithTimeRangeExceedMax_Fail(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(200);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
@@ -592,12 +574,11 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public void CreateRoom_WithPastValidUntil_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public void CreateRoom_WithPastValidUntil_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange;
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             var validFrom = DateTime.UtcNow.AddDays(-10);
             var validUntil = validFrom.AddDays(-20);
 
@@ -612,16 +593,11 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public void CreateRoomWithPstn_WithPastValidUntil_Fail(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public void CreateRoomWithPstn_WithPastValidUntil_Fail(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange;
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             var validFrom = DateTime.UtcNow.AddDays(-10);
             var validUntil = validFrom.AddDays(-20);
 
@@ -638,15 +614,15 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        public void CreateRoom_WithInvalidParticipantMri_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public void CreateRoom_WithInvalidParticipantMri_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             List<RoomParticipant> roomParticipants = new List<RoomParticipant>()
             {
                 new RoomParticipant(new CommunicationUserIdentifier("invalid_mri"))
             };
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 Participants = roomParticipants
@@ -658,20 +634,15 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public void CreateRoomWithPstn_WithInvalidParticipantMri_Fail(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public void CreateRoomWithPstn_WithInvalidParticipantMri_Fail(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             List<RoomParticipant> roomParticipants = new List<RoomParticipant>()
             {
                 new RoomParticipant(new CommunicationUserIdentifier("invalid_mri"))
             };
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
@@ -685,12 +656,18 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public void GetRoom_WithInvalidFormatRoomId_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public void GetRoom_WithInvalidFormatRoomId_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
+            if (authMethod == AuthMethod.KeyCredential)
+            {
+                // TODO: to fix bug before enabling this test for KeyCredential
+                Assert.Ignore();
+                return;
+            }
+
             // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync("invalid_id"));
@@ -698,18 +675,13 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public async Task UpdateRoomWithPstn_WithPstnDailOutEnabledAttributeOnly_Succeed(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task UpdateRoomWithPstn_WithPstnDailOutEnabledAttributeOnly_Succeed(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 ValidFrom = validFrom,
@@ -732,14 +704,13 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task UpdateRoom_WithValidTimeRange_Succeed(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task UpdateRoom_WithValidTimeRange_Succeed(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 ValidFrom = validFrom,
@@ -765,14 +736,13 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task UpdateRoom_WithEmptyUpdateRoomOptions_Succeed(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task UpdateRoom_WithEmptyUpdateRoomOptions_Succeed(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 ValidFrom = validFrom,
@@ -794,14 +764,13 @@ namespace Azure.Communication.Rooms.Test
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task UpdateRoom_WithTimeRangeExceedMax_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task UpdateRoom_WithTimeRangeExceedMax_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 ValidFrom = validFrom,
@@ -822,18 +791,13 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public async Task UpdateRoom_WithTimeRangeExceedMax_Fail(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task UpdateRoom_WithTimeRangeExceedMax_Fail(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 ValidFrom = validFrom,
@@ -856,14 +820,13 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task UpdateRoom_WithPastValidUntil_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task UpdateRoom_WithPastValidUntil_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 ValidFrom = validFrom,
@@ -885,18 +848,13 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public async Task UpdateRoom_WithPastValidUntil_Fail(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task UpdateRoom_WithPastValidUntil_Fail(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 ValidFrom = validFrom,
@@ -919,13 +877,20 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        public void UpdateRoom_WithInvalidFormatRoomId_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public void UpdateRoom_WithInvalidFormatRoomId_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
+            if (authMethod == AuthMethod.KeyCredential)
+            {
+                // TODO: to fix bug before enabling this test for KeyCredential
+                Assert.Ignore();
+                return;
+            }
+
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             UpdateRoomOptions roomUpdateOptions = new UpdateRoomOptions()
             {
@@ -939,18 +904,19 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public void UpdateRoomWithPstn_WithInvalidFormatRoomId_Fail(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public void UpdateRoomWithPstn_WithInvalidFormatRoomId_Fail(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
+            if (authMethod == AuthMethod.KeyCredential){
+                // TODO: to fix bug before enabling this test for KeyCredential
+                Assert.Ignore();
+                return;
+            }
+
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             UpdateRoomOptions roomUpdateOptions = new UpdateRoomOptions()
             {
@@ -965,14 +931,13 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task UpdateRoom_WithDeletedRoom_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task UpdateRoom_WithDeletedRoom_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
                 ValidFrom = validFrom,
@@ -993,18 +958,13 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(404, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15, false)]
-        [TestCase(ServiceVersion.V2024_04_15, true)]
-        [TestCase(ServiceVersion.V2024_04_15, null)]
-        [TestCase(ServiceVersion.V2025_03_13, false)]
-        [TestCase(ServiceVersion.V2025_03_13, true)]
-        [TestCase(ServiceVersion.V2025_03_13, null)]
-        public async Task UpdateRoomWithPstn_WithDeletedRoom_Fail(ServiceVersion apiVersion, bool? pstnDialOutEnabled)
+        [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
+        public async Task UpdateRoomWithPstn_WithDeletedRoom_Fail(AuthMethod authMethod, ServiceVersion apiVersion, bool? pstnDialOutEnabled)
         {
             // Arrange
             var validFrom = DateTime.UtcNow;
             var validUntil = validFrom.AddDays(10);
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             CreateRoomOptions roomCreateOptions = new CreateRoomOptions()
             {
@@ -1029,12 +989,11 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(404, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task AddOrUpdateParticipants_IncorrectlyFormattedMri_Fail(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task AddOrUpdateParticipants_IncorrectlyFormattedMri_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             var createRoomResponse = await roomsClient.CreateRoomAsync(options: null);
             List<RoomParticipant> roomParticipants = new List<RoomParticipant>()
             {
@@ -1046,12 +1005,11 @@ namespace Azure.Communication.Rooms.Test
             Assert.AreEqual(400, ex?.Status);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task GetRoomsLiveTest_FirstTwoPagesOfRoomIsNotNull_Succeed(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task GetRoomsLiveTest_FirstTwoPagesOfRoomIsNotNull_Succeed(AuthMethod authMethod, ServiceVersion apiVersion)
         {
             // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
             // First create a room to ensure that the list rooms will not be empty.
             CommunicationRoom createdRoom = await roomsClient.CreateRoomAsync(new CreateRoomOptions());
             int roomCounter = 0;
@@ -1076,17 +1034,23 @@ namespace Azure.Communication.Rooms.Test
             await roomsClient.DeleteRoomAsync(createdRoom.Id);
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task RoomParticipantsAddUpdateAndRemoveLiveTest(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task RoomParticipantsAddUpdateAndRemoveLiveTest(AuthMethod authMethod, ServiceVersion apiVersion)
         {
+            if (authMethod == AuthMethod.KeyCredential)
+            {
+                // TODO: to fix bug before enabling this test for KeyCredential
+                Assert.Ignore();
+                return;
+            }
+
             // Arrange
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
             var communicationUser1 = communicationIdentityClient.CreateUserAsync().Result.Value;
             var communicationUser2 = communicationIdentityClient.CreateUserAsync().Result.Value;
             var communicationUser3 = communicationIdentityClient.CreateUserAsync().Result.Value;
 
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             RoomParticipant participant1 = new RoomParticipant(communicationUser1) { Role = ParticipantRole.Presenter };
             RoomParticipant participant2 = new RoomParticipant(communicationUser2) { Role = ParticipantRole.Presenter };
@@ -1174,17 +1138,22 @@ namespace Azure.Communication.Rooms.Test
             }
         }
 
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task RoomParticipantsAddUpdateAndRemoveWithNullRolesLiveTest(ServiceVersion apiVersion)
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task RoomParticipantsAddUpdateAndRemoveWithNullRolesLiveTest(AuthMethod authMethod, ServiceVersion apiVersion)
         {
+            if (authMethod == AuthMethod.KeyCredential)
+            {
+                // TODO: to fix bug before enabling this test for KeyCredential
+                return;
+            }
+
             // Arrange
             CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
             var communicationUser1 = communicationIdentityClient.CreateUserAsync().Result.Value;
             var communicationUser2 = communicationIdentityClient.CreateUserAsync().Result.Value;
             var communicationUser3 = communicationIdentityClient.CreateUserAsync().Result.Value;
 
-            RoomsClient roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            RoomsClient roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             RoomParticipant participant1 = new RoomParticipant(communicationUser1) { Role = ParticipantRole.Presenter };
             RoomParticipant participant2 = new RoomParticipant(communicationUser2);
@@ -1315,6 +1284,98 @@ namespace Azure.Communication.Rooms.Test
             }
         }
 
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task RemoveParticipants_NonExistentParticipants_Success(AuthMethod authMethod, ServiceVersion apiVersion)
+        {
+            if (authMethod == AuthMethod.KeyCredential)
+            {
+                // TODO: to fix bug before enabling this test for KeyCredential
+                Assert.Ignore();
+                return;
+            }
+
+            // Arrange
+            CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
+            var createRoomResponse = await roomsClient.CreateRoomAsync(options: null);
+            var participant1 = await communicationIdentityClient.CreateUserAsync();
+            List<CommunicationUserIdentifier> communicationUsers = new List<CommunicationUserIdentifier>()
+            {
+                participant1
+            };
+
+            // Act
+            Response removeParticipantResponse = await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers);
+            AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createRoomResponse.Value.Id);
+            List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
+
+            // Assert
+            Assert.AreEqual(removeParticipantResponse.Status, 200);
+            Assert.AreEqual(removeRoomParticipantsResult.Count, 0);
+        }
+
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task RemoveParticipants_IncorrectlyFormattedMri_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
+        {
+            if (authMethod == AuthMethod.KeyCredential)
+            {
+                // TODO: to fix bug before enabling this test for KeyCredential
+                Assert.Ignore();
+                return;
+            }
+
+            // Arrange
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
+            var createRoomResponse = await roomsClient.CreateRoomAsync(new CreateRoomOptions());
+            List<CommunicationUserIdentifier> communicationUsers = new List<CommunicationUserIdentifier>()
+            {
+                new CommunicationUserIdentifier("invalid_mri")
+            };
+
+            // Act and assert
+            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers));
+            Assert.NotNull(ex);
+            Assert.AreEqual(400, ex?.Status);
+        }
+
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public async Task DeleteRoom_Success(AuthMethod authMethod, ServiceVersion apiVersion)
+        {
+            // Arrange
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
+            var createRoomResponse = await roomsClient.CreateRoomAsync(options: null);
+            var createdRoomId = createRoomResponse.Value.Id;
+
+            // Act
+            Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
+
+            // Assert:
+            Assert.AreEqual(204, deleteRoomResponse.Status);
+            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
+            Assert.NotNull(ex);
+            Assert.AreEqual(404, ex?.Status);
+        }
+
+        [TestCaseSource(nameof(AuthenticationVersionSource))]
+        public void DeleteInvalidRoomId_Fail(AuthMethod authMethod, ServiceVersion apiVersion)
+        {
+            if (authMethod == AuthMethod.KeyCredential)
+            {
+                // TODO: to fix bug before enabling this test for KeyCredential
+                Assert.Ignore();
+                return;
+            }
+
+            // Arrange
+            var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
+            var ivnalidRoomId = "123";
+
+            // Act and Assert:
+            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(ivnalidRoomId));
+            Assert.NotNull(ex);
+            Assert.AreEqual(400, ex?.Status);
+        }
+
         [TestCase(ServiceVersion.V2025_03_13)]
         public async Task RoomParticipantsAddUpdateAndRemoveWithCollaboratorRolesLiveTest(ServiceVersion apiVersion)
         {
@@ -1324,7 +1385,7 @@ namespace Azure.Communication.Rooms.Test
             var communicationUser2 = communicationIdentityClient.CreateUserAsync().Result.Value;
             var communicationUser3 = communicationIdentityClient.CreateUserAsync().Result.Value;
 
-            RoomsClient roomsClient = CreateInstrumentedRoomsClient(apiVersion);
+            RoomsClient roomsClient = CreateClient(apiVersion: apiVersion);
 
             RoomParticipant participant1 = new RoomParticipant(communicationUser1) { Role = ParticipantRole.Presenter };
             RoomParticipant participant2 = new RoomParticipant(communicationUser2);
@@ -1453,80 +1514,6 @@ namespace Azure.Communication.Rooms.Test
             {
                 Assert.Fail($"Unexpected error: {ex}");
             }
-        }
-
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task RemoveParticipants_NonExistentParticipants_Success(ServiceVersion apiVersion)
-        {
-            // Arrange
-            CommunicationIdentityClient communicationIdentityClient = CreateInstrumentedCommunicationIdentityClient();
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
-            var createRoomResponse = await roomsClient.CreateRoomAsync(options: null);
-            var participant1 = await communicationIdentityClient.CreateUserAsync();
-            List<CommunicationUserIdentifier> communicationUsers = new List<CommunicationUserIdentifier>()
-            {
-                participant1
-            };
-
-            // Act
-            Response removeParticipantResponse = await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers);
-            AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createRoomResponse.Value.Id);
-            List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
-
-            // Assert
-            Assert.AreEqual(removeParticipantResponse.Status, 200);
-            Assert.AreEqual(removeRoomParticipantsResult.Count, 0);
-        }
-
-        [TestCase(ServiceVersion.V2024_04_15)]
-        public async Task RemoveParticipants_IncorrectlyFormattedMri_Fail(ServiceVersion apiVersion)
-        {
-            // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
-            var createRoomResponse = await roomsClient.CreateRoomAsync(new CreateRoomOptions());
-            List<CommunicationUserIdentifier> communicationUsers = new List<CommunicationUserIdentifier>()
-            {
-                new CommunicationUserIdentifier("invalid_mri")
-            };
-
-            // Act and assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
-        }
-
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public async Task DeleteRoom_Success(ServiceVersion apiVersion)
-        {
-            // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
-            var createRoomResponse = await roomsClient.CreateRoomAsync(options: null);
-            var createdRoomId = createRoomResponse.Value.Id;
-
-            // Act
-            Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-
-            // Assert:
-            Assert.AreEqual(204, deleteRoomResponse.Status);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
-        }
-
-        [TestCase(ServiceVersion.V2024_04_15)]
-        [TestCase(ServiceVersion.V2025_03_13)]
-        public void DeleteInvalidRoomId_Fail(ServiceVersion apiVersion)
-        {
-            // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(apiVersion);
-            var ivnalidRoomId = "123";
-
-            // Act and Assert:
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(ivnalidRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
         }
 
         private void ValidateRoom(CommunicationRoom? room)

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientLiveTests.cs
@@ -159,7 +159,7 @@ namespace Azure.Communication.Rooms.Tests
         public async Task CreateRoom_WithNoAttributes_Succeed()
         {
             // Arrange
-            var roomsClient = CreateInstrumentedRoomsClient(RoomsClientOptions.ServiceVersion.V2023_06_14);
+            var roomsClient = CreateClientWithAzureKeyCredential(apiVersion: RoomsClientOptions.ServiceVersion.V2025_03_13);
 
             // Act
             var createdRoom = await roomsClient.CreateRoomAsync();


### PR DESCRIPTION
# Contributing to the Azure SDK
Update existing ACS Rooms test to point to TeamsScheduler flighting traffic manager to verify changes being developed under TS repos. The tests are run using KeyCredential as Auth method will be redirected to TS TM only. Others will still be running against legacy ACS Rooms repos.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
