### PR TITLE
Fix eventgrid pipelines after central package bumps

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There was a bump that went in yesterday in https://github.com/Azure/azure-sdk-for-net/pull/53262 due to a security issue in one of the package dependencies. The major version bump requires this new reference