### PR TITLE
Revert "Specified build command in the configuration for .NET (#52546)"

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Azure/azure-sdk-tools/main/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json",
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/documentation/sdkautomation/SwaggerToSdkConfigSchema.json",
   "generateOptions": {
     "generateScript": {
       "path": "pwsh ./eng/scripts/Invoke-GenerateAndBuildV2.ps1",
@@ -21,9 +21,6 @@
     }
   },
   "packageOptions": {
-    "packageFolderFromFileSearch": false,
-    "buildScript": {
-      "command": "dotnet build {packagePath}"
-    }
+    "packageFolderFromFileSearch": false
   }
 }


### PR DESCRIPTION
This reverts commit ca6e724d5d4d78bcf97604a94690eb5329bddb0f.

It caused a schema validation error in SDK validation pipeline. The new version of `spec-gen-sdk` hasn't been released. I will need more changes on that. So, revert this config change first.

@weshaggard can you approve?