### PR TITLE
add instructions about how to switch a RP to the new generator

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ Do the following steps to renew/change/update the generator:
     repo: Azure/azure-rest-api-specs
     emitterPackageJsonPath: <the corresponding file path for the corresponding generator>
     ```
-    After creating the above `tsp-location.yaml` file, find the `autorest.md` file inside the package directory, and rename it to `autorest.md.bak`.
+    After creating the above `tsp-location.yaml` file, find the `autorest.md` file inside the package directory, and delete it.
 4. If in the above step, the `tsp-location.yaml` existed, run the `dotnet build /t:GenerateCode` command in the package directory. Report any errors if they happen.
 If in the above step, the `tsp-location.yaml` did not exist and we just created it, report this in the PR description and emphasize everything inside it are placeholders.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,8 +40,8 @@ DO the following steps to renew/change/update the generator:
         - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-emitter-package.json"` if the new generator is `@azure-tools/http-client-csharp`.
     - If this file does not exist, create this file with the following content:
     ```yaml
-    directory: specification/<service directory>/<service name>.Management
-    commit: <put a place holder here>
+    directory: specification/placeholderServiceDir/PlaceholderServiceName.Management
+    commit: PlaceholderCommitId
     repo: Azure/azure-rest-api-specs
     emitterPackageJsonPath: <the corresponding file path for the corresponding generator>
     ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,7 @@ These are instructions when you are required to renew/change/update the generato
 
 The new generator could be `@azure-tools/http-client-csharp` or `@azure-tools/http-client-csharp-mgmt`.
 
-DO the following steps to renew/change/update the generator:
+Do the following steps to renew/change/update the generator:
 
 1. Figure out which new generator you should use. Determine this by the package name.
     - For namespace in pattern of `Azure.ResourceManager.*`, the new generator should be `@azure-tools/http-client-csharp-mgmt`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ Do the following steps to renew/change/update the generator:
 2. Find the package directory in the `sdk` directory for that package. Search for the `*.csproj` file with the request package name, you should find a directory in this pattern `sdk/<service-directory>/<requested-package-name>`, and inside this sub-directory, there is such a `<requested-package-name>.csproj` file.
 3. Find the `tsp-location.yaml` file in the above package directory.
     - If this file exists, add an extra property at the end of this file with
-        - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"` if the new generator is `@azure-tools/http-client-csharp-mgmt`.
+        - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"` if the new generator is `@azure-typespec/http-client-csharp-mgmt`.
         - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-emitter-package.json"` if the new generator is `@azure-typespec/http-client-csharp`.
     - If this file does not exist, create this file with the following content:
     ```yaml

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,7 @@ DO the following steps to renew/change/update the generator:
     repo: Azure/azure-rest-api-specs
     emitterPackageJsonPath: <the corresponding file path for the corresponding generator>
     ```
+    After creating the above `tsp-location.yaml` file, find the `autorest.md` file inside the package directory, and rename it to `autorest.md.bak`.
 4. If in the above step, the `tsp-location.yaml` existed, run the `dotnet build /t:GenerateCode` command in the package directory. Report any errors if they happen.
 If in the above step, the `tsp-location.yaml` did not exist and we just created it, report this in the PR description and emphasize everything inside it are placeholders.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ This repo contains Azure SDKs for various Azure services and tools that generate
 
 These are instructions when you are required to renew/change/update the generator of one specific package to the new generator.
 
-The new generator could be `@azure-tools/http-client-csharp` or `@azure-tools/http-client-csharp-mgmt`.
+The new generator could be `@azure-typespec/http-client-csharp` or `@azure-typespec/http-client-csharp-mgmt`.
 
 Do the following steps to renew/change/update the generator:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,7 @@ Do the following steps to renew/change/update the generator:
 1. Figure out which new generator you should use. Determine this by the package name.
     - For namespace in pattern of `Azure.ResourceManager.*`, the new generator should be `@azure-tools/http-client-csharp-mgmt`.
     - For namespace in pattern of `Azure.Provisioning.*`, you should reject this request because now we do not have a valid generator for it yet.
-    - For namespace in any other pattern, the new generator should be `@azure-tools/http-client-csharp`.
+    - For namespace in any other pattern, the new generator should be `@azure-typespec/http-client-csharp`.
 2. Find the package directory in the `sdk` directory for that package. Search for the `*.csproj` file with the request package name, you should find a directory in this pattern `sdk/<service-directory>/<requested-package-name>`, and inside this sub-directory, there is such a `<requested-package-name>.csproj` file.
 3. Find the `tsp-location.yaml` file in the above package directory.
     - If this file exists, add an extra property at the end of this file with

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,33 @@ This repo contains Azure SDKs for various Azure services and tools that generate
 - Always run `npm install` in the `/eng/packages/http-client-csharp-mgmt` directory before running the generator.
 - Always run `/eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1` to regenerate the test projects to validate the result of generator code changes.
 
+## SDK generator renew
+
+This is instructions when you are required to renew/change/update the generator of one specific package to the new generator.
+
+The new generator could be `@azure-tools/http-client-csharp` or `@azure-tools/http-client-csharp-mgmt`.
+
+DO the following steps to renew/change/update the generator:
+
+1. Figure out which new generator you should use. Determine this by the package name.
+    - For namespace in pattern of `Azure.ResourceManager.*`, the new generator should be `@azure-tools/http-client-csharp-mgmt`.
+    - For namespace in pattern of `Azure.Provisioning.*`, you should reject this request because now we do not have a valid generator for it yet.
+    - For namespace in any other pattern, the new generator should be `@azure-tools/http-client-csharp`.
+2. Find the package directory in the `sdk` directory for that package. Search for the `*.csproj` file with the request package name, you should find a directory in this pattern `sdk/<service-directory>/<requested-package-name>`, and inside this sub-directory, there is such a `<requested-package-name>.csproj` file.
+3. Find the `tsp-location.yaml` file in the above package directory.
+    - If this file exists, add an extra property at the end of this file with
+        - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"` if the new generator is `@azure-tools/http-client-csharp-mgmt`.
+        - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-emitter-package.json"` if the new generator is `@azure-tools/http-client-csharp`.
+    - If this file does not exist, create this file with the following content:
+    ```yaml
+    directory: specification/<service directory>/<service name>.Management
+    commit: <put a place holder here>
+    repo: Azure/azure-rest-api-specs
+    emitterPackageJsonPath: <the corresponding file path for the corresponding generator>
+    ```
+4. If in the above step, the `tsp-location.yaml` existed, run the `dotnet build /t:GenerateCode` command in the package directory. Report any errors if they happen.
+If in the above step, the `tsp-location.yaml` did not exist and we just created it, report this in the PR description and emphasize everything inside it are placeholders.
+
 ## SDK release
 
 There are two tools to help with SDK releases:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,7 +37,7 @@ Do the following steps to renew/change/update the generator:
 3. Find the `tsp-location.yaml` file in the above package directory.
     - If this file exists, add an extra property at the end of this file with
         - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"` if the new generator is `@azure-tools/http-client-csharp-mgmt`.
-        - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-emitter-package.json"` if the new generator is `@azure-tools/http-client-csharp`.
+        - `emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-emitter-package.json"` if the new generator is `@azure-typespec/http-client-csharp`.
     - If this file does not exist, create this file with the following content:
     ```yaml
     directory: specification/placeholderServiceDir/PlaceholderServiceName.Management

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ This repo contains Azure SDKs for various Azure services and tools that generate
 
 ## SDK generator renew
 
-These are instructions when you are required to renew/change/update the generator of one specific package to the new generator.
+These are instructions when you are required to renew, change, or update the generator of one specific package to the new generator.
 
 The new generator could be `@azure-typespec/http-client-csharp` or `@azure-typespec/http-client-csharp-mgmt`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ The new generator could be `@azure-typespec/http-client-csharp` or `@azure-types
 Do the following steps to renew/change/update the generator:
 
 1. Figure out which new generator you should use. Determine this by the package name.
-    - For namespace in pattern of `Azure.ResourceManager.*`, the new generator should be `@azure-tools/http-client-csharp-mgmt`.
+    - For namespace in pattern of `Azure.ResourceManager.*`, the new generator should be `@azure-typespec/http-client-csharp-mgmt`.
     - For namespace in pattern of `Azure.Provisioning.*`, you should reject this request because now we do not have a valid generator for it yet.
     - For namespace in any other pattern, the new generator should be `@azure-typespec/http-client-csharp`.
 2. Find the package directory in the `sdk` directory for that package. Search for the `*.csproj` file with the request package name, you should find a directory in this pattern `sdk/<service-directory>/<requested-package-name>`, and inside this sub-directory, there is such a `<requested-package-name>.csproj` file.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ This repo contains Azure SDKs for various Azure services and tools that generate
 
 ## SDK generator renew
 
-This is instructions when you are required to renew/change/update the generator of one specific package to the new generator.
+These are instructions when you are required to renew/change/update the generator of one specific package to the new generator.
 
 The new generator could be `@azure-tools/http-client-csharp` or `@azure-tools/http-client-csharp-mgmt`.
 


### PR DESCRIPTION
Since we are doing the generator switching from the old autorest.csharp to the new generator, I updated the copilot instruction so that copilot could help us on doing this.

But actually it cannot really do much because this involves cross repo effort - we need to open PRs in both this repo and `Azure/azure-rest-api-specs` for the configuration updates. Therefore currently the best copilot could do is to prepare the scaffolding for us in this repo, saving the effort of creating a PR and preparing those file changes.

BTW I locally tried this instruction, and it is working fine.