### PR TITLE
Microsoft.Maps management plane 2025-10-01-preview updates. 

### DIFF
--- a/sdk/maps/Azure.ResourceManager.Maps/assets.json
+++ b/sdk/maps/Azure.ResourceManager.Maps/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/maps/Azure.ResourceManager.Maps",
-  "Tag": "net/maps/Azure.ResourceManager.Maps_b72f3a230e"
+  "Tag": "net/maps/Azure.ResourceManager.Maps_bdbc0ab180"
 }

--- a/sdk/maps/Azure.ResourceManager.Maps/tests/MapsManagementTestBase.cs
+++ b/sdk/maps/Azure.ResourceManager.Maps/tests/MapsManagementTestBase.cs
@@ -48,7 +48,7 @@ namespace Azure.ResourceManager.Maps.Tests
 
         protected MapsAccountData GetDefaultMapsAccountData()
         {
-            var account = new MapsAccountData(DefaultLocation, new MapsSku(MapsSkuName.S0))
+            var account = new MapsAccountData(DefaultLocation, new MapsSku(MapsSkuName.G2))
             {
                 Tags = { { "key1", "value1" }, { "key2", "value2" } }
             };
@@ -88,7 +88,7 @@ namespace Azure.ResourceManager.Maps.Tests
             var accountName = Recording.GenerateAssetName("maps");
             var parameters = GetDefaultMapsAccountData();
             var newAccount = (await mapCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, parameters)).Value;
-            VerifyAccountProperties(newAccount.Data, true, MapsSkuName.S0);
+            VerifyAccountProperties(newAccount.Data, true, MapsSkuName.G2);
             return newAccount;
         }
     }

--- a/sdk/maps/Azure.ResourceManager.Maps/tests/MapsManagementTestBase.cs
+++ b/sdk/maps/Azure.ResourceManager.Maps/tests/MapsManagementTestBase.cs
@@ -68,7 +68,7 @@ namespace Azure.ResourceManager.Maps.Tests
             if (useDefaults)
             {
                 Assert.AreEqual("East US", account.Location.DisplayName);
-                Assert.AreEqual(MapsSkuName.S0, account.Sku.Name);
+                Assert.AreEqual(MapsSkuName.G2, account.Sku.Name);
 
                 Assert.NotNull(account.Tags);
                 Assert.NotNull(account.Properties.UniqueId);

--- a/sdk/maps/Azure.ResourceManager.Maps/tests/ScenarioTests/MapsAccountTests.cs
+++ b/sdk/maps/Azure.ResourceManager.Maps/tests/ScenarioTests/MapsAccountTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Azure.Core;
@@ -23,7 +24,7 @@ namespace Azure.ResourceManager.Maps.Tests
         {
         }
 
-        [Test]
+        [RecordedTest]
         public async Task MapsAccountCreateTest()
         {
             var resourceGroup = await CreateResourceGroupAsync();
@@ -34,10 +35,12 @@ namespace Azure.ResourceManager.Maps.Tests
             var parameters = GetDefaultMapsAccountData();
 
             // Create account
+            Thread.Sleep(30000);
             var newAccount = (await mapCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, parameters)).Value;
             VerifyAccountProperties(newAccount.Data, true, MapsSkuName.G2);
 
             // Now get the account
+            Thread.Sleep(30000);
             var account = (await mapCollection.GetAsync(accountName)).Value;
             VerifyAccountProperties(account.Data, true, MapsSkuName.G2);
 
@@ -47,7 +50,7 @@ namespace Azure.ResourceManager.Maps.Tests
             Assert.IsFalse(falseResult);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task MapsAccountUpdateTest()
         {
             var resourceGroup = await CreateResourceGroupAsync();
@@ -66,13 +69,14 @@ namespace Azure.ResourceManager.Maps.Tests
             newParameters.Tags.Clear();
             newParameters.Tags.Add("key3", "value3");
             newParameters.Tags.Add("key4", "value4");
+            Thread.Sleep(30000);
             var updatedAccount = (await mapCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, newParameters)).Value;
             Assert.AreEqual(2, updatedAccount.Data.Tags.Count);
             Assert.AreEqual("value3", updatedAccount.Data.Tags["key3"]);
             Assert.AreEqual("value4", updatedAccount.Data.Tags["key4"]);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task MapsAccountDeleteTest()
         {
             var resourceGroup = await CreateResourceGroupAsync();
@@ -87,13 +91,14 @@ namespace Azure.ResourceManager.Maps.Tests
             var newAccount = await CreateDefaultMapsAccount(mapCollection);
 
             // Delete an account
+            Thread.Sleep(30000);
             await newAccount.DeleteAsync(WaitUntil.Completed);
 
             // Delete an account which was just deleted
             await newAccount.DeleteAsync(WaitUntil.Completed);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task MapsAccountListByResourceGroupTest()
         {
             var resourceGroup = await CreateResourceGroupAsync();
@@ -113,7 +118,7 @@ namespace Azure.ResourceManager.Maps.Tests
             VerifyAccountProperties(accounts.Skip(1).First().Data, true, MapsSkuName.G2);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task MapsAccountListBySubscriptionTest()
         {
             // Create account
@@ -139,7 +144,7 @@ namespace Azure.ResourceManager.Maps.Tests
             VerifyAccountProperties(account2.Data, true, MapsSkuName.G2);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task MapsAccountListKeysTest()
         {
             var resourceGroup = await CreateResourceGroupAsync();
@@ -159,7 +164,7 @@ namespace Azure.ResourceManager.Maps.Tests
             Assert.NotNull(keys.SecondaryKey);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task MapsAccountRegenerateKeyTest()
         {
             var resourceGroup = await CreateResourceGroupAsync();

--- a/sdk/maps/Azure.ResourceManager.Maps/tests/ScenarioTests/MapsAccountTests.cs
+++ b/sdk/maps/Azure.ResourceManager.Maps/tests/ScenarioTests/MapsAccountTests.cs
@@ -35,11 +35,11 @@ namespace Azure.ResourceManager.Maps.Tests
 
             // Create account
             var newAccount = (await mapCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, parameters)).Value;
-            VerifyAccountProperties(newAccount.Data, true, MapsSkuName.S0);
+            VerifyAccountProperties(newAccount.Data, true, MapsSkuName.G2);
 
             // Now get the account
             var account = (await mapCollection.GetAsync(accountName)).Value;
-            VerifyAccountProperties(account.Data, true, MapsSkuName.S0);
+            VerifyAccountProperties(account.Data, true, MapsSkuName.G2);
 
             // Now delete the account
             await account.DeleteAsync(WaitUntil.Completed);
@@ -59,16 +59,14 @@ namespace Azure.ResourceManager.Maps.Tests
 
             // Create account
             var newAccount = (await mapCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, parameters)).Value;
-            VerifyAccountProperties(newAccount.Data, true, MapsSkuName.S0);
+            VerifyAccountProperties(newAccount.Data, true, MapsSkuName.G2);
 
             // Create new parameters which are almost the same, but have different tags
             var newParameters = GetDefaultMapsAccountData();
             newParameters.Tags.Clear();
             newParameters.Tags.Add("key3", "value3");
             newParameters.Tags.Add("key4", "value4");
-            newParameters.Sku.Name = MapsSkuName.S1;
             var updatedAccount = (await mapCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, newParameters)).Value;
-            VerifyAccountProperties(updatedAccount.Data, false, skuName: MapsSkuName.S1);
             Assert.AreEqual(2, updatedAccount.Data.Tags.Count);
             Assert.AreEqual("value3", updatedAccount.Data.Tags["key3"]);
             Assert.AreEqual("value4", updatedAccount.Data.Tags["key4"]);
@@ -111,8 +109,8 @@ namespace Azure.ResourceManager.Maps.Tests
             accounts = await mapCollection.GetAllAsync().ToEnumerableAsync();
             Assert.AreEqual(2, accounts.Count);
 
-            VerifyAccountProperties(accounts.First().Data, true, MapsSkuName.S0);
-            VerifyAccountProperties(accounts.Skip(1).First().Data, true, MapsSkuName.S0);
+            VerifyAccountProperties(accounts.First().Data, true, MapsSkuName.G2);
+            VerifyAccountProperties(accounts.Skip(1).First().Data, true, MapsSkuName.G2);
         }
 
         [Test]
@@ -134,11 +132,11 @@ namespace Azure.ResourceManager.Maps.Tests
 
             var account1 = accounts.First(
                 t => StringComparer.OrdinalIgnoreCase.Equals(t.Data.Name, accountName1.Data.Name));
-            VerifyAccountProperties(account1.Data, true, MapsSkuName.S0);
+            VerifyAccountProperties(account1.Data, true, MapsSkuName.G2);
 
             var account2 = accounts.First(
                 t => StringComparer.OrdinalIgnoreCase.Equals(t.Data.Name, accountName2.Data.Name));
-            VerifyAccountProperties(account2.Data, true, MapsSkuName.S0);
+            VerifyAccountProperties(account2.Data, true, MapsSkuName.G2);
         }
 
         [Test]

--- a/sdk/maps/Azure.ResourceManager.Maps/tests/ScenarioTests/MapsAccountTests.cs
+++ b/sdk/maps/Azure.ResourceManager.Maps/tests/ScenarioTests/MapsAccountTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Azure.Core;
@@ -35,12 +34,10 @@ namespace Azure.ResourceManager.Maps.Tests
             var parameters = GetDefaultMapsAccountData();
 
             // Create account
-            Thread.Sleep(30000);
             var newAccount = (await mapCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, parameters)).Value;
             VerifyAccountProperties(newAccount.Data, true, MapsSkuName.G2);
 
             // Now get the account
-            Thread.Sleep(30000);
             var account = (await mapCollection.GetAsync(accountName)).Value;
             VerifyAccountProperties(account.Data, true, MapsSkuName.G2);
 
@@ -69,7 +66,6 @@ namespace Azure.ResourceManager.Maps.Tests
             newParameters.Tags.Clear();
             newParameters.Tags.Add("key3", "value3");
             newParameters.Tags.Add("key4", "value4");
-            Thread.Sleep(30000);
             var updatedAccount = (await mapCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, newParameters)).Value;
             Assert.AreEqual(2, updatedAccount.Data.Tags.Count);
             Assert.AreEqual("value3", updatedAccount.Data.Tags["key3"]);
@@ -91,7 +87,6 @@ namespace Azure.ResourceManager.Maps.Tests
             var newAccount = await CreateDefaultMapsAccount(mapCollection);
 
             // Delete an account
-            Thread.Sleep(30000);
             await newAccount.DeleteAsync(WaitUntil.Completed);
 
             // Delete an account which was just deleted


### PR DESCRIPTION
# Contributing to the Azure SDK
New api-version removes `MapsSkuName.S0` which causes these tests to fail. 
Updating tests to use the latest SKU. 
