### PR TITLE
[Storage] [DataMovement] [Tests] Update Small chunks failure tests to print out unexpected exception

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
@@ -874,7 +874,10 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(TransferState.Completed, transfer.Status.State);
             Assert.AreEqual(true, transfer.Status.HasFailedItems);
-            Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage));
+            if (!testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage))
+            {
+                Assert.Fail($"Did not throw the expected exception. Actual exception thrown: {testEventsRaised.FailedEvents.First().Exception.Message}");
+            }
             await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
         }
         #endregion

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
@@ -876,7 +876,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(true, transfer.Status.HasFailedItems);
             if (!testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage))
             {
-                Assert.Fail($"Did not throw the expected exception. Actual exception thrown: {testEventsRaised.FailedEvents.First().Exception.Message}");
+                Assert.Fail($"Did not throw the expected exception. Actual exception thrown: {testEventsRaised.FailedEvents.First().Exception}");
             }
             await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
         }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryDownloadTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryDownloadTestBase.cs
@@ -643,7 +643,10 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(TransferState.Completed, transfer.Status.State);
             Assert.AreEqual(true, transfer.Status.HasFailedItems);
-            Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage));
+            if (!testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage))
+            {
+                Assert.Fail($"Did not throw the expected exception. Actual exception thrown: {testEventsRaised.FailedEvents.First().Exception.Message}");
+            }
             await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
         }
         #endregion

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryDownloadTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryDownloadTestBase.cs
@@ -645,7 +645,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(true, transfer.Status.HasFailedItems);
             if (!testEventsRaised.FailedEvents.First().Exception.Message.Contains(_expectedOverwriteExceptionMessage))
             {
-                Assert.Fail($"Did not throw the expected exception. Actual exception thrown: {testEventsRaised.FailedEvents.First().Exception.Message}");
+                Assert.Fail($"Did not throw the expected exception. Actual exception thrown: {testEventsRaised.FailedEvents.First().Exception}");
             }
             await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
         }


### PR DESCRIPTION
Was looking at our live test pipeline and saw the "StartTransfer_AwaitCompletion_Failed_SmallChunks" tests being flakey specifically on checking if the exception thrown is what we expected and it is not. Currently we just do a check on the exception message to confirm, however it would be more helpful it could print out the actual exception that is thrown so we can have an easier time to resolve the issue.