### PR TITLE
[AzureMonitorExporter] Add 'enduser.pseudo.id' as `ai.user.id`

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added mapping for `enduser.pseudo.id` attribute to `user_Id`
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -68,7 +68,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 Tags["ai.user.userAgent"] = userAgent;
             }
 
-            SetAuthenticatedUserId(ref activityTagsProcessor);
+            SetUserIdAndAuthenticatedUserId(ref activityTagsProcessor);
             SetResourceSdkVersionAndIkey(resource, instrumentationKey);
 
             if (sampleRate != 100f)
@@ -149,11 +149,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetAuthenticatedUserId(ref ActivityTagsProcessor activityTagsProcessor)
+        private void SetUserIdAndAuthenticatedUserId(ref ActivityTagsProcessor activityTagsProcessor)
         {
             if (activityTagsProcessor.EndUserId != null)
             {
                 Tags[ContextTagKeys.AiUserAuthUserId.ToString()] = activityTagsProcessor.EndUserId.Truncate(SchemaConstants.Tags_AiUserAuthUserId_MaxLength);
+            }
+
+            if (activityTagsProcessor.EndUserPseudoId != null)
+            {
+                Tags[ContextTagKeys.AiUserId.ToString()] = activityTagsProcessor.EndUserPseudoId.Truncate(SchemaConstants.Tags_AiUserId_MaxLength);
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -55,6 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             // Others
             SemanticConventions.AttributeEnduserId,
+            SemanticConventions.AttributeEnduserPseudoId,
             "microsoft.client.ip"
         };
 
@@ -68,6 +69,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public string? AzureNamespace { get; private set; } = null;
 
         public string? EndUserId { get; private set; } = null;
+
+        public string? EndUserPseudoId { get; private set; } = null;
 
         public ActivityTagsProcessor()
         {
@@ -105,6 +108,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             break;
                         case SemanticConventions.AttributeEnduserId:
                             EndUserId = tag.Value.ToString();
+                            continue;
+                        case SemanticConventions.AttributeEnduserPseudoId:
+                            EndUserPseudoId = tag.Value.ToString();
                             continue;
                     }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -121,6 +121,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const int Tags_AiOperationName_MaxLength = 1024;
         public const int Tags_AiOperationParentId_MaxLength = 512;
         public const int Tags_AiUserAuthUserId_MaxLength = 1024;
+        public const int Tags_AiUserId_MaxLength = 1024;
         public const int Tags_AiApplicationVer_MaxLength = 1024;
         public const int Tags_AiCloudRole_MaxLength = 256;
         public const int Tags_AiCloudRoleInstance_MaxLength = 256;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
@@ -69,6 +69,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const string AttributeNetHostName = "net.host.name";
 
         public const string AttributeEnduserId = "enduser.id";
+        public const string AttributeEnduserPseudoId = "enduser.pseudo.id";
         public const string AttributeEnduserRole = "enduser.role";
         public const string AttributeEnduserScope = "enduser.scope";
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -165,6 +165,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             string? expectedSpanId,
             IDictionary<string, string>? expectedProperties,
             string expectedAuthUserId,
+            string expectedUserId,
             bool expectedSuccess = true,
             string expectedCloudRole = "[testNamespace]/testName",
             string expectedCloudInstance = "testInstance",
@@ -175,9 +176,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(6, telemetryItem.Tags.Count);
+            Assert.Equal(7, telemetryItem.Tags.Count);
             Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
             Assert.Equal(expectedAuthUserId, telemetryItem.Tags["ai.user.authUserId"]);
+            Assert.Equal(expectedUserId, telemetryItem.Tags["ai.user.id"]);
             Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
             Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
             Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);
@@ -209,6 +211,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             IDictionary<string, string> expectedProperties,
             string? expectedSpanId,
             string expectedAuthUserId,
+            string expectedUserId,
             bool expectedSuccess = true,
             string expectedCloudRole = "[testNamespace]/testName",
             string expectedCloudInstance = "testInstance",
@@ -219,11 +222,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            var expectedTagsCount = 7;
+            var expectedTagsCount = 8;
 
             Assert.Equal(expectedTagsCount, telemetryItem.Tags.Count);
             Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
             Assert.Equal(expectedAuthUserId, telemetryItem.Tags["ai.user.authUserId"]);
+            Assert.Equal(expectedUserId, telemetryItem.Tags["ai.user.id"]);
             Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
             Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
             Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -65,6 +65,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 spanId = activity.SpanId.ToHexString();
 
                 activity.SetTag("enduser.id", "TestUser"); //authenticated user
+                activity.SetTag("enduser.pseudo.id", "TestPseudoUser"); // anonymous/pseudo user id
                 activity.SetTag("integer", 1);
                 activity.SetTag("message", "Hello World!");
                 activity.SetTag("intArray", new int[] { 1, 2, 3 });
@@ -85,6 +86,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
                 expectedAuthUserId: "TestUser",
+                expectedUserId: "TestPseudoUser",
                 expectedProperties: new Dictionary<string, string> { { "integer", "1" }, { "message", "Hello World!" }, { "intArray", "1,2,3" } });
         }
 
@@ -114,6 +116,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 spanId = activity.SpanId.ToHexString();
 
                 activity.SetTag("enduser.id", "TestUser"); //authenticated user
+                activity.SetTag("enduser.pseudo.id", "TestPseudoUser"); // anonymous/pseudo user id
                 activity.SetTag("integer", 1);
                 activity.SetTag("message", "Hello World!");
                 activity.SetTag("intArray", new int[] { 1, 2, 3 });
@@ -135,6 +138,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
                 expectedAuthUserId: "TestUser",
+                expectedUserId: "TestPseudoUser",
                 expectedProperties: new Dictionary<string, string> { { "integer", "1" }, { "message", "Hello World!" }, { "intArray", "1,2,3" } });
         }
 
@@ -163,6 +167,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 spanId = activity.SpanId.ToHexString();
 
                 activity.SetTag("enduser.id", "TestUser"); //authenticated user
+                activity.SetTag("enduser.pseudo.id", "TestPseudoUser"); // anonymous/pseudo user id
 
                 try
                 {
@@ -192,6 +197,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
                 expectedAuthUserId: "TestUser",
+                expectedUserId: "TestPseudoUser",
                 expectedProperties: null,
                 expectedSuccess: false);
 
@@ -259,6 +265,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 traceId = activity.TraceId.ToHexString();
 
                 activity.SetTag("enduser.id", "TestUser"); //authenticated user
+                activity.SetTag("enduser.pseudo.id", "TestPseudoUser"); // anonymous/pseudo user id
 
                 var logger = loggerFactory.CreateLogger(logCategoryName);
 
@@ -285,6 +292,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
                 expectedAuthUserId: "TestUser",
+                expectedUserId: "TestPseudoUser",
                 expectedProperties: null);
 
             Assert.True(logTelemetryItems?.Any(), "Unit test failed to collect telemetry.");


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
