### PR TITLE
DAC properly consideres options when using AZURE_TOKEN_CREDENTIALS

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/tests/DefaultAzureCredentialFactoryTests.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/DefaultAzureCredentialFactoryTests.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Azure.Core;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -13,27 +15,26 @@ namespace Azure.Identity.Broker.Tests
     {
         public static IEnumerable<object[]> CredSelection()
         {
-            yield return new object[] { null };
-            yield return new object[] { Constants.DevCredentials };
-            yield return new object[] { Constants.ProdCredentials };
-            yield return new object[] { Constants.VisualStudioCredential };
-            yield return new object[] { Constants.VisualStudioCodeCredential };
-            yield return new object[] { Constants.AzureCliCredential };
-            yield return new object[] { Constants.AzurePowerShellCredential };
-            yield return new object[] { Constants.AzureDeveloperCliCredential };
-            yield return new object[] { Constants.EnvironmentCredential };
-            yield return new object[] { Constants.WorkloadIdentityCredential };
-            yield return new object[] { Constants.ManagedIdentityCredential };
-            yield return new object[] { Constants.InteractiveBrowserCredential };
-            yield return new object[] { Constants.BrokerCredential };
+            yield return new object[] { null, null };
+            yield return new object[] { Constants.DevCredentials, null };
+            yield return new object[] { Constants.ProdCredentials, null };
+            yield return new object[] { Constants.VisualStudioCredential, typeof(VisualStudioCredential) };
+            yield return new object[] { Constants.VisualStudioCodeCredential, typeof(VisualStudioCodeCredential) };
+            yield return new object[] { Constants.AzureCliCredential, typeof(AzureCliCredential) };
+            yield return new object[] { Constants.AzurePowerShellCredential, typeof(AzurePowerShellCredential) };
+            yield return new object[] { Constants.AzureDeveloperCliCredential, typeof(AzureDeveloperCliCredential) };
+            yield return new object[] { Constants.EnvironmentCredential, typeof(EnvironmentCredential) };
+            yield return new object[] { Constants.WorkloadIdentityCredential, typeof(WorkloadIdentityCredential) };
+            yield return new object[] { Constants.ManagedIdentityCredential, typeof(ManagedIdentityCredential) };
+            yield return new object[] { Constants.InteractiveBrowserCredential, typeof(InteractiveBrowserCredential) };
+            yield return new object[] { Constants.BrokerCredential, typeof(InteractiveBrowserCredential) };
         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
         [Test]
         [TestCaseSource(nameof(CredSelection))]
-        public void ValidateDefaultAzureCredentialAZURE_TOKEN_CREDENTIALS_Honored_WithBroker(string credSelection)
+        public void ValidateDefaultAzureCredentialAZURE_TOKEN_CREDENTIALS_Honored_WithBroker(string credSelection, Type expectedType)
         {
-            var initFactory = new DefaultAzureCredentialFactory(new());
+            // var initFactory = new DefaultAzureCredentialFactory(new());
             using (new TestEnvVar(new Dictionary<string, string>
             {
                 { "AZURE_CLIENT_ID", null },
@@ -51,7 +52,9 @@ namespace Azure.Identity.Broker.Tests
                     Assert.IsFalse(chain.Any(cred => cred is EnvironmentCredential));
                     Assert.IsFalse(chain.Any(cred => cred is WorkloadIdentityCredential));
                     Assert.IsFalse(chain.Any(cred => cred is ManagedIdentityCredential));
+#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential));
+#pragma warning restore CS0618 // Type or member is obsolete
                     Assert.IsTrue(chain.Any(cred => cred is AzureCliCredential));
                     Assert.IsTrue(chain.Any(cred => cred is AzurePowerShellCredential));
                     Assert.IsTrue(chain.Any(cred => cred is VisualStudioCredential));
@@ -65,7 +68,9 @@ namespace Azure.Identity.Broker.Tests
                     Assert.IsTrue(chain.Any(cred => cred is EnvironmentCredential));
                     Assert.IsTrue(chain.Any(cred => cred is WorkloadIdentityCredential));
                     Assert.IsTrue(chain.Any(cred => cred is ManagedIdentityCredential));
+#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential));
+#pragma warning restore CS0618 // Type or member is obsolete
                     Assert.IsFalse(chain.Any(cred => cred is AzureCliCredential));
                     Assert.IsFalse(chain.Any(cred => cred is AzurePowerShellCredential));
                     Assert.IsFalse(chain.Any(cred => cred is VisualStudioCredential));
@@ -73,35 +78,6 @@ namespace Azure.Identity.Broker.Tests
                     Assert.IsFalse(chain.Any(cred => cred is VisualStudioCodeCredential));
                     Assert.IsFalse(chain.Any(cred => cred is InteractiveBrowserCredential));
                 }
-                else if (credSelection == Constants.VisualStudioCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is VisualStudioCredential) is VisualStudioCredential);
-                }
-                else if (credSelection == Constants.VisualStudioCodeCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is VisualStudioCodeCredential) is VisualStudioCodeCredential);
-                }
-                else if (credSelection == Constants.AzureCliCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is AzureCliCredential) is AzureCliCredential);
-                }
-                else if (credSelection == Constants.AzurePowerShellCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is AzurePowerShellCredential) is AzurePowerShellCredential);
-                }
-                else if (credSelection == Constants.AzureDeveloperCliCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is AzureDeveloperCliCredential) is AzureDeveloperCliCredential);
-                }
-                else if (credSelection == Constants.InteractiveBrowserCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is InteractiveBrowserCredential) is InteractiveBrowserCredential);
-                }
-                else if (credSelection == Constants.BrokerCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is InteractiveBrowserCredential) is InteractiveBrowserCredential);
-                }
-
                 else if (credSelection == null)
                 {
                     //check the factory created the credentials
@@ -110,7 +86,9 @@ namespace Azure.Identity.Broker.Tests
                         Assert.IsTrue(chain.Any(cred => cred is EnvironmentCredential), "EnvironmentCredential should be in the chain");
                         Assert.IsTrue(chain.Any(cred => cred is WorkloadIdentityCredential), "WorkloadIdentityCredential should be in the chain");
                         Assert.IsTrue(chain.Any(cred => cred is ManagedIdentityCredential), "ManagedIdentityCredential should be in the chain");
+#pragma warning disable CS0618 // Type or member is obsolete
                         Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential), "SharedTokenCacheCredential should not be in the chain");
+#pragma warning restore CS0618 // Type or member is obsolete
                         Assert.IsTrue(chain.Any(cred => cred is AzureCliCredential), "AzureCliCredential should be in the chain");
                         Assert.IsTrue(chain.Any(cred => cred is AzurePowerShellCredential), "AzurePowerShellCredential should be in the chain");
                         Assert.IsTrue(chain.Any(cred => cred is VisualStudioCredential), "VisualStudioCredential should be in the chain");
@@ -118,8 +96,91 @@ namespace Azure.Identity.Broker.Tests
                         Assert.IsTrue(chain.Any(cred => cred is VisualStudioCodeCredential), "VisualStudioCodeCredential should be in the chain");
                     });
                 }
+                else
+                {
+                    ValidateSingleCredSelection(expectedType, chain);
+                }
             }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CredSelection))]
+        public void ValidateDefaultAzureCredentialAZURE_TOKEN_CREDENTIALS_Honored_WithBroker_WithDacOptions(string credSelection, Type expectedType)
+        {
+            // var initFactory = new DefaultAzureCredentialFactory(new());
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_USERNAME", null },
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_TOKEN_CREDENTIALS", credSelection }
+            }))
+            {
+                var factory = new DefaultAzureCredentialFactory(new());
+                var chain = factory.CreateCredentialChain();
+
+                //check the factory created the correct credentials
+                if (credSelection == Constants.DevCredentials)
+                {
+                    Assert.IsFalse(chain.Any(cred => cred is EnvironmentCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is WorkloadIdentityCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is ManagedIdentityCredential));
+#pragma warning disable CS0618 // Type or member is obsolete
+                    Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential));
 #pragma warning restore CS0618 // Type or member is obsolete
+                    Assert.IsTrue(chain.Any(cred => cred is AzureCliCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is AzurePowerShellCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is VisualStudioCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is AzureDeveloperCliCredential));
+                    Assert.IsTrue(chain.Any(cred => cred.GetType() == typeof(VisualStudioCodeCredential)));
+                    Assert.IsTrue(chain.Any(cred => cred.GetType() == typeof(InteractiveBrowserCredential)));
+                }
+                else if (credSelection == Constants.ProdCredentials)
+                {
+                    //check the factory created the credentials
+                    Assert.IsTrue(chain.Any(cred => cred is EnvironmentCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is WorkloadIdentityCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is ManagedIdentityCredential));
+#pragma warning disable CS0618 // Type or member is obsolete
+                    Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential));
+#pragma warning restore CS0618 // Type or member is obsolete
+                    Assert.IsFalse(chain.Any(cred => cred is AzureCliCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is AzurePowerShellCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is VisualStudioCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is AzureDeveloperCliCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is VisualStudioCodeCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is InteractiveBrowserCredential));
+                }
+                else if (credSelection == null)
+                {
+                    //check the factory created the credentials
+                    Assert.Multiple(() =>
+                    {
+                        Assert.IsTrue(chain.Any(cred => cred is EnvironmentCredential), "EnvironmentCredential should be in the chain");
+                        Assert.IsTrue(chain.Any(cred => cred is WorkloadIdentityCredential), "WorkloadIdentityCredential should be in the chain");
+                        Assert.IsTrue(chain.Any(cred => cred is ManagedIdentityCredential), "ManagedIdentityCredential should be in the chain");
+#pragma warning disable CS0618 // Type or member is obsolete
+                        Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential), "SharedTokenCacheCredential should not be in the chain");
+#pragma warning restore CS0618 // Type or member is obsolete
+                        Assert.IsTrue(chain.Any(cred => cred is AzureCliCredential), "AzureCliCredential should be in the chain");
+                        Assert.IsTrue(chain.Any(cred => cred is AzurePowerShellCredential), "AzurePowerShellCredential should be in the chain");
+                        Assert.IsTrue(chain.Any(cred => cred is VisualStudioCredential), "VisualStudioCredential should be in the chain");
+                        Assert.IsTrue(chain.Any(cred => cred is AzureDeveloperCliCredential), "AzureDeveloperCliCredential should be in the chain");
+                        Assert.IsTrue(chain.Any(cred => cred is VisualStudioCodeCredential), "VisualStudioCodeCredential should be in the chain");
+                    });
+                }
+                else
+                {
+                    ValidateSingleCredSelection(expectedType, chain);
+                }
+            }
+        }
+
+        private void ValidateSingleCredSelection(Type expectedType, IReadOnlyList<TokenCredential> chain)
+        {
+            Assert.IsNotNull(chain);
+            Assert.IsTrue(chain.Single(cred => cred.GetType() == expectedType).GetType() == expectedType, $"Chain does not contain expected credential type: {expectedType}");
+            Assert.IsTrue(chain.Count == 1, $"Chain contains unexpected number of credentials: {chain.Count}");
         }
     }
 }

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Breaking Changes
 
+- Fixed a bug in `DefaultAzureCredential` that caused the credential chain to be constructed incorrectly when using AZURE_TOKEN_CREDENTIALS in combination with `DefaultAzureCredentialOptions`.
+
 ### Bugs Fixed
 
 - Fixed `AzureDeveloperCliCredential` hanging when the `AZD_DEBUG` environment variable is set by adding the `--no-prompt` flag to prevent interactive prompts ([#52005](https://github.com/Azure/azure-sdk-for-net/issues/52005)).

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -10,13 +10,12 @@
 
 ### Breaking Changes
 
-- Fixed a bug in `DefaultAzureCredential` that caused the credential chain to be constructed incorrectly when using AZURE_TOKEN_CREDENTIALS in combination with `DefaultAzureCredentialOptions`.
-
 ### Bugs Fixed
 
 - Fixed `AzureDeveloperCliCredential` hanging when the `AZD_DEBUG` environment variable is set by adding the `--no-prompt` flag to prevent interactive prompts ([#52005](https://github.com/Azure/azure-sdk-for-net/issues/52005)).
 - `BrokerCredential` is now included in the chain when `AZURE_TOKEN_CREDENTIALS` is set to `dev` and the `Azure.Identity.Broker` package is installed.
 - Fixed an issue that prevented ManagedIdentityCredential from utilizing the token cache in Workload Identity Federation environments.
+- Fixed a bug in `DefaultAzureCredential` that caused the credential chain to be constructed incorrectly when using AZURE_TOKEN_CREDENTIALS in combination with `DefaultAzureCredentialOptions`.
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using Azure.Core;
 
@@ -11,8 +10,6 @@ namespace Azure.Identity
 {
     internal class DefaultAzureCredentialFactory
     {
-        private static readonly TokenCredential[] s_defaultCredentialChain = new DefaultAzureCredentialFactory(new DefaultAzureCredentialOptions()).CreateCredentialChain();
-        private bool _useDefaultCredentialChain;
         private readonly string _customEnvironmentVariableName;
         private static string _troubleshootingMessage = $" See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/defaultazurecredential/troubleshoot";
 
@@ -27,7 +24,6 @@ namespace Azure.Identity
         protected DefaultAzureCredentialFactory(DefaultAzureCredentialOptions options, CredentialPipeline pipeline)
         {
             Pipeline = pipeline;
-            _useDefaultCredentialChain = options == null;
             Options = options?.Clone<DefaultAzureCredentialOptions>() ?? new DefaultAzureCredentialOptions();
         }
 
@@ -36,7 +32,6 @@ namespace Azure.Identity
             Argument.AssertNotNullOrEmpty(customEnvironmentVariableName, nameof(customEnvironmentVariableName));
 
             Pipeline = pipeline;
-            _useDefaultCredentialChain = options == null;
             Options = options?.Clone<DefaultAzureCredentialOptions>() ?? new DefaultAzureCredentialOptions();
             _customEnvironmentVariableName = customEnvironmentVariableName;
         }
@@ -46,35 +41,24 @@ namespace Azure.Identity
 
         public TokenCredential[] CreateCredentialChain()
         {
-            string credentialSelection;
+            TokenCredential[] tokenCredentials = Array.Empty<TokenCredential>();
+            string credentialSelection = EnvironmentVariables.CredentialSelection?.Trim().ToLower();
 
             if (_customEnvironmentVariableName != null)
             {
                 // When using custom environment variable, read from that variable and validate it's set
                 credentialSelection = ValidateAndGetCustomEnvironmentVariable(_customEnvironmentVariableName);
                 // For custom environment variables, always use the token credentials logic
-                return ProcessCredentialSelection(credentialSelection, _customEnvironmentVariableName);
+                tokenCredentials = ProcessCredentialSelection(credentialSelection, _customEnvironmentVariableName);
             }
-
-            // Use the default environment variable and existing logic
-            credentialSelection = EnvironmentVariables.CredentialSelection?.Trim().ToLower();
-
-            if (_useDefaultCredentialChain)
+            else if (credentialSelection != null)
             {
-                if (credentialSelection != null)
-                {
-                    return ProcessCredentialSelection(credentialSelection, "AZURE_TOKEN_CREDENTIALS");
-                }
-                return s_defaultCredentialChain;
+                tokenCredentials = ProcessCredentialSelection(credentialSelection, "AZURE_TOKEN_CREDENTIALS");
             }
-
-            List<TokenCredential> chain = new(10);
-
-            bool _useDevCredentials = Constants.DevCredentials.Equals(credentialSelection, StringComparison.OrdinalIgnoreCase);
-            bool _useProdCredentials = Constants.ProdCredentials.Equals(credentialSelection, StringComparison.OrdinalIgnoreCase);
-
-            if (!_useDevCredentials)
+            else
             {
+                List<TokenCredential> chain = new(10);
+
                 if (!Options.ExcludeEnvironmentCredential)
                 {
                     chain.Add(CreateEnvironmentCredential());
@@ -89,14 +73,6 @@ namespace Azure.Identity
                 {
                     chain.Add(CreateManagedIdentityCredential());
                 }
-                if (!Options.ExcludeBrokerCredential && TryCreateDevelopmentBrokerOptions(out InteractiveBrowserCredentialOptions brokerOptions))
-                {
-                    chain.Add(CreateBrokerCredential(brokerOptions));
-                }
-            }
-
-            if (!_useProdCredentials)
-            {
 #pragma warning disable CS0618 // Type of member is obsolete
                 if (!Options.ExcludeSharedTokenCacheCredential)
                 {
@@ -137,13 +113,15 @@ namespace Azure.Identity
                 {
                     chain.Add(CreateBrokerCredential(brokerOptions));
                 }
+                tokenCredentials = chain.ToArray();
             }
-            if (chain.Count == 0)
+
+            if (tokenCredentials.Length == 0)
             {
                 throw new ArgumentException("At least one credential type must be included in the authentication flow.", "options");
             }
 
-            return chain.ToArray();
+            return tokenCredentials;
         }
 
         /// <summary>
@@ -197,16 +175,29 @@ namespace Azure.Identity
         /// <returns>Array of development TokenCredential instances.</returns>
         private TokenCredential[] CreateDevelopmentCredentialChain()
         {
-            List<TokenCredential> chain =
-            [
-                CreateVisualStudioCredential(),
-                CreateVisualStudioCodeCredential(),
-                CreateAzureCliCredential(),
-                CreateAzurePowerShellCredential(),
-                CreateAzureDeveloperCliCredential()
-            ];
+            List<TokenCredential> chain = new();
+            if (!Options.ExcludeVisualStudioCredential)
+            {
+                chain.Add(CreateVisualStudioCredential());
+            }
+            if (!Options.ExcludeVisualStudioCodeCredential)
+            {
+                chain.Add(CreateVisualStudioCodeCredential());
+            }
+            if (!Options.ExcludeAzureCliCredential)
+            {
+                chain.Add(CreateAzureCliCredential());
+            }
+            if (!Options.ExcludeAzurePowerShellCredential)
+            {
+                chain.Add(CreateAzurePowerShellCredential());
+            }
+            if (!Options.ExcludeAzureDeveloperCliCredential)
+            {
+                chain.Add(CreateAzureDeveloperCliCredential());
+            }
 
-            if (TryCreateDevelopmentBrokerOptions(out InteractiveBrowserCredentialOptions brokerOptions))
+            if (!Options.ExcludeBrokerCredential && TryCreateDevelopmentBrokerOptions(out InteractiveBrowserCredentialOptions brokerOptions))
             {
                 chain.Add(CreateBrokerCredential(brokerOptions));
             }
@@ -219,12 +210,21 @@ namespace Azure.Identity
         /// <returns>Array of production TokenCredential instances.</returns>
         private TokenCredential[] CreateProductionCredentialChain()
         {
-            return
-            [
-                CreateEnvironmentCredential(),
-                CreateWorkloadIdentityCredential(),
-                CreateManagedIdentityCredential()
-            ];
+            List<TokenCredential> chain = new();
+
+            if (!Options.ExcludeEnvironmentCredential)
+            {
+                chain.Add(CreateEnvironmentCredential());
+            }
+            if (!Options.ExcludeWorkloadIdentityCredential)
+            {
+                chain.Add(CreateWorkloadIdentityCredential());
+            }
+            if (!Options.ExcludeManagedIdentityCredential)
+            {
+                chain.Add(CreateManagedIdentityCredential());
+            }
+            return chain.ToArray();
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialFactoryTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialFactoryTests.cs
@@ -416,24 +416,24 @@ namespace Azure.Identity.Tests
 
         public static IEnumerable<object[]> CredSelection()
         {
-            yield return new object[] { Constants.DevCredentials };
-            yield return new object[] { Constants.ProdCredentials };
-            yield return new object[] { Constants.VisualStudioCredential };
-            yield return new object[] { Constants.VisualStudioCodeCredential };
-            yield return new object[] { Constants.AzureCliCredential };
-            yield return new object[] { Constants.AzurePowerShellCredential };
-            yield return new object[] { Constants.AzureDeveloperCliCredential };
-            yield return new object[] { Constants.EnvironmentCredential };
-            yield return new object[] { Constants.WorkloadIdentityCredential };
-            yield return new object[] { Constants.ManagedIdentityCredential };
-            yield return new object[] { Constants.InteractiveBrowserCredential };
-            yield return new object[] { Constants.BrokerCredential };
-            yield return new object[] { null };
+            yield return new object[] { null, null };
+            yield return new object[] { Constants.DevCredentials, null };
+            yield return new object[] { Constants.ProdCredentials, null };
+            yield return new object[] { Constants.VisualStudioCredential, typeof(VisualStudioCredential) };
+            yield return new object[] { Constants.VisualStudioCodeCredential, typeof(VisualStudioCodeCredential) };
+            yield return new object[] { Constants.AzureCliCredential, typeof(AzureCliCredential) };
+            yield return new object[] { Constants.AzurePowerShellCredential, typeof(AzurePowerShellCredential) };
+            yield return new object[] { Constants.AzureDeveloperCliCredential, typeof(AzureDeveloperCliCredential) };
+            yield return new object[] { Constants.EnvironmentCredential, typeof(EnvironmentCredential) };
+            yield return new object[] { Constants.WorkloadIdentityCredential, typeof(WorkloadIdentityCredential) };
+            yield return new object[] { Constants.ManagedIdentityCredential, typeof(ManagedIdentityCredential) };
+            yield return new object[] { Constants.InteractiveBrowserCredential, typeof(InteractiveBrowserCredential) };
+            yield return new object[] { Constants.BrokerCredential, typeof(InteractiveBrowserCredential) };
         }
 
         [Test]
         [TestCaseSource(nameof(CredSelection))]
-        public void ValidateDefaultAzureCredentialAZURE_TOKEN_CREDENTIALS_Honored(string credSelection)
+        public void ValidateDefaultAzureCredentialAZURE_TOKEN_CREDENTIALS_Honored(string credSelection, Type expectedType)
         {
             using (new TestEnvVar(new Dictionary<string, string>
             {
@@ -482,31 +482,6 @@ namespace Azure.Identity.Tests
                     Assert.IsFalse(chain.Any(cred => cred is VisualStudioCodeCredential));
                     Assert.IsFalse(chain.Any(cred => cred is InteractiveBrowserCredential));
                 }
-                else if (credSelection == Constants.VisualStudioCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is VisualStudioCredential) is VisualStudioCredential);
-                }
-                else if (credSelection == Constants.VisualStudioCodeCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is VisualStudioCodeCredential) is VisualStudioCodeCredential);
-                }
-                else if (credSelection == Constants.AzureCliCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is AzureCliCredential) is AzureCliCredential);
-                }
-                else if (credSelection == Constants.AzurePowerShellCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is AzurePowerShellCredential) is AzurePowerShellCredential);
-                }
-                else if (credSelection == Constants.AzureDeveloperCliCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is AzureDeveloperCliCredential) is AzureDeveloperCliCredential);
-                }
-                else if (credSelection == Constants.InteractiveBrowserCredential)
-                {
-                    Assert.IsTrue(chain.Single(cred => cred is InteractiveBrowserCredential) is InteractiveBrowserCredential);
-                }
-
                 else if (credSelection == null)
                 {
                     //check the factory created the credentials
@@ -519,6 +494,81 @@ namespace Azure.Identity.Tests
                     Assert.IsTrue(chain.Any(cred => cred is VisualStudioCredential));
                     Assert.IsTrue(chain.Any(cred => cred is AzureDeveloperCliCredential));
                     Assert.IsTrue(chain.Any(cred => cred is VisualStudioCodeCredential));
+                }
+                else
+                {
+                    ValidateSingleCredSelection(expectedType, chain);
+                }
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CredSelection))]
+        public void ValidateDefaultAzureCredentialAZURE_TOKEN_CREDENTIALS_Honored_WithDacOptions(string credSelection, Type expectedType)
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_USERNAME", null },
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_TOKEN_CREDENTIALS", credSelection }
+            }))
+            {
+                var factory = new DefaultAzureCredentialFactory(new());
+                if (credSelection == Constants.BrokerCredential)
+                {
+                    // BrokerCredential is not supported without the Azure.Identity.Broker package.
+                    var ex = Assert.Throws<CredentialUnavailableException>(() => factory.CreateCredentialChain());
+                    Assert.AreEqual("BrokerCredential is not available without a reference to Azure.Identity.Broker.", ex.Message);
+                    return;
+                }
+                var chain = factory.CreateCredentialChain();
+
+                // check the factory created the correct credentials
+                if (credSelection == Constants.DevCredentials)
+                {
+                    Assert.IsFalse(chain.Any(cred => cred is EnvironmentCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is WorkloadIdentityCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is ManagedIdentityCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is AzureCliCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is AzurePowerShellCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is VisualStudioCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is AzureDeveloperCliCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is VisualStudioCodeCredential));
+                    // InteractiveBrowser is always excluded by default.
+                    Assert.IsFalse(chain.Any(cred => cred.GetType() == typeof(InteractiveBrowserCredential)));
+                }
+                else if (credSelection == Constants.ProdCredentials)
+                {
+                    //check the factory created the credentials
+                    Assert.IsTrue(chain.Any(cred => cred is EnvironmentCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is WorkloadIdentityCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is ManagedIdentityCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is AzureCliCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is AzurePowerShellCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is VisualStudioCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is AzureDeveloperCliCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is VisualStudioCodeCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is InteractiveBrowserCredential));
+                }
+                else if (credSelection == null)
+                {
+                    //check the factory created the credentials
+                    Assert.IsTrue(chain.Any(cred => cred is EnvironmentCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is WorkloadIdentityCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is ManagedIdentityCredential));
+                    Assert.IsFalse(chain.Any(cred => cred is SharedTokenCacheCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is AzureCliCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is AzurePowerShellCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is VisualStudioCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is AzureDeveloperCliCredential));
+                    Assert.IsTrue(chain.Any(cred => cred is VisualStudioCodeCredential));
+                }
+                else
+                {
+                    ValidateSingleCredSelection(expectedType, chain);
                 }
             }
         }
@@ -562,13 +612,11 @@ namespace Azure.Identity.Tests
             }))
             {
                 var expCredentialTypes = new List<Type>();
-                expCredentialTypes.ConditionalAdd(!excludeSharedTokenCacheCredential, typeof(SharedTokenCacheCredential));
                 expCredentialTypes.ConditionalAdd(!excludeVisualStudioCredential, typeof(VisualStudioCredential));
                 expCredentialTypes.ConditionalAdd(!excludeVisualStudioCodeCredential, typeof(VisualStudioCodeCredential));
                 expCredentialTypes.ConditionalAdd(!excludeCliCredential, typeof(AzureCliCredential));
                 expCredentialTypes.ConditionalAdd(!excludeAzurePowerShellCredential, typeof(AzurePowerShellCredential));
                 expCredentialTypes.ConditionalAdd(!excludeDeveloperCliCredential, typeof(AzureDeveloperCliCredential));
-                expCredentialTypes.ConditionalAdd(!excludeInteractiveBrowserCredential, typeof(InteractiveBrowserCredential));
 
                 var options = new DefaultAzureCredentialOptions
                 {
@@ -669,6 +717,13 @@ namespace Azure.Identity.Tests
                     Assert.IsNull(chain[i]);
                 }
             }
+        }
+
+        private void ValidateSingleCredSelection(Type expectedType, IReadOnlyList<TokenCredential> chain)
+        {
+            Assert.IsNotNull(chain);
+            Assert.IsTrue(chain.Single(cred => cred.GetType() == expectedType).GetType() == expectedType, $"Chain does not contain expected credential type: {expectedType}");
+            Assert.IsTrue(chain.Count == 1, $"Chain contains unexpected number of credentials: {chain.Count}");
         }
     }
 }


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
