### PR TITLE
DAC - attempt retries and disable probe when ManagedIdentityCredential is selected in Env

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added a new `DefaultAzureCredential` constructor that accepts a custom environment variable name for credential configuration. This provides flexibility beyond the default `AZURE_TOKEN_CREDENTIALS` environment variable. The constructor accepts any environment variable name and uses the same credential selection logic as the existing `AZURE_TOKEN_CREDENTIALS` processing.
 - Added `DefaultAzureCredential.DefaultEnvironmentVariableName` constant property that returns `"AZURE_TOKEN_CREDENTIALS"` for convenience when referencing the default environment variable name.
 - `AzureCliCredential`, `AzurePowerShellCredential`, and `AzureDeveloperCliCredential` now throw an `AuthenticationFailedException` when the `TokenRequestContext` includes claims, as these credentials do not support claims challenges. The exception message includes guidance for handling such scenarios.
+- When `AZURE_TOKEN_CREDENTIALS` or the equivalent custom environment variable is configured to `ManagedIdentityCredential`, the `DefaultAzureCredential` does not issue a probe request and performs retries with exponential backoff.
 
 ### Breaking Changes
 

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -246,7 +246,7 @@ namespace Azure.Identity
                 Constants.AzureDeveloperCliCredential => [CreateAzureDeveloperCliCredential()],
                 Constants.EnvironmentCredential => [CreateEnvironmentCredential()],
                 Constants.WorkloadIdentityCredential => [CreateWorkloadIdentityCredential()],
-                Constants.ManagedIdentityCredential => [CreateManagedIdentityCredential()],
+                Constants.ManagedIdentityCredential => [CreateManagedIdentityCredential(false)],
                 Constants.InteractiveBrowserCredential => [CreateInteractiveBrowserCredential()],
                 Constants.BrokerCredential =>
                     TryCreateDevelopmentBrokerOptions(out InteractiveBrowserCredentialOptions brokerOptions)
@@ -279,10 +279,10 @@ namespace Azure.Identity
             return new WorkloadIdentityCredential(options);
         }
 
-        public virtual TokenCredential CreateManagedIdentityCredential()
+        public virtual TokenCredential CreateManagedIdentityCredential(bool isProbeEnabled = true)
         {
             var options = Options.Clone<DefaultAzureCredentialOptions>();
-            options.IsChainedCredential = true;
+            options.IsChainedCredential = isProbeEnabled;
 
             if (options.ManagedIdentityClientId != null && options.ManagedIdentityResourceId != null)
             {

--- a/sdk/identity/Azure.Identity/tests/ImdsManagedIdentityProbeSourceTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ImdsManagedIdentityProbeSourceTests.cs
@@ -103,7 +103,7 @@ namespace Azure.Identity.Tests
                     Retry = { Delay = TimeSpan.Zero }
                 });
 
-                //First request uses a 1 second timeout and no retries
+                // When ManagedIdentityCredential is configured via environment variable, there are no timeouts and retries are performed
                 await cred.GetTokenAsync(new(new[] { "test" }));
 
                 var expectedTimeouts = new TimeSpan?[] { null, null, null, null, null, null };
@@ -156,7 +156,7 @@ namespace Azure.Identity.Tests
                     Retry = { Delay = TimeSpan.Zero }
                 });
 
-                //First request uses a 1 second timeout and no retries
+                // First request validates that there are no network timeouts and retries are performed
                 await cred.GetTokenAsync(new(new[] { "test" }));
 
                 var expectedTimeouts = new TimeSpan?[] { null, null, null, null, null, null };

--- a/sdk/identity/Azure.Identity/tests/Mock/MockDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/MockDefaultAzureCredentialFactory.cs
@@ -45,7 +45,7 @@ namespace Azure.Identity.Tests.Mock
             return mockWorkloadIdentityCredential.Object;
         }
 
-        public override TokenCredential CreateManagedIdentityCredential()
+        public override TokenCredential CreateManagedIdentityCredential(bool isProbeEnabled = true)
         {
             OnCreateManagedIdentityCredential?.Invoke(mockManagedIdentityCredential);
             return mockManagedIdentityCredential.Object;

--- a/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
@@ -24,7 +24,7 @@ namespace Azure.Identity.Tests.Mock
         public override TokenCredential CreateEnvironmentCredential()
             => new EnvironmentCredential(Pipeline, Options);
 
-        public override TokenCredential CreateManagedIdentityCredential()
+        public override TokenCredential CreateManagedIdentityCredential(bool isProbeEnabled = true)
             => new ManagedIdentityCredential(Options.ManagedIdentityClientId, Pipeline, Options);
 
         public override TokenCredential CreateSharedTokenCacheCredential()


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
