### PR TITLE
Add handling of stable database client span semantic conventions

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -18,6 +18,7 @@
   ([#52720](https://github.com/Azure/azure-sdk-for-net/pull/52720))
 
 * Added handling of stable database client span semantic conventions
+  ([#53050](https://github.com/Azure/azure-sdk-for-net/pull/53050))
 
 ### Breaking Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -17,6 +17,8 @@
   `Sdk.CreateTracerProviderBuilder().AddAzureMonitorTraceExporter(...)` path.
   ([#52720](https://github.com/Azure/azure-sdk-for-net/pull/52720))
 
+* Added handling of stable database client span semantic conventions
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -100,6 +100,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         case SemanticConventions.AttributeDbSystem:
                             activityType = OperationType.Db;
                             break;
+                        case SemanticConventions.AttributeDbSystemName:
+                            activityType = OperationType.Db | OperationType.V2;
+                            break;
                         case SemanticConventions.AttributeMessagingSystem:
                             activityType = OperationType.Messaging;
                             break;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -100,11 +100,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         case SemanticConventions.AttributeHttpRequestMethod:
                             activityType = OperationType.Http | OperationType.V2;
                             break;
-                        case SemanticConventions.AttributeDbSystem:
-                            activityType = OperationType.Db;
-                            break;
                         case SemanticConventions.AttributeDbSystemName:
                             activityType = OperationType.Db | OperationType.V2;
+                            break;
+                        case SemanticConventions.AttributeDbSystem:
+                            activityType = OperationType.Db;
                             break;
                         case SemanticConventions.AttributeMessagingSystem:
                             activityType = OperationType.Messaging;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -11,8 +11,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     {
         private static readonly string[] s_semantics = {
             SemanticConventions.AttributeDbStatement,
+            SemanticConventions.AttributeDbQueryText,
             SemanticConventions.AttributeDbSystem,
+            SemanticConventions.AttributeDbSystemName,
             SemanticConventions.AttributeDbName,
+            SemanticConventions.AttributeDbNamespace,
 
             // required - HTTP
             SemanticConventions.AttributeHttpMethod,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -331,7 +331,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ///</summary>
         internal static (string? DbName, string? DbTarget) GetDbDependencyTargetAndName(this AzMonList tagObjects, bool isNewSchemaVersion)
         {
-
             string statementDbNameKey;
             string statementDbSystemKey;
             if (isNewSchemaVersion) {
@@ -380,7 +379,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 case OperationType.Http:
                     return tagObjects.GetHttpDependencyTarget();
                 case OperationType.Db:
-                    return tagObjects.GetDbDependencyTargetAndName().DbTarget;
+                    return tagObjects.GetDbDependencyTargetAndName(type.HasFlag(OperationType.V2)).DbTarget;
                 case OperationType.Messaging:
                     return tagObjects.GetMessagingUrlAndSourceOrTarget(ActivityKind.Producer).SourceOrTarget;
                 default:

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonNewListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonNewListExtensions.cs
@@ -142,7 +142,7 @@ internal static class AzMonNewListExtensions
             case OperationType.Http:
                 return tagObjects.GetNewSchemaHttpDependencyTarget();
             case OperationType.Db:
-                return tagObjects.GetDbDependencyTargetAndName().DbTarget;
+                return tagObjects.GetDbDependencyTargetAndName(type.HasFlag(OperationType.V2)).DbTarget;
             default:
                 return null;
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
@@ -164,5 +164,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         // Messaging v1.21.0 https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/messaging.md
         public const string AttributeMessagingDestinationName = "messaging.destination.name";
         public const string AttributeNetworkProtocolName = "network.protocol.name";
+
+        // Database v1.36.0 https://github.com/open-telemetry/semantic-conventions/tree/v1.36.0/docs/database
+        public const string AttributeDbCollectionName = "db.collection.name";
+        public const string AttributeDbOperationName = "db.operation.name";
+        public const string AttributeDbSystemName = "db.system.name";
+        public const string AttributeDbNamespace = "db.namespace";
+        public const string AttributeDbResponseStatusCode = "db.response.status_code";
+        public const string AttributeDbOperationBatchSize = "db.operation.batch.size";
+        public const string AttributeDbQuerySummary = "db.query.summary";
+        public const string AttributeDbQueryText = "db.query.text";
+        public const string AttributeDbStoredProcedureName = "db.stored_procedure.name";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
@@ -564,32 +564,32 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeServerAddress, serverAddress));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, serverPort));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeServerSocketAddress, serverSocketAddress));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbName, "DbName"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbNamespace, "DbName"));
 
-            Assert.Equal(expectedTarget, mappedTags.GetDbDependencyTargetAndName(false).DbTarget);
+            Assert.Equal(expectedTarget, mappedTags.GetDbDependencyTargetAndName(true).DbTarget);
         }
 
         [Fact]
         public void DbDependencyTargetIsSetToDbNameWhenNetAttributesAreNotPresent()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbName, "DbName"));
-            Assert.Equal("DbName", mappedTags.GetDbDependencyTargetAndName(false).DbTarget);
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbNamespace, "DbName"));
+            Assert.Equal("DbName", mappedTags.GetDbDependencyTargetAndName(true).DbTarget);
         }
 
         [Fact]
         public void DbDependencyTargetIsSetToDbSystemWhenNetAndDbNameAttributesAreNotPresent()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "DbSystem"));
-            Assert.Equal("DbSystem", mappedTags.GetDbDependencyTargetAndName(false).DbTarget);
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystemName, "DbSystem"));
+            Assert.Equal("DbSystem", mappedTags.GetDbDependencyTargetAndName(true).DbTarget);
         }
 
         [Fact]
         public void DbDependencyTargetIsSetToNullByDefault()
         {
             var mappedTags = AzMonList.Initialize();
-            Assert.Null(mappedTags.GetDbDependencyTargetAndName(false).DbTarget);
+            Assert.Null(mappedTags.GetDbDependencyTargetAndName(true).DbTarget);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
@@ -566,7 +566,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeServerSocketAddress, serverSocketAddress));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbName, "DbName"));
 
-            Assert.Equal(expectedTarget, mappedTags.GetDbDependencyTargetAndName().DbTarget);
+            Assert.Equal(expectedTarget, mappedTags.GetDbDependencyTargetAndName(false).DbTarget);
         }
 
         [Fact]
@@ -574,7 +574,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var mappedTags = AzMonList.Initialize();
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbName, "DbName"));
-            Assert.Equal("DbName", mappedTags.GetDbDependencyTargetAndName().DbTarget);
+            Assert.Equal("DbName", mappedTags.GetDbDependencyTargetAndName(false).DbTarget);
         }
 
         [Fact]
@@ -582,14 +582,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var mappedTags = AzMonList.Initialize();
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "DbSystem"));
-            Assert.Equal("DbSystem", mappedTags.GetDbDependencyTargetAndName().DbTarget);
+            Assert.Equal("DbSystem", mappedTags.GetDbDependencyTargetAndName(false).DbTarget);
         }
 
         [Fact]
         public void DbDependencyTargetIsSetToNullByDefault()
         {
             var mappedTags = AzMonList.Initialize();
-            Assert.Null(mappedTags.GetDbDependencyTargetAndName().DbTarget);
+            Assert.Null(mappedTags.GetDbDependencyTargetAndName(false).DbTarget);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -157,7 +157,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Db | OperationType.V2, activityTagsProcessor.activityType);
-            Assert.Equal(5, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(4, activityTagsProcessor.MappedTags.Length);
             Assert.Equal("mysqlserver", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeDbNamespace));
             Assert.Equal("mssql", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeDbSystemName));
             Assert.Equal("localhost", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributePeerService));


### PR DESCRIPTION
Applies https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/db-migration.md for the following attributes:

* db.statement -> db.query.text
* db.system -> db.system.name
* db.name -> db.namespace

Support for the older convention is maintained by detecting the db.system/db.system.name attributes.