### PR TITLE
key vault admin: remove custom code for latest version

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Generated/KeyVaultAdministrationClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Generated/KeyVaultAdministrationClientOptions.cs
@@ -12,5 +12,6 @@ namespace Azure.Security.KeyVault.Administration
     /// <summary> Client options for <see cref="KeyVaultAccessControlClient"/>. </summary>
     public partial class KeyVaultAdministrationClientOptions : ClientOptions
     {
+        private const ServiceVersion LatestVersion = ServiceVersion.V2025_07_01;
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAdministrationClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAdministrationClientOptions.cs
@@ -14,8 +14,6 @@ namespace Azure.Security.KeyVault.Administration
     {
         internal const string CallerShouldAuditReason = "https://aka.ms/azsdk/callershouldaudit/security-keyvault-administration";
 
-        private const ServiceVersion LatestVersion = ServiceVersion.V2025_07_01;
-
         /// <summary>
         /// Gets the <see cref="KeyVaultAdministrationClientOptions.ServiceVersion"/> of the service API used when
         /// making requests. For more information, see


### PR DESCRIPTION
Now that https://github.com/microsoft/typespec/issues/8614 is fixed, this PR simply removes the custom code for setting the latest version in the `Azure.Security.KeyVault.Administration` library.
