### PR TITLE
Allow for string arrays for scopes in TokenCredtial.CreateTokenOptions

### DIFF
--- a/sdk/core/Azure.Core/src/TokenCredential.cs
+++ b/sdk/core/Azure.Core/src/TokenCredential.cs
@@ -60,23 +60,30 @@ namespace Azure.Core
             // Check if scopes are present and in a valid format
             if (properties.TryGetValue(GetTokenOptions.ScopesPropertyName, out var scopesValue))
             {
+                ReadOnlyMemory<string> scopes = null;
                 if (scopesValue is ReadOnlyMemory<string> readOnlyMemoryScopes)
                 {
-                    return new GetTokenOptions(properties);
+                    scopes = readOnlyMemoryScopes;
+                    if (properties.Count == 1)
+                    {
+                        // We only have scopes and they are already ROM. Just return the options with the existing properties..
+                        return new GetTokenOptions(properties);
+                    }
                 }
                 // Try to convert scopes to ReadOnlyMemory<string>
                 else if (scopesValue is string[] stringArrayScopes)
                 {
-                    ReadOnlyMemory<string> scopes = new ReadOnlyMemory<string>(stringArrayScopes);
-                    // Create new properties dictionary with properly formatted scopes
-                    var formattedProperties = new Dictionary<string, object>();
-                    foreach (var kvp in properties)
-                    {
-                        formattedProperties[kvp.Key] = kvp.Value;
-                    }
-                    formattedProperties[GetTokenOptions.ScopesPropertyName] = scopes;
-                    return new GetTokenOptions(formattedProperties);
+                    scopes = new ReadOnlyMemory<string>(stringArrayScopes);
                 }
+
+                // Create new properties dictionary with properly formatted scopes
+                var formattedProperties = new Dictionary<string, object>();
+                foreach (var kvp in properties)
+                {
+                    formattedProperties[kvp.Key] = kvp.Value;
+                }
+                formattedProperties[GetTokenOptions.ScopesPropertyName] = scopes;
+                return new GetTokenOptions(formattedProperties);
             }
             // No scopes provided - insufficient information to create TokenRequestContext
             return null;

--- a/sdk/core/Azure.Core/src/TokenCredential.cs
+++ b/sdk/core/Azure.Core/src/TokenCredential.cs
@@ -57,27 +57,10 @@ namespace Azure.Core
         /// <inheritdoc />
         public override GetTokenOptions? CreateTokenOptions(IReadOnlyDictionary<string, object> properties)
         {
-            // Check if scopes are present and in a valid format
+            // Check if scopes are present
             if (properties.TryGetValue(GetTokenOptions.ScopesPropertyName, out var scopesValue))
             {
-                if (scopesValue is ReadOnlyMemory<string> readOnlyMemoryScopes)
-                {
-                    // We only have scopes and they are already ROM. Just return the options with the existing properties..
-                    return new GetTokenOptions(properties);
-                }
-                // Try to convert scopes to ReadOnlyMemory<string>
-                else if (scopesValue is string[] stringArrayScopes)
-                {
-                    var scopes = new ReadOnlyMemory<string>(stringArrayScopes);
-                    // Create new properties dictionary with properly formatted scopes
-                    var formattedProperties = new Dictionary<string, object>();
-                    foreach (var kvp in properties)
-                    {
-                        formattedProperties[kvp.Key] = kvp.Value;
-                    }
-                    formattedProperties[GetTokenOptions.ScopesPropertyName] = scopes;
-                    return new GetTokenOptions(formattedProperties);
-                }
+                return new GetTokenOptions(properties);
             }
             // No scopes provided - insufficient information to create TokenRequestContext
             return null;

--- a/sdk/core/Azure.Core/src/TokenCredential.cs
+++ b/sdk/core/Azure.Core/src/TokenCredential.cs
@@ -60,30 +60,24 @@ namespace Azure.Core
             // Check if scopes are present and in a valid format
             if (properties.TryGetValue(GetTokenOptions.ScopesPropertyName, out var scopesValue))
             {
-                ReadOnlyMemory<string> scopes = null;
                 if (scopesValue is ReadOnlyMemory<string> readOnlyMemoryScopes)
                 {
-                    scopes = readOnlyMemoryScopes;
-                    if (properties.Count == 1)
-                    {
-                        // We only have scopes and they are already ROM. Just return the options with the existing properties..
-                        return new GetTokenOptions(properties);
-                    }
+                    // We only have scopes and they are already ROM. Just return the options with the existing properties..
+                    return new GetTokenOptions(properties);
                 }
                 // Try to convert scopes to ReadOnlyMemory<string>
                 else if (scopesValue is string[] stringArrayScopes)
                 {
-                    scopes = new ReadOnlyMemory<string>(stringArrayScopes);
+                    var scopes = new ReadOnlyMemory<string>(stringArrayScopes);
+                    // Create new properties dictionary with properly formatted scopes
+                    var formattedProperties = new Dictionary<string, object>();
+                    foreach (var kvp in properties)
+                    {
+                        formattedProperties[kvp.Key] = kvp.Value;
+                    }
+                    formattedProperties[GetTokenOptions.ScopesPropertyName] = scopes;
+                    return new GetTokenOptions(formattedProperties);
                 }
-
-                // Create new properties dictionary with properly formatted scopes
-                var formattedProperties = new Dictionary<string, object>();
-                foreach (var kvp in properties)
-                {
-                    formattedProperties[kvp.Key] = kvp.Value;
-                }
-                formattedProperties[GetTokenOptions.ScopesPropertyName] = scopes;
-                return new GetTokenOptions(formattedProperties);
             }
             // No scopes provided - insufficient information to create TokenRequestContext
             return null;

--- a/sdk/core/Azure.Core/src/TokenRequestContext.cs
+++ b/sdk/core/Azure.Core/src/TokenRequestContext.cs
@@ -157,7 +157,9 @@ namespace Azure.Core
         {
             var scopes = getTokenOptions.Properties.TryGetValue(GetTokenOptions.ScopesPropertyName, out var scopesValue) && scopesValue is ReadOnlyMemory<string> memoryScopes
                 ? memoryScopes.ToArray()
-                : throw new InvalidOperationException($"The '{GetTokenOptions.ScopesPropertyName}' property must be set in the {nameof(GetTokenOptions)}.");
+                : scopesValue is string[] scopeArray ?
+                    scopeArray :
+                    throw new InvalidOperationException($"The '{GetTokenOptions.ScopesPropertyName}' property must be set in the {nameof(GetTokenOptions)}.");
             string? parentRequestId = getTokenOptions.Properties.TryGetValue("parentRequestId", out var parentRequestIdValue) && parentRequestIdValue is string ? (string)parentRequestIdValue : default;
             string? claims = getTokenOptions.Properties.TryGetValue("claims", out var claimsValue) && claimsValue is string ? (string)claimsValue : default;
             string? tenantId = getTokenOptions.Properties.TryGetValue("tenantId", out var tenantIdValue) && tenantIdValue is string ? (string)tenantIdValue : default;

--- a/sdk/core/Azure.Core/tests/DelegatedTokenCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/DelegatedTokenCredentialTests.cs
@@ -78,24 +78,6 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void CreateTokenOptionsWithStringArrayScopesThrowsException()
-        {
-            // Test with string[] scopes - should now throw an exception
-            var scopesArray = new string[] { "scope1", "scope2" };
-            var properties = new Dictionary<string, object>
-            {
-                [GetTokenOptions.ScopesPropertyName] = scopesArray,
-                ["additionalProperty"] = "value"
-            };
-
-            var credential = DelegatedTokenCredential.Create(getToken);
-
-            var exception = Assert.Throws<ArgumentException>(() => credential.CreateTokenOptions(properties));
-            Assert.That(exception.Message, Does.Contain("scopes"));
-            Assert.That(exception.Message, Does.Contain("ReadOnlyMemory<string>"));
-        }
-
-        [Test]
         public void CreateTokenOptionsWithoutScopes()
         {
             // Test without scopes property
@@ -108,23 +90,6 @@ namespace Azure.Core.Tests
             var result = credential.CreateTokenOptions(properties);
 
             Assert.IsNull(result);
-        }
-
-        [Test]
-        public void CreateTokenOptionsWithInvalidScopesThrowsException()
-        {
-            // Test with invalid scopes type - should throw an exception
-            var properties = new Dictionary<string, object>
-            {
-                [GetTokenOptions.ScopesPropertyName] = "invalid_scopes_type",
-                ["additionalProperty"] = "value"
-            };
-
-            var credential = DelegatedTokenCredential.Create(getToken);
-
-            var exception = Assert.Throws<ArgumentException>(() => credential.CreateTokenOptions(properties));
-            Assert.That(exception.Message, Does.Contain("scopes"));
-            Assert.That(exception.Message, Does.Contain("ReadOnlyMemory<string>"));
         }
 
         [Test]

--- a/sdk/core/System.ClientModel/tests/Pipeline/BearerTokenPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/BearerTokenPolicyTests.cs
@@ -83,7 +83,6 @@ public class BearerTokenPolicyTests : SyncAsyncTestBase
         // Act
         var message = await SendMessageAsync(pipeline, messageContexts);
 
-        // Assert - should use message property, not service-level contexts
         AssertHasAuthorization(message);
         AssertTokenProviderCalled(tokenProvider, shouldCallAsync: true);
     }
@@ -114,7 +113,6 @@ public class BearerTokenPolicyTests : SyncAsyncTestBase
         // Act
         var message = await SendMessageAsync(pipeline);
 
-        // Assert - should use message property, not service-level contexts
         AssertHasAuthorization(message);
         AssertTokenProviderCalled(tokenProvider, shouldCallAsync: true);
         Assert.AreEqual("parentRequestIdValue", tokenProvider.ReceivedRequestContext.ParentRequestId);
@@ -153,7 +151,6 @@ public class BearerTokenPolicyTests : SyncAsyncTestBase
         // Act
         var message = await SendMessageAsync(pipeline);
 
-        // Assert - should use message property, not service-level contexts
         AssertHasAuthorization(message);
         AssertTokenProviderCalled(tokenProvider, shouldCallAsync: true);
         Assert.AreEqual("parentRequestIdValue", tokenProvider.ReceivedRequestContext.ParentRequestId);
@@ -164,6 +161,34 @@ public class BearerTokenPolicyTests : SyncAsyncTestBase
         Assert.AreEqual("proofOfPossessionNonceValue", tokenProvider.ReceivedRequestContext.ProofOfPossessionNonce);
         Assert.AreEqual(new Uri("https://example.com"), tokenProvider.ReceivedRequestContext.ResourceRequestUri);
         Assert.AreEqual("requestMethodValue", tokenProvider.ReceivedRequestContext.ResourceRequestMethod);
+    }
+
+    [Test]
+    public async Task BearerTokenPolicyWithNoScopesTokenCredential()
+    {
+        // Arrange
+        var tokenProvider = new MockTokenCredential();
+        var serviceContexts = new Dictionary<string, object>[]
+        {
+            new Dictionary<string, object>
+            {
+                { "parentRequestId", "parentRequestIdValue" },
+                { "claims", "claimsValue"},
+                { "tenantId", "tenantIdValue" },
+                { "isCaeEnabled", true },
+                { "isProofOfPossessionEnabled", true },
+                { "proofOfPossessionNonce", "proofOfPossessionNonceValue" },
+                { "requestUri", new Uri("https://example.com") },
+                { "requestMethod", "requestMethodValue" }
+            }
+        };
+        var policy = new BearerTokenPolicy(tokenProvider, serviceContexts);
+        var pipeline = CreatePipelineWithPolicy(policy);
+
+        // Act
+        var message = await SendMessageAsync(pipeline);
+
+         Assert.IsFalse(message.Request.Headers.TryGetValue("Authorization", out var authHeader));
     }
 
     [Test]


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
