### PR TITLE
Add concurrency for checkpoint tasks in eventhub GetMetricsAsync

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             _logger.LogInformation($"Querying partition information for {partitions.Length} partitions.");
 
             // Limit number of concurrent requests to eventhub client
-            const int ConcurrencyLimit = 50;
-            const int WaitTimeoutMs = 5000;
+            int ConcurrencyLimit = Environment.ProcessorCount * 2;
+            const int WaitTimeoutMs = 25000;
             using var semaphore = new SemaphoreSlim(ConcurrencyLimit, ConcurrencyLimit);
             using var cts = new CancellationTokenSource();
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
                 return metrics;
             }
 
+            // Get the PartitionRuntimeInformation for all partitions
             _logger.LogInformation($"Querying partition information for {partitions.Length} partitions.");
             var partitionPropertiesTasks = new Task<PartitionProperties>[partitions.Length];
 
@@ -115,6 +116,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             {
                 _logger.LogWarning($"Encountered an exception while getting checkpoints for Event Hub '{_client.EventHubName}' used for scaling. Error: {e.Message}");
             }
+
             return CreateTriggerMetrics(partitionPropertiesTasks.Select(t => t.Result).ToList(), checkpoints);
         }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
@@ -338,7 +338,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             // First partition triggers token cancellation
             _mockCheckpointStore
                 .Setup(s => s.GetCheckpointAsync(_namespace, _eventHubName, _consumerGroup, "0", It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new Exception(_errorMessage));
+                .Returns(async (string ns, string hub, string cg, string partitionId, CancellationToken ct) =>
+                {
+                    await Task.Delay(500);
+                    throw new Exception(_errorMessage);
+                });
 
             // Other partitions wait till cancellation is requested
             _mockCheckpointStore


### PR DESCRIPTION
Issue:
- Too many threads starting at once in case of high partition count causes resource and storage blob throttle errors.

Solution:
- Set a concurrency for task using blob resource
- Use fail fast mechanism. If one thread in Task.WhenAll() fails, the others also receive the cancellation token.

Testing:
- Built nuget package, tested end to end in local 