### PR TITLE
bump the version of `Microsoft.AspNetCore.Server.Kestrel.Core`

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -364,7 +364,7 @@
     <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
     <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.0" />
     <PackageReference Update="Microsoft.AspNetCore.Server.WebListener" Version="1.1.4" />
-    <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Update="Microsoft.Azure.Core.Spatial" Version="1.0.0" />
     <PackageReference Update="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
     <PackageReference Update="Microsoft.Azure.Devices" Version="1.38.2" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -360,9 +360,9 @@
     <PackageReference Update="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Update="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
-    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
-    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" />
+    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
+    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.0" />
     <PackageReference Update="Microsoft.AspNetCore.Server.WebListener" Version="1.1.4" />
     <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Update="Microsoft.Azure.Core.Spatial" Version="1.0.0" />
@@ -437,7 +437,7 @@
     <PackageReference Update="System.ClientModel" Version="1.7.0" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Update="System.IO.Pipelines" Version="4.5.1" />
+    <PackageReference Update="System.IO.Pipelines" Version="8.0.0" />
     <PackageReference Update="System.Linq.Async" Version="5.0.0" />
     <PackageReference Update="System.Memory.Data" Version="8.0.1" />
     <PackageReference Update="System.Net.WebSockets.Client" Version="4.3.2" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -444,7 +444,7 @@
     <PackageReference Update="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Update="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Update="System.Security.Cryptography.Cng" Version="4.5.2" />
+    <PackageReference Update="System.Security.Cryptography.Cng" Version="5.0.0" />
     <PackageReference Update="System.Security.Cryptography.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.3.2" />


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/53249

This PR bumps `Microsoft.AspNetCore.Server.Kestrel.Core` to latest `2.3.6` which is the only version without a known critical severity vulnerability.
Since this package requires `System.IO.Pipelines >= 8.0.0`, I have to bump `System.IO.Pipelines` to `8.0.0` as well.
Same reason for the changes of `Microsoft.AspNetCore.Http`
