### PR TITLE
Fix mocks to use new 4 param overload for getting a secret

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
@@ -13,7 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
+    <!-- Use package reference after Package.Data.props has a version higher than 4.7.0 -->
+    <!--<PackageReference Include="Azure.Security.KeyVault.Secrets" />-->
+    <ProjectReference Include="..\..\..\keyvault\Azure.Security.KeyVault.Secrets\src\Azure.Security.KeyVault.Secrets.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -39,8 +39,8 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             {
                 foreach (var secret in page)
                 {
-                    mock.Setup(client => client.GetSecretAsync(secret.Name, null, default))
-                        .Returns(async (string name, string label, CancellationToken token) =>
+                    mock.Setup(client => client.GetSecretAsync(secret.Name, null, null, default))
+                        .Returns(async (string name, string label, SecretContentType? contentType, CancellationToken token) =>
                         {
                             await getSecretCallback(name);
                             return Response.FromValue(secret, Mock.Of<Response>());


### PR DESCRIPTION
Fixes these errors in the pipeline https://dev.azure.com/azure-sdk/public/_build/results?buildId=5419964&view=logs&j=6a35bf62-79e1-5fa3-97e7-f99304f2a7ef&t=0d11b518-8a24-5ded-c079-29c53cd50406&l=505
