### PR TITLE
Remove invalid error check from PersistentAgentsChatClient

### DIFF
--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/PersistentAgentsChatClient.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/PersistentAgentsChatClient.cs
@@ -79,10 +79,6 @@ namespace Azure.AI.Agents.Persistent
 
             // Get the thread ID.
             string? threadId = options?.ConversationId ?? _defaultThreadId;
-            if (threadId is null && toolResults is not null)
-            {
-                throw new ArgumentException("No thread ID was provided, but chat messages includes tool results.", nameof(messages));
-            }
 
             // Get any active run ID for this thread.
             ThreadRun? threadRun = null;
@@ -105,7 +101,7 @@ namespace Azure.AI.Agents.Persistent
                 ConvertFunctionResultsToToolOutput(toolResults, out List<ToolOutput>? toolOutputs) is { } toolRunId &&
                 toolRunId == threadRun.Id)
             {
-                // There's an active run and we have tool results to submit, so submit the results and continue streaming.
+                // There's an active run and we have tool results to submit for that run, so submit the results and continue streaming.
                 // This is going to ignore any additional messages in the run options, as we are only submitting tool outputs,
                 // but there doesn't appear to be a way to submit additional messages, and having such additional messages is rare.
                 updates = _client!.Runs.SubmitToolOutputsToStreamAsync(threadRun, toolOutputs, cancellationToken);


### PR DESCRIPTION
The check is overly strict; it assumes all of the provided messages are in response to a previous conversation with this service, but the messages could be the history from a conversation with another service, as can happen in agent-based scenarios. In such cases, there may be function tool calls and results in the history; the rest of the implementation will properly ignore them, as the service doesn't provide any way to send those calls into the service, but this check was blowing up before then.