### PR TITLE
[Event Hubs] Storage breaking change fix

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -141,7 +141,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             {
                 var prefix = string.Format(CultureInfo.InvariantCulture, OwnershipPrefix, fullyQualifiedNamespace.ToLowerInvariant(), eventHubName.ToLowerInvariant(), consumerGroup.ToLowerInvariant());
 
-                await foreach (BlobItem blob in ContainerClient.GetBlobsAsync(traits: BlobTraits.Metadata, prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+                await foreach (BlobItem blob in ContainerClient.GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, prefix, cancellationToken).ConfigureAwait(false))
                 {
                     // In case this key does not exist, ownerIdentifier is set to null.  This will force the PartitionOwnership constructor
                     // to throw an exception.


### PR DESCRIPTION
# Summary

The focus of these tests is to fix a breaking change introduced in Storage where default parameters were removed from an overload, causing a build failure.

## References and resources

- [Pipeline failure](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5408388&view=logs&jobId=54c501cb-5732-5fb7-dd3b-d300d6a93f80&j=54c501cb-5732-5fb7-dd3b-d300d6a93f80&t=d79c4ed4-8b0a-5d6e-70e8-e08e626aef52) _(Microsoft internal)_
- [Storage breaking changes](https://github.com/Azure/azure-sdk-for-net/commit/ee5aeec833cd95afc36cf401a8b1a888e606ea2b#diff-d27bab6b5ba085a5bd98ac8e1f868e8cef71ebaf6e1404c6570e04eb82aceebbL157)