### PR TITLE
[Storage] Change 100-continue to per-retry

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -134,14 +134,14 @@ namespace Azure.Storage
                 switch (expectContinue.Mode)
                 {
                     case Request100ContinueMode.Auto:
-                        pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy()
+                        pipelineOptions.PerRetryPolicies.Add(new ExpectContinueOnThrottlePolicy()
                         {
                             ThrottleInterval = expectContinue.AutoInterval,
                             ContentLengthThreshold = expectContinue.ContentLengthThreshold ?? 0,
                         });
                         break;
                     case Request100ContinueMode.Always:
-                        pipelineOptions.PerCallPolicies.Add(new ExpectContinuePolicy()
+                        pipelineOptions.PerRetryPolicies.Add(new ExpectContinuePolicy()
                         {
                             ContentLengthThreshold = expectContinue.ContentLengthThreshold ?? 0,
                         });


### PR DESCRIPTION
This changes the HTTP 100-continue policies to be per-retry rather than per-call meaning the 100-continue logic will take effect immediately on retry.