### PR TITLE
[Storage][DataMovement] Fixed potential incorrect resource names for upload transfers

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue on upload transfers where file/directory names on the destination may be incorrect. The issue could occur if the path passed to `LocalFilesStorageResourceProvider.FromDirectory` contained a trailing slash.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_f1a4120258"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_2f44fdf50b"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_2f44fdf50b"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_c2f1f2fc3f"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobContainerClientExtensionsTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobContainerClientExtensionsTests.cs
@@ -46,7 +46,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
 
             var blobUri = new Uri(accountUrl + (addBlobDirectoryPath ? containerName + "/" + blobDirectoryPrefix : containerName));
 
-            var directoryPath = Path.GetTempPath();
+            var directoryPath = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
 
             var options = addTransferOptions ? new TransferOptions() : (TransferOptions)null;
 
@@ -91,7 +91,7 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
 
             var blobUri = new Uri(accountUrl + (addBlobDirectoryPath ? containerName + "/" + blobDirectoryPrefix : containerName));
 
-            var directoryPath = Path.GetTempPath();
+            var directoryPath = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
 
             var options = addTransferOptions ? new TransferOptions() : (TransferOptions)null;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue on upload transfers where file/directory names on the destination may be incorrect. The issue could occur if the path passed to `LocalFilesStorageResourceProvider.FromDirectory` contained a trailing slash.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_0f05f57f67"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_df34cc0ab7"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_df34cc0ab7"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_c847746677"
 }

--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an issue on upload transfers where file/directory names on the destination may be incorrect. The issue could occur if the path passed to `LocalFilesStorageResourceProvider.FromDirectory` contained a trailing slash.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalDirectoryStorageResourceContainer.cs
@@ -29,6 +29,7 @@ namespace Azure.Storage.DataMovement
         public LocalDirectoryStorageResourceContainer(string path)
         {
             Argument.AssertNotNullOrWhiteSpace(path, nameof(path));
+            path = path.TrimEnd(Path.DirectorySeparatorChar);
             _uri = PathScanner.GetEncodedUriFromPath(path);
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
@@ -42,6 +42,7 @@ namespace Azure.Storage.DataMovement.Tests
         [TestCase("C:\\test\\path%3Dtest%26", "C:/test/path%253Dtest%2526")]
         [TestCase("C:\\test\\folder with spaces", "C:/test/folder%20with%20spaces")]
         [TestCase("X:\\testing\\test\\", "X:/testing/test")]
+        [TestCase("X:\\testing\\test\\\\", "X:/testing/test")]
         public void Ctor_String_Encoding_Windows(string path, string absolutePath)
         {
             LocalDirectoryStorageResourceContainer storageResource = new(path);
@@ -56,6 +57,7 @@ namespace Azure.Storage.DataMovement.Tests
         [TestCase("/test/path%3Dtest%26", "/test/path%253Dtest%2526")]
         [TestCase("/test/folder with spaces", "/test/folder%20with%20spaces")]
         [TestCase("/testing/test/", "/testing/test")]
+        [TestCase("/testing/test//", "/testing/test")]
         public void Ctor_String_Encoding_Unix(string path, string absolutePath)
         {
             LocalDirectoryStorageResourceContainer storageResource = new(path);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
@@ -17,16 +17,14 @@ namespace Azure.Storage.DataMovement.Tests
            : base(async, null /* TestMode.Record /* to re-record */)
         { }
 
-        private string[] fileNames => new[]
-        {
-            "C:\\Users\\user1\\Documents\\directory",
-            "C:\\Users\\user1\\Documents\\directory1\\",
-            "/user1/Documents/directory",
-        };
-
         [Test]
         public void Ctor_string()
         {
+            string[] fileNames =
+            {
+                "C:\\Users\\user1\\Documents\\directory",
+                "/user1/Documents/directory",
+            };
             foreach (string path in fileNames)
             {
                 // Arrange
@@ -43,12 +41,13 @@ namespace Azure.Storage.DataMovement.Tests
         [TestCase("C:\\test\\path=true@&#%", "C:/test/path%3Dtrue%40%26%23%25")]
         [TestCase("C:\\test\\path%3Dtest%26", "C:/test/path%253Dtest%2526")]
         [TestCase("C:\\test\\folder with spaces", "C:/test/folder%20with%20spaces")]
+        [TestCase("X:\\testing\\test\\", "X:/testing/test")]
         public void Ctor_String_Encoding_Windows(string path, string absolutePath)
         {
             LocalDirectoryStorageResourceContainer storageResource = new(path);
             Assert.That(storageResource.Uri.AbsolutePath, Is.EqualTo(absolutePath));
-            // LocalPath should equal original path
-            Assert.That(storageResource.Uri.LocalPath, Is.EqualTo(path));
+            // LocalPath should equal original path (trimmed)
+            Assert.That(storageResource.Uri.LocalPath, Is.EqualTo(path.TrimEnd('\\')));
         }
 
         [Test]
@@ -56,12 +55,13 @@ namespace Azure.Storage.DataMovement.Tests
         [TestCase("/test/path=true@&#%", "/test/path%3Dtrue%40%26%23%25")]
         [TestCase("/test/path%3Dtest%26", "/test/path%253Dtest%2526")]
         [TestCase("/test/folder with spaces", "/test/folder%20with%20spaces")]
+        [TestCase("/testing/test/", "/testing/test")]
         public void Ctor_String_Encoding_Unix(string path, string absolutePath)
         {
             LocalDirectoryStorageResourceContainer storageResource = new(path);
             Assert.That(storageResource.Uri.AbsolutePath, Is.EqualTo(absolutePath));
-            // LocalPath should equal original path
-            Assert.That(storageResource.Uri.LocalPath, Is.EqualTo(path));
+            // LocalPath should equal original path (trimmed)
+            Assert.That(storageResource.Uri.LocalPath, Is.EqualTo(path.TrimEnd('/')));
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferUploadDirectoryTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferUploadDirectoryTestBase.cs
@@ -523,5 +523,32 @@ namespace Azure.Storage.DataMovement.Tests
                 expectedTransfers: files.Count,
                 cancellationToken: cancellationToken);
         }
+
+        [RecordedTest]
+        public async Task Upload_TrailingSlash()
+        {
+            using DisposingLocalDirectory disposingLocalDirectory = DisposingLocalDirectory.GetTestDirectory();
+            await using IDisposingContainer<TContainerClient> test = await GetDisposingContainerAsync();
+
+            List<string> files =
+            [
+                GetNewObjectName(),
+                GetNewObjectName(),
+            ];
+
+            CancellationToken cancellationToken = TestHelper.GetTimeoutToken(30);
+            await SetupDirectoryAsync(
+                disposingLocalDirectory.DirectoryPath,
+                files.Select(path => (path, (long)Constants.KB)).ToList(),
+                cancellationToken);
+
+            // Intentionally append trailing slash
+            string sourcePath = disposingLocalDirectory.DirectoryPath + Path.DirectorySeparatorChar;
+            await UploadDirectoryAndVerifyAsync(
+                sourcePath,
+                test.Container,
+                expectedTransfers: files.Count,
+                cancellationToken: cancellationToken);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferUploadDirectoryTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferUploadDirectoryTestBase.cs
@@ -530,11 +530,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory disposingLocalDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using IDisposingContainer<TContainerClient> test = await GetDisposingContainerAsync();
 
-            List<string> files =
-            [
-                GetNewObjectName(),
-                GetNewObjectName(),
-            ];
+            List<string> files = [ "file1", "file2", "dir1/file1" ];
 
             CancellationToken cancellationToken = TestHelper.GetTimeoutToken(30);
             await SetupDirectoryAsync(

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/TransferValidator.Local.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/TransferValidator.Local.cs
@@ -30,6 +30,7 @@ namespace Azure.Storage.DataMovement.Tests
 
         public static ListFilesAsync GetLocalFileLister(string directoryPath)
         {
+            directoryPath = directoryPath.TrimEnd(Path.DirectorySeparatorChar);
             Task<List<IResourceEnumerationItem>> ListFiles(CancellationToken cancellationToken)
             {
                 List<IResourceEnumerationItem> result = new();


### PR DESCRIPTION
There was an issue where if a path with a trailing path separator was passed to `LocalFilesStorageResourceProvider.FromDirectory` during an upload transfer, the destination resource names may be missing the first character. This was because some path parsing logic assumed the path did not end with a trailing separator. This fixes the issue by always trimming the end of the path when constructing `LocalDirectoryStorageResourceContainer`.

Also added another change in `TransferJobInternal` to harden the logic during enumeration for the same case. While either change would address the issue, this should harden against future issues or missed cases.