### PR TITLE
build: bump System.Threading.Tasks.Extensions to 4.6.0

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -98,7 +98,7 @@
     <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.Cose" Version="8.0.1" />
     <PackageReference Update="System.Threading.Channels" Version="8.0.0" />
-    <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.6.0" />
     <PackageReference Update="System.Text.Json" Version="8.0.6" />
     <PackageReference Update="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
Addresses [this build](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5470002&view=logs&j=dc5dc96a-fd07-54f1-2edc-36571303c52b&t=98cb261d-762c-570a-5639-f8b073478463) error being seen:

```
\a\_work\1\s\sdk\eventgrid\Azure.Messaging.EventGrid.SystemEvents\tests\Azure.Messaging.EventGrid.SystemEvents.Tests.csproj : error NU1605: Warning As Error: Detected package downgrade: System.Threading.Tasks.Extensions from 4.6.0 to 4.5.4. Reference the package directly from the project to select a different version.  [D:\a\_work\1\s\eng\service.proj]
D:\a\_work\1\s\sdk\eventgrid\Azure.Messaging.EventGrid.SystemEvents\tests\Azure.Messaging.EventGrid.SystemEvents.Tests.csproj : error NU1605:  Azure.Messaging.EventGrid.SystemEvents.Tests -> Azure.Core.TestFramework -> Microsoft.AspNetCore.Server.Kestrel.Core 2.3.6 -> System.Threading.Tasks.Extensions (>= 4.6.0)  [D:\a\_work\1\s\eng\service.proj]
D:\a\_work\1\s\sdk\eventgrid\Azure.Messaging.EventGrid.SystemEvents\tests\Azure.Messaging.EventGrid.SystemEvents.Tests.csproj : error NU1605:  Azure.Messaging.EventGrid.SystemEvents.Tests -> System.Threading.Tasks.Extensions (>= 4.5.4) [D:\a\_work\1\s\eng\service.proj]
```