### PR TITLE
docs(playwrighttesting): Readme update with deprecation message

### DIFF
--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/CHANGELOG.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.0.0-beta.5 (2025-09-08)
+## 1.0.0-beta.5 (2025-09-10)
 
 ### Other Changes
 
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright.NUnit**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **March 8, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright.NUnit**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 ## 1.0.0-beta.4 (2025-01-17)
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/CHANGELOG.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.5 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.5 (2025-09-08)
 
 ### Other Changes
+
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright.NUnit**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 ## 1.0.0-beta.4 (2025-01-17)
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/README.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/README.md
@@ -2,7 +2,7 @@
 
 **Deprecation message**
  
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright.NUnit**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **March 8, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright.NUnit**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 Microsoft Playwright Testing is a fully managed service that uses the cloud to enable you to run Playwright tests with much higher parallelization across different operating system-browser combinations simultaneously. This means faster test runs with broader scenario coverage, which helps speed up delivery of features without sacrificing quality. The service also enables you to publish test results and related artifacts to the service and view them in the service portal enabling faster and easier troubleshooting. With Microsoft Playwright Testing service, you can release features faster and more confidently.
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/README.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/README.md
@@ -2,7 +2,7 @@
 
 **Deprecation message**
  
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright.NUnit**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright.NUnit**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 Microsoft Playwright Testing is a fully managed service that uses the cloud to enable you to run Playwright tests with much higher parallelization across different operating system-browser combinations simultaneously. This means faster test runs with broader scenario coverage, which helps speed up delivery of features without sacrificing quality. The service also enables you to publish test results and related artifacts to the service and view them in the service portal enabling faster and easier troubleshooting. With Microsoft Playwright Testing service, you can release features faster and more confidently.
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/README.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/README.md
@@ -1,5 +1,9 @@
 # Microsoft Azure Playwright Testing NUnit client library for .NET
 
+**Deprecation message**
+ 
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright.NUnit**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+
 Microsoft Playwright Testing is a fully managed service that uses the cloud to enable you to run Playwright tests with much higher parallelization across different operating system-browser combinations simultaneously. This means faster test runs with broader scenario coverage, which helps speed up delivery of features without sacrificing quality. The service also enables you to publish test results and related artifacts to the service and view them in the service portal enabling faster and easier troubleshooting. With Microsoft Playwright Testing service, you can release features faster and more confidently.
 
 Ready to get started? Jump into our [quickstart guide]<!--(https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.NUnit/README.md#getting-started)-->!

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/CHANGELOG.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.0.0-beta.5 (2025-09-08)
+## 1.0.0-beta.5 (2025-09-10)
 
 ### Other Changes
 
-- This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+- This package has been deprecated and will no longer be maintained after **March 8, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 ## 1.0.0-beta.4 (2025-01-17)
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/CHANGELOG.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.5 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.5 (2025-09-08)
 
 ### Other Changes
+
+- This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 ## 1.0.0-beta.4 (2025-01-17)
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/README.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/README.md
@@ -2,7 +2,7 @@
 
 **Deprecation message**
  
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **March 8, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 Microsoft Playwright Testing is a fully managed service that uses the cloud to enable you to run Playwright tests with much higher parallelization across different operating system-browser combinations simultaneously. This means faster test runs with broader scenario coverage, which helps speed up delivery of features without sacrificing quality. The service also enables you to publish test results and related artifacts to the service and view them in the service portal enabling faster and easier troubleshooting. With Microsoft Playwright Testing service, you can release features faster and more confidently.
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/README.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/README.md
@@ -2,7 +2,7 @@
 
 **Deprecation message**
  
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 Microsoft Playwright Testing is a fully managed service that uses the cloud to enable you to run Playwright tests with much higher parallelization across different operating system-browser combinations simultaneously. This means faster test runs with broader scenario coverage, which helps speed up delivery of features without sacrificing quality. The service also enables you to publish test results and related artifacts to the service and view them in the service portal enabling faster and easier troubleshooting. With Microsoft Playwright Testing service, you can release features faster and more confidently.
 

--- a/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/README.md
+++ b/sdk/playwrighttesting/Azure.Developer.MicrosoftPlaywrightTesting.TestLogger/README.md
@@ -1,5 +1,9 @@
 # Microsoft Azure Playwright Testing client library for .NET
 
+**Deprecation message**
+ 
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.Developer.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+
 Microsoft Playwright Testing is a fully managed service that uses the cloud to enable you to run Playwright tests with much higher parallelization across different operating system-browser combinations simultaneously. This means faster test runs with broader scenario coverage, which helps speed up delivery of features without sacrificing quality. The service also enables you to publish test results and related artifacts to the service and view them in the service portal enabling faster and easier troubleshooting. With Microsoft Playwright Testing service, you can release features faster and more confidently.
 
 ## Getting started

--- a/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/CHANGELOG.md
+++ b/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.1.0-beta.1 (2025-09-08)
+## 1.1.0-beta.1 (2025-09-09)
 
 ### Other Changes
 
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.ResourceManager.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **March 8, 2026**. Upgrade to the replacement package, **Azure.ResourceManager.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 ## 1.0.0 (2024-12-18)
 

--- a/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/CHANGELOG.md
+++ b/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.0-beta.1 (2025-09-08)
 
 ### Other Changes
+
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.ResourceManager.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 ## 1.0.0 (2024-12-18)
 

--- a/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/README.md
+++ b/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/README.md
@@ -2,7 +2,7 @@
 
 **Deprecation message**
  
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.ResourceManager.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **March 8, 2026**. Upgrade to the replacement package, **Azure.ResourceManager.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 Microsoft Playwright Testing is a fully managed service for end-to-end testing built on top of Playwright. With Playwright, you can automate end-to-end tests to ensure your web applications work the way you expect it to, across different web browsers and operating systems. The service abstracts the complexity and infrastructure for running Playwright tests with high parallelization.
 

--- a/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/README.md
+++ b/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/README.md
@@ -2,7 +2,7 @@
 
 **Deprecation message**
  
-This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.ResourceManager.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.ResourceManager.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
 
 Microsoft Playwright Testing is a fully managed service for end-to-end testing built on top of Playwright. With Playwright, you can automate end-to-end tests to ensure your web applications work the way you expect it to, across different web browsers and operating systems. The service abstracts the complexity and infrastructure for running Playwright tests with high parallelization.
 

--- a/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/README.md
+++ b/sdk/playwrighttesting/Azure.ResourceManager.PlaywrightTesting/README.md
@@ -1,5 +1,9 @@
 # Microsoft Azure Playwright Testing management client library for .NET
 
+**Deprecation message**
+ 
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **Azure.ResourceManager.Playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+
 Microsoft Playwright Testing is a fully managed service for end-to-end testing built on top of Playwright. With Playwright, you can automate end-to-end tests to ensure your web applications work the way you expect it to, across different web browsers and operating systems. The service abstracts the complexity and infrastructure for running Playwright tests with high parallelization.
 
 This library follows the [new Azure SDK guidelines](https://azure.github.io/azure-sdk/general_introduction.html), and provides many core capabilities:


### PR DESCRIPTION
**Deprecation of Microsoft Playwright Testing SDKs (Control Plane & Data Plane) _Note: This PR should not be merged before September 8th._**

As part of the retirement of Microsoft Playwright Testing (MPT) and its merger into Azure App Testing, we plan to deprecate the SDK packages associated with this service. This aligns with Azure’s service retirement policy and the ARM API Deprecation guidelines.

MPT’s core web testing capabilities are being integrated into Azure App Testing to provide a unified experience for both Load Testing and Playwright-based web testing. The standalone MPT service will be retired, and customers will need to migrate to Azure App Testing.
