### PR TITLE
Bump commit sha for spec

### DIFF
--- a/sdk/communication/Azure.Communication.Messages/tsp-location.yaml
+++ b/sdk/communication/Azure.Communication.Messages/tsp-location.yaml
@@ -1,4 +1,4 @@
-commit: 8b1307d5cc71bd93208a2baf423217084456dcd5
+commit: 5fda13cee42cecc2e7da20bb4fd82bec5be9d0c7
 directory: specification/communication/Communication.Messages
 additionalDirectories: []
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
This PR updates the spec reference for this library to reference the version that removed the deprecated `useDepedency ` decorator.

fixes: https://github.com/microsoft/typespec/issues/8731