### PR TITLE
[Storage][DataMovement] Fix some failing live tests

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_c2f1f2fc3f"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs_be4448c888"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobStartTransferCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/PageBlobStartTransferCopyTests.cs
@@ -251,9 +251,12 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
                 {
                     Assert.That(destinationProperties.AccessTier.ToString(), Is.Not.EqualTo(_defaultAccessTier.ToString()));
                 }
-
-                GetBlobTagResult destinationTags = await destinationClient.GetTagsAsync();
-                Assert.IsEmpty(destinationTags.Tags);
+                if (!premium)
+                {
+                    // Premium accounts do not support tags
+                    GetBlobTagResult destinationTags = await destinationClient.GetTagsAsync();
+                    Assert.IsEmpty(destinationTags.Tags);
+                }
             }
             else if (transferPropertiesTestType == TransferPropertiesTestType.NewProperties)
             {


### PR DESCRIPTION
There are some consistently failing Live tests that are caused by attempting to call Get Tags on a premium account, which is not supported. Honestly not sure how they pass in playback and got merged but here is the fix.