### PR TITLE
Replace incorrect header name in XML docs

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -13,7 +13,7 @@ using Azure.Core.Diagnostics;
 namespace Azure.Core.Pipeline
 {
     /// <summary>
-    /// A policy that sends an <see cref="AccessToken"/> provided by a <see cref="TokenCredential"/> as an Authentication header.
+    /// A policy that sends an <see cref="AccessToken"/> provided by a <see cref="TokenCredential"/> as an <see cref="HttpHeader.Names.Authorization"/> header.
     /// </summary>
     public class BearerTokenAuthenticationPolicy : HttpPipelinePolicy
     {


### PR DESCRIPTION
The wrong header name was mentioned in the class-level XML docs. See the code at the following locations:

https://github.com/Azure/azure-sdk-for-net/blob/93950946ccc4d7c3d359d98d5b99be5cba41d47a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs#L205

https://github.com/Azure/azure-sdk-for-net/blob/93950946ccc4d7c3d359d98d5b99be5cba41d47a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs#L216
