### PR TITLE
add IsWasi for Azure.Core and System.ClientModel

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
@@ -156,7 +156,11 @@ namespace Azure.Core.Pipeline
             {
                 // Disable response caching and enable streaming in Blazor apps
                 // see https://github.com/dotnet/aspnetcore/blob/3143d9550014006080bb0def5b5c96608b025a13/src/Components/WebAssembly/WebAssembly/src/Http/WebAssemblyHttpRequestMessageExtensions.cs
+                #if NET8_0_OR_GREATER
+                if (OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
+                #else
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+                #endif
                 {
                     SetPropertiesOrOptions(currentRequest, "WebAssemblyFetchOptions", new Dictionary<string, object> { { "cache", "no-store" } });
                     SetPropertiesOrOptions(currentRequest, "WebAssemblyEnableStreamingResponse", true);

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
@@ -157,7 +157,7 @@ namespace Azure.Core.Pipeline
                 // Disable response caching and enable streaming in Blazor apps
                 // see https://github.com/dotnet/aspnetcore/blob/3143d9550014006080bb0def5b5c96608b025a13/src/Components/WebAssembly/WebAssembly/src/Http/WebAssemblyHttpRequestMessageExtensions.cs
                 #if NET8_0_OR_GREATER
-                if (OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
+                if (OperatingSystem.IsBrowser())
                 #else
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
                 #endif

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -203,7 +203,7 @@ namespace Azure.Core.Pipeline
 #if NETCOREAPP
         private static SocketsHttpHandler ApplyOptionsToHandler(SocketsHttpHandler httpHandler, HttpPipelineTransportOptions? options)
         {
-            #if NET5_0_OR_GREATER
+            #if NET8_0_OR_GREATER
             if (options == null || OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
             #else
             if (options == null || RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -153,7 +153,11 @@ namespace Azure.Core.Pipeline
 
         private static HttpMessageHandler CreateDefaultHandler(HttpPipelineTransportOptions? options = null)
         {
+            #if NET8_0_OR_GREATER
+            if (OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
+            #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            #endif
             {
                 // UseCookies is not supported on "browser"
                 return new HttpClientHandler();
@@ -168,7 +172,11 @@ namespace Azure.Core.Pipeline
 
         private static void SetProxySettings(HttpMessageHandler messageHandler)
         {
+            #if NET8_0_OR_GREATER
+            if (OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
+            #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            #endif
             {
                 return;
             }
@@ -195,7 +203,11 @@ namespace Azure.Core.Pipeline
 #if NETCOREAPP
         private static SocketsHttpHandler ApplyOptionsToHandler(SocketsHttpHandler httpHandler, HttpPipelineTransportOptions? options)
         {
+            #if NET5_0_OR_GREATER
+            if (options == null || OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
+            #else
             if (options == null || RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            #endif
             {
                 return httpHandler;
             }
@@ -224,7 +236,11 @@ namespace Azure.Core.Pipeline
 #else
         private static HttpClientHandler ApplyOptionsToHandler(HttpClientHandler httpHandler, HttpPipelineTransportOptions? options)
         {
+            #if NET8_0_OR_GREATER
+            if (options == null || OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
+            #else
             if (options == null || RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            #endif
             {
                 return httpHandler;
             }

--- a/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs
@@ -60,7 +60,11 @@ namespace Azure.Core.Pipeline
 #endif
         public static void SetLimits(HttpMessageHandler messageHandler)
         {
+            #if NET8_0_OR_GREATER
+            if (OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
+            #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            #endif
             {
                 return;
             }

--- a/sdk/core/System.ClientModel/src/Internal/ServicePointHelpers.cs
+++ b/sdk/core/System.ClientModel/src/Internal/ServicePointHelpers.cs
@@ -58,7 +58,11 @@ internal static class ServicePointHelpers
 #endif
     public static void SetLimits(HttpMessageHandler messageHandler)
     {
+        #if NET8_0_OR_GREATER
+        if (OperatingSystem.IsBrowser() || OperatingSystem.IsWasi())
+        #else
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+        #endif
         {
             return;
         }


### PR DESCRIPTION
This adds a `IsWasi` check in Azure.Core & System.ClientModel in the same places where `IsBrowser()` was being checked prior. It allowed me to make http requests when targeting wasi.