### PR TITLE
[EnySys] Governance Alert Fixes

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -122,7 +122,7 @@
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.21.0" />
     <PackageReference Update="Azure.Messaging.EventGrid.SystemEvents" Version="1.0.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.4.0" />
+    <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.6.0" />
     <PackageReference Update="Azure.MixedReality.Authentication" version= "1.2.0" />
     <PackageReference Update="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Update="Azure.Monitor.Query" Version="1.1.0" />
@@ -183,7 +183,7 @@
 
     <!-- Other approved packages -->
     <PackageReference Update="Microsoft.Azure.Amqp" Version="2.7.0" />
-    <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.4.0" />
+    <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.76.0" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.76.0" />
     <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.76.0" />

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Traversal": "3.2.0"
   },
   "sdk": {
-    "version": "9.0.102",
+    "version": "9.0.306",
     "rollForward": "feature"
   }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the global .NET SDK version and central WebPubSub package references to address governance alerts.

## References and resources

- [Governance report](https://dev.azure.com/azure-sdk/internal/_componentGovernance/98522/alert/12942588?typeId=13681981) _(Microsoft internal)_