### PR TITLE
Implementing lightweight detection for new write operations

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 string prefix = GetSearchPrefix("blob", hourCursor, hourCursor);
 
                 await foreach (var page in containerClient
-                    .GetBlobsAsync(traits: BlobTraits.Metadata, prefix: prefix, cancellationToken: cancellationToken)
+                    .GetBlobsAsync(traits: BlobTraits.Metadata, prefix: prefix, states: BlobStates.None, cancellationToken: cancellationToken)
                     .AsPages(pageSizeHint: 200)
                     .ConfigureAwait(false))
                 {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         private readonly StorageAnalyticsLogParser _parser;
         private readonly ILogger<BlobListener> _logger;
 
-        private BlobLogListener(BlobServiceClient blobClient, ILogger<BlobListener> logger)
+        public BlobLogListener(BlobServiceClient blobClient, ILogger<BlobListener> logger)
         {
             _blobClient = blobClient;
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobScalerMonitorProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobScalerMonitorProvider.cs
@@ -63,11 +63,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 _logger = loggerFactory.CreateLogger<ZeroToOneScaleMonitor>();
             }
 
-            #pragma warning disable 0649
-            // For tests, in PROD the value is always null
-            private BlobWithContainer<BlobBaseClient> _recentWrite;
-            #pragma warning restore 0649
-
             public ScaleMonitorDescriptor Descriptor => _scaleMonitorDescriptor;
 
             public async Task<ScaleMetrics> GetMetricsAsync()
@@ -77,26 +72,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                     // if new blob were detected we want to GetScaleStatus return scale out vote at least once
                     if (Interlocked.Equals(_threadSafeWritesDetectedValue, 1))
                     {
-                        _logger.LogInformation($"New writes were detectd but GetScaleStatus was not called. Waiting GetScaleStatus to call.");
+                        _logger.LogInformation($"Recent writes were detectd but GetScaleStatus was not called. Waiting GetScaleStatus to call.");
                         return new ScaleMetrics();
                     }
 
                     var blobLogListener = await _blobLogListener.Value.ConfigureAwait(false);
-                    BlobWithContainer<BlobBaseClient>[] recentWrites = _recentWrite == null ? (await blobLogListener.GetRecentBlobWritesAsync(CancellationToken.None).ConfigureAwait(false)).ToArray()
-                        : new BlobWithContainer<BlobBaseClient>[] { _recentWrite };
-                    if (recentWrites.Length > 0)
+                    bool hasBlobWrites = await blobLogListener.HasBlobWritesAsync(CancellationToken.None).ConfigureAwait(false);
+                    if (hasBlobWrites)
                     {
-                        StringBuilder stringBuilder = new StringBuilder();
-                        foreach (var write in recentWrites)
-                        {
-                            stringBuilder.Append($"'{write.BlobClient.Name}', ");
-                            if (stringBuilder.Length > 1000)
-                            {
-                                stringBuilder.Append("[truncated]");
-                                break;
-                            }
-                        }
-                        _logger.LogInformation($"'{recentWrites.Length}' recent writes were detected for '{_scaleMonitorDescriptor.FunctionId}': {stringBuilder}");
+                        _logger.LogInformation($"Recent writes were detected for '{_scaleMonitorDescriptor.FunctionId}'");
                         Interlocked.CompareExchange(ref _threadSafeWritesDetectedValue, 1, 0);
                     }
                     else

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobScalerMonitorProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobScalerMonitorProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                     // if new blob were detected we want to GetScaleStatus return scale out vote at least once
                     if (Interlocked.Equals(_threadSafeWritesDetectedValue, 1))
                     {
-                        _logger.LogInformation($"Recent writes were detectd but GetScaleStatus was not called. Waiting GetScaleStatus to call.");
+                        _logger.LogInformation($"Recent writes were detected but GetScaleStatus was not called. Waiting GetScaleStatus to call.");
                         return new ScaleMetrics();
                     }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobLogListenerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobLogListenerTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 .Setup(c => c.GetBlobContainerClient("$logs"))
                 .Returns(containerClientMock.Object);
 
-            var listener = CreateBlobLogListener(blobServiceClientMock.Object);
+            var listener = new BlobLogListener(blobServiceClientMock.Object, NullLogger<BlobListener>.Instance);
 
             // Act
             bool result = await listener.HasBlobWritesAsync(CancellationToken.None, hoursWindow: 1);
@@ -113,22 +113,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             BlobPath singlePath = validPaths.Single();
             Assert.AreEqual("sample-container", singlePath.ContainerName);
             Assert.AreEqual(@"""0x8D199A96CB71468""/sample-blob.txt", singlePath.BlobName);
-        }
-
-        private static BlobLogListener CreateBlobLogListener(BlobServiceClient serviceClient)
-        {
-            var logger = NullLogger<BlobListener>.Instance;
-            var ctor = typeof(BlobLogListener)
-                .GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic,
-                                binder: null,
-                                types: new[] { typeof(BlobServiceClient), typeof(ILogger<BlobListener>) },
-                                modifiers: null);
-            if (ctor == null)
-            {
-                throw new InvalidOperationException("BlobLogListener non-public constructor not found.");
-            }
-
-            return (BlobLogListener)ctor.Invoke(new object[] { serviceClient, logger });
         }
 
         private static class BlobItemFactory

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobLogListenerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobLogListenerTests.cs
@@ -1,36 +1,105 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using NUnit.Framework;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
 {
     public class BlobLogListenerTests
     {
+        [TestCase("write", 1, null, 0, true, TestName = "HasBlobWritesAsync_WriteLogPresent_ReturnsTrue")]
+        [TestCase("read", 1, null, 0, false, TestName = "HasBlobWritesAsync_NonWriteLogPresent_ReturnsFalse")]
+        [TestCase(null, 1, null, 0, false, TestName = "HasBlobWritesAsync_NoBlobs_ReturnsFalse")]
+        [TestCase("read", 100, "write", 1, true, TestName = "HasBlobWritesAsync_WriteLogPresentMultipleLogBlobs_ReturnsTrue")]
+        [TestCase("delete", 100, "read", 100, false, TestName = "HasBlobWritesAsync_NonWriteLogPresentMultipleLogBlobs_ReturnsFalse")]
+        public async Task HasBlobWritesAsync_VariousCases(string logType1, int logType1Count, string logType2, int logType2Count, bool expected)
+        {
+            // Arrange
+            var blobServiceClientMock = new Mock<BlobServiceClient>(MockBehavior.Strict);
+            var containerClientMock = new Mock<BlobContainerClient>(MockBehavior.Strict);
+
+            TestAsyncPageable<BlobItem> pageable;
+            var blobItems = new List<BlobItem>();
+            if (logType1 != null)
+            {
+                for (int i = 0; i < logType1Count; i++)
+                {
+                    var blobItem = BlobItemFactory.Create(
+                        name: Guid.NewGuid().ToString(),
+                        metadata: new Dictionary<string, string> { { "LogType", logType1 } });
+                    blobItems.Add(blobItem);
+                }
+            }
+            if (logType2 != null)
+            {
+                for (int i = 0; i < logType2Count; i++)
+                {
+                    var blobItem = BlobItemFactory.Create(
+                        name: Guid.NewGuid().ToString(),
+                        metadata: new Dictionary<string, string> { { "LogType", logType2 } });
+                    blobItems.Add(blobItem);
+                }
+            }
+
+            if (blobItems.Count == 0)
+            {
+                pageable = new TestAsyncPageable<BlobItem>(Enumerable.Empty<BlobItem>());
+            }
+            else
+            {
+                pageable = new TestAsyncPageable<BlobItem>(blobItems);
+            }
+
+            containerClientMock
+                .Setup(c => c.GetBlobsAsync(
+                    It.IsAny<BlobTraits>(),
+                    It.IsAny<BlobStates>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(pageable);
+
+            blobServiceClientMock
+                .Setup(c => c.GetBlobContainerClient("$logs"))
+                .Returns(containerClientMock.Object);
+
+            var listener = CreateBlobLogListener(blobServiceClientMock.Object);
+
+            // Act
+            bool result = await listener.HasBlobWritesAsync(CancellationToken.None, hoursWindow: 1);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
         [Test]
         public void GetPathsForValidBlobWrites_Returns_ValidBlobWritesOnly()
         {
             StorageAnalyticsLogEntry[] entries = new[]
             {
-                // This is a valid write entry with a valid path
                 new StorageAnalyticsLogEntry
                 {
                     ServiceType = StorageServiceType.Blob,
                     OperationType = StorageServiceOperationType.PutBlob,
                     RequestedObjectKey = @"/storagesample/sample-container/""0x8D199A96CB71468""/sample-blob.txt"
                 },
-
-                // This is an invalid path and will be filtered out
                 new StorageAnalyticsLogEntry
                 {
                     ServiceType = StorageServiceType.Blob,
                     OperationType = StorageServiceOperationType.PutBlob,
                     RequestedObjectKey = "/"
                 },
-
-                // This does not constitute a write and will be filtered out
                 new StorageAnalyticsLogEntry
                 {
                     ServiceType = StorageServiceType.Blob,
@@ -44,6 +113,69 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             BlobPath singlePath = validPaths.Single();
             Assert.AreEqual("sample-container", singlePath.ContainerName);
             Assert.AreEqual(@"""0x8D199A96CB71468""/sample-blob.txt", singlePath.BlobName);
+        }
+
+        private static BlobLogListener CreateBlobLogListener(BlobServiceClient serviceClient)
+        {
+            var logger = NullLogger<BlobListener>.Instance;
+            var ctor = typeof(BlobLogListener)
+                .GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic,
+                                binder: null,
+                                types: new[] { typeof(BlobServiceClient), typeof(ILogger<BlobListener>) },
+                                modifiers: null);
+            if (ctor == null)
+            {
+                throw new InvalidOperationException("BlobLogListener non-public constructor not found.");
+            }
+
+            return (BlobLogListener)ctor.Invoke(new object[] { serviceClient, logger });
+        }
+
+        private static class BlobItemFactory
+        {
+            private static readonly Type BlobItemType = typeof(BlobItem);
+            private static readonly System.Reflection.PropertyInfo NameProp = BlobItemType.GetProperty(nameof(BlobItem.Name))!;
+            private static readonly System.Reflection.PropertyInfo MetadataProp = BlobItemType.GetProperty(nameof(BlobItem.Metadata))!;
+
+            public static BlobItem Create(string name, IDictionary<string, string> metadata)
+            {
+                var ctor = BlobItemType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, binder: null, types: Type.EmptyTypes, modifiers: null)
+                          ?? throw new InvalidOperationException("BlobItem internal constructor not found.");
+                object raw = ctor.Invoke(null);
+
+                NameProp.SetValue(raw, name);
+                var dict = new Dictionary<string, string>(metadata, StringComparer.OrdinalIgnoreCase);
+                MetadataProp.SetValue(raw, dict);
+
+                return (BlobItem)raw;
+            }
+        }
+
+        private sealed class TestAsyncPageable<T> : AsyncPageable<T>
+        {
+            private readonly IReadOnlyList<Page<T>> _pages;
+
+            public TestAsyncPageable(IEnumerable<T> items)
+            {
+                var list = items.ToList();
+                var responseMock = new Mock<Response>();
+                responseMock.Setup(r => r.Status).Returns(200);
+                responseMock.Setup(r => r.ClientRequestId).Returns(Guid.NewGuid().ToString());
+
+                _pages = new[]
+                {
+                    Page<T>.FromValues(list, continuationToken: null, response: responseMock.Object)
+                };
+            }
+
+            public override async IAsyncEnumerable<Page<T>> AsPages(string continuationToken = null, int? pageSizeHint = null)
+            {
+                foreach (var p in _pages)
+                {
+                    yield return p;
+                    await Task.Yield();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces a streamlined approach to zero-to-one scaling logic within the Azure SDK. The current implementation reads and parses all classic monitoring logs in the $log container to extract modified blob paths. However, for scale-out from zero to one, this level of detail is unnecessary.
The updated logic simplifies the process by checking only for the presence of write operations within the last two hours—without downloading or parsing the full log content. This optimization reduces memory consumption and improves performance, especially in environments with high write volumes.

