### PR TITLE
[CODEOWNERS] Fix linter errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -941,10 +941,7 @@
 # ServiceOwners:                                                   @alexyaang
 
 # PRLabel: %Arize AI %Mgmt
-/sdk/arizeaiobservabilityeval/Azure.ResourceManager.*/             @aggarwalsw
-
-# ServiceLabel: %Arize AI %Mgmt
-# ServiceOwners:                                                   @aggarwalsw
+/sdk/arizeaiobservabilityeval/Azure.ResourceManager.*/             @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %ARM
 /sdk/resources/Azure.ResourceManager.*/                            @Azure/arm-sdk-owners
@@ -1037,10 +1034,7 @@
 # ServiceOwners:                                                   @apmehrotra
 
 # PRLabel: %LambdaTest HyperExecute
-/sdk/lambdatesthyperexecute/Azure.ResourceManager.*/               @aggarwalsw
-
-# ServiceLabel: %LambdaTest HyperExecute %Mgmt
-# ServiceOwners:                                                   @aggarwalsw
+/sdk/lambdatesthyperexecute/Azure.ResourceManager.*/               @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %Large Instance
 /sdk/azurelargeinstance/Azure.ResourceManager.*/                   @8Gitbrix @ArcturusZhang @ArthurMa1978
@@ -1109,10 +1103,7 @@
 # ServiceOwners:                                                   @ArthurMa1978
 
 # PRLabel: %Pinecone
-/sdk/pineconevectordb/Azure.ResourceManager.*/                     @aggarwalsw
-
-# ServiceLabel: %Pinecone %Mgmt
-# ServiceOwners:                                                   @aggarwalsw
+/sdk/pineconevectordb/Azure.ResourceManager.*/                     @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %Planetary Computer
 /sdk/planetarycomputer/Azure.ResourceManager.*/                    @shaktichetan23 @ArthurMa1978
@@ -1163,18 +1154,13 @@
 # ServiceOwners:                                                   @jchavaherrera
 
 # PRLabel: %Weights & Biases
-/sdk/weightsandbiases/Azure.ResourceManager.*/                     @aggarwalsw
-
-# ServiceLabel: %Weights & Biases %Mgmt
-# ServiceOwners:                                                   @aggarwalsw
-
+/sdk/weightsandbiases/Azure.ResourceManager.*/                     @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %Workload Orchestration
 /sdk/workloadorchestration/Azure.ResourceManager.*/                @atharvau
 
 # ServiceLabel: %Workload Orchestration %Mgmt
 # ServiceOwners:                                                   @atharvau
-
 
 # ######## Eng Sys ########
 /eng/                                                              @hallipr @weshaggard @benbp


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner that the linter is flagging as no longer valid.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5427959&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4&l=26) _(Microsoft internal)_