### PR TITLE
Hide obsolete property from API ref docs and IntelliSense

### DIFF
--- a/sdk/identity/Azure.Identity/api/Azure.Identity.net8.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.net8.0.cs
@@ -116,7 +116,7 @@ namespace Azure.Identity
         public string ErrorMessage { get { throw null; } set { } }
         public string SuccessMessage { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead.")]
+        [System.ObsoleteAttribute("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead")]
         public bool? UseEmbeddedWebView { get { throw null; } set { } }
     }
     public partial class ChainedTokenCredential : Azure.Core.TokenCredential

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.net8.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.net8.0.cs
@@ -115,7 +115,8 @@ namespace Azure.Identity
         public BrowserCustomizationOptions() { }
         public string ErrorMessage { get { throw null; } set { } }
         public string SuccessMessage { get { throw null; } set { } }
-        [System.ObsoleteAttribute("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead.")]
         public bool? UseEmbeddedWebView { get { throw null; } set { } }
     }
     public partial class ChainedTokenCredential : Azure.Core.TokenCredential

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -113,7 +113,8 @@ namespace Azure.Identity
         public BrowserCustomizationOptions() { }
         public string ErrorMessage { get { throw null; } set { } }
         public string SuccessMessage { get { throw null; } set { } }
-        [System.ObsoleteAttribute("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead.")]
         public bool? UseEmbeddedWebView { get { throw null; } set { } }
     }
     public partial class ChainedTokenCredential : Azure.Core.TokenCredential

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -114,7 +114,7 @@ namespace Azure.Identity
         public string ErrorMessage { get { throw null; } set { } }
         public string SuccessMessage { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead.")]
+        [System.ObsoleteAttribute("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead")]
         public bool? UseEmbeddedWebView { get { throw null; } set { } }
     }
     public partial class ChainedTokenCredential : Azure.Core.TokenCredential

--- a/sdk/identity/Azure.Identity/src/Credentials/BrowserCustomizationOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/BrowserCustomizationOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 using Microsoft.Identity.Client;
@@ -17,7 +18,8 @@ namespace Azure.Identity
         /// Specifies if the public client application should used an embedded web browser
         /// or the system default browser
         /// </summary>
-        [Obsolete("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead")]
+        [Obsolete("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool? UseEmbeddedWebView { get; set; }
 
         internal SystemWebViewOptions SystemBrowserOptions;

--- a/sdk/identity/Azure.Identity/src/Credentials/BrowserCustomizationOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/BrowserCustomizationOptions.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity
         /// Specifies if the public client application should used an embedded web browser
         /// or the system default browser
         /// </summary>
-        [Obsolete("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead.")]
+        [Obsolete("This option requires additional dependencies on Microsoft.Identity.Client.Desktop and is no longer supported. Consider using brokered authentication instead")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool? UseEmbeddedWebView { get; set; }
 


### PR DESCRIPTION
In an effort to discourage further use, we don't want this obsolete property to appear in IntelliSense. The API ref docs also aren't worth publishing.