### PR TITLE
[Storage] Change Blobs package dependency in Webjobs from Project to Package Ref

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -15,10 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-		<ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" />
-		<!-- The PackageReference is commented out because Azure.Storage.Blobs is now included via ProjectReference above. -->
-		<!-- It is retained here until after the next release, and the dependency will be switched back to a PackageReference in the future. -->
-		<!-- <PackageReference Include="Azure.Storage.Blobs" /> -->
+		<PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-		<PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>


### PR DESCRIPTION
Undoing what I did here in this PR https://github.com/Azure/azure-sdk-for-net/pull/52987/files#r2400097003

I had to temporarily switch the `Azure.Storage.Blobs` dependency to a `ProjectReference` so the tests and the source could point to the correct API change for `BlobContainerClient.GetBlobs`. This PR is just to change it back to a `PackageReference` so we can maintain stability of the version we are pointing at in the WebJobs Extension.