### PR TITLE
Add QueryDebugMode Debug to list of parameters copied for SearchOptions.

### DIFF
--- a/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
@@ -428,6 +428,7 @@ namespace Azure.Search.Documents
             destination.Skip = source.Skip;
             destination.QueryLanguage = source.QueryLanguage;
             destination.QuerySpeller = source.QuerySpeller;
+            destination.Debug = source.Debug;
             destination.SemanticSearch = source.SemanticSearch;
             destination.VectorSearch = source.VectorSearch;
             destination.HybridSearch  = source.HybridSearch;

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
@@ -1015,6 +1015,7 @@ namespace Azure.Search.Documents.Tests
             source.SessionId = "SessionId";
             source.Size = 100;
             source.Skip = null;
+            source.Debug = QueryDebugMode.All;
             source.SemanticSearch = new SemanticSearchOptions()
             {
                 SemanticConfigurationName = "my-config",
@@ -1044,6 +1045,7 @@ namespace Azure.Search.Documents.Tests
             Assert.AreEqual(source.SessionId, clonedSearchOptions.SessionId); // A string value
             Assert.AreEqual(source.Size, clonedSearchOptions.Size); // An int? value
             Assert.IsNull(clonedSearchOptions.Skip); // An int? value set as `null`
+            Assert.AreEqual(source.Debug, clonedSearchOptions.Debug);
             Assert.AreEqual(source.SemanticSearch.SemanticConfigurationName, clonedSearchOptions.SemanticSearch.SemanticConfigurationName);
             Assert.AreEqual(source.SemanticSearch.QueryAnswer.AnswerType, clonedSearchOptions.SemanticSearch.QueryAnswer.AnswerType);
             Assert.AreEqual(source.SemanticSearch.QueryAnswer.Count, clonedSearchOptions.SemanticSearch.QueryAnswer.Count);


### PR DESCRIPTION
Add Debug to list of parameters copied for SearchOptions.
Add to existing test to cover.

I believe this was introduced by https://github.com/Azure/azure-sdk-for-net/pull/52485 when `QueryDebugMode` was migrated from `SemanticSearchOptions` to `SearchOptions`.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
