### PR TITLE
[Monitor] Suppress package links until publish

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -109,9 +109,6 @@ known_content_issues:
   - ['sdk/search/README.md','Not a package: azure-sdk-tools/issues/42']
   - ['sdk/storage/README.md','Not a package: azure-sdk-tools/issues/42']
 
-  - ['sdk/monitor/Azure.Monitor.Query.Logs/*','404s clear at release: azure-sdk-tools/issues/42']
-  - ['sdk/monitor/Azure.Monitor.Query.Metrics/*','404s clear at release: azure-sdk-tools/issues/42']
-
   - ['sdk/core/Azure.Core.Amqp/README.md', 'Opt out of sections: https://github.com/Azure/azure-sdk-tools/issues/404']
   - ['sdk/core/Azure.Core.Experimental/README.md', 'Opt out of sections: https://github.com/Azure/azure-sdk-tools/issues/404']
   - ['sdk/core/Azure.Core.TestFramework/README.md', 'Opt out of sections: https://github.com/Azure/azure-sdk-tools/issues/404']

--- a/eng/ignore-links.txt
+++ b/eng/ignore-links.txt
@@ -6,3 +6,8 @@ https://github.com/Azure/azure-sdk-for-net-pr/blob/feature/IoT-ADT/sdk/iot/Azure
 https://www.nuget.org/packages/Azure.ResourceManager.DigitalTwins
 https://contoso.azureedge.net/urlsigning/test?expires=2145916800&amp;keyid:key1&amp;signature=iTsrLX9rVAIJkSahBA_j5o9Azf5-j331ohxDR1Gx2js=
 https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/testproxy/transition-scripts/generate-assets-json.ps1
+https://learn.microsoft.com/dotnet/api/overview/azure/monitor.query.logs-readme
+https://www.nuget.org/packages/Azure.Monitor.Query.Logs
+https://learn.microsoft.com/dotnet/api/azure.monitor.query.logs.logsqueryclient.queryworkspaceasync
+https://www.nuget.org/packages/Azure.Monitor.Query.Metrics
+https://learn.microsoft.com/dotnet/api/overview/azure/monitor.query.metrics-readme?view=azure-dotnet

--- a/sdk/monitor/Azure.Monitor.Query.Metrics/MigrationGuide.md
+++ b/sdk/monitor/Azure.Monitor.Query.Metrics/MigrationGuide.md
@@ -208,4 +208,4 @@ foreach (MetricsQueryResult value in metricsQueryResults.Values)
 More examples can be found in the [Azure Monitor Query Metrics samples][metrics-samples].
 
 <!-- Links -->
-[metrics-samples]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query.Metrics/src/README.md#examples
+[metrics-samples]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query.Metrics/README.md#examples


### PR DESCRIPTION
# Summary

The focus of these changes is to suppress the set of package-focused links for the Monitor Logs and Metrics packages, as they will 404 until the packages are published and the documentation pipeline runs.