### PR TITLE
Fix alignment in codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -898,7 +898,7 @@
 # ServiceOwners:                                                   @giakas
 
 # PRLabel: %Voice Live
-/sdk/ai/Azure.AI.VoiceLive/                                       @rhurey @xitzhang
+/sdk/ai/Azure.AI.VoiceLive/                                        @rhurey @xitzhang
 
 # ServiceLabel: %Voice Live
 # ServiceOwners:                                                   @rhurey @xitzhang


### PR DESCRIPTION
Missed a space throwing the alignment off.