### PR TITLE
fix(Monitor.Query): fix LogsTableRow.GetDecimal()

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientTests.cs
@@ -79,7 +79,7 @@ namespace Azure.Monitor.Query.Tests
         public void CanGetMetricQueryResult()
         {
             var metadata = new Dictionary<string, string> { { "metadatatest1", "metadatatest2" } };
-            var metricValue = MonitorQueryModelFactory.MetricValue(new DateTimeOffset(new DateTime(10)));
+            var metricValue = MonitorQueryModelFactory.MetricValue(new DateTimeOffset(new DateTime(10, DateTimeKind.Utc)));
             var metricValueList = new List<MetricValue>() { metricValue };
             MetricTimeSeriesElement metricTimeSeriesElement = MonitorQueryModelFactory.MetricTimeSeriesElement(metadata, metricValueList);
             Assert.IsNotNull(metricTimeSeriesElement);
@@ -88,7 +88,7 @@ namespace Azure.Monitor.Query.Tests
             Assert.AreEqual("metadatatest1", firstElement.Key);
             Assert.AreEqual("metadatatest2", firstElement.Value);
             Assert.AreEqual(1, metricTimeSeriesElement.Values.Count);
-            Assert.AreEqual(new DateTimeOffset(new DateTime(10)), metricTimeSeriesElement.Values[0].TimeStamp);
+            Assert.AreEqual(new DateTimeOffset(new DateTime(10, DateTimeKind.Utc)), metricTimeSeriesElement.Values[0].TimeStamp);
             IEnumerable<MetricTimeSeriesElement> metricTimeSeriesElements = new[] { metricTimeSeriesElement };
 
             MetricUnit metricUnit = new MetricUnit("test");

--- a/sdk/monitor/Azure.Monitor.Query/tests/MonitorQueryDateTimeRangeTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MonitorQueryDateTimeRangeTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
+    [SetCulture("en-US")]
     public class MonitorQueryDateTimeRangeTests
     {
         [Test]


### PR DESCRIPTION
## Changes

Make GetDecimal robust across JSON kinds, don't assume string.

- Treat Null/Undefined as null
- Map booleans: true => 1m, false => 0m
- Use JsonElement.GetDecimal() for JsonValueKind.Number
- Parse strings with InvariantCulture and NumberStyles.Number
- Throw OverflowException for "NaN", "Infinity", "-Infinity" and out-of-range values
- Throw InvalidOperationException for unsupported JsonValueKind
- Add XML docs for FormatException, OverflowException, InvalidOperationException
- fixes #41245

This replaces string-based decimal parsing with a value-kind switch for correctness and clearer error semantics.

Fix timezone handling in Monitor Query tests (Currently tests fail negative UTC or non en-US culture machines)

- Specify DateTimeKind.Utc for DateTime constructors to ensure consistent timezone behavior
- Add SetCulture attribute to MonitorQueryDateTimeRangeTests to prevent culture-dependent test failures

## Given
```kql
 let dt = datatable (Int: int, String: string, Bool:bool, Double: double, Decimal: decimal)
 [
     1, 'a', false, 0.0, decimal(0.0),
     2, 'b', true, 1.2, decimal(2.2),
     3, 'c', false, 1.1, decimal(2.3),
 ];
 dt
     | distinct *
     | project String, Int, Bool, Double, Decimal
     | order by String asc
```

## When

```csharp
  Assert.AreEqual(0.0m, resultTable.Rows[0].GetDecimal(4));
  Assert.AreEqual(0.0m, resultTable.Rows[0].GetDecimal("Decimal"));
```

## Before fix

```
System.InvalidOperationException
  HResult=0x80131509
  Message=The requested operation requires an element of type 'String', but the target element has type 'Number'.
  Source=System.Text.Json
  StackTrace:
   at System.Text.Json.ThrowHelper.ThrowJsonElementWrongTypeException(JsonTokenType expectedType, JsonTokenType actualType)
   at System.Text.Json.JsonDocument.GetString(Int32 index, JsonTokenType expectedType)
   at Azure.Monitor.Query.Models.LogsTableRow.GetDecimal(Int32 index) in azure-sdk-for-net\sdk\monitor\Azure.Monitor.Query\src\Models\LogsTableRow.cs:line 61
   at Azure.Monitor.Query.Models.LogsTableRow.GetDecimal(String name) in azure-sdk-for-net\sdk\monitor\Azure.Monitor.Query\src\Models\LogsTableRow.cs:line 153
   at Program.<<Main>$>d__0.MoveNext() in D:\source\temp\Azure.Monitor.Query.Repro\Azure.Monitor.Query.Repro\Program.cs:line 34
```

## After fix

No exception