### PR TITLE
Specified build command in the configuration for .NET

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/documentation/sdkautomation/SwaggerToSdkConfigSchema.json",
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-sdk-tools/main/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json",
   "generateOptions": {
     "generateScript": {
       "path": "pwsh ./eng/scripts/Invoke-GenerateAndBuildV2.ps1",
@@ -21,6 +21,9 @@
     }
   },
   "packageOptions": {
-    "packageFolderFromFileSearch": false
+    "packageFolderFromFileSearch": false,
+    "buildScript": {
+      "command": "dotnet build {packagePath}"
+    }
   }
 }


### PR DESCRIPTION
Added back the `swagger_to_sdk_config.json` change since the `spec-gen-sdk` had released the new version with support on `command` option and it's already deployed to spec repo.

