### PR TITLE
Improve the exception message when the client side network timeout is reached

### DIFF
--- a/sdk/core/System.ClientModel/samples/Configuration.md
+++ b/sdk/core/System.ClientModel/samples/Configuration.md
@@ -107,7 +107,7 @@ MapsClientOptions options = new();
 // In a library's client class constructor:
 var userAgentPolicy = new UserAgentPolicy(Assembly.GetExecutingAssembly());
 ClientPipeline pipeline = ClientPipeline.Create(
-    options, 
+    options,
     perCallPolicies: new[] { userAgentPolicy },
     perTryPolicies: ReadOnlySpan<PipelinePolicy>.Empty,
     beforeTransportPolicies: ReadOnlySpan<PipelinePolicy>.Empty);
@@ -116,9 +116,22 @@ ClientPipeline pipeline = ClientPipeline.Create(
 var customUserAgent = new UserAgentPolicy(Assembly.GetExecutingAssembly(), "MyApp/1.0");
 ClientPipeline pipeline2 = ClientPipeline.Create(
     options,
-    perCallPolicies: new[] { customUserAgent }, 
+    perCallPolicies: new[] { customUserAgent },
     perTryPolicies: ReadOnlySpan<PipelinePolicy>.Empty,
     beforeTransportPolicies: ReadOnlySpan<PipelinePolicy>.Empty);
 ```
 
 The generated User-Agent header follows the format: `"LibraryName/Version (.NET Framework; OS Information)"` or `"ApplicationId LibraryName/Version (.NET Framework; OS Information)"` when an application ID is provided.
+
+## Configure a custom network timeout duration
+
+Some services have operations that can take more than the duration of the default timeout value to complete. The `NetworkTimeout` property in `ClientPipelineOptions` can be configured to override the default.
+
+```C# Snippet:ConfigurationCustomNetworkTimeout
+MapsClientOptions options = new()
+{
+    // Increase the default network timeout.
+    NetworkTimeout = TimeSpan.FromMinutes(5)
+};
+MapsClient client = new(new Uri("https://atlas.microsoft.com"), credential, options);
+```

--- a/sdk/core/System.ClientModel/src/Internal/CancellationHelper.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CancellationHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ClientModel.Primitives;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -66,7 +67,8 @@ internal static class CancellationHelper
             throw CreateOperationCanceledException(
                 innerException,
                 timeoutToken,
-                $"The operation was cancelled because it exceeded the configured timeout of {timeout:g}. ");
+                $"The operation was cancelled because it exceeded the configured timeout of {timeout:g}. " +
+                    $"The default network timeout can be adjusted in the client options type via {nameof(ClientPipelineOptions)}.{nameof(ClientPipelineOptions.NetworkTimeout)}");
         }
     }
 }

--- a/sdk/core/System.ClientModel/src/Internal/CancellationHelper.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CancellationHelper.cs
@@ -68,7 +68,7 @@ internal static class CancellationHelper
                 innerException,
                 timeoutToken,
                 $"The operation was cancelled because it exceeded the configured timeout of {timeout:g}. " +
-                    $"The default network timeout can be adjusted in the client options type via {nameof(ClientPipelineOptions)}.{nameof(ClientPipelineOptions.NetworkTimeout)}.");
+                    $"The default timeout can be adjusted by passing a custom {nameof(ClientPipelineOptions)}.{nameof(ClientPipelineOptions.NetworkTimeout)} value to the client's constructor. See https://aka.ms/net/scm/configure/networktimeout for more information.");
         }
     }
 }

--- a/sdk/core/System.ClientModel/src/Internal/CancellationHelper.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CancellationHelper.cs
@@ -68,7 +68,7 @@ internal static class CancellationHelper
                 innerException,
                 timeoutToken,
                 $"The operation was cancelled because it exceeded the configured timeout of {timeout:g}. " +
-                    $"The default network timeout can be adjusted in the client options type via {nameof(ClientPipelineOptions)}.{nameof(ClientPipelineOptions.NetworkTimeout)}");
+                    $"The default network timeout can be adjusted in the client options type via {nameof(ClientPipelineOptions)}.{nameof(ClientPipelineOptions.NetworkTimeout)}.");
         }
     }
 }

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineFunctionalTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineFunctionalTests.cs
@@ -211,7 +211,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
         message.BufferResponse = true;
 
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await pipeline.SendSyncOrAsync(message, IsAsync));
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. ", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout", exception!.Message);
 
         testDoneTcs.Cancel();
     }
@@ -243,7 +243,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
         message.BufferResponse = true;
 
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await pipeline.SendSyncOrAsync(message, IsAsync));
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. ", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout", exception!.Message);
 
         testDoneTcs.Cancel();
     }
@@ -284,7 +284,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
 #pragma warning disable CA2022 // This test is validating an exception is thrown and doesn't need to check the return value of ReadAsync.
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await responseContentStream.ReadAsync(buffer, 0, 10));
 #pragma warning restore CA2022
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. ", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout", exception!.Message);
 
         testDoneTcs.Cancel();
     }

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineFunctionalTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineFunctionalTests.cs
@@ -211,7 +211,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
         message.BufferResponse = true;
 
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await pipeline.SendSyncOrAsync(message, IsAsync));
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout.", exception!.Message);
 
         testDoneTcs.Cancel();
     }
@@ -243,7 +243,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
         message.BufferResponse = true;
 
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await pipeline.SendSyncOrAsync(message, IsAsync));
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout.", exception!.Message);
 
         testDoneTcs.Cancel();
     }
@@ -284,7 +284,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
 #pragma warning disable CA2022 // This test is validating an exception is thrown and doesn't need to check the return value of ReadAsync.
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await responseContentStream.ReadAsync(buffer, 0, 10));
 #pragma warning restore CA2022
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout.", exception!.Message);
 
         testDoneTcs.Cancel();
     }

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineFunctionalTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineFunctionalTests.cs
@@ -211,7 +211,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
         message.BufferResponse = true;
 
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await pipeline.SendSyncOrAsync(message, IsAsync));
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout.", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default timeout can be adjusted by passing a custom ClientPipelineOptions.NetworkTimeout value to the client's constructor. See https://aka.ms/net/scm/configure/networktimeout for more information.", exception!.Message);
 
         testDoneTcs.Cancel();
     }
@@ -243,7 +243,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
         message.BufferResponse = true;
 
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await pipeline.SendSyncOrAsync(message, IsAsync));
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout.", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default timeout can be adjusted by passing a custom ClientPipelineOptions.NetworkTimeout value to the client's constructor. See https://aka.ms/net/scm/configure/networktimeout for more information.", exception!.Message);
 
         testDoneTcs.Cancel();
     }
@@ -284,7 +284,7 @@ public class ClientPipelineFunctionalTests : SyncAsyncTestBase
 #pragma warning disable CA2022 // This test is validating an exception is thrown and doesn't need to check the return value of ReadAsync.
         var exception = Assert.ThrowsAsync<TaskCanceledException>(async () => await responseContentStream.ReadAsync(buffer, 0, 10));
 #pragma warning restore CA2022
-        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default network timeout can be adjusted in the client options type via ClientPipelineOptions.NetworkTimeout.", exception!.Message);
+        Assert.AreEqual("The operation was cancelled because it exceeded the configured timeout of 0:00:00.5. The default timeout can be adjusted by passing a custom ClientPipelineOptions.NetworkTimeout value to the client's constructor. See https://aka.ms/net/scm/configure/networktimeout for more information.", exception!.Message);
 
         testDoneTcs.Cancel();
     }

--- a/sdk/core/System.ClientModel/tests/Samples/ConfigurationSamples.cs
+++ b/sdk/core/System.ClientModel/tests/Samples/ConfigurationSamples.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Maps;
 using NUnit.Framework;
 
@@ -140,6 +141,21 @@ public class ConfigurationSamples
             perCallPolicies: new[] { customUserAgent },
             perTryPolicies: ReadOnlySpan<PipelinePolicy>.Empty,
             beforeTransportPolicies: ReadOnlySpan<PipelinePolicy>.Empty);
+        #endregion
+    }
+
+    [Test]
+    public void ConfigurationCustomNetworkTimeout()
+    {
+        ApiKeyCredential credential = new("myKey");
+
+        #region Snippet:ConfigurationCustomNetworkTimeout
+        MapsClientOptions options = new()
+        {
+            // Increase the default network timeout.
+            NetworkTimeout = TimeSpan.FromMinutes(5)
+        };
+        MapsClient client = new(new Uri("https://atlas.microsoft.com"), credential, options);
         #endregion
     }
 }


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
