### PR TITLE
Specify CodeQL languages for analysis

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -104,7 +104,8 @@ jobs:
             componentgovernance:
               enabled: true
             codeql:
-              binaryLanguages: csharp # Need to specify the language because we clone after the codeql initialize step
+              # Need to specify the language because we clone after the codeql initialize step
+              language: csharp, javascript
               compiled:
                 enabled: true
 


### PR DESCRIPTION
S360 is complaining we don't scan the JS code for codeql so adding JS to the languages.
