### PR TITLE
[Storage] [DataMovement] NFS over REST Phase 1.5

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_bedde4490a"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_0f05f57f67"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -155,6 +155,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ResourceProperties = response.Value.ToStorageResourceContainerProperties();
             }
+            ResourceProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.ShareProtocol, ResourceOptions.ShareProtocol);
             _isResourcePropertiesFullySet = true;
             return ResourceProperties;
         }
@@ -219,10 +220,11 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ShareProtocol sourceProtocol = sourceShareDirectoryResource.ResourceOptions?.ShareProtocol ?? ShareProtocol.Smb;
                 ShareProtocol destinationProtocol = ResourceOptions?.ShareProtocol ?? ShareProtocol.Smb;
-                // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
-                if (destinationProtocol != sourceProtocol)
+                bool destinationFilePermissions = ResourceOptions?.FilePermissions ?? false;
+                // if NFS <-> SMB and attempting to preserve permissions
+                if (destinationProtocol != sourceProtocol && destinationFilePermissions)
                 {
-                    throw Errors.ShareTransferNotSupported();
+                    throw Errors.HeterogenousTransferPermissionPreservationNotSupported();
                 }
 
                 // Validate the source protocol

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -155,7 +155,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ResourceProperties = response.Value.ToStorageResourceContainerProperties();
             }
-            ResourceProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.ShareProtocol, ResourceOptions.ShareProtocol);
+            ResourceProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.ShareProtocol, ResourceOptions?.ShareProtocol ?? ShareProtocol.Smb);
             _isResourcePropertiesFullySet = true;
             return ResourceProperties;
         }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -66,7 +66,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         internal async Task CreateAsync(
             bool overwrite,
             long maxSize,
-            StorageResourceItemProperties properties,
+            StorageResourceItemProperties sourceProperties,
             CancellationToken cancellationToken)
         {
             if (!overwrite)
@@ -80,14 +80,14 @@ namespace Azure.Storage.DataMovement.Files.Shares
                     throw Errors.ShareFileAlreadyExists(ShareFileClient.Path);
                 }
             }
-            ShareFileHttpHeaders httpHeaders = _options?.GetShareFileHttpHeaders(properties?.RawProperties);
-            IDictionary<string, string> metadata = _options?.GetFileMetadata(properties?.RawProperties);
-            string filePermission = _options?.GetFilePermission(properties);
-            FileSmbProperties smbProperties = _options?.GetFileSmbProperties(properties, _destinationPermissionKey);
-            FilePosixProperties posixProperties = _options?.GetFilePosixProperties(properties);
+            ShareFileHttpHeaders httpHeaders = _options?.GetShareFileHttpHeaders(sourceProperties?.RawProperties);
+            IDictionary<string, string> metadata = _options?.GetFileMetadata(sourceProperties?.RawProperties);
+            string filePermission = _options?.GetFilePermission(sourceProperties);
+            FileSmbProperties smbProperties = _options?.GetFileSmbProperties(sourceProperties, _destinationPermissionKey);
+            FilePosixProperties posixProperties = _options?.GetFilePosixProperties(sourceProperties);
 
             // if transfer is not empty and File Attribute contains ReadOnly, we should not set it before creating the file.
-            if ((properties == null || properties.ResourceLength > 0) && IsReadOnlySet(smbProperties.FileAttributes))
+            if ((sourceProperties == null || sourceProperties.ResourceLength > 0) && IsReadOnlySet(smbProperties.FileAttributes))
             {
                 smbProperties.FileAttributes = default;
             }
@@ -257,6 +257,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ResourceProperties = response.Value.ToStorageResourceItemProperties();
             }
+            ResourceProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.ShareProtocol, _options.ShareProtocol);
             _isResourcePropertiesFullySet = true;
             return ResourceProperties;
         }
@@ -397,10 +398,11 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ShareProtocol sourceProtocol = sourceShareFileResource._options?.ShareProtocol ?? ShareProtocol.Smb;
                 ShareProtocol destinationProtocol = _options?.ShareProtocol ?? ShareProtocol.Smb;
-                // Ensure the transfer is supported (NFS -> NFS and SMB -> SMB)
-                if (destinationProtocol != sourceProtocol)
+                bool destinationFilePermissions = _options?.FilePermissions ?? false;
+                // if NFS <-> SMB and attempting to preserve permissions
+                if (destinationProtocol != sourceProtocol && destinationFilePermissions)
                 {
-                    throw Errors.ShareTransferNotSupported();
+                    throw Errors.HeterogenousTransferPermissionPreservationNotSupported();
                 }
 
                 // Validate the source protocol
@@ -441,8 +443,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             => new UnauthorizedAccessException($"Authorization failure on the {endpoint} when validating the Protocol. " +
                 $"To skip this validation, please enable SkipProtocolValidation.", ex);
 
-        public static NotSupportedException ShareTransferNotSupported()
-            => new NotSupportedException("This Share transfer is not supported. " +
-                "Currently only NFS -> NFS and SMB -> SMB Share transfers are supported");
+        public static NotSupportedException HeterogenousTransferPermissionPreservationNotSupported()
+            => new NotSupportedException("Permission preservation is not supported in NFS -> SMB or SMB -> NFS transfers");
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -257,7 +257,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
             {
                 ResourceProperties = response.Value.ToStorageResourceItemProperties();
             }
-            ResourceProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.ShareProtocol, _options.ShareProtocol);
+            ResourceProperties.RawProperties.WriteKeyValue(DataMovementConstants.ResourceProperties.ShareProtocol, _options?.ShareProtocol ?? ShareProtocol.Smb);
             _isResourcePropertiesFullySet = true;
             return ResourceProperties;
         }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -180,7 +180,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         }
 
         /// <summary>
-        /// The file system attributes for this file/directory. This is intended to be set on the destination Share.
+        /// The file system attributes for this file/directory. This is intended to be set on the destination SMB Share.
         ///
         /// By default preserves the Attributes from the source for copy transfers. If explicitly set, the Attributes of the destination will be set to this value.
         /// </summary>
@@ -201,7 +201,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         /// which is a operation called on the Destination Share, which requires Share level permissions.
         ///
         /// By default the permissions will not be preserved from the source Share to the destination Share. If explicitly set to null, the permissions will not be preserved.
-        /// Applies only to copy transfers.
+        /// Applies only to SMB -> SMB or NFS -> NFS copy transfers.
         /// </summary>
         public bool? FilePermissions { get; set; }
 
@@ -237,7 +237,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
         }
 
         /// <summary>
-        /// The change time of the file/directory. This is intended to be set on the destination Share.
+        /// The change time of the file/directory. This is intended to be set on the destination SMB Share.
         ///
         /// By default preserves the Changed On Time from the source for copy transfers. If explicitly set, the Changed On Time of the destination will be set to this value.
         /// </summary>

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileResourceTests.cs
@@ -2428,7 +2428,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             await destinationResource.CreateAsync(
                 overwrite: false,
                 maxSize: length,
-                properties: properties,
+                sourceProperties: properties,
                 cancellationToken: CancellationToken.None);
 
             mockDestination.Verify(b => b.CreateAsync(
@@ -2510,7 +2510,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             await destinationResource.CreateAsync(
                 overwrite: false,
                 maxSize: length,
-                properties: properties,
+                sourceProperties: properties,
                 cancellationToken: CancellationToken.None);
 
             mockDestination.Verify(b => b.CreateAsync(
@@ -2595,7 +2595,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             await destinationResource.CreateAsync(
                 overwrite: false,
                 maxSize: length,
-                properties: properties,
+                sourceProperties: properties,
                 cancellationToken: CancellationToken.None);
 
             mockDestination.Verify(b => b.CreateAsync(

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFileStartTransferCopyTests.cs
@@ -1406,40 +1406,6 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         }
 
         [RecordedTest]
-        [TestCase(ShareProtocol.Nfs, ShareProtocol.Smb)]
-        [TestCase(ShareProtocol.Smb, ShareProtocol.Nfs)]
-        public async Task ValidateProtocolAsync_ShareFileToShareFile_ShareTransferNotSupported(ShareProtocol sourceProtocol, ShareProtocol destProtocol)
-        {
-            // Arrange
-            await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
-            await using IDisposingContainer<ShareClient> destination = await GetDestinationDisposingContainerAsync();
-
-            // Create file with properties
-            ShareFileClient sourceClient = await CreateFileClientWithShortPermissionsAsync(
-                container: source.Container,
-                objectLength: DataMovementTestConstants.KB,
-                createResource: true);
-            StorageResourceItem sourceResource = new ShareFileStorageResource(sourceClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = sourceProtocol, SkipProtocolValidation = true });
-
-            // Destination client - Set Properties
-            ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
-                container: destination.Container,
-                createResource: false);
-            StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
-                new ShareFileStorageResourceOptions() { ShareProtocol = destProtocol, SkipProtocolValidation = true });
-
-            TransferOptions options = new TransferOptions();
-            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
-            TransferManager transferManager = new TransferManager();
-
-            // Act and Assert
-            var ex = Assert.ThrowsAsync<NotSupportedException>(async () =>
-                await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
-            Assert.AreEqual("This Share transfer is not supported. Currently only NFS -> NFS and SMB -> SMB Share transfers are supported", ex.Message);
-        }
-
-        [RecordedTest]
         public async Task ShareFileToShareFile_NfsHardLink()
         {
             // Arrange
@@ -1588,6 +1554,186 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             // Assert that Symlinks are skipped and not copied
             bool destExists = await destinationClient.ExistsAsync();
             Assert.IsFalse(destExists);
+        }
+
+        [RecordedTest]
+        [TestCase(true)]
+        [TestCase(false)]
+        [TestCase(null)]
+        public async Task ShareFileNfsToShareFileSmb(bool? filePermissions)
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await SourceClientBuilder.GetTestShareSasNfsAsync();
+            await using IDisposingContainer<ShareClient> destination = await GetDestinationDisposingContainerAsync();
+
+            ShareFileCreateOptions sharefileCreateOptions = new ShareFileCreateOptions()
+            {
+                HttpHeaders = new ShareFileHttpHeaders()
+                {
+                    ContentLanguage = _defaultContentLanguage,
+                    ContentDisposition = _defaultContentDisposition,
+                    CacheControl = _defaultCacheControl
+                },
+                Metadata = _defaultMetadata,
+                SmbProperties = new FileSmbProperties()
+                {
+                    FileCreatedOn = _defaultFileCreatedOn,
+                    FileLastWrittenOn = _defaultFileLastWrittenOn,
+                },
+                PosixProperties = new FilePosixProperties()
+                {
+                    Owner = "345",
+                    Group = "123",
+                    FileMode = NfsFileMode.ParseOctalFileMode("1777"),
+                }
+            };
+
+            // Create source file with properties
+            ShareFileClient sourceClient = await CreateFileClientWithOptionsAsync(
+                container: source.Container,
+                objectLength: Constants.KB,
+                createResource: true,
+                options: sharefileCreateOptions);
+            StorageResourceItem sourceResource = new ShareFileStorageResource(sourceClient,
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs });
+
+            // Create destination file
+            ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
+                container: destination.Container,
+                createResource: false);
+            StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
+                new ShareFileStorageResourceOptions() { FilePermissions = filePermissions });
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            TransferManager transferManager = new TransferManager();
+
+            if (filePermissions == true)
+            {
+                var ex = Assert.ThrowsAsync<NotSupportedException>(async () =>
+                    await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
+                Assert.AreEqual("Permission preservation is not supported in NFS -> SMB or SMB -> NFS transfers", ex.Message);
+            }
+            else
+            {
+                TransferOperation transfer = await transferManager.StartTransferAsync(
+                    sourceResource,
+                    destinationResource,
+                    options);
+                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await TestTransferWithTimeout.WaitForCompletionAsync(
+                    transfer,
+                    testEventsRaised,
+                    cancellationTokenSource.Token);
+
+                // Assert
+                Assert.NotNull(transfer);
+                Assert.IsTrue(transfer.HasCompleted);
+                Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+                // Verify Copy - using original source File and Copying the destination
+                await testEventsRaised.AssertSingleCompletedCheck();
+                using Stream sourceStream = await sourceClient.OpenReadAsync();
+                using Stream destinationStream = await destinationClient.OpenReadAsync();
+                Assert.IsTrue(StreamsAreEqual(sourceStream, destinationStream));
+
+                ShareFileProperties sourceProperties = await sourceClient.GetPropertiesAsync();
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
+                Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
+                Assert.AreEqual(sourceProperties.SmbProperties.FileCreatedOn, destinationProperties.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(sourceProperties.SmbProperties.FileLastWrittenOn, destinationProperties.SmbProperties.FileLastWrittenOn);
+                // FileChangedOn is not preserved for NFS -> SMB transfers
+            }
+        }
+
+        [RecordedTest]
+        [TestCase(true)]
+        [TestCase(false)]
+        [TestCase(null)]
+        public async Task ShareFileSmbToShareFileNfs(bool? filePermissions)
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await GetSourceDisposingContainerAsync();
+            await using IDisposingContainer<ShareClient> destination = await DestinationClientBuilder.GetTestShareSasNfsAsync();
+
+            ShareFileCreateOptions sharefileCreateOptions = new ShareFileCreateOptions()
+            {
+                HttpHeaders = new ShareFileHttpHeaders()
+                {
+                    ContentLanguage = _defaultContentLanguage,
+                    ContentDisposition = _defaultContentDisposition,
+                    CacheControl = _defaultCacheControl
+                },
+                Metadata =  _defaultMetadata,
+                SmbProperties = new FileSmbProperties()
+                {
+                    FileAttributes = NtfsFileAttributes.ReadOnly | NtfsFileAttributes.Archive,
+                    FileCreatedOn = _defaultFileCreatedOn,
+                    FileChangedOn = _defaultFileChangedOn,
+                    FileLastWrittenOn = _defaultFileLastWrittenOn,
+                }
+            };
+
+            // Create file with properties
+            ShareFileClient sourceClient = await CreateFileClientWithOptionsAsync(
+                container: source.Container,
+                objectLength: DataMovementTestConstants.KB,
+                createResource: true,
+                options: sharefileCreateOptions);
+            StorageResourceItem sourceResource = GetSourceStorageResourceItem(sourceClient);
+
+            // Create destination file
+            ShareFileClient destinationClient = await CreateFileClientWithOptionsAsync(
+                container: destination.Container,
+                createResource: false);
+            StorageResourceItem destinationResource = new ShareFileStorageResource(destinationClient,
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Nfs, FilePermissions = filePermissions });
+
+            TransferOptions options = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+            TransferManager transferManager = new TransferManager();
+
+            if (filePermissions == true)
+            {
+                var ex = Assert.ThrowsAsync<NotSupportedException>(async () =>
+                    await transferManager.StartTransferAsync(sourceResource, destinationResource, options));
+                Assert.AreEqual("Permission preservation is not supported in NFS -> SMB or SMB -> NFS transfers", ex.Message);
+            }
+            else
+            {
+                TransferOperation transfer = await transferManager.StartTransferAsync(
+                    sourceResource,
+                    destinationResource,
+                    options);
+                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await TestTransferWithTimeout.WaitForCompletionAsync(
+                    transfer,
+                    testEventsRaised,
+                    cancellationTokenSource.Token);
+
+                // Assert
+                Assert.NotNull(transfer);
+                Assert.IsTrue(transfer.HasCompleted);
+                Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+                // Verify Copy - using original source File and Copying the destination
+                await testEventsRaised.AssertSingleCompletedCheck();
+                using Stream sourceStream = await sourceClient.OpenReadAsync();
+                using Stream destinationStream = await destinationClient.OpenReadAsync();
+                Assert.IsTrue(StreamsAreEqual(sourceStream, destinationStream));
+
+                ShareFileProperties sourceProperties = await sourceClient.GetPropertiesAsync();
+                ShareFileProperties destinationProperties = await destinationClient.GetPropertiesAsync();
+                Assert.That(sourceProperties.Metadata, Is.EqualTo(destinationProperties.Metadata));
+                Assert.AreEqual(sourceProperties.ContentDisposition, destinationProperties.ContentDisposition);
+                Assert.AreEqual(sourceProperties.ContentLanguage, destinationProperties.ContentLanguage);
+                Assert.AreEqual(sourceProperties.CacheControl, destinationProperties.CacheControl);
+                Assert.AreEqual(sourceProperties.ContentType, destinationProperties.ContentType);
+                Assert.AreEqual(sourceProperties.SmbProperties.FileCreatedOn, destinationProperties.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(sourceProperties.SmbProperties.FileLastWrittenOn, destinationProperties.SmbProperties.FileLastWrittenOn);
+            }
         }
 
         [RecordedTest]

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
@@ -166,6 +166,7 @@ namespace Azure.Storage.DataMovement
             internal const string FileMode = "FileMode";
             internal const string FileType = "FileType";
             internal const string LinkCount = "LinkCount";
+            internal const string ShareProtocol = "ShareProtocol";
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
@@ -45,6 +45,8 @@ namespace Azure.Storage.DataMovement.Tests
             PreserveNoPermissions = 4,
             PreserveNfs = 5,
             PreserveNfsNoPermissions = 6,
+            PreserveNfsToSmb = 7,
+            PreserveSmbToNfs = 8,
         }
 
         /// <summary>


### PR DESCRIPTION
Here are the specs from the Files team: https://microsoft.sharepoint.com/:w:/t/AzureFiles/EagOwYP1mypBg91t6cU1LVEBklb4bmNXesgm_aiPCQwqUA?e=6fRbWb&nav=eyJoIjoiMTQ0NTgwNDk0OSJ9

- Added support for NFS -> SMB and SMB -> NFS transfers. 
- [Spec](https://microsoft.sharepoint.com/:w:/t/AzureFiles/EagOwYP1mypBg91t6cU1LVEBklb4bmNXesgm_aiPCQwqUA?e=pFXWSj&nav=eyJoIjoiNzI0MDQ1NjUyIn0) requires that only CreateTime & LastWriteTime be preserved, so put in additional logic to not preserve LastChangeTime in NFS -> SMB
- Fail transfer immediately for NFS <-> SMB when attempting to preserve permissions
