### PR TITLE
fix: add IncludeAutorestDependency property

### DIFF
--- a/sdk/arizeaiobservabilityeval/Azure.ResourceManager.ArizeAIObservabilityEval/src/Azure.ResourceManager.ArizeAIObservabilityEval.csproj
+++ b/sdk/arizeaiobservabilityeval/Azure.ResourceManager.ArizeAIObservabilityEval/src/Azure.ResourceManager.ArizeAIObservabilityEval.csproj
@@ -6,5 +6,6 @@
     <PackageId>Azure.ResourceManager.ArizeAIObservabilityEval</PackageId>
     <Description>Azure Resource Manager client SDK for Azure resource provider liftrarize.</Description>
     <PackageTags>azure;management;arm;resource manager;liftrarize</PackageTags>
+    <IncludeAutorestDependency>true</IncludeAutorestDependency>
   </PropertyGroup>
 </Project>

--- a/sdk/lambdatesthyperexecute/Azure.ResourceManager.LambdaTestHyperExecute/src/Azure.ResourceManager.LambdaTestHyperExecute.csproj
+++ b/sdk/lambdatesthyperexecute/Azure.ResourceManager.LambdaTestHyperExecute/src/Azure.ResourceManager.LambdaTestHyperExecute.csproj
@@ -6,5 +6,6 @@
     <PackageId>Azure.ResourceManager.LambdaTestHyperExecute</PackageId>
     <Description>Azure Resource Manager client SDK for Azure resource provider liftrhyperexecute.</Description>
     <PackageTags>azure;management;arm;resource manager;liftrhyperexecute</PackageTags>
+    <IncludeAutorestDependency>true</IncludeAutorestDependency>
   </PropertyGroup>
 </Project>

--- a/sdk/pineconevectordb/Azure.ResourceManager.PineconeVectorDB/src/Azure.ResourceManager.PineconeVectorDB.csproj
+++ b/sdk/pineconevectordb/Azure.ResourceManager.PineconeVectorDB/src/Azure.ResourceManager.PineconeVectorDB.csproj
@@ -4,5 +4,6 @@
     <PackageId>Azure.ResourceManager.PineconeVectorDB</PackageId>
     <Description>Azure Resource Manager client SDK for Azure resource provider liftrpinecone.</Description>
     <PackageTags>azure;management;arm;resource manager;liftrpinecone</PackageTags>
+    <IncludeAutorestDependency>true</IncludeAutorestDependency>
   </PropertyGroup>
 </Project>

--- a/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases/src/Azure.ResourceManager.WeightsAndBiases.csproj
+++ b/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases/src/Azure.ResourceManager.WeightsAndBiases.csproj
@@ -4,5 +4,6 @@
     <PackageId>Azure.ResourceManager.WeightsAndBiases</PackageId>
     <Description>Azure Resource Manager client SDK for Azure resource provider liftrweightsandbiases.</Description>
     <PackageTags>azure;management;arm;resource manager;liftrweightsandbiases</PackageTags>
+    <IncludeAutorestDependency>true</IncludeAutorestDependency>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/53149. Adds the `IncludeAutorestDependency` property to more libraries that require it. 

contributes to: https://github.com/Azure/azure-sdk-for-net/issues/53148
