### PR TITLE
Trigger WebJobs Extensions when Azure.Storage.Blobs changes

### DIFF
--- a/sdk/storage/ci.functions.yml
+++ b/sdk/storage/ci.functions.yml
@@ -31,8 +31,12 @@ extends:
     - name: Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
       safeName: MicrosoftAzureWebJobsExtensionsStorageBlobs
       skipSmokeTests: true
+      triggeringPaths:
+      - /sdk/storage/Azure.Storage.Blobs/
     - name: Microsoft.Azure.WebJobs.Extensions.Storage.Queues
       safeName: MicrosoftAzureWebJobsExtensionsStorageQueues
       skipSmokeTests: true
+      triggeringPaths:
+      - /sdk/storage/Azure.Storage.Queues/
     TestSetupSteps:
     - template: /sdk/storage/tests-install-azurite.yml


### PR DESCRIPTION
See title. The ask was for `Microsoft.Azure.WebJobs.Extensions.Storage.Blobs`...but I noticed there was one for `storage.queues` too so I added that as well.