### PR TITLE
[Identity] Prepare Azure.Identity 1.16.0 release

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -9,8 +9,6 @@
 - `AzureCliCredential`, `AzurePowerShellCredential`, and `AzureDeveloperCliCredential` now throw an `AuthenticationFailedException` when the `TokenRequestContext` includes claims, as these credentials do not support claims challenges. The exception message includes guidance for handling such scenarios.
 - When `AZURE_TOKEN_CREDENTIALS` or the equivalent custom environment variable is configured to `ManagedIdentityCredential`, the `DefaultAzureCredential` does not issue a probe request and performs retries with exponential backoff.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed `AzureDeveloperCliCredential` hanging when the `AZD_DEBUG` environment variable is set by adding the `--no-prompt` flag to prevent interactive prompts ([#52005](https://github.com/Azure/azure-sdk-for-net/issues/52005)).

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.16.0-beta.1 (Unreleased)
+## 1.16.0 (2025-09-09)
 
 ### Features Added
 
@@ -14,11 +14,13 @@
 ### Bugs Fixed
 
 - Fixed `AzureDeveloperCliCredential` hanging when the `AZD_DEBUG` environment variable is set by adding the `--no-prompt` flag to prevent interactive prompts ([#52005](https://github.com/Azure/azure-sdk-for-net/issues/52005)).
-- `BrokerCredential` is now included in the chain when `AZURE_TOKEN_CREDENTIALS` is set to `dev` and the `Azure.Identity.Broker` package is installed.
+- `BrokerCredential` is now included in the chain when `AZURE_TOKEN_CREDENTIALS` is set to `dev`.
 - Fixed an issue that prevented ManagedIdentityCredential from utilizing the token cache in Workload Identity Federation environments.
 - Fixed a bug in `DefaultAzureCredential` that caused the credential chain to be constructed incorrectly when using AZURE_TOKEN_CREDENTIALS in combination with `DefaultAzureCredentialOptions`.
 
 ### Other Changes
+
+- The `BrokerCredential` is now always included in the `DefaultAzureCredential` chain. If the `Azure.Identity.Broker` package is not referenced, an exception will be thrown when `GetToken` is called, making its behavior consistent with the rest of the credentials in the chain.
 
 ## 1.15.0 (2025-08-11)
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -21,6 +21,8 @@
 ### Other Changes
 
 - The `BrokerCredential` is now always included in the `DefaultAzureCredential` chain. If the `Azure.Identity.Broker` package is not referenced, an exception will be thrown when `GetToken` is called, making its behavior consistent with the rest of the credentials in the chain.
+- Updated `Microsoft.Identity.Client` dependency to version 4.76.0.
+- Updated `Microsoft.Identity.Client.Extensions.Msal` dependency to version 4.76.0.
 
 ## 1.15.0 (2025-08-11)
 

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides APIs for authenticating to Microsoft Entra ID</Description>
     <AssemblyTitle>Microsoft Azure.Identity Component</AssemblyTitle>
-    <Version>1.16.0-beta.1</Version>
+    <Version>1.16.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.15.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
This PR gets `Azure.Identity` ready for the v1.16.0 release.