### PR TITLE
Remove parameter causing error

### DIFF
--- a/eng/scripts/New-TestResources-Bootstrapper.ps1
+++ b/eng/scripts/New-TestResources-Bootstrapper.ps1
@@ -6,7 +6,7 @@ param(
 )
 $run = Read-Host "The resources needed to run the live tests could not be located.`nWould you like to run the resource creation script? [y/n]"
 if ($run -eq 'y'){
-    & "$PSScriptRoot\..\common\TestResources\New-TestResources.ps1" $ServiceDirectory -UserAuth true
+    & "$PSScriptRoot\..\common\TestResources\New-TestResources.ps1" $ServiceDirectory
 
     Read-Host "Press enter to close this window and resume your test run."
 }


### PR DESCRIPTION
New-TestResources.ps1 throws if -UserAuth is set since it's the default.

https://github.com/Azure/azure-sdk-for-net/blob/f051f8da3a17bafe413a9f1484d659594bca23f6/eng/common/TestResources/New-TestResources.ps1#L134