### PR TITLE
chore: bump spec SHA and remove deprecated service version

### DIFF
--- a/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/api/Azure.AI.Language.Text.Authoring.net8.0.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/api/Azure.AI.Language.Text.Authoring.net8.0.cs
@@ -669,9 +669,8 @@ namespace Azure.AI.Language.Text.Authoring
         public enum ServiceVersion
         {
             V2023_04_01 = 1,
-            V2023_04_15_Preview = 2,
-            V2024_11_15_Preview = 3,
-            V2025_05_15_Preview = 4,
+            V2024_11_15_Preview = 2,
+            V2025_05_15_Preview = 3,
         }
     }
     public static partial class TextAnalysisAuthoringModelFactory

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/api/Azure.AI.Language.Text.Authoring.netstandard2.0.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/api/Azure.AI.Language.Text.Authoring.netstandard2.0.cs
@@ -669,9 +669,8 @@ namespace Azure.AI.Language.Text.Authoring
         public enum ServiceVersion
         {
             V2023_04_01 = 1,
-            V2023_04_15_Preview = 2,
-            V2024_11_15_Preview = 3,
-            V2025_05_15_Preview = 4,
+            V2024_11_15_Preview = 2,
+            V2025_05_15_Preview = 3,
         }
     }
     public static partial class TextAnalysisAuthoringModelFactory

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/src/Generated/TextAnalysisAuthoringClientOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/src/Generated/TextAnalysisAuthoringClientOptions.cs
@@ -20,12 +20,10 @@ namespace Azure.AI.Language.Text.Authoring
         {
             /// <summary> Service version "2023-04-01". </summary>
             V2023_04_01 = 1,
-            /// <summary> Service version "2023-04-15-preview". </summary>
-            V2023_04_15_Preview = 2,
             /// <summary> Service version "2024-11-15-preview". </summary>
-            V2024_11_15_Preview = 3,
+            V2024_11_15_Preview = 2,
             /// <summary> Service version "2025-05-15-preview". </summary>
-            V2025_05_15_Preview = 4,
+            V2025_05_15_Preview = 3,
         }
 
         internal string Version { get; }
@@ -36,7 +34,6 @@ namespace Azure.AI.Language.Text.Authoring
             Version = version switch
             {
                 ServiceVersion.V2023_04_01 => "2023-04-01",
-                ServiceVersion.V2023_04_15_Preview => "2023-04-15-preview",
                 ServiceVersion.V2024_11_15_Preview => "2024-11-15-preview",
                 ServiceVersion.V2025_05_15_Preview => "2025-05-15-preview",
                 _ => throw new NotSupportedException()

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/tests/Infrastructure/TextAuthoringTestBase.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/tests/Infrastructure/TextAuthoringTestBase.cs
@@ -12,7 +12,6 @@ namespace Azure.AI.Language.Text.Authoring.Tests
     /// <typeparam name="TClient">The type of client being tested.</typeparam>
     [ClientTestFixture(
         TextAnalysisAuthoringClientOptions.ServiceVersion.V2023_04_01,
-        TextAnalysisAuthoringClientOptions.ServiceVersion.V2023_04_15_Preview,
         TextAnalysisAuthoringClientOptions.ServiceVersion.V2024_11_15_Preview,
         TextAnalysisAuthoringClientOptions.ServiceVersion.V2025_05_15_Preview
     )]

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/tsp-location.yaml
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/cognitiveservices/Language.AnalyzeText-authoring
-commit: 0f1c9e2f3e8fb8fcd824d89d5aeecffc157a05c3
+commit: 51222a6a7977e9753a709144cb554d40144c81de
 repo: Azure/azure-rest-api-specs

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text/tsp-location.yaml
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text/tsp-location.yaml
@@ -1,4 +1,4 @@
 repo: azure/azure-rest-api-specs
-commit: 52dae3e072fa71d0e6df8e29e36811571df79d5d
+commit: 51222a6a7977e9753a709144cb554d40144c81de
 directory: specification/cognitiveservices/Language.AnalyzeText
 


### PR DESCRIPTION
This PR updates the spec reference for these libraries to reference the versions that removed the deprecated `useDepedency` decorator and regenerates the libraries.

fixes: https://github.com/Azure/azure-sdk-for-net/issues/53226
