### PR TITLE
Make HttpRequestProvider public

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/Abstraction/HttpRequestProvider.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/Abstraction/HttpRequestProvider.cs
@@ -12,32 +12,46 @@ using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Providers
 {
-    internal record HttpRequestProvider : HttpRequestApi
+    /// <summary>
+    /// Provides functionality to construct and manipulate HTTP request objects for Azure.
+    /// </summary>
+    public record HttpRequestProvider : HttpRequestApi
     {
         private static HttpRequestApi? _instance;
         internal static HttpRequestApi Instance => _instance ??= new HttpRequestProvider(Empty);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestProvider"/> class.
+        /// </summary>
+        /// <param name="original"></param>
         public HttpRequestProvider(ValueExpression original) : base(typeof(Request), original)
         {
         }
 
+        /// <inheritdoc/>
         public override Type UriBuilderType => typeof(RawRequestUriBuilder);
 
+        /// <inheritdoc/>
         public override ValueExpression Content()
             => Original.Property(nameof(Request.Content));
 
+        /// <inheritdoc/>
         public override HttpRequestApi FromExpression(ValueExpression original)
             => new HttpRequestProvider(original);
 
+        /// <inheritdoc/>
         public override MethodBodyStatement SetHeaders(IReadOnlyList<ValueExpression> arguments)
             => Original.Property(nameof(Request.Headers)).Invoke(nameof(RequestHeaders.SetValue), arguments).Terminate();
 
+        /// <inheritdoc/>
         public MethodBodyStatement SetMethod(ScopedApi<string> httpMethod)
             => Original.Property(nameof(Request.Method)).Assign(CreateRequestMethod(httpMethod)).Terminate();
 
+        /// <inheritdoc/>
         public MethodBodyStatement SetUri(ValueExpression value)
             => Original.Property("Uri").Assign(value).Terminate();
 
+        /// <inheritdoc/>
         public override HttpRequestApi ToExpression() => this;
 
         private ValueExpression CreateRequestMethod(ScopedApi<string> httpMethod)

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/Abstraction/HttpRequestProvider.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/Abstraction/HttpRequestProvider.cs
@@ -23,7 +23,7 @@ namespace Azure.Generator.Providers
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpRequestProvider"/> class.
         /// </summary>
-        /// <param name="original"></param>
+        /// <param name="original">The original value expression to wrap.</param>
         public HttpRequestProvider(ValueExpression original) : base(typeof(Request), original)
         {
         }


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/pull/52422/files#r2317907293

We have changed the abstraction implementation in
https://github.com/Azure/azure-sdk-for-net/blob/f192187604dbedb92001e9d7c53344ec8ce29cde/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/Abstraction/HttpPipelineProvider.cs#L48-L71

Mgmt implementation only updates part of the current implementation in Azure.Generator, and it needs to construct an instance of `HttpRequestProvider`.