### PR TITLE
Make Azure.AI.Agents.Persistent AOT safe

### DIFF
--- a/sdk/ai/Azure.AI.Agents.Persistent/CHANGELOG.md
+++ b/sdk/ai/Azure.AI.Agents.Persistent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Updated `Microsoft.Extensions.AI.Abstractions` dependency to version 9.8.0.`
 - Added support of `FileSearchTool` and `CodeInterpreterTool` for `PersistentAgentsChatClient`
 - Bugfix: Addressed issues related to `ResponseFormat` when using `PersistentAgentsChatClient` with Structured Outputs.
+- Updated the library to enable .NET Ahead-of-Time (AOT) compilation support.
 
 ### Breaking Changes
 

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/CustomSharedJsonContext.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/CustomSharedJsonContext.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Azure.AI.Agents.Persistent;
+
+/// <summary>
+/// Shared JsonSerializerContext for common types used across Custom implementations.
+/// </summary>
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(List<JsonElement>))]
+internal partial class CustomSharedJsonContext : JsonSerializerContext
+{
+}

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/FunctionToolDefinition.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/FunctionToolDefinition.cs
@@ -52,7 +52,7 @@ public partial class FunctionToolDefinition
     /// <param name="description"> A description of what the function does, used by the model to choose when and how to call the function. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="name"/> or <paramref name="description"/> is null. </exception>
     public FunctionToolDefinition(string name, string description)
-        : this(name, description, BinaryData.FromObjectAsJson(new { type = "object", properties = new { } }))
+        : this(name, description, BinaryData.FromString("{\"type\":\"object\",\"properties\":{}}"))
     { }
 
     /*

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/AsyncStreamingUpdateCollection.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/AsyncStreamingUpdateCollection.cs
@@ -99,7 +99,7 @@ internal class AsyncStreamingUpdateCollection : AsyncCollectionResult<StreamingU
                         }
                         catch (Exception ex)
                         {
-                            string errorJson = JsonSerializer.Serialize(new { error = ex.GetBaseException().Message });
+                            string errorJson = JsonSerializer.Serialize(new StreamingErrorInfo { Error = ex.GetBaseException().Message }, StreamingJsonContext.Default.StreamingErrorInfo);
                             toolOutput = new ToolOutput(newActionUpdate.ToolCallId, errorJson);
                             hasError = true;
                         }

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingErrorInfo.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingErrorInfo.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.Agents.Persistent;
+
+/// <summary>
+/// Represents error details for streaming scenarios.
+/// </summary>
+internal class StreamingErrorInfo
+{
+    public string Error { get; set; } = string.Empty;
+}

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingJsonContext.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingJsonContext.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.AI.Agents.Persistent;
+
+[JsonSerializable(typeof(StreamingErrorInfo))]
+internal partial class StreamingJsonContext : JsonSerializerContext
+{
+}

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdateCollection.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdateCollection.cs
@@ -95,7 +95,7 @@ internal class StreamingUpdateCollection : CollectionResult<StreamingUpdate>
                     }
                     catch (Exception ex)
                     {
-                        string errorJson = JsonSerializer.Serialize(new { error = ex.GetBaseException().Message });
+                        string errorJson = JsonSerializer.Serialize(new StreamingErrorInfo { Error = ex.GetBaseException().Message }, StreamingJsonContext.Default.StreamingErrorInfo);
                         toolOutput = new ToolOutput(newActionUpdate.ToolCallId, errorJson);
                         hasError = true;
                     }

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs
@@ -140,7 +140,7 @@ namespace Azure.AI.Agents.Persistent
 
             // Serialize the plain text into JSON so that the underlying generated code
             // sees a properly quoted/escaped string instead of raw text.
-            BinaryData contentJson = BinaryData.FromObjectAsJson(content);
+            BinaryData contentJson = BinaryData.FromString(JsonSerializer.Serialize(content, CustomSharedJsonContext.Default.String));
 
             return await CreateMessageAsync(
                 threadId,
@@ -181,7 +181,7 @@ namespace Azure.AI.Agents.Persistent
 
             // Serialize the plain text into JSON so that the underlying generated code
             // sees a properly quoted/escaped string instead of raw text.
-            BinaryData contentJson = BinaryData.FromObjectAsJson(content);
+            BinaryData contentJson = BinaryData.FromString(JsonSerializer.Serialize(content, CustomSharedJsonContext.Default.String));
 
             // Reuse the existing generated method internally by converting the string to BinaryData.
             return CreateMessage(
@@ -246,7 +246,7 @@ namespace Azure.AI.Agents.Persistent
             }
 
             // Now serialize the array of JsonElements into a single BinaryData for the request:
-            BinaryData serializedBlocks = BinaryData.FromObjectAsJson(jsonElements);
+            BinaryData serializedBlocks = BinaryData.FromString(JsonSerializer.Serialize(jsonElements, CustomSharedJsonContext.Default.ListJsonElement));
 
             return await CreateMessageAsync(
                 threadId,
@@ -310,7 +310,7 @@ namespace Azure.AI.Agents.Persistent
             }
 
             // Now serialize the array of JsonElements into a single BinaryData for the request:
-            BinaryData serializedBlocks = BinaryData.FromObjectAsJson(jsonElements);
+            BinaryData serializedBlocks = BinaryData.FromString(JsonSerializer.Serialize(jsonElements, CustomSharedJsonContext.Default.ListJsonElement));
 
             return CreateMessage(
                 threadId,

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs
@@ -1111,11 +1111,13 @@ namespace Azure.AI.Agents.Persistent.Telemetry
                     switch (toolCall)
                     {
                         case RunStepFunctionToolCall functionToolCall:
-                            var parsedArguments = JsonSerializer.Deserialize(functionToolCall.Arguments, OpenTelemetryJsonContext.Default.DictionaryStringObject);
+                            var argsDict = string.IsNullOrEmpty(functionToolCall.Arguments)
+                                ? new Dictionary<string, object>()
+                                : JsonSerializer.Deserialize(functionToolCall.Arguments, OpenTelemetryJsonContext.Default.DictionaryStringObject);
                             toolCallAttributes["function"] = new Dictionary<string, object>
                             {
                                 { "name", functionToolCall.Name },
-                                { "arguments", parsedArguments }
+                                { "arguments", argsDict }
                             };
                             break;
 

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs
@@ -65,6 +65,7 @@ namespace Azure.AI.Agents.Persistent.Telemetry
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, // Allow non-ASCII characters
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             TypeInfoResolver = OpenTelemetryJsonContext.Default
         };
 
@@ -124,7 +125,7 @@ namespace Azure.AI.Agents.Persistent.Telemetry
 
             string eventContent = s_traceContent
                 ? JsonSerializer.Serialize(new InstructionsEvent { Content = createAgentRequest.Instructions }, OpenTelemetryJsonContext.Default.InstructionsEvent)
-                : "";
+                : JsonSerializer.Serialize("", OpenTelemetryJsonContext.Default.String);
             ActivityTagsCollection messageTags = new() {
                    { GenAiSystemKey, GenAiSystemValue},
                    { GenAiEventContent, eventContent }
@@ -1241,23 +1242,29 @@ namespace Azure.AI.Agents.Persistent.Telemetry
 
     internal class InstructionsEvent
     {
+        [JsonPropertyName("content")]
         public string Content { get; set; }
     }
 
     internal class MessageEvent
     {
+        [JsonPropertyName("content")]
         public string Content { get; set; }
+        [JsonPropertyName("role")]
         public string Role { get; set; }
     }
 
     internal class RoleEvent
     {
+        [JsonPropertyName("role")]
         public string Role { get; set; }
     }
 
     internal class ToolOutputEvent
     {
+        [JsonPropertyName("content")]
         public string Content { get; set; }
+        [JsonPropertyName("id")]
         public string Id { get; set; }
     }
 
@@ -1272,6 +1279,8 @@ namespace Azure.AI.Agents.Persistent.Telemetry
     [JsonSerializable(typeof(RoleEvent))]
     [JsonSerializable(typeof(ToolOutputEvent))]
     [JsonSerializable(typeof(ToolCallsEvent))]
+    [JsonSerializable(typeof(string))]
+    [JsonSerializable(typeof(JsonElement))]
     [JsonSerializable(typeof(Dictionary<string, object>))]
     [JsonSerializable(typeof(List<Dictionary<string, object>>))]
     internal partial class OpenTelemetryJsonContext : JsonSerializerContext


### PR DESCRIPTION
This pr addresses the AOT violations in `Azure.AI.Agents.Persistent` library. To find AOT violations in any library you can run the EngSys script `Check-AOT-Compatibility.ps1`. For example, for "Azure.AI.Agents.Persistent" package -

> PS /azure-sdk-for-net/eng/scripts/compatibility> ./Check-AOT-Compatibility.ps1 -ServiceDirectory "ai" -PackageName "Azure.AI.Agents.Persistent"

See this reference from Microsoft .NET AOT team for more details: https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/

Here are the violations reported by the above script, those fixed in this pr.

```
./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/FunctionToolDefinition.cs(55): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.FunctionToolDefinition.FunctionToolDefinition(String,String): Using member 'System.BinaryData.FromObjectAsJson<<>f__AnonymousType0`2<String,<>f__AnonymousType1>>(<>f__AnonymousType0`2<String,<>f__AnonymousType1>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/FunctionToolDefinition.cs(55): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.FunctionToolDefinition.FunctionToolDefinition(String,String): Using member 'System.BinaryData.FromObjectAsJson<<>f__AnonymousType0`2<String,<>f__AnonymousType1>>(<>f__AnonymousType0`2<String,<>f__AnonymousType1>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj] 

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessageOptions.cs(52): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.ThreadMessageOptions.ThreadMessageOptions(MessageRole,String): Using member 'System.BinaryData.FromObjectAsJson<String>(String,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj] 

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessageOptions.cs(52): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.ThreadMessageOptions.ThreadMessageOptions(MessageRole,String): Using member 'System.BinaryData.FromObjectAsJson<String>(String,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessageOptions.cs(115): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.ThreadMessageOptions.SerializeContentBlocks(IEnumerable`1<MessageInputContentBlock>): Using member 'System.BinaryData.FromObjectAsJson<List`1<JsonElement>>(List`1<JsonElement>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessageOptions.cs(115): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.ThreadMessageOptions.SerializeContentBlocks(IEnumerable`1<MessageInputContentBlock>): Using member 'System.BinaryData.FromObjectAsJson<List`1<JsonElement>>(List`1<JsonElement>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessageOptions.cs(129): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.ThreadMessageOptions.GetTextContent(): Using member 'System.BinaryData.ToObjectFromJson<String>(JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessageOptions.cs(129): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.ThreadMessageOptions.GetTextContent(): Using member 'System.BinaryData.ToObjectFromJson<String>(JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessageOptions.cs(147): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.ThreadMessageOptions.GetContentBlocks(): Using member 'System.BinaryData.ToObjectFromJson<IEnumerable`1<MessageInputContentBlock>>(JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessageOptions.cs(147): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.ThreadMessageOptions.GetContentBlocks(): Using member 'System.BinaryData.ToObjectFromJson<IEnumerable`1<MessageInputContentBlock>>(JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs(184): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.ThreadMessages.CreateMessage(String,MessageRole,String,IEnumerable`1<MessageAttachment>,IReadOnlyDictionary`2<String,String>,CancellationToken): Using member 'System.BinaryData.FromObjectAsJson<String>(String,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs(184): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.ThreadMessages.CreateMessage(String,MessageRole,String,IEnumerable`1<MessageAttachment>,IReadOnlyDictionary`2<String,String>,CancellationToken): Using member 'System.BinaryData.FromObjectAsJson<String>(String,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs(313): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.ThreadMessages.CreateMessage(String,MessageRole,IEnumerable`1<MessageInputContentBlock>,IEnumerable`1<MessageAttachment>,IReadOnlyDictionary`2<String,String>,CancellationToken): Using member 'System.BinaryData.FromObjectAsJson<List`1<JsonElement>>(List`1<JsonElement>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs(313): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.ThreadMessages.CreateMessage(String,MessageRole,IEnumerable`1<MessageInputContentBlock>,IEnumerable`1<MessageAttachment>,IReadOnlyDictionary`2<String,String>,CancellationToken): Using member 'System.BinaryData.FromObjectAsJson<List`1<JsonElement>>(List`1<JsonElement>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(125): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.StartCreateAgent(RequestContent,Uri): Using member 'System.Text.Json.JsonSerializer.Serialize<Object>(Object,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(125): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.StartCreateAgent(RequestContent,Uri): Using member 'System.Text.Json.JsonSerializer.Serialize<Object>(Object,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(191): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.StartCreateMessage(String,RequestContent,Uri): Using member 'System.Text.Json.JsonSerializer.Serialize<Object>(Object,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(191): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.StartCreateMessage(String,RequestContent,Uri): Using member 'System.Text.Json.JsonSerializer.Serialize<Object>(Object,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(617): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.RecordToolOutputEvent(ToolOutput): Using member 'System.Text.Json.JsonSerializer.Serialize<<>f__AnonymousType6`2<String,String>>(<>f__AnonymousType6`2<String,String>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(617): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.RecordToolOutputEvent(ToolOutput): Using member 'System.Text.Json.JsonSerializer.Serialize<<>f__AnonymousType6`2<String,String>>(<>f__AnonymousType6`2<String,String>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(971): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.RecordThreadMessageEventAttributes(PersistentThreadMessage,RunStep): Using member 'System.Text.Json.JsonSerializer.Serialize<Dictionary`2<String,Object>>(Dictionary`2<String,Object>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(971): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.RecordThreadMessageEventAttributes(PersistentThreadMessage,RunStep): Using member 'System.Text.Json.JsonSerializer.Serialize<Dictionary`2<String,Object>>(Dictionary`2<String,Object>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(1087): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.RecordRunStepEventAttributes(RunStep,Boolean): Using member 'System.Text.Json.JsonSerializer.Serialize<<>f__AnonymousType7`1<List`1<Dictionary`2<String,Object>>>>(<>f__AnonymousType7`1<List`1<Dictionary`2<String,Object>>>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(1087): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.RecordRunStepEventAttributes(RunStep,Boolean): Using member 'System.Text.Json.JsonSerializer.Serialize<<>f__AnonymousType7`1<List`1<Dictionary`2<String,Object>>>>(<>f__AnonymousType7`1<List`1<Dictionary`2<String,Object>>>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(1118): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.ProcessToolCalls(RunStepToolCallDetails): Using member 'System.Text.Json.JsonSerializer.Deserialize<Dictionary`2<String,Object>>(String,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(1118): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.ProcessToolCalls(RunStepToolCallDetails): Using member 'System.Text.Json.JsonSerializer.Deserialize<Dictionary`2<String,Object>>(String,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(1210): Trim analysis warning IL2075: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.ConvertToDictionary(Object): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperties(BindingFlags)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs(1234): Trim analysis warning IL2075: Azure.AI.Agents.Persistent.Telemetry.OpenTelemetryScope.GetToolCallAttributes(RunStepToolCall): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String,BindingFlags)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/AsyncStreamingUpdateCollection.cs(102): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.AsyncStreamingUpdateCollection.<GetValuesFromPageAsync>d__11.MoveNext(): Using member 'System.Text.Json.JsonSerializer.Serialize<<>f__AnonymousType2`1<String>>(<>f__AnonymousType2`1<String>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/AsyncStreamingUpdateCollection.cs(102): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.AsyncStreamingUpdateCollection.<GetValuesFromPageAsync>d__11.MoveNext(): Using member 'System.Text.Json.JsonSerializer.Serialize<<>f__AnonymousType2`1<String>>(<>f__AnonymousType2`1<String>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdateCollection.cs(98): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.StreamingUpdateCollection.<GetValuesFromPage>d__11.MoveNext(): Using member 'System.Text.Json.JsonSerializer.Serialize<<>f__AnonymousType2`1<String>>(<>f__AnonymousType2`1<String>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdateCollection.cs(98): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.StreamingUpdateCollection.<GetValuesFromPage>d__11.MoveNext(): Using member 'System.Text.Json.JsonSerializer.Serialize<<>f__AnonymousType2`1<String>>(<>f__AnonymousType2`1<String>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs(143): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.ThreadMessages.<CreateMessageAsync>d__2.MoveNext(): Using member 'System.BinaryData.FromObjectAsJson<String>(String,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs(143): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.ThreadMessages.<CreateMessageAsync>d__2.MoveNext(): Using member 'System.BinaryData.FromObjectAsJson<String>(String,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs(249): Trim analysis warning IL2026: Azure.AI.Agents.Persistent.ThreadMessages.<CreateMessageAsync>d__4.MoveNext(): Using member 'System.BinaryData.FromObjectAsJson<List`1<JsonElement>>(List`1<JsonElement>,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]

./azure-sdk-for-net/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/ThreadMessages.cs(249): AOT analysis warning IL3050: Azure.AI.Agents.Persistent.ThreadMessages.<CreateMessageAsync>d__4.MoveNext(): Using member 'System.BinaryData.FromObjectAsJson<List`1<JsonElement>>(List`1<JsonElement>,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. [./azure-sdk-for-net/eng/scripts/compatibility/TempAotCompatFiles/aotcompatibility.csproj]


```
