### PR TITLE
Update namespace for resource model during PreVisitModel

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ResourceVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ResourceVisitor.cs
@@ -23,15 +23,19 @@ internal class ResourceVisitor : ScmLibraryVisitor
     {
         if (type is ModelProvider && ManagementClientGenerator.Instance.InputLibrary.IsResourceModel(model))
         {
+            // Update the type name and namespace for resource models
+            // We need to update this during PreVisitModel because we will create multiple ParameterProvider with the same model type
             type.Update(
                 relativeFilePath: TransformRelativeFilePath(type),
-                name: TransformName(type));
+                name: TransformName(type),
+                @namespace: ManagementClientGenerator.Instance.TypeFactory.PrimaryNamespace);
 
             foreach (var serialization in type.SerializationProviders)
             {
                 serialization.Update(
                     relativeFilePath: TransformRelativeFilePathForSerialization(serialization),
-                    name: TransformName(serialization));
+                    name: TransformName(serialization),
+                @namespace: ManagementClientGenerator.Instance.TypeFactory.PrimaryNamespace);
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/OperationSourceProviderTests/Verify_CreateResult.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/OperationSourceProviderTests/Verify_CreateResult.cs
@@ -1,3 +1,3 @@
 ﻿using global::System.Text.Json.JsonDocument document = global::System.Text.Json.JsonDocument.Parse(response.ContentStream);
-global::Samples.Models.ResponseTypeData data = global::Samples.Models.ResponseTypeData.DeserializeResponseTypeData(document.RootElement, global::Samples.ModelSerializationExtensions.WireOptions);
+global::Samples.ResponseTypeData data = global::Samples.ResponseTypeData.DeserializeResponseTypeData(document.RootElement, global::Samples.ModelSerializationExtensions.WireOptions);
 return new global::Samples.ResponseTypeResource(_client, data);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/OperationSourceProviderTests/Verify_CreateResultAsync.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/OperationSourceProviderTests/Verify_CreateResultAsync.cs
@@ -1,3 +1,3 @@
 ﻿using global::System.Text.Json.JsonDocument document = await global::System.Text.Json.JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-global::Samples.Models.ResponseTypeData data = global::Samples.Models.ResponseTypeData.DeserializeResponseTypeData(document.RootElement, global::Samples.ModelSerializationExtensions.WireOptions);
+global::Samples.ResponseTypeData data = global::Samples.ResponseTypeData.DeserializeResponseTypeData(document.RootElement, global::Samples.ModelSerializationExtensions.WireOptions);
 return new global::Samples.ResponseTypeResource(_client, data);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceClientProviderTests/Verify_AsyncOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceClientProviderTests/Verify_AsyncOperationMethod.cs
@@ -8,7 +8,7 @@ try
     };
     global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, this.Id.Name, context);
     global::Azure.Response result = await this.Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+    global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
     if ((response.Value == null))
     {
         throw new global::Azure.RequestFailedException(response.GetRawResponse());

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceClientProviderTests/Verify_SyncOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceClientProviderTests/Verify_SyncOperationMethod.cs
@@ -8,7 +8,7 @@ try
     };
     global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, this.Id.Name, context);
     global::Azure.Response result = this.Pipeline.ProcessMessage(message, context);
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+    global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
     if ((response.Value == null))
     {
         throw new global::Azure.RequestFailedException(response.GetRawResponse());

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_CreateOrUpdateAsyncOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_CreateOrUpdateAsyncOperationMethod.cs
@@ -9,9 +9,9 @@ try
     {
         CancellationToken = cancellationToken
     };
-    global::Azure.Core.HttpMessage message = _testClientRestClient.CreateCreateTestRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, global::Samples.Models.ResponseTypeData.ToRequestContent(data), context);
+    global::Azure.Core.HttpMessage message = _testClientRestClient.CreateCreateTestRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, global::Samples.ResponseTypeData.ToRequestContent(data), context);
     global::Azure.Response result = await this.Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+    global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
     global::Azure.Core.RequestUriBuilder uri = message.Request.Uri;
     global::Azure.Core.RehydrationToken rehydrationToken = global::Azure.Core.NextLinkOperationImplementation.GetRehydrationToken(global::Azure.Core.RequestMethod.Get, uri.ToUri(), uri.ToString(), "None", null, global::Azure.Core.OperationFinalStateVia.OriginalUri.ToString());
     global::Samples.SamplesArmOperation<global::Samples.ResponseTypeResource> operation = new global::Samples.SamplesArmOperation<global::Samples.ResponseTypeResource>(global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse()), rehydrationToken);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_CreateOrUpdateOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_CreateOrUpdateOperationMethod.cs
@@ -9,9 +9,9 @@ try
     {
         CancellationToken = cancellationToken
     };
-    global::Azure.Core.HttpMessage message = _testClientRestClient.CreateCreateTestRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, global::Samples.Models.ResponseTypeData.ToRequestContent(data), context);
+    global::Azure.Core.HttpMessage message = _testClientRestClient.CreateCreateTestRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, global::Samples.ResponseTypeData.ToRequestContent(data), context);
     global::Azure.Response result = this.Pipeline.ProcessMessage(message, context);
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+    global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
     global::Azure.Core.RequestUriBuilder uri = message.Request.Uri;
     global::Azure.Core.RehydrationToken rehydrationToken = global::Azure.Core.NextLinkOperationImplementation.GetRehydrationToken(global::Azure.Core.RequestMethod.Get, uri.ToUri(), uri.ToString(), "None", null, global::Azure.Core.OperationFinalStateVia.OriginalUri.ToString());
     global::Samples.SamplesArmOperation<global::Samples.ResponseTypeResource> operation = new global::Samples.SamplesArmOperation<global::Samples.ResponseTypeResource>(global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse()), rehydrationToken);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_ExistsAsyncOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_ExistsAsyncOperationMethod.cs
@@ -11,14 +11,14 @@ try
     global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, context);
     await this.Pipeline.SendAsync(message, context.CancellationToken).ConfigureAwait(false);
     global::Azure.Response result = message.Response;
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = default;
+    global::Azure.Response<global::Samples.ResponseTypeData> response = default;
     switch (result.Status)
     {
         case 200:
-            response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+            response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
             break;
         case 404:
-            response = global::Azure.Response.FromValue(((global::Samples.Models.ResponseTypeData)null), result);
+            response = global::Azure.Response.FromValue(((global::Samples.ResponseTypeData)null), result);
             break;
         default:
             throw new global::Azure.RequestFailedException(result);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_ExistsOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_ExistsOperationMethod.cs
@@ -11,14 +11,14 @@ try
     global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, context);
     this.Pipeline.Send(message, context.CancellationToken);
     global::Azure.Response result = message.Response;
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = default;
+    global::Azure.Response<global::Samples.ResponseTypeData> response = default;
     switch (result.Status)
     {
         case 200:
-            response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+            response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
             break;
         case 404:
-            response = global::Azure.Response.FromValue(((global::Samples.Models.ResponseTypeData)null), result);
+            response = global::Azure.Response.FromValue(((global::Samples.ResponseTypeData)null), result);
             break;
         default:
             throw new global::Azure.RequestFailedException(result);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_GetAsyncOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_GetAsyncOperationMethod.cs
@@ -10,7 +10,7 @@ try
     };
     global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, context);
     global::Azure.Response result = await this.Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+    global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
     if ((response.Value == null))
     {
         throw new global::Azure.RequestFailedException(response.GetRawResponse());

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_GetIfExistsAsyncOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_GetIfExistsAsyncOperationMethod.cs
@@ -11,14 +11,14 @@ try
     global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, context);
     await this.Pipeline.SendAsync(message, context.CancellationToken).ConfigureAwait(false);
     global::Azure.Response result = message.Response;
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = default;
+    global::Azure.Response<global::Samples.ResponseTypeData> response = default;
     switch (result.Status)
     {
         case 200:
-            response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+            response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
             break;
         case 404:
-            response = global::Azure.Response.FromValue(((global::Samples.Models.ResponseTypeData)null), result);
+            response = global::Azure.Response.FromValue(((global::Samples.ResponseTypeData)null), result);
             break;
         default:
             throw new global::Azure.RequestFailedException(result);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_GetIfExistsOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_GetIfExistsOperationMethod.cs
@@ -11,14 +11,14 @@ try
     global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, context);
     this.Pipeline.Send(message, context.CancellationToken);
     global::Azure.Response result = message.Response;
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = default;
+    global::Azure.Response<global::Samples.ResponseTypeData> response = default;
     switch (result.Status)
     {
         case 200:
-            response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+            response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
             break;
         case 404:
-            response = global::Azure.Response.FromValue(((global::Samples.Models.ResponseTypeData)null), result);
+            response = global::Azure.Response.FromValue(((global::Samples.ResponseTypeData)null), result);
             break;
         default:
             throw new global::Azure.RequestFailedException(result);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_GetOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_GetOperationMethod.cs
@@ -10,7 +10,7 @@ try
     };
     global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, testName, context);
     global::Azure.Response result = this.Pipeline.ProcessMessage(message, context);
-    global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+    global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
     if ((response.Value == null))
     {
         throw new global::Azure.RequestFailedException(response.GetRawResponse());

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_AddTag.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_AddTag.cs
@@ -16,13 +16,13 @@ try
         };
         global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, this.Id.Name, context);
         global::Azure.Response result = this.Pipeline.ProcessMessage(message, context);
-        global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+        global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
         return global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse());
     }
     else
     {
-        global::Samples.Models.ResponseTypeData current = (this.Get(cancellationToken: cancellationToken)).Value.Data;
-        global::Samples.Models.ResponseTypeData patch = new global::Samples.Models.ResponseTypeData();
+        global::Samples.ResponseTypeData current = (this.Get(cancellationToken: cancellationToken)).Value.Data;
+        global::Samples.ResponseTypeData patch = new global::Samples.ResponseTypeData();
         foreach (global::System.Collections.Generic.KeyValuePair<string, string> tag in current.Tags)
         {
             patch.Tags.Add(tag);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_AddTagAsync.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_AddTagAsync.cs
@@ -16,13 +16,13 @@ try
         };
         global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, this.Id.Name, context);
         global::Azure.Response result = await this.Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
-        global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+        global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
         return global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse());
     }
     else
     {
-        global::Samples.Models.ResponseTypeData current = (await this.GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false)).Value.Data;
-        global::Samples.Models.ResponseTypeData patch = new global::Samples.Models.ResponseTypeData();
+        global::Samples.ResponseTypeData current = (await this.GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false)).Value.Data;
+        global::Samples.ResponseTypeData patch = new global::Samples.ResponseTypeData();
         foreach (global::System.Collections.Generic.KeyValuePair<string, string> tag in current.Tags)
         {
             patch.Tags.Add(tag);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_RemoveTag.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_RemoveTag.cs
@@ -15,13 +15,13 @@ try
         };
         global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, this.Id.Name, context);
         global::Azure.Response result = this.Pipeline.ProcessMessage(message, context);
-        global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+        global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
         return global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse());
     }
     else
     {
-        global::Samples.Models.ResponseTypeData current = (this.Get(cancellationToken: cancellationToken)).Value.Data;
-        global::Samples.Models.ResponseTypeData patch = new global::Samples.Models.ResponseTypeData();
+        global::Samples.ResponseTypeData current = (this.Get(cancellationToken: cancellationToken)).Value.Data;
+        global::Samples.ResponseTypeData patch = new global::Samples.ResponseTypeData();
         foreach (global::System.Collections.Generic.KeyValuePair<string, string> tag in current.Tags)
         {
             patch.Tags.Add(tag);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_RemoveTagAsync.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_RemoveTagAsync.cs
@@ -15,13 +15,13 @@ try
         };
         global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, this.Id.Name, context);
         global::Azure.Response result = await this.Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
-        global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+        global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
         return global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse());
     }
     else
     {
-        global::Samples.Models.ResponseTypeData current = (await this.GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false)).Value.Data;
-        global::Samples.Models.ResponseTypeData patch = new global::Samples.Models.ResponseTypeData();
+        global::Samples.ResponseTypeData current = (await this.GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false)).Value.Data;
+        global::Samples.ResponseTypeData patch = new global::Samples.ResponseTypeData();
         foreach (global::System.Collections.Generic.KeyValuePair<string, string> tag in current.Tags)
         {
             patch.Tags.Add(tag);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_SetTags.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_SetTags.cs
@@ -16,13 +16,13 @@ try
         };
         global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, this.Id.Name, context);
         global::Azure.Response result = this.Pipeline.ProcessMessage(message, context);
-        global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+        global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
         return global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse());
     }
     else
     {
-        global::Samples.Models.ResponseTypeData current = (this.Get(cancellationToken: cancellationToken)).Value.Data;
-        global::Samples.Models.ResponseTypeData patch = new global::Samples.Models.ResponseTypeData();
+        global::Samples.ResponseTypeData current = (this.Get(cancellationToken: cancellationToken)).Value.Data;
+        global::Samples.ResponseTypeData patch = new global::Samples.ResponseTypeData();
         patch.Tags.ReplaceWith(tags);
         global::Azure.Response<global::Samples.ResponseTypeResource> result = this.Update(patch, cancellationToken);
         return global::Azure.Response.FromValue(result.Value, result.GetRawResponse());

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_SetTagsAsync.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/TagMethodProviderTests/Verify_SetTagsAsync.cs
@@ -16,13 +16,13 @@ try
         };
         global::Azure.Core.HttpMessage message = _testClientRestClient.CreateGetRequest(global::System.Guid.Parse(this.Id.SubscriptionId), this.Id.ResourceGroupName, this.Id.Name, context);
         global::Azure.Response result = await this.Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
-        global::Azure.Response<global::Samples.Models.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.Models.ResponseTypeData.FromResponse(result), result);
+        global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
         return global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse());
     }
     else
     {
-        global::Samples.Models.ResponseTypeData current = (await this.GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false)).Value.Data;
-        global::Samples.Models.ResponseTypeData patch = new global::Samples.Models.ResponseTypeData();
+        global::Samples.ResponseTypeData current = (await this.GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false)).Value.Data;
+        global::Samples.ResponseTypeData patch = new global::Samples.ResponseTypeData();
         patch.Tags.ReplaceWith(tags);
         global::Azure.Response<global::Samples.ResponseTypeResource> result = await this.UpdateAsync(patch, cancellationToken).ConfigureAwait(false);
         return global::Azure.Response.FromValue(result.Value, result.GetRawResponse());


### PR DESCRIPTION
We are creating multiple `ParameterProvider`, we need to update the resource model namespace during PreVisitModel to align the updated namespace  for them.
