### PR TITLE
Fix tenantId selection in MSAL

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Use `WithTenantId` instead of `WithTenantIdFromAuthority` for setting the tenant for the authentication session to prevent malformed Uris to the authority.
+
 ### Other Changes
 
 ## 1.16.0 (2025-09-09)

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Use `WithTenantId` instead of `WithTenantIdFromAuthority` for setting the tenant for the authentication session to prevent malformed Uris to the authority.
+- TenantId is now configured via MSAL's `WithTenantId` instead of `WithTenantIdFromAuthority` to prevent malformed Uris to the authority.
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity/src/MsalClientBase.cs
+++ b/sdk/identity/Azure.Identity/src/MsalClientBase.cs
@@ -108,20 +108,5 @@ namespace Azure.Identity
 
             return asyncLock.HasValue ? asyncLock.Value.Cache : null;
         }
-
-        public UriBuilder BuildTenantIdWithAuthorityHost(string tenantId)
-        {
-            UriBuilder uriBuilder = new(AuthorityHost);
-            if (uriBuilder.Path.EndsWith("/"))
-            {
-                uriBuilder.Path += tenantId;
-            }
-            else
-            {
-                uriBuilder.Path = uriBuilder.Path + "/" + tenantId;
-            }
-
-            return uriBuilder;
-        }
     }
 }

--- a/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
@@ -169,8 +169,7 @@ namespace Azure.Identity
 
             if (!string.IsNullOrEmpty(tenantId))
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(tenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(tenantId);
             }
             if (!string.IsNullOrEmpty(claims))
             {
@@ -211,8 +210,7 @@ namespace Azure.Identity
             var builder = client.AcquireTokenSilent(scopes, account);
             if (!string.IsNullOrEmpty(tenantId))
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(tenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(tenantId);
             }
             if (!string.IsNullOrEmpty(claims))
             {
@@ -254,8 +252,7 @@ namespace Azure.Identity
 
             if (!string.IsNullOrEmpty(tenantId))
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(tenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(tenantId);
             }
             if (!string.IsNullOrEmpty(claims))
             {
@@ -297,8 +294,7 @@ namespace Azure.Identity
 
             if (!string.IsNullOrEmpty(tenantId))
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(tenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(tenantId);
             }
             if (!string.IsNullOrEmpty(claims))
             {

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -126,8 +126,7 @@ namespace Azure.Identity
             }
             if (tenantId != null)
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(tenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(tenantId);
             }
 
             if (context.IsProofOfPossessionEnabled)
@@ -182,8 +181,7 @@ namespace Azure.Identity
 
             if (tenantId != null || record.TenantId != null)
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(tenantId ?? record.TenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(tenantId ?? record.TenantId);
             }
 
             if (!string.IsNullOrEmpty(claims))
@@ -284,8 +282,7 @@ namespace Azure.Identity
             }
             if (tenantId != null)
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(tenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(tenantId);
             }
             if (browserOptions != null)
             {
@@ -328,8 +325,7 @@ namespace Azure.Identity
             }
             if (!string.IsNullOrEmpty(tenantId))
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(tenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(tenantId);
             }
             return await builder.ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
@@ -353,8 +349,7 @@ namespace Azure.Identity
             }
             if (!string.IsNullOrEmpty(TenantId))
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(TenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(TenantId);
             }
 
             return await builder.ExecuteAsync(async, cancellationToken)
@@ -380,8 +375,7 @@ namespace Azure.Identity
 
             if (!string.IsNullOrEmpty(TenantId))
             {
-                UriBuilder uriBuilder = BuildTenantIdWithAuthorityHost(TenantId);
-                builder.WithTenantIdFromAuthority(uriBuilder.Uri);
+                builder.WithTenantId(TenantId);
             }
 
             return await builder.ExecuteAsync(async, cancellationToken)


### PR DESCRIPTION
Using `WithTenantIdFromAuthority` the way we were previously could result in authority Uris like the following:

`https://login.microsoftonline.com/<tenant1>/<tenant2>`

The simple workaround is to use `WithTenantId` as opposed to `WithTenantIdFromAuthority`