### PR TITLE
Should be able to rename list operation

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -426,7 +426,6 @@ namespace Azure.Generator.Management.Providers
                 if (method is InputPagingServiceMethod pagingMethod)
                 {
                     // Use PageableOperationMethodProvider for InputPagingServiceMethod
-                    // If the method's resource scope matches the contextual path, we use the original method name
                     operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, true, methodName: ResourceHelpers.GetOperationMethodName(methodKind, true, false)));
                     operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, false, methodName: ResourceHelpers.GetOperationMethodName(methodKind, false, false)));
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -427,8 +427,8 @@ namespace Azure.Generator.Management.Providers
                 {
                     // Use PageableOperationMethodProvider for InputPagingServiceMethod
                     // If the method's resource scope matches the contextual path, we use the original method name
-                    operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, true, methodName: resourceMethod.ResourceScope == _contextualPath ? null : ResourceHelpers.GetOperationMethodName(methodKind, true)));
-                    operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, false, methodName: resourceMethod.ResourceScope == _contextualPath ? null : ResourceHelpers.GetOperationMethodName(methodKind, false)));
+                    operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, true, methodName: ResourceHelpers.GetOperationMethodName(methodKind, true, false)));
+                    operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, false, methodName: ResourceHelpers.GetOperationMethodName(methodKind, false, false)));
 
                     continue;
                 }
@@ -446,9 +446,9 @@ namespace Azure.Generator.Management.Providers
                 }
                 else
                 {
-                    var asyncMethodName = ResourceHelpers.GetOperationMethodName(methodKind, true);
+                    var asyncMethodName = ResourceHelpers.GetOperationMethodName(methodKind, true, false);
                     operationMethods.Add(new ResourceOperationMethodProvider(this, _contextualPath, restClientInfo, method, true, asyncMethodName, forceLro: isFakeLro));
-                    var methodName = ResourceHelpers.GetOperationMethodName(methodKind, false);
+                    var methodName = ResourceHelpers.GetOperationMethodName(methodKind, false, false);
                     operationMethods.Add(new ResourceOperationMethodProvider(this, _contextualPath, restClientInfo, method, false, methodName, forceLro: isFakeLro));
                 }
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -426,6 +426,7 @@ namespace Azure.Generator.Management.Providers
                 if (method is InputPagingServiceMethod pagingMethod)
                 {
                     // Use PageableOperationMethodProvider for InputPagingServiceMethod
+                    // If the method's resource scope matches the contextual path, we use the original method name
                     operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, true, methodName: resourceMethod.ResourceScope == _contextualPath ? null : ResourceHelpers.GetOperationMethodName(methodKind, true)));
                     operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, false, methodName: resourceMethod.ResourceScope == _contextualPath ? null : ResourceHelpers.GetOperationMethodName(methodKind, false)));
 
@@ -447,7 +448,6 @@ namespace Azure.Generator.Management.Providers
                 {
                     var asyncMethodName = ResourceHelpers.GetOperationMethodName(methodKind, true);
                     operationMethods.Add(new ResourceOperationMethodProvider(this, _contextualPath, restClientInfo, method, true, asyncMethodName, forceLro: isFakeLro));
-                    // If the method's resource scope matches the contextual path, we use the original method name
                     var methodName = ResourceHelpers.GetOperationMethodName(methodKind, false);
                     operationMethods.Add(new ResourceOperationMethodProvider(this, _contextualPath, restClientInfo, method, false, methodName, forceLro: isFakeLro));
                 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -426,8 +426,8 @@ namespace Azure.Generator.Management.Providers
                 if (method is InputPagingServiceMethod pagingMethod)
                 {
                     // Use PageableOperationMethodProvider for InputPagingServiceMethod
-                    operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, true, methodName: ResourceHelpers.GetOperationMethodName(methodKind, true)));
-                    operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, false, methodName: ResourceHelpers.GetOperationMethodName(methodKind, false)));
+                    operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, true, methodName: resourceMethod.ResourceScope == _contextualPath ? null : ResourceHelpers.GetOperationMethodName(methodKind, true)));
+                    operationMethods.Add(new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingMethod, false, methodName: resourceMethod.ResourceScope == _contextualPath ? null : ResourceHelpers.GetOperationMethodName(methodKind, false)));
 
                     continue;
                 }
@@ -447,6 +447,7 @@ namespace Azure.Generator.Management.Providers
                 {
                     var asyncMethodName = ResourceHelpers.GetOperationMethodName(methodKind, true);
                     operationMethods.Add(new ResourceOperationMethodProvider(this, _contextualPath, restClientInfo, method, true, asyncMethodName, forceLro: isFakeLro));
+                    // If the method's resource scope matches the contextual path, we use the original method name
                     var methodName = ResourceHelpers.GetOperationMethodName(methodKind, false);
                     operationMethods.Add(new ResourceOperationMethodProvider(this, _contextualPath, restClientInfo, method, false, methodName, forceLro: isFakeLro));
                 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -338,7 +338,7 @@ namespace Azure.Generator.Management.Providers
             foreach (var isAsync in new List<bool> { true, false })
             {
                 var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_create.InputMethod.Operation, isAsync);
-                var methodName = ResourceHelpers.GetOperationMethodName(ResourceOperationKind.Create, isAsync);
+                var methodName = ResourceHelpers.GetOperationMethodName(ResourceOperationKind.Create, isAsync, true);
                 result.Add(new ResourceOperationMethodProvider(this, _contextualPath, restClientInfo, _create.InputMethod, isAsync, methodName: methodName, forceLro: true));
             }
 
@@ -348,7 +348,7 @@ namespace Azure.Generator.Management.Providers
         private MethodProvider BuildGetAllMethod(ResourceMethod getAll, bool isAsync)
         {
             var restClientInfo = _clientInfos[getAll.InputClient];
-            var methodName = ResourceHelpers.GetOperationMethodName(ResourceOperationKind.List, isAsync);
+            var methodName = ResourceHelpers.GetOperationMethodName(ResourceOperationKind.List, isAsync, true);
             return getAll.InputMethod switch
             {
                 InputPagingServiceMethod pagingGetAll => new PageableOperationMethodProvider(this, _contextualPath, restClientInfo, pagingGetAll, isAsync, methodName),

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceHelpers.cs
@@ -58,6 +58,7 @@ namespace Azure.Generator.Management.Utilities
             return operationKind switch
             {
                 ResourceOperationKind.Create => isAsync ? "CreateOrUpdateAsync" : "CreateOrUpdate",
+                // For List operation, only resource collections have GetAll or GetAllAsync methods.
                 ResourceOperationKind.List => !isResourceCollection ? null : isAsync ? "GetAllAsync" : "GetAll",
                 _ => null
             };

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceHelpers.cs
@@ -51,13 +51,14 @@ namespace Azure.Generator.Management.Utilities
         /// </summary>
         /// <param name="operationKind">The kind of resource operation.</param>
         /// <param name="isAsync">Whether this is an async method.</param>
+        /// <param name="isResourceCollection">Whether this is used for resource collection.</param>
         /// <returns>The method name to use, or null if no override is needed.</returns>
-        public static string? GetOperationMethodName(ResourceOperationKind operationKind, bool isAsync)
+        public static string? GetOperationMethodName(ResourceOperationKind operationKind, bool isAsync, bool isResourceCollection)
         {
             return operationKind switch
             {
                 ResourceOperationKind.Create => isAsync ? "CreateOrUpdateAsync" : "CreateOrUpdate",
-                ResourceOperationKind.List => isAsync ? "GetAllAsync" : "GetAll",
+                ResourceOperationKind.List => !isResourceCollection ? null : isAsync ? "GetAllAsync" : "GetAll",
                 _ => null
             };
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/main.tsp
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/main.tsp
@@ -39,3 +39,4 @@ enum Versions {
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Foo.properties);
 
 @@alternateType(FooProperties.something, Azure.ResourceManager.Foundations.ManagedServiceIdentity, "csharp");
+@@clientName(Employees.listByParent, "GetEmployees", "csharp");

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarResource.cs
@@ -283,13 +283,13 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <summary> List Employee resources by Bar. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="Employee"/> that may take multiple service requests to iterate over. </returns>
-        public virtual AsyncPageable<Employee> GetAllAsync(CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<Employee> GetEmployeesAsync(CancellationToken cancellationToken = default)
         {
             RequestContext context = new RequestContext
             {
                 CancellationToken = cancellationToken
             };
-            return new EmployeesGetByParentAsyncCollectionResultOfT(
+            return new EmployeesGetEmployeesAsyncCollectionResultOfT(
                 _employeesRestClient,
                 Guid.Parse(Id.SubscriptionId),
                 Id.ResourceGroupName,
@@ -301,13 +301,13 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <summary> List Employee resources by Bar. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="Employee"/> that may take multiple service requests to iterate over. </returns>
-        public virtual Pageable<Employee> GetAll(CancellationToken cancellationToken = default)
+        public virtual Pageable<Employee> GetEmployees(CancellationToken cancellationToken = default)
         {
             RequestContext context = new RequestContext
             {
                 CancellationToken = cancellationToken
             };
-            return new EmployeesGetByParentCollectionResultOfT(
+            return new EmployeesGetEmployeesCollectionResultOfT(
                 _employeesRestClient,
                 Guid.Parse(Id.SubscriptionId),
                 Id.ResourceGroupName,

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EmployeesGetEmployeesAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EmployeesGetEmployeesAsyncCollectionResultOfT.cs
@@ -15,7 +15,7 @@ using Azure.Generator.MgmtTypeSpec.Tests.Models;
 
 namespace Azure.Generator.MgmtTypeSpec.Tests
 {
-    internal partial class EmployeesGetByParentAsyncCollectionResultOfT : AsyncPageable<Employee>
+    internal partial class EmployeesGetEmployeesAsyncCollectionResultOfT : AsyncPageable<Employee>
     {
         private readonly Employees _client;
         private readonly Guid _subscriptionId;
@@ -24,7 +24,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         private readonly string _barName;
         private readonly RequestContext _context;
 
-        /// <summary> Initializes a new instance of EmployeesGetByParentAsyncCollectionResultOfT, which is used to iterate over the pages of a collection. </summary>
+        /// <summary> Initializes a new instance of EmployeesGetEmployeesAsyncCollectionResultOfT, which is used to iterate over the pages of a collection. </summary>
         /// <param name="client"> The Employees client used to send requests. </param>
         /// <param name="subscriptionId"> The ID of the target subscription. The value must be an UUID. </param>
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
@@ -33,7 +33,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <param name="context"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceGroupName"/>, <paramref name="fooName"/> or <paramref name="barName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="resourceGroupName"/>, <paramref name="fooName"/> or <paramref name="barName"/> is an empty string, and was expected to be non-empty. </exception>
-        public EmployeesGetByParentAsyncCollectionResultOfT(Employees client, Guid subscriptionId, string resourceGroupName, string fooName, string barName, RequestContext context) : base(context?.CancellationToken ?? default)
+        public EmployeesGetEmployeesAsyncCollectionResultOfT(Employees client, Guid subscriptionId, string resourceGroupName, string fooName, string barName, RequestContext context) : base(context?.CancellationToken ?? default)
         {
             Argument.AssertNotNullOrEmpty(resourceGroupName, nameof(resourceGroupName));
             Argument.AssertNotNullOrEmpty(fooName, nameof(fooName));
@@ -47,10 +47,10 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             _context = context;
         }
 
-        /// <summary> Gets the pages of EmployeesGetByParentAsyncCollectionResultOfT as an enumerable collection. </summary>
+        /// <summary> Gets the pages of EmployeesGetEmployeesAsyncCollectionResultOfT as an enumerable collection. </summary>
         /// <param name="continuationToken"> A continuation token indicating where to resume paging. </param>
         /// <param name="pageSizeHint"> The number of items per page. </param>
-        /// <returns> The pages of EmployeesGetByParentAsyncCollectionResultOfT as an enumerable collection. </returns>
+        /// <returns> The pages of EmployeesGetEmployeesAsyncCollectionResultOfT as an enumerable collection. </returns>
         public override async IAsyncEnumerable<Page<Employee>> AsPages(string continuationToken, int? pageSizeHint)
         {
             Uri nextPage = continuationToken != null ? new Uri(continuationToken) : null;
@@ -76,8 +76,8 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <param name="nextLink"> The next link to use for the next page of results. </param>
         private async ValueTask<Response> GetNextResponseAsync(int? pageSizeHint, Uri nextLink)
         {
-            HttpMessage message = nextLink != null ? _client.CreateNextGetByParentRequest(nextLink, _subscriptionId, _resourceGroupName, _fooName, _barName, _context) : _client.CreateGetByParentRequest(_subscriptionId, _resourceGroupName, _fooName, _barName, _context);
-            using DiagnosticScope scope = _client.ClientDiagnostics.CreateScope("BarResource.GetAll");
+            HttpMessage message = nextLink != null ? _client.CreateNextGetEmployeesRequest(nextLink, _subscriptionId, _resourceGroupName, _fooName, _barName, _context) : _client.CreateGetEmployeesRequest(_subscriptionId, _resourceGroupName, _fooName, _barName, _context);
+            using DiagnosticScope scope = _client.ClientDiagnostics.CreateScope("BarResource.GetEmployees");
             scope.Start();
             try
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EmployeesGetEmployeesCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EmployeesGetEmployeesCollectionResultOfT.cs
@@ -14,7 +14,7 @@ using Azure.Generator.MgmtTypeSpec.Tests.Models;
 
 namespace Azure.Generator.MgmtTypeSpec.Tests
 {
-    internal partial class EmployeesGetByParentCollectionResultOfT : Pageable<Employee>
+    internal partial class EmployeesGetEmployeesCollectionResultOfT : Pageable<Employee>
     {
         private readonly Employees _client;
         private readonly Guid _subscriptionId;
@@ -23,7 +23,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         private readonly string _barName;
         private readonly RequestContext _context;
 
-        /// <summary> Initializes a new instance of EmployeesGetByParentCollectionResultOfT, which is used to iterate over the pages of a collection. </summary>
+        /// <summary> Initializes a new instance of EmployeesGetEmployeesCollectionResultOfT, which is used to iterate over the pages of a collection. </summary>
         /// <param name="client"> The Employees client used to send requests. </param>
         /// <param name="subscriptionId"> The ID of the target subscription. The value must be an UUID. </param>
         /// <param name="resourceGroupName"> The name of the resource group. The name is case insensitive. </param>
@@ -32,7 +32,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <param name="context"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceGroupName"/>, <paramref name="fooName"/> or <paramref name="barName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="resourceGroupName"/>, <paramref name="fooName"/> or <paramref name="barName"/> is an empty string, and was expected to be non-empty. </exception>
-        public EmployeesGetByParentCollectionResultOfT(Employees client, Guid subscriptionId, string resourceGroupName, string fooName, string barName, RequestContext context) : base(context?.CancellationToken ?? default)
+        public EmployeesGetEmployeesCollectionResultOfT(Employees client, Guid subscriptionId, string resourceGroupName, string fooName, string barName, RequestContext context) : base(context?.CancellationToken ?? default)
         {
             Argument.AssertNotNullOrEmpty(resourceGroupName, nameof(resourceGroupName));
             Argument.AssertNotNullOrEmpty(fooName, nameof(fooName));
@@ -46,10 +46,10 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             _context = context;
         }
 
-        /// <summary> Gets the pages of EmployeesGetByParentCollectionResultOfT as an enumerable collection. </summary>
+        /// <summary> Gets the pages of EmployeesGetEmployeesCollectionResultOfT as an enumerable collection. </summary>
         /// <param name="continuationToken"> A continuation token indicating where to resume paging. </param>
         /// <param name="pageSizeHint"> The number of items per page. </param>
-        /// <returns> The pages of EmployeesGetByParentCollectionResultOfT as an enumerable collection. </returns>
+        /// <returns> The pages of EmployeesGetEmployeesCollectionResultOfT as an enumerable collection. </returns>
         public override IEnumerable<Page<Employee>> AsPages(string continuationToken, int? pageSizeHint)
         {
             Uri nextPage = continuationToken != null ? new Uri(continuationToken) : null;
@@ -75,8 +75,8 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <param name="nextLink"> The next link to use for the next page of results. </param>
         private Response GetNextResponse(int? pageSizeHint, Uri nextLink)
         {
-            HttpMessage message = nextLink != null ? _client.CreateNextGetByParentRequest(nextLink, _subscriptionId, _resourceGroupName, _fooName, _barName, _context) : _client.CreateGetByParentRequest(_subscriptionId, _resourceGroupName, _fooName, _barName, _context);
-            using DiagnosticScope scope = _client.ClientDiagnostics.CreateScope("BarResource.GetAll");
+            HttpMessage message = nextLink != null ? _client.CreateNextGetEmployeesRequest(nextLink, _subscriptionId, _resourceGroupName, _fooName, _barName, _context) : _client.CreateGetEmployeesRequest(_subscriptionId, _resourceGroupName, _fooName, _barName, _context);
+            using DiagnosticScope scope = _client.ClientDiagnostics.CreateScope("BarResource.GetEmployees");
             scope.Start();
             try
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/RestOperations/EmployeesRestOperations.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/RestOperations/EmployeesRestOperations.cs
@@ -41,7 +41,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <summary> The ClientDiagnostics is used to provide tracing support for the client library. </summary>
         internal ClientDiagnostics ClientDiagnostics { get; }
 
-        internal HttpMessage CreateGetByParentRequest(Guid subscriptionId, string resourceGroupName, string fooName, string barName, RequestContext context)
+        internal HttpMessage CreateGetEmployeesRequest(Guid subscriptionId, string resourceGroupName, string fooName, string barName, RequestContext context)
         {
             RawRequestUriBuilder uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
@@ -63,7 +63,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             return message;
         }
 
-        internal HttpMessage CreateNextGetByParentRequest(Uri nextPage, Guid subscriptionId, string resourceGroupName, string fooName, string barName, RequestContext context)
+        internal HttpMessage CreateNextGetEmployeesRequest(Uri nextPage, Guid subscriptionId, string resourceGroupName, string fooName, string barName, RequestContext context)
         {
             RawRequestUriBuilder uri = new RawRequestUriBuilder();
             uri.Reset(nextPage);

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
@@ -14958,7 +14958,7 @@
             {
               "$id": "1105",
               "kind": "paging",
-              "name": "listByParent",
+              "name": "GetEmployees",
               "accessibility": "public",
               "apiVersions": [
                 "2024-05-01"
@@ -14966,7 +14966,7 @@
               "doc": "List Employee resources by Bar",
               "operation": {
                 "$id": "1106",
-                "name": "listByParent",
+                "name": "GetEmployees",
                 "resourceName": "Employee",
                 "doc": "List Employee resources by Bar",
                 "accessibility": "public",


### PR DESCRIPTION
Only rename list method to `GetAll` for resource collection method, keep it as it is for resource method.