### PR TITLE
Specified build command in the configuration for .NET

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/documentation/sdkautomation/SwaggerToSdkConfigSchema.json",
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-sdk-tools/main/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json",
   "generateOptions": {
     "generateScript": {
       "path": "pwsh ./eng/scripts/Invoke-GenerateAndBuildV2.ps1",
@@ -23,8 +23,7 @@
   "packageOptions": {
     "packageFolderFromFileSearch": false,
     "buildScript": {
-      "command": "dotnet build {packagePath}",
-      "path": ""
+      "command": "dotnet build {packagePath}"
     }
   }
 }

--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -21,6 +21,10 @@
     }
   },
   "packageOptions": {
-    "packageFolderFromFileSearch": false
+    "packageFolderFromFileSearch": false,
+    "buildScript": {
+      "command": "dotnet build {packagePath}",
+      "path": ""
+    }
   }
 }


### PR DESCRIPTION
Use inline command for .NET `Build SDK` process.

Refer to [this activity](https://github.com/Azure/azure-sdk-tools/issues/11402) for details.